### PR TITLE
feat: ExecutionContext and system instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace --all-targets
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace

--- a/crates/crypto/benches/falcon_bench.rs
+++ b/crates/crypto/benches/falcon_bench.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use pyde_crypto::falcon::{falcon_keygen, falcon_sign, falcon_verify, falcon_batch_verify};
+use pyde_crypto::falcon::{falcon_batch_verify, falcon_keygen, falcon_sign, falcon_verify};
 
 fn bench_keygen() {
     println!("=== FALCON-512 keygen ===\n");

--- a/crates/crypto/benches/threshold_bench.rs
+++ b/crates/crypto/benches/threshold_bench.rs
@@ -1,8 +1,8 @@
 use std::time::Instant;
 
 use pyde_crypto::threshold::{
-    EpochKeyMaterial, combine_shares, generate_decryption_share, pss_refresh, threshold_encrypt,
-    threshold_keygen,
+    combine_shares, generate_decryption_share, pss_refresh, threshold_encrypt, threshold_keygen,
+    EpochKeyMaterial,
 };
 
 fn bench_keygen() {

--- a/crates/crypto/src/falcon.rs
+++ b/crates/crypto/src/falcon.rs
@@ -89,8 +89,7 @@ pub fn falcon_keygen() -> (FalconPublicKey, FalconSecretKey) {
 
 /// Sign a message with a FALCON-512 secret key.
 pub fn falcon_sign(sk: &FalconSecretKey, msg: &[u8]) -> FalconSignature {
-    let kp =
-        FnDsaKeyPair::from_private_key(&sk.0).expect("invalid FALCON-512 secret key");
+    let kp = FnDsaKeyPair::from_private_key(&sk.0).expect("invalid FALCON-512 secret key");
     let sig = kp
         .sign(msg, &DomainSeparation::None)
         .expect("FALCON-512 signing failed");
@@ -104,9 +103,7 @@ pub fn falcon_verify(pk: &FalconPublicKey, msg: &[u8], sig: &FalconSignature) ->
 
 /// Batch verify multiple FALCON-512 signatures.
 /// Returns true only if ALL signatures are valid.
-pub fn falcon_batch_verify(
-    items: &[(&FalconPublicKey, &[u8], &FalconSignature)],
-) -> bool {
+pub fn falcon_batch_verify(items: &[(&FalconPublicKey, &[u8], &FalconSignature)]) -> bool {
     items
         .iter()
         .all(|(pk, msg, sig)| falcon_verify(pk, msg, sig))

--- a/crates/crypto/src/kyber.rs
+++ b/crates/crypto/src/kyber.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 
 use ml_kem::{
-    Decapsulate, MlKem768, Seed,
     kem::{Encapsulate, Kem, KeyExport},
+    Decapsulate, MlKem768, Seed,
 };
 
 // ML-KEM-768 sizes

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -5,8 +5,8 @@ use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_goldilocks::Goldilocks;
 
 use crate::kyber::{
-    KyberCiphertext, KyberPublicKey, KyberSecretKey, SharedSecret, kyber_decapsulate,
-    kyber_encapsulate, kyber_keygen,
+    kyber_decapsulate, kyber_encapsulate, kyber_keygen, KyberCiphertext, KyberPublicKey,
+    KyberSecretKey, SharedSecret,
 };
 use crate::poseidon2::poseidon2_hash;
 
@@ -167,7 +167,10 @@ fn compute_mac(shared_secret: &SharedSecret, ciphertext: &[u8]) -> [u8; 32] {
 }
 
 fn xor_bytes(data: &[u8], keystream: &[u8]) -> Vec<u8> {
-    data.iter().zip(keystream.iter()).map(|(a, b)| a ^ b).collect()
+    data.iter()
+        .zip(keystream.iter())
+        .map(|(a, b)| a ^ b)
+        .collect()
 }
 
 // --- Public API ---
@@ -350,34 +353,29 @@ pub fn generate_refresh_contribution(
     let mut all_deltas: Vec<Vec<Vec<Goldilocks>>> = Vec::with_capacity(SEED_ELEMENTS);
     for elem_idx in 0..SEED_ELEMENTS {
         // shamir_split with secret=0 gives us zero-secret shares
-        let zero_shares =
-            shamir_split(Goldilocks::ZERO, n, threshold, domain_entropy.as_bytes(), elem_idx);
+        let zero_shares = shamir_split(
+            Goldilocks::ZERO,
+            n,
+            threshold,
+            domain_entropy.as_bytes(),
+            elem_idx,
+        );
         let element_deltas: Vec<Goldilocks> = zero_shares.iter().map(|s| s.y).collect();
         all_deltas.push(vec![element_deltas]);
     }
 
     // Transpose to per-validator: deltas[validator_idx][elem_idx]
     let deltas: Vec<Vec<Goldilocks>> = (0..n)
-        .map(|v| {
-            (0..SEED_ELEMENTS)
-                .map(|e| all_deltas[e][0][v])
-                .collect()
-        })
+        .map(|v| (0..SEED_ELEMENTS).map(|e| all_deltas[e][0][v]).collect())
         .collect();
 
-    RefreshContribution {
-        from_index,
-        deltas,
-    }
+    RefreshContribution { from_index, deltas }
 }
 
 /// Apply refresh contributions to a validator's key share.
 /// Each validator sums the delta values from all contributions into their share.
 /// The underlying secret remains the same, but all shares change.
-pub fn apply_refresh(
-    key_share: &KeyShare,
-    contributions: &[RefreshContribution],
-) -> KeyShare {
+pub fn apply_refresh(key_share: &KeyShare, contributions: &[RefreshContribution]) -> KeyShare {
     let validator_idx = key_share.index - 1; // 0-based index into deltas
     let mut new_shares = key_share.shares.clone();
 
@@ -395,10 +393,7 @@ pub fn apply_refresh(
 
 /// Verify a refresh contribution by checking that each zero-secret polynomial
 /// evaluates correctly (the shares from this contribution alone reconstruct to zero).
-pub fn verify_refresh_contribution(
-    contribution: &RefreshContribution,
-    threshold: usize,
-) -> bool {
+pub fn verify_refresh_contribution(contribution: &RefreshContribution, threshold: usize) -> bool {
     // For each seed element, take `threshold` shares and verify they reconstruct to zero
     for elem_idx in 0..SEED_ELEMENTS {
         let field_shares: Vec<FieldShare> = (0..threshold)
@@ -601,11 +596,21 @@ mod tests {
         let shares = shamir_split(secret, 5, 3, entropy.as_bytes(), 0);
 
         // Reconstruct from first 3
-        let reconstructed = shamir_reconstruct(&shares[..3].iter().map(|s| FieldShare { x: s.x, y: s.y }).collect::<Vec<_>>());
+        let reconstructed = shamir_reconstruct(
+            &shares[..3]
+                .iter()
+                .map(|s| FieldShare { x: s.x, y: s.y })
+                .collect::<Vec<_>>(),
+        );
         assert_eq!(gl_to_u64(reconstructed), 12345);
 
         // Reconstruct from last 3
-        let reconstructed2 = shamir_reconstruct(&shares[2..5].iter().map(|s| FieldShare { x: s.x, y: s.y }).collect::<Vec<_>>());
+        let reconstructed2 = shamir_reconstruct(
+            &shares[2..5]
+                .iter()
+                .map(|s| FieldShare { x: s.x, y: s.y })
+                .collect::<Vec<_>>(),
+        );
         assert_eq!(gl_to_u64(reconstructed2), 12345);
     }
 
@@ -681,12 +686,15 @@ mod tests {
         // Mix old and new shares from different validators — should fail
         // because shares from different epochs lie on different polynomials
         let mixed_shares = vec![
-            generate_decryption_share(&shares[0], &ct),      // old share, validator 1
-            generate_decryption_share(&new_shares[1], &ct),   // new share, validator 2
-            generate_decryption_share(&new_shares[2], &ct),   // new share, validator 3
+            generate_decryption_share(&shares[0], &ct), // old share, validator 1
+            generate_decryption_share(&new_shares[1], &ct), // new share, validator 2
+            generate_decryption_share(&new_shares[2], &ct), // new share, validator 3
         ];
         let result = combine_shares(&mixed_shares, 3, &ct);
-        assert!(result.is_err(), "mixing old and new epoch shares should fail");
+        assert!(
+            result.is_err(),
+            "mixing old and new epoch shares should fail"
+        );
     }
 
     #[test]

--- a/crates/crypto/src/vrf.rs
+++ b/crates/crypto/src/vrf.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use crate::falcon::{FalconPublicKey, FalconSecretKey, falcon_sign, falcon_verify};
+use crate::falcon::{falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey};
 use crate::hash::Hash256;
 use crate::poseidon2::poseidon2_hash;
 
@@ -46,8 +46,7 @@ fn compute_vrf_output(sk: &FalconSecretKey, input: &[u8]) -> VrfOutput {
     let sk_fingerprint = poseidon2_hash(&sk_input);
 
     // Compute output = H(domain || fingerprint || input)
-    let mut output_input =
-        Vec::with_capacity(VRF_DOMAIN_OUTPUT.len() + 32 + input.len());
+    let mut output_input = Vec::with_capacity(VRF_DOMAIN_OUTPUT.len() + 32 + input.len());
     output_input.extend_from_slice(VRF_DOMAIN_OUTPUT);
     output_input.extend_from_slice(sk_fingerprint.as_bytes());
     output_input.extend_from_slice(input);

--- a/crates/pvm/src/asm.rs
+++ b/crates/pvm/src/asm.rs
@@ -229,8 +229,33 @@ fn parse_pseudo_mem(s: &str) -> Option<PseudoMem> {
     }
 }
 
+/// Pseudo-mnemonics for system/env instructions that map to Caller/Callvalue
+/// with a sub-code in the immediate field.
+#[derive(Clone, Copy, Debug)]
+enum PseudoEnv {
+    /// GP-width query: maps to Caller opcode with sub-code in imm
+    Gp(u32),
+    /// Wide query: maps to Callvalue opcode with sub-code in imm
+    Wide(u32),
+    /// Wide query that also takes an rs1 input (e.g., balance)
+    WideWithInput(u32),
+}
+
+fn parse_pseudo_env(s: &str) -> Option<PseudoEnv> {
+    use crate::vm::{env_gp, env_wide};
+    match s {
+        "address" => Some(PseudoEnv::Gp(env_gp::ADDRESS)),
+        "blocknumber" => Some(PseudoEnv::Gp(env_gp::BLOCK_NUMBER)),
+        "timestamp" => Some(PseudoEnv::Gp(env_gp::TIMESTAMP)),
+        "gasremaining" => Some(PseudoEnv::Gp(env_gp::GAS_REMAINING)),
+        "gasprice" => Some(PseudoEnv::Wide(env_wide::GAS_PRICE)),
+        "balance" => Some(PseudoEnv::WideWithInput(env_wide::BALANCE)),
+        _ => None,
+    }
+}
+
 fn is_mnemonic(s: &str) -> bool {
-    parse_pseudo_mem(s).is_some() || mnemonic_to_opcode(s).is_some()
+    parse_pseudo_mem(s).is_some() || parse_pseudo_env(s).is_some() || mnemonic_to_opcode(s).is_some()
 }
 
 fn mnemonic_to_opcode(s: &str) -> Option<Opcode> {
@@ -389,6 +414,8 @@ struct ParsedInstr {
     opcode: Opcode,
     /// For pseudo load/store, the width.
     mem_width: Option<MemWidth>,
+    /// For pseudo env instructions, the sub-code and variant.
+    env_pseudo: Option<PseudoEnv>,
     operands: Vec<Operand>,
 }
 
@@ -423,6 +450,8 @@ fn parse(tokens: &[(usize, Token)]) -> Result<(Vec<ParsedInstr>, HashMap<String,
                 let mut mem_width = None;
                 let opcode;
 
+                let mut env_pseudo = None;
+
                 if let Some(pseudo) = parse_pseudo_mem(mnem) {
                     match pseudo {
                         PseudoMem::Load(w) => {
@@ -434,6 +463,12 @@ fn parse(tokens: &[(usize, Token)]) -> Result<(Vec<ParsedInstr>, HashMap<String,
                             mem_width = Some(w);
                         }
                     }
+                } else if let Some(pseudo) = parse_pseudo_env(mnem) {
+                    env_pseudo = Some(pseudo);
+                    opcode = match pseudo {
+                        PseudoEnv::Gp(_) => Opcode::Caller,
+                        PseudoEnv::Wide(_) | PseudoEnv::WideWithInput(_) => Opcode::Callvalue,
+                    };
                 } else {
                     opcode = mnemonic_to_opcode(mnem).ok_or_else(|| AsmError::Parse {
                         line,
@@ -481,6 +516,7 @@ fn parse(tokens: &[(usize, Token)]) -> Result<(Vec<ParsedInstr>, HashMap<String,
                     line,
                     opcode,
                     mem_width,
+                    env_pseudo,
                     operands,
                 });
                 offset += 4;
@@ -583,6 +619,37 @@ fn encode_instr(
 ) -> Result<Instruction, AsmError> {
     let ops = &pi.operands;
     let line = pi.line;
+
+    // Env pseudo-mnemonics (address, blocknumber, timestamp, etc.)
+    if let Some(env) = pi.env_pseudo {
+        match env {
+            PseudoEnv::Gp(sub) => {
+                // e.g., "address r1" → Caller r1, r0, sub
+                if ops.len() != 1 {
+                    return Err(AsmError::Parse { line, msg: "env query requires 1 operand: rd".into() });
+                }
+                let rd = expect_gp(&ops[0], line, "rd")?;
+                return Ok(encode(Opcode::Caller, rd, 0, sub));
+            }
+            PseudoEnv::Wide(sub) => {
+                // e.g., "gasprice w0" → Callvalue w0, r0, sub
+                if ops.len() != 1 {
+                    return Err(AsmError::Parse { line, msg: "env query requires 1 operand: wd".into() });
+                }
+                let wd = expect_wide(&ops[0], line, "wd")?;
+                return Ok(encode(Opcode::Callvalue, wd, 0, sub));
+            }
+            PseudoEnv::WideWithInput(sub) => {
+                // e.g., "balance w0, r1" → Callvalue w0, r1, sub
+                if ops.len() != 2 {
+                    return Err(AsmError::Parse { line, msg: "balance requires 2 operands: wd, rs1".into() });
+                }
+                let wd = expect_wide(&ops[0], line, "wd")?;
+                let rs1 = expect_gp(&ops[1], line, "rs1")?;
+                return Ok(encode(Opcode::Callvalue, wd, rs1, sub));
+            }
+        }
+    }
 
     // Width-encoded LOAD/STORE
     if let Some(width) = pi.mem_width {
@@ -775,6 +842,34 @@ fn encode_instr(
             Ok(encode(pi.opcode, 0, 0, 0))
         }
 
+        // --- System: caller rd (shorthand for Caller with sub=0) ---
+        Opcode::Caller => {
+            if ops.len() != 1 {
+                return Err(AsmError::Parse { line, msg: "caller requires 1 operand: rd".into() });
+            }
+            let rd = expect_gp(&ops[0], line, "rd")?;
+            Ok(encode(pi.opcode, rd, 0, 0)) // sub-code 0 = CALLER
+        }
+
+        // --- System: callvalue wd ---
+        Opcode::Callvalue => {
+            if ops.len() != 1 {
+                return Err(AsmError::Parse { line, msg: "callvalue requires 1 operand: wd".into() });
+            }
+            let wd = expect_wide(&ops[0], line, "wd")?;
+            Ok(encode(pi.opcode, wd, 0, 0)) // sub-code 0 = CALL_VALUE
+        }
+
+        // --- System: blockhash wd, rs1 ---
+        Opcode::Blockhash => {
+            if ops.len() != 2 {
+                return Err(AsmError::Parse { line, msg: "blockhash requires 2 operands: wd, rs1".into() });
+            }
+            let wd = expect_wide(&ops[0], line, "wd")?;
+            let rs1 = expect_gp(&ops[1], line, "rs1")?;
+            Ok(encode(pi.opcode, wd, rs1, 0))
+        }
+
         // --- Assert: assert rs1 ---
         Opcode::Assert => {
             if ops.len() != 1 {
@@ -927,6 +1022,33 @@ fn disassemble_one(opcode: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> String {
         Opcode::Ret => "ret".into(),
         Opcode::Halt => "halt".into(),
         Opcode::Revert => "revert".into(),
+
+        // System: Caller (GP env query dispatched by immediate)
+        Opcode::Caller => {
+            use crate::vm::env_gp;
+            match rs2_or_imm {
+                env_gp::CALLER => format!("caller r{}", rd),
+                env_gp::ADDRESS => format!("address r{}", rd),
+                env_gp::BLOCK_NUMBER => format!("blocknumber r{}", rd),
+                env_gp::TIMESTAMP => format!("timestamp r{}", rd),
+                env_gp::GAS_REMAINING => format!("gasremaining r{}", rd),
+                _ => format!("caller r{}, r{}, {}", rd, rs1, rs2_or_imm),
+            }
+        }
+
+        // System: Callvalue (wide env query dispatched by immediate)
+        Opcode::Callvalue => {
+            use crate::vm::env_wide;
+            match rs2_or_imm {
+                env_wide::CALL_VALUE => format!("callvalue w{}", rd),
+                env_wide::GAS_PRICE => format!("gasprice w{}", rd),
+                env_wide::BALANCE => format!("balance w{}, r{}", rd, rs1),
+                _ => format!("callvalue w{}, r{}, {}", rd, rs1, rs2_or_imm),
+            }
+        }
+
+        // System: Blockhash
+        Opcode::Blockhash => format!("blockhash w{}, r{}", rd, rs1),
 
         // Assert
         Opcode::Assert => format!("assert r{}", rs1),
@@ -1263,5 +1385,87 @@ mod tests {
         assert_eq!(d1.opcode, Opcode::Narrow);
         assert_eq!(d1.rd, 2); // rd
         assert_eq!(d1.rs1, 3); // ws1
+    }
+
+    #[test]
+    fn assemble_system_pseudo_mnemonics() {
+        use crate::vm::env_gp;
+
+        // GP env queries
+        let code = assemble("caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt").unwrap();
+        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        assert_eq!(d0.opcode, Opcode::Caller);
+        assert_eq!(d0.rd, 1);
+        assert_eq!(d0.rs2_or_imm, env_gp::CALLER);
+
+        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        assert_eq!(d1.opcode, Opcode::Caller);
+        assert_eq!(d1.rd, 2);
+        assert_eq!(d1.rs2_or_imm, env_gp::ADDRESS);
+
+        let d2 = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+        assert_eq!(d2.opcode, Opcode::Caller);
+        assert_eq!(d2.rs2_or_imm, env_gp::BLOCK_NUMBER);
+
+        let d3 = decode(Instruction(u32::from_le_bytes(code[12..16].try_into().unwrap())));
+        assert_eq!(d3.opcode, Opcode::Caller);
+        assert_eq!(d3.rs2_or_imm, env_gp::TIMESTAMP);
+
+        let d4 = decode(Instruction(u32::from_le_bytes(code[16..20].try_into().unwrap())));
+        assert_eq!(d4.opcode, Opcode::Caller);
+        assert_eq!(d4.rs2_or_imm, env_gp::GAS_REMAINING);
+    }
+
+    #[test]
+    fn assemble_wide_env_pseudo_mnemonics() {
+        use crate::vm::env_wide;
+
+        let code = assemble("callvalue w0\ngasprice w1\nbalance w2, r3\nhalt").unwrap();
+        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        assert_eq!(d0.opcode, Opcode::Callvalue);
+        assert_eq!(d0.rd, 0);
+        assert_eq!(d0.rs2_or_imm, env_wide::CALL_VALUE);
+
+        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        assert_eq!(d1.opcode, Opcode::Callvalue);
+        assert_eq!(d1.rd, 1);
+        assert_eq!(d1.rs2_or_imm, env_wide::GAS_PRICE);
+
+        let d2 = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+        assert_eq!(d2.opcode, Opcode::Callvalue);
+        assert_eq!(d2.rd, 2);
+        assert_eq!(d2.rs1, 3);
+        assert_eq!(d2.rs2_or_imm, env_wide::BALANCE);
+    }
+
+    #[test]
+    fn assemble_blockhash() {
+        let code = assemble("blockhash w0, r1\nhalt").unwrap();
+        let d = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        assert_eq!(d.opcode, Opcode::Blockhash);
+        assert_eq!(d.rd, 0);
+        assert_eq!(d.rs1, 1);
+    }
+
+    #[test]
+    fn disassemble_system_roundtrip() {
+        let src = "caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt\n";
+        let code = assemble(src).unwrap();
+        let text = disassemble(&code);
+        assert!(text.contains("caller r1"));
+        assert!(text.contains("address r2"));
+        assert!(text.contains("blocknumber r3"));
+        assert!(text.contains("timestamp r4"));
+        assert!(text.contains("gasremaining r5"));
+    }
+
+    #[test]
+    fn disassemble_wide_env_roundtrip() {
+        let src = "callvalue w0\ngasprice w1\nbalance w2, r3\nhalt\n";
+        let code = assemble(src).unwrap();
+        let text = disassemble(&code);
+        assert!(text.contains("callvalue w0"));
+        assert!(text.contains("gasprice w1"));
+        assert!(text.contains("balance w2, r3"));
     }
 }

--- a/crates/pvm/src/asm.rs
+++ b/crates/pvm/src/asm.rs
@@ -17,9 +17,8 @@
 //! ```
 
 use crate::isa::{
-    decode, encode, encode_immediate, encode_mem_immediate, sign_extend_18,
-    decode_mem_offset, decode_mem_width,
-    Instruction, MemWidth, Opcode,
+    decode, decode_mem_offset, decode_mem_width, encode, encode_immediate, encode_mem_immediate,
+    sign_extend_18, Instruction, MemWidth, Opcode,
 };
 use std::collections::HashMap;
 use thiserror::Error;
@@ -47,11 +46,11 @@ pub enum AsmError {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum Token {
     Mnemonic(String),
-    Register(u8),      // r0-r15
-    WideRegister(u8),  // w0-w7
+    Register(u8),     // r0-r15
+    WideRegister(u8), // w0-w7
     Immediate(i64),
-    Label(String),     // "foo:"
-    LabelRef(String),  // "foo" used as operand
+    Label(String),    // "foo:"
+    LabelRef(String), // "foo" used as operand
     Comma,
     Newline,
 }
@@ -193,16 +192,20 @@ fn parse_int(s: &str) -> Result<i64, String> {
 }
 
 fn parse_gp_reg(s: &str) -> Option<u8> {
-    if s.starts_with('r') {
-        s[1..].parse::<u8>().ok().filter(|&n| n <= 15)
+    if let Some(rest) = s.strip_prefix('r') {
+        rest.parse::<u8>().ok().filter(|&n| n <= 15)
     } else {
         None
     }
 }
 
 fn parse_wide_reg(s: &str) -> Option<u8> {
-    if s.starts_with('w') && s.len() == 2 {
-        s[1..].parse::<u8>().ok().filter(|&n| n <= 7)
+    if let Some(rest) = s.strip_prefix('w') {
+        if rest.len() == 1 {
+            rest.parse::<u8>().ok().filter(|&n| n <= 7)
+        } else {
+            None
+        }
     } else {
         None
     }
@@ -255,7 +258,9 @@ fn parse_pseudo_env(s: &str) -> Option<PseudoEnv> {
 }
 
 fn is_mnemonic(s: &str) -> bool {
-    parse_pseudo_mem(s).is_some() || parse_pseudo_env(s).is_some() || mnemonic_to_opcode(s).is_some()
+    parse_pseudo_mem(s).is_some()
+        || parse_pseudo_env(s).is_some()
+        || mnemonic_to_opcode(s).is_some()
 }
 
 fn mnemonic_to_opcode(s: &str) -> Option<Opcode> {
@@ -626,7 +631,10 @@ fn encode_instr(
             PseudoEnv::Gp(sub) => {
                 // e.g., "address r1" → Caller r1, r0, sub
                 if ops.len() != 1 {
-                    return Err(AsmError::Parse { line, msg: "env query requires 1 operand: rd".into() });
+                    return Err(AsmError::Parse {
+                        line,
+                        msg: "env query requires 1 operand: rd".into(),
+                    });
                 }
                 let rd = expect_gp(&ops[0], line, "rd")?;
                 return Ok(encode(Opcode::Caller, rd, 0, sub));
@@ -634,7 +642,10 @@ fn encode_instr(
             PseudoEnv::Wide(sub) => {
                 // e.g., "gasprice w0" → Callvalue w0, r0, sub
                 if ops.len() != 1 {
-                    return Err(AsmError::Parse { line, msg: "env query requires 1 operand: wd".into() });
+                    return Err(AsmError::Parse {
+                        line,
+                        msg: "env query requires 1 operand: wd".into(),
+                    });
                 }
                 let wd = expect_wide(&ops[0], line, "wd")?;
                 return Ok(encode(Opcode::Callvalue, wd, 0, sub));
@@ -642,7 +653,10 @@ fn encode_instr(
             PseudoEnv::WideWithInput(sub) => {
                 // e.g., "balance w0, r1" → Callvalue w0, r1, sub
                 if ops.len() != 2 {
-                    return Err(AsmError::Parse { line, msg: "balance requires 2 operands: wd, rs1".into() });
+                    return Err(AsmError::Parse {
+                        line,
+                        msg: "balance requires 2 operands: wd, rs1".into(),
+                    });
                 }
                 let wd = expect_wide(&ops[0], line, "wd")?;
                 let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -657,7 +671,10 @@ fn encode_instr(
         if ops.len() != 3 {
             return Err(AsmError::Parse {
                 line,
-                msg: format!("{} requires 3 operands: rd, rs1, offset", opcode_to_mnemonic(actual_op)),
+                msg: format!(
+                    "{} requires 3 operands: rd, rs1, offset",
+                    opcode_to_mnemonic(actual_op)
+                ),
             });
         }
         let rd = expect_gp(&ops[0], line, "rd")?;
@@ -669,12 +686,27 @@ fn encode_instr(
 
     match pi.opcode {
         // --- Three-register ops: op rd, rs1, rs2 ---
-        Opcode::Add | Opcode::Sub | Opcode::Mul | Opcode::Div | Opcode::Mod
-        | Opcode::And | Opcode::Or | Opcode::Xor
-        | Opcode::Shl | Opcode::Shr | Opcode::Sar
-        | Opcode::Lt | Opcode::Gt | Opcode::Eq | Opcode::Slt | Opcode::Sgt => {
+        Opcode::Add
+        | Opcode::Sub
+        | Opcode::Mul
+        | Opcode::Div
+        | Opcode::Mod
+        | Opcode::And
+        | Opcode::Or
+        | Opcode::Xor
+        | Opcode::Shl
+        | Opcode::Shr
+        | Opcode::Sar
+        | Opcode::Lt
+        | Opcode::Gt
+        | Opcode::Eq
+        | Opcode::Slt
+        | Opcode::Sgt => {
             if ops.len() != 3 {
-                return Err(AsmError::Parse { line, msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -683,10 +715,19 @@ fn encode_instr(
         }
 
         // --- Wide three-register: op wd, ws1, ws2 ---
-        Opcode::Wadd | Opcode::Wsub | Opcode::Wmul | Opcode::Wdiv | Opcode::Wmod
-        | Opcode::Wand | Opcode::Wor | Opcode::Wxor => {
+        Opcode::Wadd
+        | Opcode::Wsub
+        | Opcode::Wmul
+        | Opcode::Wdiv
+        | Opcode::Wmod
+        | Opcode::Wand
+        | Opcode::Wor
+        | Opcode::Wxor => {
             if ops.len() != 3 {
-                return Err(AsmError::Parse { line, msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let ws1 = expect_wide(&ops[1], line, "ws1")?;
@@ -697,7 +738,10 @@ fn encode_instr(
         // --- Wide compare: op rd, ws1, ws2 (result → GP register) ---
         Opcode::Weq | Opcode::Wlt => {
             if ops.len() != 3 {
-                return Err(AsmError::Parse { line, msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!("{} requires 3 operands", opcode_to_mnemonic(pi.opcode)),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             let ws1 = expect_wide(&ops[1], line, "ws1")?;
@@ -708,7 +752,10 @@ fn encode_instr(
         // --- rd = rs1 op imm: addi rd, rs1, imm ---
         Opcode::Addi => {
             if ops.len() != 3 {
-                return Err(AsmError::Parse { line, msg: "addi requires 3 operands: rd, rs1, imm".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "addi requires 3 operands: rd, rs1, imm".into(),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -719,7 +766,10 @@ fn encode_instr(
         // --- Unary: not rd, rs1 ---
         Opcode::Not => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "not requires 2 operands: rd, rs1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "not requires 2 operands: rd, rs1".into(),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -729,7 +779,10 @@ fn encode_instr(
         // --- Wide unary: wnot wd, ws1 ---
         Opcode::Wnot => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "wnot requires 2 operands: wd, ws1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "wnot requires 2 operands: wd, ws1".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let ws1 = expect_wide(&ops[1], line, "ws1")?;
@@ -739,7 +792,10 @@ fn encode_instr(
         // --- Wide move: wmov wd, ws1 ---
         Opcode::Wmov => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "wmov requires 2 operands: wd, ws1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "wmov requires 2 operands: wd, ws1".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let ws1 = expect_wide(&ops[1], line, "ws1")?;
@@ -749,7 +805,10 @@ fn encode_instr(
         // --- Narrow: narrow rd, ws1 ---
         Opcode::Narrow => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "narrow requires 2 operands: rd, ws1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "narrow requires 2 operands: rd, ws1".into(),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             let ws1 = expect_wide(&ops[1], line, "ws1")?;
@@ -759,7 +818,10 @@ fn encode_instr(
         // --- Widen: widen wd, rs1 ---
         Opcode::Widen => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "widen requires 2 operands: wd, rs1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "widen requires 2 operands: wd, rs1".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -769,7 +831,10 @@ fn encode_instr(
         // --- WLOAD: wload wd, rs1, imm ---
         Opcode::Wload => {
             if ops.len() < 2 || ops.len() > 3 {
-                return Err(AsmError::Parse { line, msg: "wload requires 2-3 operands: wd, rs1[, offset]".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "wload requires 2-3 operands: wd, rs1[, offset]".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -784,7 +849,10 @@ fn encode_instr(
         // --- WSTORE: wstore ws, rs1, imm ---
         Opcode::Wstore => {
             if ops.len() < 2 || ops.len() > 3 {
-                return Err(AsmError::Parse { line, msg: "wstore requires 2-3 operands: ws, rs1[, offset]".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "wstore requires 2-3 operands: ws, rs1[, offset]".into(),
+                });
             }
             let ws = expect_wide(&ops[0], line, "ws")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -799,7 +867,10 @@ fn encode_instr(
         // --- Push/Pop: push rd / pop rd ---
         Opcode::Push | Opcode::Pop => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: format!("{} requires 1 operand: rd", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!("{} requires 1 operand: rd", opcode_to_mnemonic(pi.opcode)),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             Ok(encode(pi.opcode, rd, 0, 0))
@@ -808,7 +879,10 @@ fn encode_instr(
         // --- JMP: jmp imm/label ---
         Opcode::Jmp => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: "jmp requires 1 operand: target".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "jmp requires 1 operand: target".into(),
+                });
             }
             let imm = expect_imm_or_label(&ops[0], pc, labels, line)?;
             Ok(encode(pi.opcode, 0, 0, encode_immediate(imm)))
@@ -817,7 +891,13 @@ fn encode_instr(
         // --- Branches: beq rd, rs1, imm/label ---
         Opcode::Beq | Opcode::Bne | Opcode::Blt | Opcode::Bge => {
             if ops.len() != 3 {
-                return Err(AsmError::Parse { line, msg: format!("{} requires 3 operands: rs1, rs2, target", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!(
+                        "{} requires 3 operands: rs1, rs2, target",
+                        opcode_to_mnemonic(pi.opcode)
+                    ),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rs1")?;
             let rs1 = expect_gp(&ops[1], line, "rs2")?;
@@ -828,7 +908,10 @@ fn encode_instr(
         // --- CALL: call imm/label ---
         Opcode::Call => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: "call requires 1 operand: target".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "call requires 1 operand: target".into(),
+                });
             }
             let imm = expect_imm_or_label(&ops[0], pc, labels, line)?;
             Ok(encode(pi.opcode, 0, 0, encode_immediate(imm)))
@@ -837,7 +920,10 @@ fn encode_instr(
         // --- No operand: ret, halt, revert ---
         Opcode::Ret | Opcode::Halt | Opcode::Revert => {
             if !ops.is_empty() {
-                return Err(AsmError::Parse { line, msg: format!("{} takes no operands", opcode_to_mnemonic(pi.opcode)) });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: format!("{} takes no operands", opcode_to_mnemonic(pi.opcode)),
+                });
             }
             Ok(encode(pi.opcode, 0, 0, 0))
         }
@@ -845,7 +931,10 @@ fn encode_instr(
         // --- System: caller rd (shorthand for Caller with sub=0) ---
         Opcode::Caller => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: "caller requires 1 operand: rd".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "caller requires 1 operand: rd".into(),
+                });
             }
             let rd = expect_gp(&ops[0], line, "rd")?;
             Ok(encode(pi.opcode, rd, 0, 0)) // sub-code 0 = CALLER
@@ -854,7 +943,10 @@ fn encode_instr(
         // --- System: callvalue wd ---
         Opcode::Callvalue => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: "callvalue requires 1 operand: wd".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "callvalue requires 1 operand: wd".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             Ok(encode(pi.opcode, wd, 0, 0)) // sub-code 0 = CALL_VALUE
@@ -863,7 +955,10 @@ fn encode_instr(
         // --- System: blockhash wd, rs1 ---
         Opcode::Blockhash => {
             if ops.len() != 2 {
-                return Err(AsmError::Parse { line, msg: "blockhash requires 2 operands: wd, rs1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "blockhash requires 2 operands: wd, rs1".into(),
+                });
             }
             let wd = expect_wide(&ops[0], line, "wd")?;
             let rs1 = expect_gp(&ops[1], line, "rs1")?;
@@ -873,7 +968,10 @@ fn encode_instr(
         // --- Assert: assert rs1 ---
         Opcode::Assert => {
             if ops.len() != 1 {
-                return Err(AsmError::Parse { line, msg: "assert requires 1 operand: rs1".into() });
+                return Err(AsmError::Parse {
+                    line,
+                    msg: "assert requires 1 operand: rs1".into(),
+                });
             }
             let rs1 = expect_gp(&ops[0], line, "rs1")?;
             Ok(encode(pi.opcode, 0, rs1, 0))
@@ -881,9 +979,21 @@ fn encode_instr(
 
         // --- Fallback for unimplemented syscalls: encode raw ---
         _ => {
-            let rd = if !ops.is_empty() { expect_reg_or_imm(&ops[0], line)? as u8 } else { 0 };
-            let rs1 = if ops.len() > 1 { expect_reg_or_imm(&ops[1], line)? as u8 } else { 0 };
-            let rs2 = if ops.len() > 2 { expect_reg_or_imm(&ops[2], line)? as u32 } else { 0 };
+            let rd = if !ops.is_empty() {
+                expect_reg_or_imm(&ops[0], line)? as u8
+            } else {
+                0
+            };
+            let rs1 = if ops.len() > 1 {
+                expect_reg_or_imm(&ops[1], line)? as u8
+            } else {
+                0
+            };
+            let rs2 = if ops.len() > 2 {
+                expect_reg_or_imm(&ops[2], line)? as u32
+            } else {
+                0
+            };
             Ok(encode(pi.opcode, rd, rs1, rs2))
         }
     }
@@ -919,22 +1029,58 @@ pub fn disassemble(bytecode: &[u8]) -> String {
 fn disassemble_one(opcode: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> String {
     match opcode {
         // Three-register GP
-        Opcode::Add | Opcode::Sub | Opcode::Mul | Opcode::Div | Opcode::Mod
-        | Opcode::And | Opcode::Or | Opcode::Xor
-        | Opcode::Shl | Opcode::Shr | Opcode::Sar
-        | Opcode::Lt | Opcode::Gt | Opcode::Eq | Opcode::Slt | Opcode::Sgt => {
-            format!("{} r{}, r{}, r{}", opcode_to_mnemonic(opcode), rd, rs1, rs2_or_imm & 0xF)
+        Opcode::Add
+        | Opcode::Sub
+        | Opcode::Mul
+        | Opcode::Div
+        | Opcode::Mod
+        | Opcode::And
+        | Opcode::Or
+        | Opcode::Xor
+        | Opcode::Shl
+        | Opcode::Shr
+        | Opcode::Sar
+        | Opcode::Lt
+        | Opcode::Gt
+        | Opcode::Eq
+        | Opcode::Slt
+        | Opcode::Sgt => {
+            format!(
+                "{} r{}, r{}, r{}",
+                opcode_to_mnemonic(opcode),
+                rd,
+                rs1,
+                rs2_or_imm & 0xF
+            )
         }
 
         // Three-register wide
-        Opcode::Wadd | Opcode::Wsub | Opcode::Wmul | Opcode::Wdiv | Opcode::Wmod
-        | Opcode::Wand | Opcode::Wor | Opcode::Wxor => {
-            format!("{} w{}, w{}, w{}", opcode_to_mnemonic(opcode), rd, rs1, rs2_or_imm & 0x7)
+        Opcode::Wadd
+        | Opcode::Wsub
+        | Opcode::Wmul
+        | Opcode::Wdiv
+        | Opcode::Wmod
+        | Opcode::Wand
+        | Opcode::Wor
+        | Opcode::Wxor => {
+            format!(
+                "{} w{}, w{}, w{}",
+                opcode_to_mnemonic(opcode),
+                rd,
+                rs1,
+                rs2_or_imm & 0x7
+            )
         }
 
         // Wide compare → GP
         Opcode::Weq | Opcode::Wlt => {
-            format!("{} r{}, w{}, w{}", opcode_to_mnemonic(opcode), rd, rs1, rs2_or_imm & 0x7)
+            format!(
+                "{} r{}, w{}, w{}",
+                opcode_to_mnemonic(opcode),
+                rd,
+                rs1,
+                rs2_or_imm & 0x7
+            )
         }
 
         // ADDI
@@ -1054,7 +1200,13 @@ fn disassemble_one(opcode: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> String {
         Opcode::Assert => format!("assert r{}", rs1),
 
         // Fallback
-        _ => format!("{} {}, {}, {}", opcode_to_mnemonic(opcode), rd, rs1, rs2_or_imm),
+        _ => format!(
+            "{} {}, {}, {}",
+            opcode_to_mnemonic(opcode),
+            rd,
+            rs1,
+            rs2_or_imm
+        ),
     }
 }
 
@@ -1088,7 +1240,9 @@ mod tests {
     #[test]
     fn assemble_add_three_reg() {
         let code = assemble("add r3, r1, r2").unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[..4].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Add);
         assert_eq!(d.rd, 3);
         assert_eq!(d.rs1, 1);
@@ -1098,7 +1252,9 @@ mod tests {
     #[test]
     fn assemble_wide_ops() {
         let code = assemble("wadd w0, w1, w2").unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[..4].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Wadd);
         assert_eq!(d.rd, 0);
         assert_eq!(d.rs1, 1);
@@ -1114,8 +1270,10 @@ mod tests {
             halt";
         let code = assemble(src).unwrap();
         assert_eq!(code.len(), 12); // 3 instructions
-        // JMP should encode offset = +8 (skip addi, land on halt)
-        let d = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+                                    // JMP should encode offset = +8 (skip addi, land on halt)
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Jmp);
         assert_eq!(sign_extend_18(d.rs2_or_imm), 8);
     }
@@ -1128,7 +1286,9 @@ mod tests {
             jmp loop";
         let code = assemble(src).unwrap();
         // JMP is at offset 4, loop is at offset 0, so offset = -4
-        let d = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Jmp);
         assert_eq!(sign_extend_18(d.rs2_or_imm), -4);
     }
@@ -1144,8 +1304,10 @@ mod tests {
             halt";
         let code = assemble(src).unwrap();
         assert_eq!(code.len(), 20); // 5 instructions
-        // BEQ at offset 8, done at offset 16, so offset = +8
-        let d = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+                                    // BEQ at offset 8, done at offset 16, so offset = +8
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[8..12].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Beq);
         assert_eq!(sign_extend_18(d.rs2_or_imm), 8);
     }
@@ -1171,17 +1333,23 @@ mod tests {
         let code = assemble(src).unwrap();
         assert_eq!(code.len(), 20);
 
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Load);
         assert_eq!(decode_mem_width(d0.rs2_or_imm), MemWidth::W8);
         assert_eq!(decode_mem_offset(d0.rs2_or_imm), 0);
 
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Load);
         assert_eq!(decode_mem_width(d1.rs2_or_imm), MemWidth::W16);
         assert_eq!(decode_mem_offset(d1.rs2_or_imm), 4);
 
-        let d2 = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+        let d2 = decode(Instruction(u32::from_le_bytes(
+            code[8..12].try_into().unwrap(),
+        )));
         assert_eq!(d2.opcode, Opcode::Store);
         assert_eq!(decode_mem_width(d2.rs2_or_imm), MemWidth::W32);
         assert_eq!(decode_mem_offset(d2.rs2_or_imm), -8);
@@ -1191,10 +1359,14 @@ mod tests {
     fn assemble_push_pop() {
         let src = "push r5\npop r6\nhalt";
         let code = assemble(src).unwrap();
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Push);
         assert_eq!(d0.rd, 5);
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Pop);
         assert_eq!(d1.rd, 6);
     }
@@ -1208,7 +1380,9 @@ mod tests {
             addi r1, r0, 1
             ret";
         let code = assemble(src).unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Call);
         assert_eq!(sign_extend_18(d.rs2_or_imm), 8); // func at offset 8
     }
@@ -1216,14 +1390,18 @@ mod tests {
     #[test]
     fn assemble_negative_immediate() {
         let code = assemble("addi r1, r0, -100").unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[..4].try_into().unwrap(),
+        )));
         assert_eq!(sign_extend_18(d.rs2_or_imm), -100);
     }
 
     #[test]
     fn assemble_hex_immediate() {
         let code = assemble("addi r1, r0, 0xFF").unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[..4].try_into().unwrap(),
+        )));
         assert_eq!(sign_extend_18(d.rs2_or_imm), 255);
     }
 
@@ -1362,12 +1540,16 @@ mod tests {
     #[test]
     fn weq_wlt_assembly() {
         let code = assemble("weq r1, w0, w1\nwlt r2, w3, w4\nhalt").unwrap();
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Weq);
         assert_eq!(d0.rd, 1);
         assert_eq!(d0.rs1, 0);
         assert_eq!(d0.rs2_or_imm, 1);
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Wlt);
         assert_eq!(d1.rd, 2);
         assert_eq!(d1.rs1, 3);
@@ -1377,11 +1559,15 @@ mod tests {
     #[test]
     fn narrow_widen_assembly() {
         let code = assemble("widen w0, r1\nnarrow r2, w3\nhalt").unwrap();
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Widen);
         assert_eq!(d0.rd, 0); // wd
         assert_eq!(d0.rs1, 1); // rs1
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Narrow);
         assert_eq!(d1.rd, 2); // rd
         assert_eq!(d1.rs1, 3); // ws1
@@ -1392,26 +1578,38 @@ mod tests {
         use crate::vm::env_gp;
 
         // GP env queries
-        let code = assemble("caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt").unwrap();
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let code =
+            assemble("caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt")
+                .unwrap();
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Caller);
         assert_eq!(d0.rd, 1);
         assert_eq!(d0.rs2_or_imm, env_gp::CALLER);
 
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Caller);
         assert_eq!(d1.rd, 2);
         assert_eq!(d1.rs2_or_imm, env_gp::ADDRESS);
 
-        let d2 = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+        let d2 = decode(Instruction(u32::from_le_bytes(
+            code[8..12].try_into().unwrap(),
+        )));
         assert_eq!(d2.opcode, Opcode::Caller);
         assert_eq!(d2.rs2_or_imm, env_gp::BLOCK_NUMBER);
 
-        let d3 = decode(Instruction(u32::from_le_bytes(code[12..16].try_into().unwrap())));
+        let d3 = decode(Instruction(u32::from_le_bytes(
+            code[12..16].try_into().unwrap(),
+        )));
         assert_eq!(d3.opcode, Opcode::Caller);
         assert_eq!(d3.rs2_or_imm, env_gp::TIMESTAMP);
 
-        let d4 = decode(Instruction(u32::from_le_bytes(code[16..20].try_into().unwrap())));
+        let d4 = decode(Instruction(u32::from_le_bytes(
+            code[16..20].try_into().unwrap(),
+        )));
         assert_eq!(d4.opcode, Opcode::Caller);
         assert_eq!(d4.rs2_or_imm, env_gp::GAS_REMAINING);
     }
@@ -1421,17 +1619,23 @@ mod tests {
         use crate::vm::env_wide;
 
         let code = assemble("callvalue w0\ngasprice w1\nbalance w2, r3\nhalt").unwrap();
-        let d0 = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d0 = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d0.opcode, Opcode::Callvalue);
         assert_eq!(d0.rd, 0);
         assert_eq!(d0.rs2_or_imm, env_wide::CALL_VALUE);
 
-        let d1 = decode(Instruction(u32::from_le_bytes(code[4..8].try_into().unwrap())));
+        let d1 = decode(Instruction(u32::from_le_bytes(
+            code[4..8].try_into().unwrap(),
+        )));
         assert_eq!(d1.opcode, Opcode::Callvalue);
         assert_eq!(d1.rd, 1);
         assert_eq!(d1.rs2_or_imm, env_wide::GAS_PRICE);
 
-        let d2 = decode(Instruction(u32::from_le_bytes(code[8..12].try_into().unwrap())));
+        let d2 = decode(Instruction(u32::from_le_bytes(
+            code[8..12].try_into().unwrap(),
+        )));
         assert_eq!(d2.opcode, Opcode::Callvalue);
         assert_eq!(d2.rd, 2);
         assert_eq!(d2.rs1, 3);
@@ -1441,7 +1645,9 @@ mod tests {
     #[test]
     fn assemble_blockhash() {
         let code = assemble("blockhash w0, r1\nhalt").unwrap();
-        let d = decode(Instruction(u32::from_le_bytes(code[0..4].try_into().unwrap())));
+        let d = decode(Instruction(u32::from_le_bytes(
+            code[0..4].try_into().unwrap(),
+        )));
         assert_eq!(d.opcode, Opcode::Blockhash);
         assert_eq!(d.rd, 0);
         assert_eq!(d.rs1, 1);

--- a/crates/pvm/src/cpu.rs
+++ b/crates/pvm/src/cpu.rs
@@ -309,13 +309,7 @@ mod tests {
         cpu.exec_alu(encode(op, rd, rs1, encode_immediate(imm)))
     }
 
-    fn exec_wide_rr(
-        cpu: &mut Cpu,
-        op: Opcode,
-        wd: u8,
-        ws1: u8,
-        ws2: u8,
-    ) -> Result<(), Trap> {
+    fn exec_wide_rr(cpu: &mut Cpu, op: Opcode, wd: u8, ws1: u8, ws2: u8) -> Result<(), Trap> {
         use crate::isa::encode;
         cpu.exec_wide(encode(op, wd, ws1, ws2 as u32))
     }
@@ -447,10 +441,7 @@ mod tests {
         cpu.write_wide(1, u256(0xFF00, 0xFF00, 0xFF00, 0xFF00));
         cpu.write_wide(2, u256(0x0FF0, 0x0FF0, 0x0FF0, 0x0FF0));
         exec_wide_rr(&mut cpu, Opcode::Wand, 3, 1, 2).unwrap();
-        assert_eq!(
-            cpu.read_wide(3),
-            u256(0x0F00, 0x0F00, 0x0F00, 0x0F00)
-        );
+        assert_eq!(cpu.read_wide(3), u256(0x0F00, 0x0F00, 0x0F00, 0x0F00));
     }
 
     // ========== Task 0113b: WOR ==========

--- a/crates/pvm/src/isa.rs
+++ b/crates/pvm/src/isa.rs
@@ -370,7 +370,7 @@ pub fn sign_extend_18(raw: u32) -> i32 {
 /// Panics if the value is out of range [-131072, 131071].
 pub fn encode_immediate(val: i32) -> u32 {
     assert!(
-        val >= -131072 && val <= 131071,
+        (-131072..=131071).contains(&val),
         "immediate {} out of 18-bit signed range",
         val
     );
@@ -417,7 +417,7 @@ pub fn decode_mem_offset(raw: u32) -> i32 {
 /// Panics if offset is out of range [-32768, 32767].
 pub fn encode_mem_immediate(offset: i32, width: MemWidth) -> u32 {
     assert!(
-        offset >= -32768 && offset <= 32767,
+        (-32768..=32767).contains(&offset),
         "memory offset {} out of 16-bit signed range",
         offset
     );

--- a/crates/pvm/src/memory.rs
+++ b/crates/pvm/src/memory.rs
@@ -101,7 +101,9 @@ impl Memory {
         }
 
         // Bounds check
-        let end = addr.checked_add(len).ok_or(MemoryError::OutOfBounds(addr))?;
+        let end = addr
+            .checked_add(len)
+            .ok_or(MemoryError::OutOfBounds(addr))?;
         if end > MEMORY_SIZE as u32 {
             return Err(MemoryError::OutOfBounds(addr));
         }
@@ -121,7 +123,7 @@ impl Memory {
 
     /// Check that the address is not in the code section (for writes).
     fn check_writable(&self, addr: u32) -> Result<(), MemoryError> {
-        if addr >= CODE_START && addr < CODE_END {
+        if (CODE_START..CODE_END).contains(&addr) {
             return Err(MemoryError::CodeWriteProtected(addr));
         }
         Ok(())
@@ -129,7 +131,9 @@ impl Memory {
 
     /// Grow the heap by `bytes` bytes. Returns the old heap_top (start of allocation).
     pub fn heap_alloc(&mut self, bytes: u32) -> Result<u32, MemoryError> {
-        let new_top = self.heap_top.checked_add(bytes)
+        let new_top = self
+            .heap_top
+            .checked_add(bytes)
             .ok_or(MemoryError::OutOfBounds(self.heap_top))?;
         if new_top > self.stack_pointer {
             return Err(MemoryError::HeapStackCollision);
@@ -141,7 +145,9 @@ impl Memory {
 
     /// Push to stack (decrement SP). Returns new SP.
     pub fn stack_alloc(&mut self, bytes: u32) -> Result<u32, MemoryError> {
-        let new_sp = self.stack_pointer.checked_sub(bytes)
+        let new_sp = self
+            .stack_pointer
+            .checked_sub(bytes)
             .ok_or(MemoryError::HeapStackCollision)?;
         if new_sp < self.heap_top {
             return Err(MemoryError::HeapStackCollision);
@@ -188,7 +194,10 @@ impl Memory {
         self.check_access(addr, 4)?;
         let a = addr as usize;
         Ok(u32::from_le_bytes([
-            self.data[a], self.data[a + 1], self.data[a + 2], self.data[a + 3],
+            self.data[a],
+            self.data[a + 1],
+            self.data[a + 2],
+            self.data[a + 3],
         ]))
     }
 
@@ -207,8 +216,14 @@ impl Memory {
         self.check_access(addr, 8)?;
         let a = addr as usize;
         Ok(u64::from_le_bytes([
-            self.data[a], self.data[a + 1], self.data[a + 2], self.data[a + 3],
-            self.data[a + 4], self.data[a + 5], self.data[a + 6], self.data[a + 7],
+            self.data[a],
+            self.data[a + 1],
+            self.data[a + 2],
+            self.data[a + 3],
+            self.data[a + 4],
+            self.data[a + 5],
+            self.data[a + 6],
+            self.data[a + 7],
         ]))
     }
 
@@ -403,7 +418,7 @@ mod tests {
     fn load_code_too_large() {
         let mut m = mem();
         let big = vec![0u8; 65536]; // exactly 64 KB — should fail (code section is 60 KB)
-        // CODE_START=0x1000, CODE_END=0x10000, so max code = 0xF000 = 61440
+                                    // CODE_START=0x1000, CODE_END=0x10000, so max code = 0xF000 = 61440
         assert!(m.load_code(&big).is_err());
     }
 

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1,9 +1,11 @@
 //! PVM execution engine: ties CPU, memory, and control flow together.
 
 use crate::cpu::{Cpu, Trap};
-use crate::isa::{decode, decode_mem_offset, decode_mem_width, sign_extend_18, Instruction, MemWidth, Opcode};
-use crate::wide::U256;
+use crate::isa::{
+    decode, decode_mem_offset, decode_mem_width, sign_extend_18, Instruction, MemWidth, Opcode,
+};
 use crate::memory::Memory;
+use crate::wide::U256;
 
 /// Maximum call depth (nested function calls).
 const MAX_CALL_DEPTH: usize = 1024;
@@ -142,10 +144,7 @@ impl Vm {
 
     /// Create a new VM with an execution context.
     pub fn with_context(ctx: ExecutionContext) -> Self {
-        Self {
-            ctx,
-            ..Self::new()
-        }
+        Self { ctx, ..Self::new() }
     }
 
     /// Create a new VM with both a gas limit and execution context.
@@ -159,7 +158,9 @@ impl Vm {
 
     /// Load bytecode and prepare for execution.
     pub fn load(&mut self, bytecode: &[u8]) -> Result<(), Trap> {
-        self.memory.load_code(bytecode).map_err(|_| Trap::MemoryFault)?;
+        self.memory
+            .load_code(bytecode)
+            .map_err(|_| Trap::MemoryFault)?;
         self.pc = 0;
         Ok(())
     }
@@ -267,19 +268,43 @@ impl Vm {
             }
 
             // --- ALU ops: delegate to cpu ---
-            Opcode::Add | Opcode::Sub | Opcode::Mul | Opcode::Div | Opcode::Mod
-            | Opcode::Addi | Opcode::And | Opcode::Or | Opcode::Xor | Opcode::Not
-            | Opcode::Shl | Opcode::Shr | Opcode::Sar
-            | Opcode::Lt | Opcode::Gt | Opcode::Eq | Opcode::Slt | Opcode::Sgt => {
+            Opcode::Add
+            | Opcode::Sub
+            | Opcode::Mul
+            | Opcode::Div
+            | Opcode::Mod
+            | Opcode::Addi
+            | Opcode::And
+            | Opcode::Or
+            | Opcode::Xor
+            | Opcode::Not
+            | Opcode::Shl
+            | Opcode::Shr
+            | Opcode::Sar
+            | Opcode::Lt
+            | Opcode::Gt
+            | Opcode::Eq
+            | Opcode::Slt
+            | Opcode::Sgt => {
                 self.cpu.exec_alu(instr)?;
                 self.pc += 4;
             }
 
             // --- Wide ops: delegate to cpu ---
-            Opcode::Wadd | Opcode::Wsub | Opcode::Wmul | Opcode::Wdiv | Opcode::Wmod
-            | Opcode::Wand | Opcode::Wor | Opcode::Wxor | Opcode::Wnot
-            | Opcode::Wmov | Opcode::Narrow | Opcode::Widen
-            | Opcode::Weq | Opcode::Wlt => {
+            Opcode::Wadd
+            | Opcode::Wsub
+            | Opcode::Wmul
+            | Opcode::Wdiv
+            | Opcode::Wmod
+            | Opcode::Wand
+            | Opcode::Wor
+            | Opcode::Wxor
+            | Opcode::Wnot
+            | Opcode::Wmov
+            | Opcode::Narrow
+            | Opcode::Widen
+            | Opcode::Weq
+            | Opcode::Wlt => {
                 self.cpu.exec_wide(instr)?;
                 self.pc += 4;
             }
@@ -292,8 +317,12 @@ impl Vm {
                 let addr = (base as i64 + offset) as u32;
                 let val = match width {
                     MemWidth::W8 => self.memory.load8(addr).map_err(|_| Trap::MemoryFault)? as u64,
-                    MemWidth::W16 => self.memory.load16(addr).map_err(|_| Trap::MemoryFault)? as u64,
-                    MemWidth::W32 => self.memory.load32(addr).map_err(|_| Trap::MemoryFault)? as u64,
+                    MemWidth::W16 => {
+                        self.memory.load16(addr).map_err(|_| Trap::MemoryFault)? as u64
+                    }
+                    MemWidth::W32 => {
+                        self.memory.load32(addr).map_err(|_| Trap::MemoryFault)? as u64
+                    }
                     MemWidth::W64 => self.memory.load64(addr).map_err(|_| Trap::MemoryFault)?,
                 };
                 self.cpu.write_gp(d.rd, val);
@@ -306,10 +335,22 @@ impl Vm {
                 let addr = (base as i64 + offset) as u32;
                 let val = self.cpu.read_gp(d.rd);
                 match width {
-                    MemWidth::W8 => self.memory.store8(addr, val as u8).map_err(|_| Trap::MemoryFault)?,
-                    MemWidth::W16 => self.memory.store16(addr, val as u16).map_err(|_| Trap::MemoryFault)?,
-                    MemWidth::W32 => self.memory.store32(addr, val as u32).map_err(|_| Trap::MemoryFault)?,
-                    MemWidth::W64 => self.memory.store64(addr, val).map_err(|_| Trap::MemoryFault)?,
+                    MemWidth::W8 => self
+                        .memory
+                        .store8(addr, val as u8)
+                        .map_err(|_| Trap::MemoryFault)?,
+                    MemWidth::W16 => self
+                        .memory
+                        .store16(addr, val as u16)
+                        .map_err(|_| Trap::MemoryFault)?,
+                    MemWidth::W32 => self
+                        .memory
+                        .store32(addr, val as u32)
+                        .map_err(|_| Trap::MemoryFault)?,
+                    MemWidth::W64 => self
+                        .memory
+                        .store64(addr, val)
+                        .map_err(|_| Trap::MemoryFault)?,
                 };
                 self.pc += 4;
             }
@@ -326,18 +367,23 @@ impl Vm {
                 let offset = sign_extend_18(d.rs2_or_imm) as i64;
                 let addr = (base as i64 + offset) as u32;
                 let val = self.cpu.read_wide(d.rd);
-                self.memory.store256(addr, &val.to_le_bytes()).map_err(|_| Trap::MemoryFault)?;
+                self.memory
+                    .store256(addr, &val.to_le_bytes())
+                    .map_err(|_| Trap::MemoryFault)?;
                 self.pc += 4;
             }
             Opcode::Push => {
                 let val = self.cpu.read_gp(d.rd);
                 self.memory.stack_pointer -= 8;
-                self.memory.store64(self.memory.stack_pointer, val)
+                self.memory
+                    .store64(self.memory.stack_pointer, val)
                     .map_err(|_| Trap::MemoryFault)?;
                 self.pc += 4;
             }
             Opcode::Pop => {
-                let val = self.memory.load64(self.memory.stack_pointer)
+                let val = self
+                    .memory
+                    .load64(self.memory.stack_pointer)
                     .map_err(|_| Trap::MemoryFault)?;
                 self.cpu.write_gp(d.rd, val);
                 self.memory.stack_pointer += 8;
@@ -378,7 +424,11 @@ impl Vm {
                 // Only allow recent blocks (up to 256 back), and not current/future
                 let hash = if height < current && current - height <= 256 {
                     let idx = (current - height - 1) as usize;
-                    self.ctx.block_hashes.get(idx).copied().unwrap_or(U256::ZERO)
+                    self.ctx
+                        .block_hashes
+                        .get(idx)
+                        .copied()
+                        .unwrap_or(U256::ZERO)
                 } else {
                     U256::ZERO
                 };
@@ -446,7 +496,9 @@ mod tests {
 
     /// Helper: encode a LOAD/STORE instruction with width and offset.
     fn instr_mem(op: Opcode, rd: u8, rs1: u8, offset: i32, width: MemWidth) -> [u8; 4] {
-        encode(op, rd, rs1, encode_mem_immediate(offset, width)).0.to_le_bytes()
+        encode(op, rd, rs1, encode_mem_immediate(offset, width))
+            .0
+            .to_le_bytes()
     }
 
     /// Build bytecode from instruction byte arrays.
@@ -798,22 +850,22 @@ mod tests {
         // [64] RET
         let code = bytecode(&[
             instr_ri(Opcode::Addi, 1, 0, 0),    // [0]
-            instr_ri(Opcode::Call, 0, 0, 8),     // [4]
-            instr_bytes(Opcode::Halt, 0, 0, 0),  // [8]
-            instr_ri(Opcode::Addi, 1, 1, 1),     // [12]
-            instr_ri(Opcode::Call, 0, 0, 8),     // [16]
-            instr_bytes(Opcode::Ret, 0, 0, 0),   // [20]
-            instr_ri(Opcode::Addi, 1, 1, 1),     // [24]
-            instr_ri(Opcode::Call, 0, 0, 8),     // [28]
-            instr_bytes(Opcode::Ret, 0, 0, 0),   // [32]
-            instr_ri(Opcode::Addi, 1, 1, 1),     // [36]
-            instr_ri(Opcode::Call, 0, 0, 8),     // [40]
-            instr_bytes(Opcode::Ret, 0, 0, 0),   // [44]
-            instr_ri(Opcode::Addi, 1, 1, 1),     // [48]
-            instr_ri(Opcode::Call, 0, 0, 8),     // [52]
-            instr_bytes(Opcode::Ret, 0, 0, 0),   // [56]
-            instr_ri(Opcode::Addi, 1, 1, 1),     // [60]
-            instr_bytes(Opcode::Ret, 0, 0, 0),   // [64]
+            instr_ri(Opcode::Call, 0, 0, 8),    // [4]
+            instr_bytes(Opcode::Halt, 0, 0, 0), // [8]
+            instr_ri(Opcode::Addi, 1, 1, 1),    // [12]
+            instr_ri(Opcode::Call, 0, 0, 8),    // [16]
+            instr_bytes(Opcode::Ret, 0, 0, 0),  // [20]
+            instr_ri(Opcode::Addi, 1, 1, 1),    // [24]
+            instr_ri(Opcode::Call, 0, 0, 8),    // [28]
+            instr_bytes(Opcode::Ret, 0, 0, 0),  // [32]
+            instr_ri(Opcode::Addi, 1, 1, 1),    // [36]
+            instr_ri(Opcode::Call, 0, 0, 8),    // [40]
+            instr_bytes(Opcode::Ret, 0, 0, 0),  // [44]
+            instr_ri(Opcode::Addi, 1, 1, 1),    // [48]
+            instr_ri(Opcode::Call, 0, 0, 8),    // [52]
+            instr_bytes(Opcode::Ret, 0, 0, 0),  // [56]
+            instr_ri(Opcode::Addi, 1, 1, 1),    // [60]
+            instr_bytes(Opcode::Ret, 0, 0, 0),  // [64]
         ]);
         let mut vm = Vm::new();
         vm.load(&code).unwrap();
@@ -825,9 +877,7 @@ mod tests {
 
     #[test]
     fn ret_without_call_traps() {
-        let code = bytecode(&[
-            instr_bytes(Opcode::Ret, 0, 0, 0),
-        ]);
+        let code = bytecode(&[instr_bytes(Opcode::Ret, 0, 0, 0)]);
         let mut vm = Vm::new();
         vm.load(&code).unwrap();
         assert_eq!(vm.run(), Err(Trap::StackUnderflow));
@@ -904,10 +954,10 @@ mod tests {
     fn load_store_8bit() {
         let heap = crate::memory::HEAP_START;
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, heap as i32),       // r1 = heap addr
-            instr_ri(Opcode::Addi, 2, 0, 0xAB),              // r2 = 0xAB
+            instr_ri(Opcode::Addi, 1, 0, heap as i32), // r1 = heap addr
+            instr_ri(Opcode::Addi, 2, 0, 0xAB),        // r2 = 0xAB
             instr_mem(Opcode::Store, 2, 1, 0, MemWidth::W8), // store8(r1+0, r2)
-            instr_mem(Opcode::Load, 3, 1, 0, MemWidth::W8),  // r3 = load8(r1+0)
+            instr_mem(Opcode::Load, 3, 1, 0, MemWidth::W8), // r3 = load8(r1+0)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
         let mut vm = Vm::new();
@@ -937,7 +987,7 @@ mod tests {
         let heap = crate::memory::HEAP_START;
         let code = bytecode(&[
             instr_ri(Opcode::Addi, 1, 0, heap as i32),
-            instr_ri(Opcode::Addi, 2, 0, 0x7FFF),            // small value that fits in imm
+            instr_ri(Opcode::Addi, 2, 0, 0x7FFF), // small value that fits in imm
             instr_mem(Opcode::Store, 2, 1, 0, MemWidth::W32),
             instr_mem(Opcode::Load, 3, 1, 0, MemWidth::W32),
             instr_bytes(Opcode::Halt, 0, 0, 0),
@@ -1007,10 +1057,10 @@ mod tests {
         vm.memory.store256(heap, &val.to_le_bytes()).unwrap();
 
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, heap as i32),        // r1 = heap addr
+            instr_ri(Opcode::Addi, 1, 0, heap as i32), // r1 = heap addr
             instr_ri(Opcode::Addi, 2, 0, (heap + 32) as i32), // r2 = heap+32
-            instr_bytes(Opcode::Wload, 0, 1, 0),              // w0 = mem256[r1]
-            instr_bytes(Opcode::Wstore, 0, 2, 0),             // mem256[r2] = w0
+            instr_bytes(Opcode::Wload, 0, 1, 0),       // w0 = mem256[r1]
+            instr_bytes(Opcode::Wstore, 0, 2, 0),      // mem256[r2] = w0
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
         vm.load(&code).unwrap();
@@ -1050,7 +1100,7 @@ mod tests {
         let mut vm = Vm::new();
         vm.load(&code).unwrap();
         vm.run().unwrap();
-        assert_eq!(vm.gas.exec, 2);  // ADDI(1) + HALT(1)
+        assert_eq!(vm.gas.exec, 2); // ADDI(1) + HALT(1)
         assert_eq!(vm.gas.prove, 3); // ADDI(2) + HALT(1)
         assert_eq!(vm.gas.total(), 5);
     }
@@ -1115,10 +1165,10 @@ mod tests {
         // Loop: ADDI + BNE + ADDI costs per iteration
         // Counter from 0 to 100 — should run out of gas partway
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0),     // r1 = 0 (counter)
-            instr_ri(Opcode::Addi, 2, 0, 100),   // r2 = 100 (limit)
-            instr_ri(Opcode::Addi, 1, 1, 1),     // r1++ (3 gas)
-            instr_ri(Opcode::Bne, 1, 2, -4),     // if r1 != r2, jump back (3 gas)
+            instr_ri(Opcode::Addi, 1, 0, 0),   // r1 = 0 (counter)
+            instr_ri(Opcode::Addi, 2, 0, 100), // r2 = 100 (limit)
+            instr_ri(Opcode::Addi, 1, 1, 1),   // r1++ (3 gas)
+            instr_ri(Opcode::Bne, 1, 2, -4),   // if r1 != r2, jump back (3 gas)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
         let mut vm = Vm::with_gas_limit(30); // not enough for 100 iterations
@@ -1306,7 +1356,7 @@ mod tests {
         ctx.balances.insert(100, bal);
 
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 100),  // r1 = address 100
+            instr_ri(Opcode::Addi, 1, 0, 100), // r1 = address 100
             instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE), // w0 = balance(r1)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
@@ -1338,7 +1388,7 @@ mod tests {
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 9),  // r1 = block height 9
+            instr_ri(Opcode::Addi, 1, 0, 9),         // r1 = block height 9
             instr_bytes(Opcode::Blockhash, 0, 1, 0), // w0 = blockhash(9)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
@@ -1356,7 +1406,7 @@ mod tests {
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 43),  // block 43 (300 - 43 = 257 blocks ago)
+            instr_ri(Opcode::Addi, 1, 0, 43), // block 43 (300 - 43 = 257 blocks ago)
             instr_bytes(Opcode::Blockhash, 0, 1, 0),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
@@ -1374,7 +1424,7 @@ mod tests {
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 10),  // current block
+            instr_ri(Opcode::Addi, 1, 0, 10), // current block
             instr_bytes(Opcode::Blockhash, 0, 1, 0),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
@@ -1392,7 +1442,7 @@ mod tests {
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 15),  // future block
+            instr_ri(Opcode::Addi, 1, 0, 15), // future block
             instr_bytes(Opcode::Blockhash, 0, 1, 0),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -8,6 +8,60 @@ use crate::memory::Memory;
 /// Maximum call depth (nested function calls).
 const MAX_CALL_DEPTH: usize = 1024;
 
+/// Sub-codes for the `Caller` opcode (GP-width environment queries).
+/// The immediate field selects which value to return.
+pub mod env_gp {
+    pub const CALLER: u32 = 0;
+    pub const ADDRESS: u32 = 1;
+    pub const BLOCK_NUMBER: u32 = 2;
+    pub const TIMESTAMP: u32 = 3;
+    pub const GAS_REMAINING: u32 = 4;
+}
+
+/// Sub-codes for the `Callvalue` opcode (wide environment queries).
+pub mod env_wide {
+    pub const CALL_VALUE: u32 = 0;
+    pub const GAS_PRICE: u32 = 1;
+    pub const BALANCE: u32 = 2;
+}
+
+/// Execution context: caller info, block info, and balances.
+#[derive(Clone, Debug)]
+pub struct ExecutionContext {
+    /// Address of the caller (msg.sender).
+    pub caller: u64,
+    /// Address of the current contract.
+    pub self_address: u64,
+    /// Value sent with the call (msg.value), 256-bit.
+    pub call_value: U256,
+    /// Current block number.
+    pub block_number: u64,
+    /// Current block timestamp (Unix seconds).
+    pub timestamp: u64,
+    /// Current base fee / gas price, 256-bit.
+    pub gas_price: U256,
+    /// Recent block hashes (index 0 = most recent). Up to 256 entries.
+    pub block_hashes: Vec<U256>,
+    /// Balance lookup function: address → balance.
+    /// Stored as a simple map for now.
+    pub balances: std::collections::HashMap<u64, U256>,
+}
+
+impl Default for ExecutionContext {
+    fn default() -> Self {
+        Self {
+            caller: 0,
+            self_address: 0,
+            call_value: U256::ZERO,
+            block_number: 0,
+            timestamp: 0,
+            gas_price: U256::ZERO,
+            block_hashes: Vec::new(),
+            balances: std::collections::HashMap::new(),
+        }
+    }
+}
+
 /// A saved call frame on the call stack.
 #[derive(Clone, Copy, Debug)]
 struct CallFrame {
@@ -58,6 +112,8 @@ pub struct Vm {
     pub gas_limit: u64,
     /// Accumulated gas refund (e.g. from SDELETE).
     pub gas_refund: u64,
+    /// Execution context (caller, block info, etc.).
+    pub ctx: ExecutionContext,
 }
 
 impl Vm {
@@ -72,6 +128,7 @@ impl Vm {
             gas: GasUsed::default(),
             gas_limit: 0,
             gas_refund: 0,
+            ctx: ExecutionContext::default(),
         }
     }
 
@@ -79,6 +136,23 @@ impl Vm {
     pub fn with_gas_limit(gas_limit: u64) -> Self {
         Self {
             gas_limit,
+            ..Self::new()
+        }
+    }
+
+    /// Create a new VM with an execution context.
+    pub fn with_context(ctx: ExecutionContext) -> Self {
+        Self {
+            ctx,
+            ..Self::new()
+        }
+    }
+
+    /// Create a new VM with both a gas limit and execution context.
+    pub fn with_gas_limit_and_context(gas_limit: u64, ctx: ExecutionContext) -> Self {
+        Self {
+            gas_limit,
+            ctx,
             ..Self::new()
         }
     }
@@ -267,6 +341,48 @@ impl Vm {
                     .map_err(|_| Trap::MemoryFault)?;
                 self.cpu.write_gp(d.rd, val);
                 self.memory.stack_pointer += 8;
+                self.pc += 4;
+            }
+
+            // --- System instructions (environment queries) ---
+            Opcode::Caller => {
+                let sub = d.rs2_or_imm;
+                let val = match sub {
+                    env_gp::CALLER => self.ctx.caller,
+                    env_gp::ADDRESS => self.ctx.self_address,
+                    env_gp::BLOCK_NUMBER => self.ctx.block_number,
+                    env_gp::TIMESTAMP => self.ctx.timestamp,
+                    env_gp::GAS_REMAINING => self.gas_remaining(),
+                    _ => return Err(Trap::InvalidOpcode),
+                };
+                self.cpu.write_gp(d.rd, val);
+                self.pc += 4;
+            }
+            Opcode::Callvalue => {
+                let sub = d.rs2_or_imm;
+                let val = match sub {
+                    env_wide::CALL_VALUE => self.ctx.call_value,
+                    env_wide::GAS_PRICE => self.ctx.gas_price,
+                    env_wide::BALANCE => {
+                        let addr = self.cpu.read_gp(d.rs1);
+                        *self.ctx.balances.get(&addr).unwrap_or(&U256::ZERO)
+                    }
+                    _ => return Err(Trap::InvalidOpcode),
+                };
+                self.cpu.write_wide(d.rd, val);
+                self.pc += 4;
+            }
+            Opcode::Blockhash => {
+                let height = self.cpu.read_gp(d.rs1);
+                let current = self.ctx.block_number;
+                // Only allow recent blocks (up to 256 back), and not current/future
+                let hash = if height < current && current - height <= 256 {
+                    let idx = (current - height - 1) as usize;
+                    self.ctx.block_hashes.get(idx).copied().unwrap_or(U256::ZERO)
+                } else {
+                    U256::ZERO
+                };
+                self.cpu.write_wide(d.rd, hash);
                 self.pc += 4;
             }
 
@@ -1068,5 +1184,232 @@ mod tests {
         assert!(vm_mul.gas.total() > vm_add.gas.total());
         assert!(vm_mul.gas.exec > vm_add.gas.exec);
         assert!(vm_mul.gas.prove > vm_add.gas.prove);
+    }
+
+    // ========== System instructions (M1.8) ==========
+
+    #[test]
+    fn caller_returns_msg_sender() {
+        let ctx = ExecutionContext {
+            caller: 0xDEAD_BEEF,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, env_gp::CALLER),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_gp(1), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn address_returns_self() {
+        let ctx = ExecutionContext {
+            self_address: 0xCAFE_BABE,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, env_gp::ADDRESS),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_gp(1), 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn blocknumber_returns_height() {
+        let ctx = ExecutionContext {
+            block_number: 12345,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, env_gp::BLOCK_NUMBER),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_gp(1), 12345);
+    }
+
+    #[test]
+    fn timestamp_returns_unix_time() {
+        let ctx = ExecutionContext {
+            timestamp: 1_700_000_000,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, env_gp::TIMESTAMP),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_gp(1), 1_700_000_000);
+    }
+
+    #[test]
+    fn gasremaining_returns_remaining() {
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, env_gp::GAS_REMAINING),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_gas_limit(1000);
+        vm.load(&code).unwrap();
+        // After executing Caller (gas cost 3), remaining should be 1000 - 3 = 997
+        vm.step().unwrap();
+        assert_eq!(vm.cpu.read_gp(1), 997);
+    }
+
+    #[test]
+    fn callvalue_returns_msg_value() {
+        let val = U256::from(1_000_000_000u64) * U256::from(10u64).pow(9); // 1e18
+        let ctx = ExecutionContext {
+            call_value: val,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Callvalue, 0, 0, env_wide::CALL_VALUE),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), val);
+    }
+
+    #[test]
+    fn gasprice_returns_base_fee() {
+        let price = U256::from(25_000_000_000u64); // 25 gwei
+        let ctx = ExecutionContext {
+            gas_price: price,
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_bytes(Opcode::Callvalue, 0, 0, env_wide::GAS_PRICE),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), price);
+    }
+
+    #[test]
+    fn balance_returns_account_balance() {
+        let bal = U256::from(42_000u64);
+        let mut ctx = ExecutionContext::default();
+        ctx.balances.insert(100, bal);
+
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 100),  // r1 = address 100
+            instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE), // w0 = balance(r1)
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), bal);
+    }
+
+    #[test]
+    fn balance_unknown_address_returns_zero() {
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 999),
+            instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), U256::ZERO);
+    }
+
+    #[test]
+    fn blockhash_recent_block() {
+        let hash = U256::from(0xABCD_1234u64) << 128 | U256::from(0x5678u64);
+        let ctx = ExecutionContext {
+            block_number: 10,
+            block_hashes: vec![hash], // index 0 = block 9 (most recent)
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 9),  // r1 = block height 9
+            instr_bytes(Opcode::Blockhash, 0, 1, 0), // w0 = blockhash(9)
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), hash);
+    }
+
+    #[test]
+    fn blockhash_too_old_returns_zero() {
+        let ctx = ExecutionContext {
+            block_number: 300,
+            block_hashes: vec![U256::from(1u64); 256], // 256 recent hashes
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 43),  // block 43 (300 - 43 = 257 blocks ago)
+            instr_bytes(Opcode::Blockhash, 0, 1, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), U256::ZERO); // too old
+    }
+
+    #[test]
+    fn blockhash_current_block_returns_zero() {
+        let ctx = ExecutionContext {
+            block_number: 10,
+            block_hashes: vec![U256::from(1u64); 10],
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 10),  // current block
+            instr_bytes(Opcode::Blockhash, 0, 1, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), U256::ZERO); // current block not available
+    }
+
+    #[test]
+    fn blockhash_future_block_returns_zero() {
+        let ctx = ExecutionContext {
+            block_number: 10,
+            block_hashes: vec![U256::from(1u64); 10],
+            ..Default::default()
+        };
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 15),  // future block
+            instr_bytes(Opcode::Blockhash, 0, 1, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::with_context(ctx);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+        assert_eq!(vm.cpu.read_wide(0), U256::ZERO);
+    }
+
+    #[test]
+    fn invalid_env_subcode_traps() {
+        let code = bytecode(&[
+            instr_bytes(Opcode::Caller, 1, 0, 99), // invalid sub-code
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run(), Err(Trap::InvalidOpcode));
     }
 }

--- a/crates/pvm/src/wide.rs
+++ b/crates/pvm/src/wide.rs
@@ -44,7 +44,10 @@ mod tests {
 
     #[test]
     fn add_basic() {
-        assert_eq!(wide_add(U256::from(100u64), U256::from(200u64)).unwrap(), U256::from(300u64));
+        assert_eq!(
+            wide_add(U256::from(100u64), U256::from(200u64)).unwrap(),
+            U256::from(300u64)
+        );
     }
 
     #[test]
@@ -54,7 +57,10 @@ mod tests {
 
     #[test]
     fn sub_basic() {
-        assert_eq!(wide_sub(U256::from(300u64), U256::from(100u64)).unwrap(), U256::from(200u64));
+        assert_eq!(
+            wide_sub(U256::from(300u64), U256::from(100u64)).unwrap(),
+            U256::from(200u64)
+        );
     }
 
     #[test]
@@ -64,7 +70,10 @@ mod tests {
 
     #[test]
     fn mul_basic() {
-        assert_eq!(wide_mul(U256::from(7u64), U256::from(6u64)).unwrap(), U256::from(42u64));
+        assert_eq!(
+            wide_mul(U256::from(7u64), U256::from(6u64)).unwrap(),
+            U256::from(42u64)
+        );
     }
 
     #[test]
@@ -75,22 +84,34 @@ mod tests {
 
     #[test]
     fn div_basic() {
-        assert_eq!(wide_div(U256::from(42u64), U256::from(7u64)).unwrap(), U256::from(6u64));
+        assert_eq!(
+            wide_div(U256::from(42u64), U256::from(7u64)).unwrap(),
+            U256::from(6u64)
+        );
     }
 
     #[test]
     fn div_by_zero() {
-        assert_eq!(wide_div(U256::from(42u64), U256::ZERO), Err(Trap::DivisionByZero));
+        assert_eq!(
+            wide_div(U256::from(42u64), U256::ZERO),
+            Err(Trap::DivisionByZero)
+        );
     }
 
     #[test]
     fn mod_basic() {
-        assert_eq!(wide_mod(U256::from(10u64), U256::from(3u64)).unwrap(), U256::from(1u64));
+        assert_eq!(
+            wide_mod(U256::from(10u64), U256::from(3u64)).unwrap(),
+            U256::from(1u64)
+        );
     }
 
     #[test]
     fn mod_by_zero() {
-        assert_eq!(wide_mod(U256::from(10u64), U256::ZERO), Err(Trap::DivisionByZero));
+        assert_eq!(
+            wide_mod(U256::from(10u64), U256::ZERO),
+            Err(Trap::DivisionByZero)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **ExecutionContext struct**: Holds caller address, contract address, call value (U256), block number, timestamp, gas price (U256), recent block hashes, and account balances
- **GP environment queries** via `Caller` opcode with immediate-based dispatch:
  - `caller rd` → msg.sender
  - `address rd` → current contract address
  - `blocknumber rd` → current block height
  - `timestamp rd` → block timestamp (Unix seconds)
  - `gasremaining rd` → remaining gas
- **Wide environment queries** via `Callvalue` opcode with immediate-based dispatch:
  - `callvalue wd` → msg.value (256-bit)
  - `gasprice wd` → current base fee (256-bit)
  - `balance wd, rs1` → account balance of address in rs1 (256-bit)
- **Blockhash**: `blockhash wd, rs1` → hash of block at height rs1 (up to 256 blocks back, zero for too-old/current/future)
- **Assembler**: pseudo-mnemonics for all system instructions with disassembler roundtrip support
- **19 new tests** (14 VM + 5 assembler) covering all instructions and edge cases (invalid sub-codes, unknown addresses, too-old blocks, future blocks)

## Design

All 64 opcode slots were already allocated, so system instructions reuse existing `Caller` (0x23) and `Callvalue` (0x24) opcodes with the immediate field selecting the query type. The assembler maps user-friendly mnemonics (`blocknumber`, `timestamp`, etc.) to the correct opcode + sub-code automatically.

## Test plan

- [x] Each GP env query returns correct context value (caller, address, blocknumber, timestamp, gasremaining)
- [x] Each wide env query returns correct value (callvalue, gasprice, balance)
- [x] Balance of unknown address returns zero
- [x] Blockhash for recent, too-old, current, and future blocks
- [x] Invalid env sub-code traps as InvalidOpcode
- [x] Assembler encodes/disassembles all pseudo-mnemonics correctly