### PR TITLE
Harden SMT verify, add compiled proofs and batch benchmarks

### DIFF
--- a/crates/state/benches/smt_bench.rs
+++ b/crates/state/benches/smt_bench.rs
@@ -77,8 +77,30 @@ fn bench_proof() {
     println!("  {iterations:>6} verifies: {us_per_verify:>8.1} µs/verify");
 }
 
+fn bench_batch_insert() {
+    println!("\n=== SMT batch insert (update_all) ===\n");
+
+    for count in [100u64, 1_000, 10_000] {
+        let pairs: Vec<_> = (0..count)
+            .map(|i| (key_from_seed(i + 100_000), format!("v{i}").into_bytes()))
+            .collect();
+
+        let mut smt = PydeSMT::new();
+        let start = Instant::now();
+        smt.update_all(pairs);
+        let elapsed = start.elapsed();
+
+        let ops_sec = count as f64 / elapsed.as_secs_f64();
+        println!(
+            "  {count:>6} batch:    {ops_sec:>10.0} ops/sec ({:.1}ms)",
+            elapsed.as_secs_f64() * 1000.0
+        );
+    }
+}
+
 fn main() {
     bench_insert();
+    bench_batch_insert();
     bench_get();
     bench_proof();
     println!();

--- a/crates/state/src/smt.rs
+++ b/crates/state/src/smt.rs
@@ -174,6 +174,15 @@ pub struct MerkleProof {
 }
 
 impl MerkleProof {
+    /// Compile this proof into a more compact representation for serialization.
+    pub fn compile(self, keys: Vec<Key>) -> CompiledProof {
+        let compiled = self
+            .inner
+            .compile(keys)
+            .expect("proof compilation failed");
+        CompiledProof { inner: compiled }
+    }
+
     /// Verify this proof against a root hash and expected leaves.
     /// `leaves` is a list of (key, value) pairs. Use empty vec for non-existence.
     pub fn verify(
@@ -191,7 +200,7 @@ impl MerkleProof {
         self.inner
             .clone()
             .verify::<Poseidon2Hasher>(&root, smt_leaves)
-            .is_ok()
+            .unwrap_or(false)
     }
 
     /// Verify non-existence of keys against a root hash.
@@ -203,7 +212,41 @@ impl MerkleProof {
         self.inner
             .clone()
             .verify::<Poseidon2Hasher>(&root, smt_leaves)
-            .is_ok()
+            .unwrap_or(false)
+    }
+}
+
+/// A compiled Merkle proof — more compact, better for serialization and wire transfer.
+pub struct CompiledProof {
+    inner: sparse_merkle_tree::CompiledMerkleProof,
+}
+
+impl CompiledProof {
+    /// Verify this compiled proof against a root and leaves.
+    pub fn verify(&self, root: H256, leaves: Vec<(Key, Vec<u8>)>) -> bool {
+        let smt_leaves: Vec<(Key, H256)> = leaves
+            .iter()
+            .map(|(k, v)| {
+                let val = SmtValue(v.clone());
+                (*k, val.to_h256())
+            })
+            .collect();
+        self.inner
+            .clone()
+            .verify::<Poseidon2Hasher>(&root, smt_leaves)
+            .unwrap_or(false)
+    }
+
+    /// Serialize to bytes for wire transfer.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.inner.clone().into()
+    }
+
+    /// Deserialize from bytes.
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self {
+            inner: sparse_merkle_tree::CompiledMerkleProof(data),
+        }
     }
 }
 
@@ -433,5 +476,54 @@ mod tests {
     fn empty_tree_is_empty() {
         let smt = PydeSMT::new();
         assert!(smt.is_empty());
+    }
+
+    #[test]
+    fn verify_rejects_tampered_value() {
+        let mut smt = PydeSMT::new();
+        let key = key_from_seed(1);
+        smt.insert(key, b"real".to_vec());
+
+        let root = smt.root();
+        let proof = smt.prove(vec![key]);
+
+        // Correct value passes
+        assert!(proof.verify(root, vec![(key, b"real".to_vec())]));
+        // Tampered value fails
+        assert!(!proof.verify(root, vec![(key, b"fake".to_vec())]));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_root() {
+        let mut smt = PydeSMT::new();
+        let key = key_from_seed(1);
+        let value = b"data".to_vec();
+        smt.insert(key, value.clone());
+
+        let root = smt.root();
+        let proof = smt.prove(vec![key]);
+
+        // Correct root passes
+        assert!(proof.verify(root, vec![(key, value.clone())]));
+        // Wrong root fails
+        let fake_root = H256::from(poseidon2_hash(b"wrong").to_bytes());
+        assert!(!proof.verify(fake_root, vec![(key, value)]));
+    }
+
+    // ========== Compiled proof ==========
+
+    #[test]
+    fn compiled_proof_verifies() {
+        let mut smt = PydeSMT::new();
+        let key = key_from_seed(1);
+        let value = b"value".to_vec();
+        smt.insert(key, value.clone());
+
+        let root = smt.root();
+        let proof = smt.prove(vec![key]);
+        let compiled = proof.compile(vec![key]);
+
+        assert!(compiled.verify(root, vec![(key, value.clone())]));
+        assert!(!compiled.verify(root, vec![(key, b"wrong".to_vec())]));
     }
 }


### PR DESCRIPTION
## Summary
- Fix verify() bug: was using `.is_ok()` instead of `.unwrap_or(false)` — Nervos returns `Ok(false)` for mismatched proofs, not `Err`
- Tamper detection now works correctly: wrong values and wrong roots are rejected
- Add `CompiledProof` with verify, to_bytes, from_bytes for efficient wire transfer
- Add batch insert benchmark via `update_all()`

## Benchmark results
| Operation | Sequential | Batch |
|-----------|-----------|-------|
| 10K inserts | 10.6K ops/sec | **15.1K ops/sec** (42% faster) |

## Test plan
- [x] 428 tests pass across workspace
- [x] verify() rejects tampered values
- [x] verify() rejects wrong roots
- [x] Compiled proof verifies correctly
- [x] Compiled proof rejects wrong values