### PR TITLE
Refactor addresses from u64 to 32-byte post-quantum safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +64,16 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2b-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89a8565807f21b913288968e391819e7f9b2f0f46c7b89549c051cccf3a2771"
+dependencies = [
+ "cc",
+ "cty",
+]
 
 [[package]]
 name = "block-buffer"
@@ -57,10 +94,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -215,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "digest"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +326,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ethnum"
@@ -260,10 +361,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
@@ -271,9 +390,21 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -282,9 +413,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -302,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,7 +450,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -321,6 +458,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -358,6 +500,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -370,6 +521,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "keccak"
@@ -403,10 +564,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -424,6 +627,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +659,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "ml-kem"
@@ -461,6 +689,16 @@ dependencies = [
  "hybrid-array",
  "num-traits",
  "subtle",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -492,6 +730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "p3-challenger"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +755,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
@@ -526,7 +770,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "num-bigint",
  "p3-maybe-rayon",
  "p3-util",
@@ -561,7 +805,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
@@ -596,7 +840,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "num-bigint",
  "p3-dft",
  "p3-field",
@@ -633,7 +877,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "p3-field",
  "serde",
 ]
@@ -658,6 +902,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "prettyplease"
@@ -705,6 +955,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyde-state"
+version = "0.1.0"
+dependencies = [
+ "lru",
+ "pyde-crypto",
+ "rocksdb",
+ "sparse-merkle-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "pyde-vm"
 version = "0.1.0"
 dependencies = [
@@ -721,6 +982,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -764,6 +1031,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "region"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,10 +1072,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "scopeguard"
@@ -847,10 +1166,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sparse-merkle-tree"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8851f6c92491ebe5528eabc1244292175a739eb0162974f9f9670a7dc748748b"
+dependencies = [
+ "blake2b-rs",
+ "cc",
+ "cfg-if 0.1.10",
+]
 
 [[package]]
 name = "spin"
@@ -901,6 +1237,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -979,6 +1328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,10 +1398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec5e8552e01692e6c2e5293171704fed8abdec79d1a6995a0870ab190e5747d1"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1243,3 +1604,13 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/aot/benches/aot_bench.rs
+++ b/crates/aot/benches/aot_bench.rs
@@ -126,8 +126,10 @@ fn transfer_code() -> Vec<u8> {
 }
 
 fn setup_transfer_vm(code: &[u8]) -> Vm {
+    let mut addr = [0u8; 32];
+    addr[..8].copy_from_slice(&0xAAAAu64.to_le_bytes());
     let ctx = ExecutionContext {
-        self_address: 0xAAAA,
+        self_address: addr,
         ..Default::default()
     };
     let mut vm = Vm::with_context(ctx);

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -175,9 +175,10 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
     // Environment host functions: (ctx) -> u64
-    let fn_caller = module.declare_function("host_caller", Linkage::Import, &sig_pop)
+    // host_caller(ctx, wd) -> u64, host_address(ctx, wd) -> u64
+    let fn_caller = module.declare_function("host_caller", Linkage::Import, &sig_sdel)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
-    let fn_address = module.declare_function("host_address", Linkage::Import, &sig_pop)
+    let fn_address = module.declare_function("host_address", Linkage::Import, &sig_sdel)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
     let fn_block_number = module.declare_function("host_block_number", Linkage::Import, &sig_pop)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
@@ -730,11 +731,9 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let sub = d.rs2_or_imm;
                         let call = match sub {
-                            0 => builder.ins().call(fn_caller_ref, &[vm_ctx]),      // CALLER
-                            1 => builder.ins().call(fn_address_ref, &[vm_ctx]),     // ADDRESS
-                            2 => builder.ins().call(fn_block_number_ref, &[vm_ctx]),// BLOCK_NUMBER
-                            3 => builder.ins().call(fn_timestamp_ref, &[vm_ctx]),   // TIMESTAMP
-                            4 => builder.ins().call(fn_gas_remaining_ref, &[vm_ctx]),// GAS_REMAINING
+                            0 => builder.ins().call(fn_block_number_ref, &[vm_ctx]),
+                            1 => builder.ins().call(fn_timestamp_ref, &[vm_ctx]),
+                            2 => builder.ins().call(fn_gas_remaining_ref, &[vm_ctx]),
                             _ => {
                                 builder.ins().jump(trap_block, &[]);
                                 terminated = true;
@@ -755,6 +754,8 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                                 let addr = builder.use_var(Variable::from_u32(d.rs1 as u32));
                                 builder.ins().call(fn_balance_ref, &[vm_ctx, addr, wd]);
                             }
+                            3 => { builder.ins().call(fn_caller_ref, &[vm_ctx, wd]); }  // CALLER
+                            4 => { builder.ins().call(fn_address_ref, &[vm_ctx, wd]); } // ADDRESS
                             _ => {
                                 builder.ins().jump(trap_block, &[]);
                                 terminated = true;

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -308,16 +308,18 @@ pub extern "C" fn host_log(ctx: *mut VmCtx, desc_ptr: u64, num_topics: u64) -> u
 
 // ── Environment queries ────────────────────────────────────────────────
 
-/// Host: get caller (msg.sender). Returns the caller address.
-pub extern "C" fn host_caller(ctx: *mut VmCtx) -> u64 {
+/// Host: get caller (msg.sender) into wide register wd.
+pub extern "C" fn host_caller(ctx: *mut VmCtx, wd: u64) -> u64 {
     let vm = unsafe { &mut *ctx };
-    vm.ctx.caller
+    vm.cpu.write_wide(wd as u8, pyde_vm::wide::U256::from_le_bytes(vm.ctx.caller));
+    0
 }
 
-/// Host: get self address.
-pub extern "C" fn host_address(ctx: *mut VmCtx) -> u64 {
+/// Host: get self address into wide register wd.
+pub extern "C" fn host_address(ctx: *mut VmCtx, wd: u64) -> u64 {
     let vm = unsafe { &mut *ctx };
-    vm.ctx.self_address
+    vm.cpu.write_wide(wd as u8, pyde_vm::wide::U256::from_le_bytes(vm.ctx.self_address));
+    0
 }
 
 /// Host: get block number.
@@ -352,9 +354,11 @@ pub extern "C" fn host_gasprice(ctx: *mut VmCtx, wd: u64) -> u64 {
     0
 }
 
-/// Host: get balance of address into wide register.
-pub extern "C" fn host_balance(ctx: *mut VmCtx, addr: u64, wd: u64) -> u64 {
+/// Host: get balance of address (in wide register ws) into wide register wd.
+pub extern "C" fn host_balance(ctx: *mut VmCtx, ws_addr: u64, wd: u64) -> u64 {
     let vm = unsafe { &mut *ctx };
+    let addr_u256 = vm.cpu.read_wide(ws_addr as u8);
+    let addr: [u8; 32] = addr_u256.to_le_bytes();
     let bal = vm.ctx.balances.get(&addr).copied().unwrap_or(U256::ZERO);
     vm.cpu.write_wide(wd as u8, bal);
     0

--- a/crates/pvm/benches/interpreter_bench.rs
+++ b/crates/pvm/benches/interpreter_bench.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use pyde_vm::isa::{encode, encode_immediate, Opcode};
-use pyde_vm::vm::{ExecutionContext, ExecResult, Outcome, Vm};
+use pyde_vm::vm::{ExecutionContext, ExecResult, Outcome, Vm, ZERO_ADDRESS};
 use pyde_vm::wide::U256;
 
 /// Helper: encode an instruction to little-endian bytes.
@@ -159,7 +159,11 @@ fn transfer_code() -> Vec<u8> {
 /// Set up a VM with pre-populated storage for a token transfer.
 fn setup_transfer_vm(code: &[u8], gas_limit: u64) -> Vm {
     let ctx = ExecutionContext {
-        self_address: 0xAAAA,
+        self_address: {
+            let mut a = ZERO_ADDRESS;
+            a[..8].copy_from_slice(&0xAAAAu64.to_le_bytes());
+            a
+        },
         ..Default::default()
     };
     let mut vm = if gas_limit > 0 {

--- a/crates/pvm/src/asm.rs
+++ b/crates/pvm/src/asm.rs
@@ -299,10 +299,11 @@ enum PseudoEnv {
 fn parse_pseudo_env(s: &str) -> Option<PseudoEnv> {
     use crate::vm::{env_gp, env_wide};
     match s {
-        "address" => Some(PseudoEnv::Gp(env_gp::ADDRESS)),
         "blocknumber" => Some(PseudoEnv::Gp(env_gp::BLOCK_NUMBER)),
         "timestamp" => Some(PseudoEnv::Gp(env_gp::TIMESTAMP)),
         "gasremaining" => Some(PseudoEnv::Gp(env_gp::GAS_REMAINING)),
+        "caller" => Some(PseudoEnv::Wide(env_wide::CALLER)),
+        "address" => Some(PseudoEnv::Wide(env_wide::ADDRESS)),
         "gasprice" => Some(PseudoEnv::Wide(env_wide::GAS_PRICE)),
         "balance" => Some(PseudoEnv::WideWithInput(env_wide::BALANCE)),
         _ => None,
@@ -1505,8 +1506,6 @@ fn disassemble_one(opcode: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> String {
         Opcode::Caller => {
             use crate::vm::env_gp;
             match rs2_or_imm {
-                env_gp::CALLER => format!("caller r{}", rd),
-                env_gp::ADDRESS => format!("address r{}", rd),
                 env_gp::BLOCK_NUMBER => format!("blocknumber r{}", rd),
                 env_gp::TIMESTAMP => format!("timestamp r{}", rd),
                 env_gp::GAS_REMAINING => format!("gasremaining r{}", rd),
@@ -1521,6 +1520,8 @@ fn disassemble_one(opcode: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> String {
                 env_wide::CALL_VALUE => format!("callvalue w{}", rd),
                 env_wide::GAS_PRICE => format!("gasprice w{}", rd),
                 env_wide::BALANCE => format!("balance w{}, r{}", rd, rs1),
+                env_wide::CALLER => format!("caller w{}", rd),
+                env_wide::ADDRESS => format!("address w{}", rd),
                 _ => format!("callvalue w{}, r{}, {}", rd, rs1, rs2_or_imm),
             }
         }
@@ -1940,25 +1941,26 @@ mod tests {
 
     #[test]
     fn assemble_system_pseudo_mnemonics() {
-        use crate::vm::env_gp;
+        use crate::vm::{env_gp, env_wide};
 
         // GP env queries
         let code =
-            assemble("caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt")
+            assemble("caller w1\naddress w2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt")
                 .unwrap();
         let d0 = decode(Instruction(u32::from_le_bytes(
             code[0..4].try_into().unwrap(),
         )));
-        assert_eq!(d0.opcode, Opcode::Caller);
+        // caller and address are now wide queries (Callvalue opcode)
+        assert_eq!(d0.opcode, Opcode::Callvalue);
         assert_eq!(d0.rd, 1);
-        assert_eq!(d0.rs2_or_imm, env_gp::CALLER);
+        assert_eq!(d0.rs2_or_imm, env_wide::CALLER);
 
         let d1 = decode(Instruction(u32::from_le_bytes(
             code[4..8].try_into().unwrap(),
         )));
-        assert_eq!(d1.opcode, Opcode::Caller);
+        assert_eq!(d1.opcode, Opcode::Callvalue);
         assert_eq!(d1.rd, 2);
-        assert_eq!(d1.rs2_or_imm, env_gp::ADDRESS);
+        assert_eq!(d1.rs2_or_imm, env_wide::ADDRESS);
 
         let d2 = decode(Instruction(u32::from_le_bytes(
             code[8..12].try_into().unwrap(),
@@ -2020,11 +2022,11 @@ mod tests {
 
     #[test]
     fn disassemble_system_roundtrip() {
-        let src = "caller r1\naddress r2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt\n";
+        let src = "caller w1\naddress w2\nblocknumber r3\ntimestamp r4\ngasremaining r5\nhalt\n";
         let code = assemble(src).unwrap();
         let text = disassemble(&code);
-        assert!(text.contains("caller r1"));
-        assert!(text.contains("address r2"));
+        assert!(text.contains("caller w1"));
+        assert!(text.contains("address w2"));
         assert!(text.contains("blocknumber r3"));
         assert!(text.contains("timestamp r4"));
         assert!(text.contains("gasremaining r5"));

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -9,33 +9,40 @@ use crate::memory::Memory;
 use crate::wide::U256;
 use std::collections::HashMap;
 
+/// 32-byte address type (Poseidon2 hash of FALCON-512 public key).
+pub type Address = [u8; 32];
+
+/// Zero address constant.
+pub const ZERO_ADDRESS: Address = [0u8; 32];
+
 /// Maximum call depth (nested function calls).
 const MAX_CALL_DEPTH: usize = 1024;
 
 /// Sub-codes for the `Caller` opcode (GP-width environment queries).
 /// The immediate field selects which value to return.
 pub mod env_gp {
-    pub const CALLER: u32 = 0;
-    pub const ADDRESS: u32 = 1;
-    pub const BLOCK_NUMBER: u32 = 2;
-    pub const TIMESTAMP: u32 = 3;
-    pub const GAS_REMAINING: u32 = 4;
+    pub const BLOCK_NUMBER: u32 = 0;
+    pub const TIMESTAMP: u32 = 1;
+    pub const GAS_REMAINING: u32 = 2;
 }
 
 /// Sub-codes for the `Callvalue` opcode (wide environment queries).
+/// Addresses are 32 bytes, so CALLER and ADDRESS are wide.
 pub mod env_wide {
     pub const CALL_VALUE: u32 = 0;
     pub const GAS_PRICE: u32 = 1;
     pub const BALANCE: u32 = 2;
+    pub const CALLER: u32 = 3;
+    pub const ADDRESS: u32 = 4;
 }
 
 /// Execution context: caller info, block info, and balances.
 #[derive(Clone, Debug)]
 pub struct ExecutionContext {
-    /// Address of the caller (msg.sender).
-    pub caller: u64,
-    /// Address of the current contract.
-    pub self_address: u64,
+    /// Address of the caller (msg.sender), 32 bytes.
+    pub caller: Address,
+    /// Address of the current contract, 32 bytes.
+    pub self_address: Address,
     /// Value sent with the call (msg.value), 256-bit.
     pub call_value: U256,
     /// Current block number.
@@ -46,22 +53,21 @@ pub struct ExecutionContext {
     pub gas_price: U256,
     /// Recent block hashes (index 0 = most recent). Up to 256 entries.
     pub block_hashes: Vec<U256>,
-    /// Balance lookup function: address → balance.
-    /// Stored as a simple map for now.
-    pub balances: std::collections::HashMap<u64, U256>,
+    /// Balance lookup: address → balance.
+    pub balances: HashMap<Address, U256>,
 }
 
 impl Default for ExecutionContext {
     fn default() -> Self {
         Self {
-            caller: 0,
-            self_address: 0,
+            caller: ZERO_ADDRESS,
+            self_address: ZERO_ADDRESS,
             call_value: U256::ZERO,
             block_number: 0,
             timestamp: 0,
             gas_price: U256::ZERO,
             block_hashes: Vec::new(),
-            balances: std::collections::HashMap::new(),
+            balances: HashMap::new(),
         }
     }
 }
@@ -159,7 +165,7 @@ impl GasUsed {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EventLog {
     /// Contract address that emitted the event.
-    pub address: u64,
+    pub address: Address,
     /// Indexed topics (up to 4: topic0 = event signature hash, topic1-3 = indexed fields).
     pub topics: Vec<U256>,
     /// Non-indexed data payload.
@@ -209,7 +215,7 @@ pub struct Vm {
     /// Keys already journaled (O(1) dedup instead of O(n) scan).
     storage_journal_keys: std::collections::HashSet<U256>,
     /// Contract registry: address → deployed bytecode.
-    pub contracts: HashMap<u64, Vec<u8>>,
+    pub contracts: HashMap<Address, Vec<u8>>,
     /// Calldata: input bytes passed to this contract.
     pub calldata: Vec<u8>,
     /// Return data from the last external call.
@@ -217,7 +223,7 @@ pub struct Vm {
     /// Whether this execution is in static mode (no state writes allowed).
     pub static_mode: bool,
     /// Set of contract addresses currently on the external call stack (reentrancy detection).
-    reentrancy_set: std::collections::HashSet<u64>,
+    reentrancy_set: std::collections::HashSet<Address>,
     /// Current external call depth.
     ext_call_depth: usize,
 }
@@ -543,8 +549,6 @@ impl Vm {
             Opcode::Caller => {
                 let sub = d.rs2_or_imm;
                 let val = match sub {
-                    env_gp::CALLER => self.ctx.caller,
-                    env_gp::ADDRESS => self.ctx.self_address,
                     env_gp::BLOCK_NUMBER => self.ctx.block_number,
                     env_gp::TIMESTAMP => self.ctx.timestamp,
                     env_gp::GAS_REMAINING => self.gas_remaining(),
@@ -559,9 +563,13 @@ impl Vm {
                     env_wide::CALL_VALUE => self.ctx.call_value,
                     env_wide::GAS_PRICE => self.ctx.gas_price,
                     env_wide::BALANCE => {
-                        let addr = self.cpu.read_gp(d.rs1);
+                        // Address in wide register ws1
+                        let addr_u256 = self.cpu.read_wide(d.rs1);
+                        let addr: Address = addr_u256.to_le_bytes();
                         *self.ctx.balances.get(&addr).unwrap_or(&U256::ZERO)
                     }
+                    env_wide::CALLER => U256::from_le_bytes(self.ctx.caller),
+                    env_wide::ADDRESS => U256::from_le_bytes(self.ctx.self_address),
                     _ => return Err(Trap::InvalidOpcode),
                 };
                 self.cpu.write_wide(d.rd, val);
@@ -830,29 +838,30 @@ impl Vm {
             // --- Cross-contract call instructions ---
 
             Opcode::CallExt => {
-                // call_ext rd, rs1, imm
-                // rd = register with target address
-                // rs1 = register with calldata pointer in memory
-                // imm[3:0] = register with calldata length
-                // imm[7:4] = register with gas to forward
-                // Result: rd = 1 (success) or 0 (failure)
+                // call_ext wd, rs1, imm
+                // wd = wide register with target address (32 bytes)
+                // rs1 = GP register with calldata pointer in memory
+                // imm[3:0] = GP register with calldata length
+                // imm[7:4] = GP register with gas to forward
+                // imm[11:8] = GP register for result (1=success, 0=failure)
                 if self.static_mode {
                     return Err(Trap::StaticModeViolation);
                 }
+                let result_reg = ((d.rs2_or_imm >> 8) & 0xF) as u8;
                 let result = self.do_ext_call(d, false, false)?;
-                self.cpu.write_gp(d.rd, if result.success { 1 } else { 0 });
+                self.cpu.write_gp(result_reg, if result.success { 1 } else { 0 });
                 self.return_data = result.return_data;
                 self.pc += 4;
             }
 
             Opcode::Delegate => {
-                // delegate rd, rs1, imm — same encoding as CallExt
-                // Runs callee code with caller's storage and address
+                // delegate wd, rs1, imm — same encoding as CallExt
                 if self.static_mode {
                     return Err(Trap::StaticModeViolation);
                 }
+                let result_reg = ((d.rs2_or_imm >> 8) & 0xF) as u8;
                 let result = self.do_ext_call(d, false, true)?;
-                self.cpu.write_gp(d.rd, if result.success { 1 } else { 0 });
+                self.cpu.write_gp(result_reg, if result.success { 1 } else { 0 });
                 self.return_data = result.return_data;
                 self.pc += 4;
             }
@@ -866,15 +875,15 @@ impl Vm {
             // CallExt with imm bit 8 set. The VM checks this bit.
 
             Opcode::Create => {
-                // create rd, rs1, imm
-                // rs1 = register with init code pointer
-                // imm[3:0] = register with init code length
-                // Result: rd = new contract address (0 on failure)
+                // create wd, rs1, imm
+                // wd = wide register for new contract address (32 bytes)
+                // rs1 = GP register with init code pointer
+                // imm[3:0] = GP register with init code length
                 if self.static_mode {
                     return Err(Trap::StaticModeViolation);
                 }
-                let result = self.do_create(d, false)?;
-                self.cpu.write_gp(d.rd, result);
+                let new_addr = self.do_create(d, false)?;
+                self.cpu.write_wide(d.rd, U256::from_le_bytes(new_addr));
                 self.pc += 4;
             }
 
@@ -1010,9 +1019,9 @@ impl Vm {
     /// Derive a storage key from a slot and the contract's address.
     /// key = poseidon2(slot_bytes ++ address_bytes)
     pub fn derive_storage_key(&self, slot: U256) -> U256 {
-        let mut buf = [0u8; 40]; // 32 (slot) + 8 (address)
+        let mut buf = [0u8; 64]; // 32 (slot) + 32 (address)
         buf[..32].copy_from_slice(&slot.to_le_bytes());
-        buf[32..].copy_from_slice(&self.ctx.self_address.to_le_bytes());
+        buf[32..64].copy_from_slice(&self.ctx.self_address);
         let hash = pyde_crypto::poseidon2::poseidon2_hash(&buf);
         U256::from_le_bytes(hash.to_bytes())
     }
@@ -1039,13 +1048,13 @@ impl Vm {
             return Err(Trap::StackOverflow);
         }
 
-        let target_addr = self.cpu.read_gp(d.rd);
+        let target_addr: Address = self.cpu.read_wide(d.rd).to_le_bytes();
         let calldata_ptr = self.cpu.read_gp(d.rs1) as u32;
         let len_reg = (d.rs2_or_imm & 0xF) as u8;
         let gas_reg = ((d.rs2_or_imm >> 4) & 0xF) as u8;
         let calldata_len = self.cpu.read_gp(len_reg) as usize;
         let gas_to_forward = self.cpu.read_gp(gas_reg);
-        let is_static_call = is_static || ((d.rs2_or_imm >> 8) & 1) == 1;
+        let is_static_call = is_static || ((d.rs2_or_imm >> 12) & 1) == 1;
 
         // Read calldata from caller's memory
         let mut calldata = vec![0u8; calldata_len];
@@ -1175,8 +1184,8 @@ impl Vm {
         })
     }
 
-    /// Deploy a new contract (CREATE).
-    fn do_create(&mut self, d: DecodedInstruction, is_create2: bool) -> Result<u64, Trap> {
+    /// Deploy a new contract (CREATE/CREATE2). Returns the 32-byte address.
+    fn do_create(&mut self, d: DecodedInstruction, is_create2: bool) -> Result<Address, Trap> {
         if self.ext_call_depth >= MAX_EXT_CALL_DEPTH {
             return Err(Trap::StackOverflow);
         }
@@ -1188,26 +1197,23 @@ impl Vm {
         let init_code = self.memory.checked_read_slice(code_ptr, code_len)
             .map_err(|_| Trap::MemoryFault)?;
 
-        // Derive contract address
-        let new_addr = if is_create2 {
+        // Derive 32-byte contract address
+        let new_addr: Address = if is_create2 {
             // CREATE2: address = poseidon2(0xFF ++ sender ++ salt ++ code_hash)
-            // salt is in the wide register w0
             let salt = self.cpu.read_wide(0);
             let code_hash = pyde_crypto::poseidon2::poseidon2_hash(&init_code);
-            let mut addr_input = Vec::with_capacity(1 + 8 + 32 + 32);
+            let mut addr_input = Vec::with_capacity(1 + 32 + 32 + 32);
             addr_input.push(0xFF);
-            addr_input.extend_from_slice(&self.ctx.self_address.to_le_bytes());
+            addr_input.extend_from_slice(&self.ctx.self_address);
             addr_input.extend_from_slice(&salt.to_le_bytes());
             addr_input.extend_from_slice(&code_hash.to_bytes());
-            let hash = pyde_crypto::poseidon2::poseidon2_hash(&addr_input);
-            u64::from_le_bytes(hash.to_bytes()[..8].try_into().unwrap())
+            pyde_crypto::poseidon2::poseidon2_hash(&addr_input).to_bytes()
         } else {
             // CREATE: address = poseidon2(sender ++ code)
-            let mut addr_input = Vec::with_capacity(8 + init_code.len());
-            addr_input.extend_from_slice(&self.ctx.self_address.to_le_bytes());
+            let mut addr_input = Vec::with_capacity(32 + init_code.len());
+            addr_input.extend_from_slice(&self.ctx.self_address);
             addr_input.extend_from_slice(&init_code);
-            let hash = pyde_crypto::poseidon2::poseidon2_hash(&addr_input);
-            u64::from_le_bytes(hash.to_bytes()[..8].try_into().unwrap())
+            pyde_crypto::poseidon2::poseidon2_hash(&addr_input).to_bytes()
         };
 
         self.contracts.insert(new_addr, init_code);
@@ -1272,6 +1278,13 @@ mod tests {
     /// Build bytecode from instruction byte arrays.
     fn bytecode(instrs: &[[u8; 4]]) -> Vec<u8> {
         instrs.iter().flat_map(|i| i.iter().copied()).collect()
+    }
+
+    /// Helper: create a 32-byte Address from a u64 seed (for test readability).
+    fn addr(seed: u64) -> Address {
+        let mut a = ZERO_ADDRESS;
+        a[..8].copy_from_slice(&seed.to_le_bytes());
+        a
     }
 
     // ========== Task 0145: JMP ==========
@@ -2008,34 +2021,37 @@ mod tests {
 
     #[test]
     fn caller_returns_msg_sender() {
+        let caller_addr = addr(0xDEAD_BEEF);
         let ctx = ExecutionContext {
-            caller: 0xDEAD_BEEF,
+            caller: caller_addr,
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_bytes(Opcode::Caller, 1, 0, env_gp::CALLER),
+            // CALLER returns 32-byte address via wide register
+            instr_bytes(Opcode::Callvalue, 0, 0, env_wide::CALLER),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
         let mut vm = Vm::with_context(ctx);
         vm.load(&code).unwrap();
         assert_eq!(vm.run().unwrap(), ExecResult::Halt);
-        assert_eq!(vm.cpu.read_gp(1), 0xDEAD_BEEF);
+        assert_eq!(vm.cpu.read_wide(0).to_le_bytes(), caller_addr);
     }
 
     #[test]
     fn address_returns_self() {
+        let self_addr = addr(0xCAFE_BABE);
         let ctx = ExecutionContext {
-            self_address: 0xCAFE_BABE,
+            self_address: self_addr,
             ..Default::default()
         };
         let code = bytecode(&[
-            instr_bytes(Opcode::Caller, 1, 0, env_gp::ADDRESS),
+            instr_bytes(Opcode::Callvalue, 0, 0, env_wide::ADDRESS),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
         let mut vm = Vm::with_context(ctx);
         vm.load(&code).unwrap();
         assert_eq!(vm.run().unwrap(), ExecResult::Halt);
-        assert_eq!(vm.cpu.read_gp(1), 0xCAFE_BABE);
+        assert_eq!(vm.cpu.read_wide(0).to_le_bytes(), self_addr);
     }
 
     #[test]
@@ -2120,15 +2136,17 @@ mod tests {
     #[test]
     fn balance_returns_account_balance() {
         let bal = U256::from(42_000u64);
+        let target_addr = addr(100);
         let mut ctx = ExecutionContext::default();
-        ctx.balances.insert(100, bal);
+        ctx.balances.insert(target_addr, bal);
 
+        // Put target address into wide register w1, query balance into w0
+        let mut vm = Vm::with_context(ctx);
+        vm.cpu.write_wide(1, U256::from_le_bytes(target_addr));
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 100), // r1 = address 100
-            instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE), // w0 = balance(r1)
+            instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE), // w0 = balance(w1)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
-        let mut vm = Vm::with_context(ctx);
         vm.load(&code).unwrap();
         assert_eq!(vm.run().unwrap(), ExecResult::Halt);
         assert_eq!(vm.cpu.read_wide(0), bal);
@@ -2136,12 +2154,12 @@ mod tests {
 
     #[test]
     fn balance_unknown_address_returns_zero() {
+        let mut vm = Vm::new();
+        vm.cpu.write_wide(1, U256::from(999u64));
         let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 999),
             instr_bytes(Opcode::Callvalue, 0, 1, env_wide::BALANCE),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
-        let mut vm = Vm::new();
         vm.load(&code).unwrap();
         assert_eq!(vm.run().unwrap(), ExecResult::Halt);
         assert_eq!(vm.cpu.read_wide(0), U256::ZERO);
@@ -2465,7 +2483,7 @@ mod tests {
     #[test]
     fn sstore_then_sload_roundtrip() {
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -2485,7 +2503,7 @@ mod tests {
     #[test]
     fn sdelete_sets_value_to_zero_and_grants_refund() {
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -2521,11 +2539,11 @@ mod tests {
     fn storage_key_derivation_uses_contract_address() {
         // Same slot, different contract address → different derived key
         let ctx1 = ExecutionContext {
-            self_address: 0xAAAA,
+            self_address: addr(0xAAAA),
             ..Default::default()
         };
         let ctx2 = ExecutionContext {
-            self_address: 0xBBBB,
+            self_address: addr(0xBBBB),
             ..Default::default()
         };
         let mut vm1 = Vm::with_context(ctx1);
@@ -2578,7 +2596,7 @@ mod tests {
         // Store a 50-byte value via memory mode, load it back
         let heap = crate::memory::HEAP_START;
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -2759,7 +2777,7 @@ mod tests {
     fn log_emits_event_with_topics_and_data() {
         let heap = crate::memory::HEAP_START;
         let ctx = ExecutionContext {
-            self_address: 0xCAFE,
+            self_address: addr(0xCAFE),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -2780,7 +2798,7 @@ mod tests {
 
         assert_eq!(vm.logs.len(), 1);
         let log = &vm.logs[0];
-        assert_eq!(log.address, 0xCAFE);
+        assert_eq!(log.address, addr(0xCAFE));
         assert_eq!(log.topics.len(), 2);
         assert_eq!(log.topics[0], topic0);
         assert_eq!(log.topics[1], topic1);
@@ -2929,7 +2947,7 @@ mod tests {
     #[test]
     fn execute_revert_rolls_back_storage() {
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -2981,7 +2999,7 @@ mod tests {
     #[test]
     fn execute_out_of_gas_rolls_back() {
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_gas_limit_and_context(10, ctx); // very tight gas limit
@@ -3012,7 +3030,7 @@ mod tests {
         // w0 = slot 0 (sender balance)
         // w1 = loaded balance
         let ctx = ExecutionContext {
-            self_address: 0xAAAA,
+            self_address: addr(0xAAAA),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -3046,7 +3064,7 @@ mod tests {
     #[test]
     fn execute_token_transfer_insufficient_reverts() {
         let ctx = ExecutionContext {
-            self_address: 0xAAAA,
+            self_address: addr(0xAAAA),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -3106,7 +3124,7 @@ mod tests {
     fn execute_success_preserves_storage_and_logs() {
         let heap = crate::memory::HEAP_START;
         let ctx = ExecutionContext {
-            self_address: 0xBEEF,
+            self_address: addr(0xBEEF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -3138,10 +3156,10 @@ mod tests {
     // --- M1.13: Contract Call Instruction tests ---
 
     /// Helper: create a VM with a contract registry containing the given contracts.
-    fn vm_with_contracts(contracts: Vec<(u64, Vec<u8>)>) -> Vm {
+    fn vm_with_contracts(contracts: Vec<(Address, Vec<u8>)>) -> Vm {
         let mut vm = Vm::new();
-        for (addr, code) in contracts {
-            vm.contracts.insert(addr, code);
+        for (a, code) in contracts {
+            vm.contracts.insert(a, code);
         }
         vm
     }
@@ -3157,26 +3175,22 @@ mod tests {
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
-        // Caller: set up target addr + calldata, CALL_EXT, HALT
-        // r1 = target address (0xBBB)
-        // r2 = calldata ptr (doesn't matter, len=0)
-        // r3 = calldata len (0)
-        // r4 = gas to forward (0 = all)
-        // CALL_EXT rd=1, rs1=2, imm = (gas_reg=4 << 4) | len_reg=3 = 0x43
+        // Caller: target address in w0, calldata in r2, len in r3, gas in r4
+        // CallExt wd=0, rs1=2, imm = (result_reg=1 << 8) | (gas_reg=4 << 4) | len_reg=3
         let caller_code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0xBBB),       // r1 = target
             instr_ri(Opcode::Addi, 3, 0, 0),            // r3 = calldata len = 0
             instr_ri(Opcode::Addi, 4, 0, 0),            // r4 = gas = 0 (all)
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),   // call_ext r1, r2, (r4<<4|r3)
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),  // call_ext w0, r2, (r1<<8|r4<<4|r3)
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0xAAA,
+            self_address: addr(0xAAA),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
-        vm.contracts.insert(0xBBB, callee_code);
+        vm.cpu.write_wide(0, U256::from_le_bytes(addr(0xBBB)));
+        vm.contracts.insert(addr(0xBBB), callee_code);
         vm.load(&caller_code).unwrap();
         let output = vm.execute();
 
@@ -3188,71 +3202,71 @@ mod tests {
 
     #[test]
     fn ext_call_reentrancy_blocked() {
-        // Contract A calls contract B, contract B tries to call A back → Reentrancy trap
-        // B's code: call A (which is already on the call stack)
+        // B's code: load addr A into w0, call A (reentrancy!)
         let code_b = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0xAA),         // r1 = addr of A
-            instr_ri(Opcode::Addi, 3, 0, 0),             // r3 = calldata len = 0
-            instr_ri(Opcode::Addi, 4, 0, 0),             // r4 = gas = 0
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),    // call_ext → A (reentrancy!)
+            instr_ri(Opcode::Addi, 1, 0, 0xAA),
+            instr_bytes(Opcode::Widen, 0, 1, 0),         // w0 = addr(0xAA)
+            instr_ri(Opcode::Addi, 3, 0, 0),
+            instr_ri(Opcode::Addi, 4, 0, 0),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),   // result→r1
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
+        // A's code: load addr B into w0, call B
         let code_a = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0xBB),         // r1 = addr of B
+            instr_ri(Opcode::Addi, 1, 0, 0xBB),
+            instr_bytes(Opcode::Widen, 0, 1, 0),         // w0 = addr(0xBB)
             instr_ri(Opcode::Addi, 3, 0, 0),
             instr_ri(Opcode::Addi, 4, 0, 0),
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),    // call B
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),   // result→r1
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0xAA,
+            self_address: addr(0xAA),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
-        vm.contracts.insert(0xAA, code_a.clone());
-        vm.contracts.insert(0xBB, code_b);
+        vm.contracts.insert(addr(0xAA), code_a.clone());
+        vm.contracts.insert(addr(0xBB), code_b);
         vm.load(&code_a).unwrap();
         let output = vm.execute();
 
-        // A's call to B succeeds (B itself runs and halts OK).
-        // B's internal call back to A fails silently (reentrancy blocked, B's r1 = 0).
-        // But B still completes with HALT, so A sees success.
         assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(vm.cpu.read_gp(1), 1); // A→B call succeeded (B halted OK)
+        assert_eq!(vm.cpu.read_gp(1), 1);
     }
 
     // ========== Task 0205: STATICCALL reverts on state modification ==========
 
     #[test]
     fn staticcall_reverts_on_sstore() {
-        // Callee tries to SSTORE — should fail in static mode
         let callee_code = bytecode(&[
-            instr_bytes(Opcode::Sstore, 0, 0, 0),  // attempt state write
+            instr_bytes(Opcode::Sstore, 0, 0, 0),
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
-        // Caller does a static call (imm bit 8 set): imm = 0x143 = (1<<8) | (r4<<4) | r3
+        // imm = (result_reg=1 << 8) | (static=1 << 12) | (gas_reg=4 << 4) | len_reg=3
+        // But we need static bit — with new encoding, static is imm[12]
+        // For simplicity, pre-load w0 with target and set static_mode on caller
         let caller_code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0xCC),         // r1 = target
             instr_ri(Opcode::Addi, 3, 0, 0),
             instr_ri(Opcode::Addi, 4, 0, 0),
-            instr_bytes(Opcode::CallExt, 1, 2, 0x143),   // static call (bit 8 set)
+            instr_bytes(Opcode::CallExt, 0, 2, 0x1143), // result→r1, static bit[12]=1
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0xDD,
+            self_address: addr(0xDD),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
-        vm.contracts.insert(0xCC, callee_code);
+        vm.cpu.write_wide(0, U256::from_le_bytes(addr(0xCC)));
+        vm.contracts.insert(addr(0xCC), callee_code);
         vm.load(&caller_code).unwrap();
         let output = vm.execute();
 
         assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(vm.cpu.read_gp(1), 0); // static call failed (callee tried to write)
+        assert_eq!(vm.cpu.read_gp(1), 0);
     }
 
     // ========== Task 0206: Nested calls (A calls B calls C) ==========
@@ -3266,29 +3280,30 @@ mod tests {
 
         // B: calls C, then halts
         let code_b = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0x30),         // r1 = addr C
+            instr_ri(Opcode::Addi, 1, 0, 0x30),
+            instr_bytes(Opcode::Widen, 0, 1, 0),         // w0 = addr(0x30)
             instr_ri(Opcode::Addi, 3, 0, 0),
             instr_ri(Opcode::Addi, 4, 0, 0),
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),   // result→r1
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
-        // A: calls B, checks success, then halts
         let code_a = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0x20),         // r1 = addr B
+            instr_ri(Opcode::Addi, 1, 0, 0x20),
+            instr_bytes(Opcode::Widen, 0, 1, 0),         // w0 = addr(0x20)
             instr_ri(Opcode::Addi, 3, 0, 0),
             instr_ri(Opcode::Addi, 4, 0, 0),
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),   // result→r1
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0x10,
+            self_address: addr(0x10),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
-        vm.contracts.insert(0x20, code_b);
-        vm.contracts.insert(0x30, code_c);
+        vm.contracts.insert(addr(0x20), code_b);
+        vm.contracts.insert(addr(0x30), code_c);
         vm.load(&code_a).unwrap();
         let output = vm.execute();
 
@@ -3310,22 +3325,21 @@ mod tests {
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
-        // Caller: forward very little gas (10)
         let caller_code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 0xEE),
             instr_ri(Opcode::Addi, 3, 0, 0),
             instr_ri(Opcode::Addi, 4, 0, 10),            // only 10 gas forwarded
-            instr_bytes(Opcode::CallExt, 1, 2, 0x43),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x143),   // result→r1
             instr_ri(Opcode::Addi, 5, 0, 99),            // parent continues
             instr_bytes(Opcode::Halt, 0, 0, 0),
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0xFF,
+            self_address: addr(0xFF),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
-        vm.contracts.insert(0xEE, callee_code);
+        vm.cpu.write_wide(0, U256::from_le_bytes(addr(0xEE)));
+        vm.contracts.insert(addr(0xEE), callee_code);
         vm.load(&caller_code).unwrap();
         let output = vm.execute();
 
@@ -3347,7 +3361,7 @@ mod tests {
         ]);
 
         let ctx = ExecutionContext {
-            self_address: 0x1234,
+            self_address: addr(0x1234),
             ..Default::default()
         };
         let mut vm = Vm::with_context(ctx);
@@ -3359,7 +3373,8 @@ mod tests {
         vm.cpu.write_gp(2, heap as u64);            // r2 = code ptr
         vm.cpu.write_gp(3, init_code.len() as u64); // r3 = code len
 
-        // CREATE rd=1, rs1=2, imm = len_reg=3 → 0x03
+        // CREATE wd=1, rs1=2, imm = len_reg=3 → 0x03
+        // Result address written to wide register w1
         let caller_code = bytecode(&[
             instr_bytes(Opcode::Create, 1, 2, 0x03),
             instr_bytes(Opcode::Halt, 0, 0, 0),
@@ -3368,8 +3383,8 @@ mod tests {
         let output = vm.execute();
 
         assert_eq!(output.outcome, Outcome::Success);
-        let new_addr = vm.cpu.read_gp(1);
-        assert_ne!(new_addr, 0);
+        let new_addr: Address = vm.cpu.read_wide(1).to_le_bytes();
+        assert_ne!(new_addr, ZERO_ADDRESS);
         // Contract should be registered
         assert!(vm.contracts.contains_key(&new_addr));
         assert_eq!(vm.contracts[&new_addr], init_code);
@@ -3388,7 +3403,7 @@ mod tests {
         let mut addrs = Vec::new();
         for _ in 0..2 {
             let ctx = ExecutionContext {
-                self_address: 0x5678,
+                self_address: addr(0x5678),
                 ..Default::default()
             };
             let mut vm = Vm::with_context(ctx);
@@ -3404,10 +3419,11 @@ mod tests {
             ]);
             vm.load(&code).unwrap();
             vm.execute();
-            addrs.push(vm.cpu.read_gp(1));
+            let new_addr: Address = vm.cpu.read_wide(1).to_le_bytes();
+            addrs.push(new_addr);
         }
 
         assert_eq!(addrs[0], addrs[1]);
-        assert_ne!(addrs[0], 0);
+        assert_ne!(addrs[0], ZERO_ADDRESS);
     }
 }

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -1,0 +1,186 @@
+//! State key derivation: deterministic, domain-separated Poseidon2 hashing
+//! for mapping account addresses, storage slots, and map entries to SMT keys.
+//!
+//! Each domain has a unique tag to prevent collisions:
+//! - Account:      Poseidon2(address || "account")
+//! - Storage slot: Poseidon2(contract || "storage" || slot_index)
+//! - Map entry:    Poseidon2(Poseidon2(contract || "storage" || slot) || map_key)
+//! - Nested map:   Poseidon2(Poseidon2(Poseidon2(contract || "storage" || slot) || key1) || key2)
+
+use pyde_crypto::poseidon2::poseidon2_hash;
+use sparse_merkle_tree::H256;
+
+/// 32-byte address type (matches PVM Address).
+pub type Address = [u8; 32];
+
+/// Domain tag for account keys.
+const DOMAIN_ACCOUNT: &[u8] = b"account";
+/// Domain tag for storage slot keys.
+const DOMAIN_STORAGE: &[u8] = b"storage";
+
+/// Derive the SMT key for an account's metadata (balance, nonce, code_hash).
+///
+/// `key = Poseidon2(address_bytes || "account")`
+pub fn account_key(address: &Address) -> H256 {
+    let mut input = Vec::with_capacity(32 + DOMAIN_ACCOUNT.len());
+    input.extend_from_slice(address);
+    input.extend_from_slice(DOMAIN_ACCOUNT);
+    let hash = poseidon2_hash(&input);
+    H256::from(hash.to_bytes())
+}
+
+/// Derive the SMT key for a contract's storage slot.
+///
+/// `key = Poseidon2(contract_address || "storage" || slot_index_bytes)`
+pub fn storage_slot_key(contract: &Address, slot: u64) -> H256 {
+    let mut input = Vec::with_capacity(32 + DOMAIN_STORAGE.len() + 8);
+    input.extend_from_slice(contract);
+    input.extend_from_slice(DOMAIN_STORAGE);
+    input.extend_from_slice(&slot.to_le_bytes());
+    let hash = poseidon2_hash(&input);
+    H256::from(hash.to_bytes())
+}
+
+/// Derive the SMT key for a map entry within a contract's storage slot.
+///
+/// `key = Poseidon2(Poseidon2(contract || "storage" || slot) || map_key_bytes)`
+pub fn map_entry_key(contract: &Address, slot: u64, map_key: &[u8]) -> H256 {
+    let slot_key = storage_slot_key(contract, slot);
+    let mut input = Vec::with_capacity(32 + map_key.len());
+    input.extend_from_slice(slot_key.as_slice());
+    input.extend_from_slice(map_key);
+    let hash = poseidon2_hash(&input);
+    H256::from(hash.to_bytes())
+}
+
+/// Derive the SMT key for a nested map entry (2-level deep).
+///
+/// `key = Poseidon2(Poseidon2(Poseidon2(contract || "storage" || slot) || key1) || key2)`
+pub fn nested_map_key(contract: &Address, slot: u64, key1: &[u8], key2: &[u8]) -> H256 {
+    let level1 = map_entry_key(contract, slot, key1);
+    let mut input = Vec::with_capacity(32 + key2.len());
+    input.extend_from_slice(level1.as_slice());
+    input.extend_from_slice(key2);
+    let hash = poseidon2_hash(&input);
+    H256::from(hash.to_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_addr(seed: u64) -> Address {
+        let mut a = [0u8; 32];
+        a[..8].copy_from_slice(&seed.to_le_bytes());
+        a
+    }
+
+    #[test]
+    fn account_key_deterministic() {
+        let a = test_addr(0xAAAA);
+        assert_eq!(account_key(&a), account_key(&a));
+    }
+
+    #[test]
+    fn storage_slot_key_deterministic() {
+        let a = test_addr(0xBBBB);
+        assert_eq!(storage_slot_key(&a, 0), storage_slot_key(&a, 0));
+    }
+
+    #[test]
+    fn map_entry_key_deterministic() {
+        let a = test_addr(0xCCCC);
+        assert_eq!(map_entry_key(&a, 1, b"alice"), map_entry_key(&a, 1, b"alice"));
+    }
+
+    #[test]
+    fn nested_map_key_deterministic() {
+        let a = test_addr(0xDDDD);
+        assert_eq!(
+            nested_map_key(&a, 2, b"alice", b"token_1"),
+            nested_map_key(&a, 2, b"alice", b"token_1")
+        );
+    }
+
+    #[test]
+    fn different_contracts_different_account_keys() {
+        assert_ne!(account_key(&test_addr(0xAAAA)), account_key(&test_addr(0xBBBB)));
+    }
+
+    #[test]
+    fn different_contracts_same_slot_different_keys() {
+        let a = test_addr(0xAAAA);
+        let b = test_addr(0xBBBB);
+        assert_ne!(storage_slot_key(&a, 0), storage_slot_key(&b, 0));
+    }
+
+    #[test]
+    fn same_contract_different_slots() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(storage_slot_key(&a, 0), storage_slot_key(&a, 1));
+    }
+
+    #[test]
+    fn different_map_keys() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(map_entry_key(&a, 0, b"alice"), map_entry_key(&a, 0, b"bob"));
+    }
+
+    #[test]
+    fn different_slots_same_map_key() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(map_entry_key(&a, 0, b"alice"), map_entry_key(&a, 1, b"alice"));
+    }
+
+    #[test]
+    fn nested_map_different_key2() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(
+            nested_map_key(&a, 0, b"alice", b"token_1"),
+            nested_map_key(&a, 0, b"alice", b"token_2")
+        );
+    }
+
+    #[test]
+    fn nested_map_different_key1() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(
+            nested_map_key(&a, 0, b"alice", b"token_1"),
+            nested_map_key(&a, 0, b"bob", b"token_1")
+        );
+    }
+
+    #[test]
+    fn account_vs_storage_no_collision() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(account_key(&a), storage_slot_key(&a, 0));
+    }
+
+    #[test]
+    fn storage_vs_map_no_collision() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(storage_slot_key(&a, 0), map_entry_key(&a, 0, &[]));
+    }
+
+    #[test]
+    fn map_vs_nested_no_collision() {
+        let a = test_addr(0xAAAA);
+        assert_ne!(map_entry_key(&a, 0, b"key"), nested_map_key(&a, 0, b"key", b""));
+    }
+
+    #[test]
+    fn all_domains_unique() {
+        let a = test_addr(0x1234);
+        let keys = vec![
+            account_key(&a),
+            storage_slot_key(&a, 0),
+            map_entry_key(&a, 0, b"k"),
+            nested_map_key(&a, 0, b"k", b"v"),
+        ];
+        for i in 0..keys.len() {
+            for j in (i + 1)..keys.len() {
+                assert_ne!(keys[i], keys[j], "collision between domain {i} and {j}");
+            }
+        }
+    }
+}

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod backend;
+pub mod keys;
 pub mod smt;


### PR DESCRIPTION
## Summary
Cross-cutting refactor: all addresses changed from `u64` (64-bit, collision-vulnerable) to `[u8; 32]` (256-bit, post-quantum safe, matches Poseidon2 hash output).

**PVM changes:**
- `Address = [u8; 32]` type alias with `ZERO_ADDRESS` constant
- CALLER/ADDRESS moved from GP register queries to wide register queries
- CallExt/Delegate read target address from wide register
- CREATE returns 32-byte address via wide register
- ExecutionContext, EventLog, contract registry, reentrancy set updated

**ASM changes:**
- `caller` and `address` assemble/disassemble as wide register queries

**AOT changes:**
- host_caller/host_address write to wide registers
- host_balance reads address from wide register

**State changes:**
- Key derivation (M2.3) uses `&[u8; 32]` addresses
- Domain-separated account, storage, map, nested map key derivation

## Test plan
- [x] 454 tests pass across workspace (76 crypto + 313 PVM + 46 state + 19 AOT)
- [x] All benchmarks compile
- [x] Cargo.lock included