### PR TITLE
Add slashing with double-sign detection and liveness penalties

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -4,5 +4,6 @@ pub mod block;
 pub mod finality;
 pub mod hotstuff;
 pub mod proposer;
+pub mod slashing;
 pub mod validator;
 pub mod view_change;

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -1,0 +1,612 @@
+//! Slashing conditions per Chapter 6, Section 6.10.
+//!
+//! | Offense               | Slash Amount        | Description                               |
+//! |-----------------------|---------------------|-------------------------------------------|
+//! | Double signing        | 100% (10,000 PYDE)  | Two different blocks for same slot         |
+//! | Equivocation          | 100% (10,000 PYDE)  | Conflicting votes in same round            |
+//! | Liveness < 90%        | 1% of stake         | Missed > 10% of slots in epoch             |
+//! | Liveness < 50%        | 5% of stake + eject | Missed > 50% of slots in epoch             |
+//! | Liveness == 0%        | 10% + forced unbond  | Completely absent for entire epoch          |
+//! | Invalid block proposal| 50% (5,000 PYDE)    | Proposing block with invalid structure     |
+//! | Decryption withholding| 2% per offense      | Failing to provide decryption shares       |
+//! | Invalid proof (prover)| 100% of bond (1K)   | Prover submits invalid STARK proof         |
+//!
+//! Evidence submitter receives 10% finder's fee from slashed stake.
+//! No time limit on evidence — previous epoch evidence is still valid.
+//!
+//! ## Prover Slashing (TODO: Phase 8)
+//!
+//! Provers don't stake — they post a **bond** of 1,000 PYDE. The prover
+//! registry and bond management will be implemented in Phase 8 (ZK Proving).
+//! `slash_invalid_proof` computes the slash amounts; actual bond deduction
+//! requires the prover registry.
+
+use crate::block::BlockHeader;
+use crate::validator::{Validator, ValidatorSet, ValidatorStatus, VALIDATOR_STAKE};
+use pyde_account::address::Address;
+use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
+
+/// Prover bond amount (in quanta, 1,000 PYDE).
+pub const PROVER_BOND: u128 = 1_000_000_000_000;
+
+/// Finder's fee percentage (10% of slashed amount).
+pub const FINDER_FEE_PERCENT: u128 = 10;
+
+/// Slash percentages for liveness tiers.
+pub const LIVENESS_SLASH_MINOR: u128 = 1;   // 1% — participation < 90%
+pub const LIVENESS_SLASH_MAJOR: u128 = 5;   // 5% — participation < 50%
+pub const LIVENESS_SLASH_ABSENT: u128 = 10;  // 10% — participation == 0%
+
+/// Slash percentage for invalid block proposal.
+pub const INVALID_PROPOSAL_SLASH: u128 = 50; // 50%
+
+/// Slash percentage for decryption withholding.
+pub const DECRYPTION_WITHHOLD_SLASH: u128 = 2; // 2% per offense
+
+/// Slashing offense type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SlashingOffense {
+    DoubleSigning,
+    Equivocation,
+    LivenessMinor,    // < 90% participation
+    LivenessMajor,    // < 50% participation
+    LivenessAbsent,   // 0% participation
+    InvalidProposal,
+    DecryptionWithholding,
+    InvalidProof,     // prover offense
+}
+
+/// The result of processing a slashing event.
+#[derive(Clone, Debug)]
+pub struct SlashResult {
+    /// Address of the slashed validator/prover.
+    pub offender: Address,
+    /// Amount burned.
+    pub amount_burned: u128,
+    /// Finder's fee paid to evidence submitter.
+    pub finder_fee: u128,
+    /// Whether the offender is ejected from the validator set.
+    pub ejected: bool,
+    /// Whether forced unbonding is triggered.
+    pub forced_unbonding: bool,
+    /// The offense type.
+    pub offense: SlashingOffense,
+}
+
+/// Double-signing evidence: two different blocks signed for the same slot.
+#[derive(Clone, Debug)]
+pub struct DoubleSignEvidence {
+    /// The slot where double-signing occurred.
+    pub slot: u64,
+    /// First block header.
+    pub block_1: BlockHeader,
+    /// FALCON signature over block_1.hash().
+    pub signature_1: Vec<u8>,
+    /// Second block header (must have different hash from block_1).
+    pub block_2: BlockHeader,
+    /// FALCON signature over block_2.hash().
+    pub signature_2: Vec<u8>,
+    /// Address of the signer.
+    pub signer: Address,
+    /// Address of the evidence submitter (receives finder's fee).
+    pub submitter: Address,
+}
+
+/// Liveness report for a validator over an epoch.
+#[derive(Clone, Debug)]
+pub struct LivenessReport {
+    pub validator: Address,
+    /// Number of slots the validator participated in.
+    pub slots_participated: u64,
+    /// Total slots in the epoch.
+    pub total_slots: u64,
+}
+
+impl LivenessReport {
+    /// Participation rate as a percentage (0-100).
+    pub fn participation_percent(&self) -> u64 {
+        if self.total_slots == 0 {
+            return 100;
+        }
+        (self.slots_participated * 100) / self.total_slots
+    }
+}
+
+/// Invalid proof evidence: prover submitted a proof that doesn't verify.
+#[derive(Clone, Debug)]
+pub struct InvalidProofEvidence {
+    /// Slot the proof was for.
+    pub slot: u64,
+    /// Block hash the proof claimed to cover.
+    pub block_hash: [u8; 32],
+    /// The invalid proof hash.
+    pub proof_hash: [u8; 32],
+    /// Prover's address.
+    pub prover: Address,
+    /// Submitter's address (receives finder's fee).
+    pub submitter: Address,
+}
+
+// ========== Verification ==========
+
+/// Verify double-sign evidence.
+///
+/// Checks:
+/// 1. Both blocks are for the same slot
+/// 2. Block hashes are different
+/// 3. Both signatures are valid for the signer's public key
+pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> bool {
+    // Same slot
+    if evidence.block_1.slot != evidence.slot || evidence.block_2.slot != evidence.slot {
+        return false;
+    }
+
+    let hash_1 = evidence.block_1.hash();
+    let hash_2 = evidence.block_2.hash();
+
+    // Different blocks
+    if hash_1 == hash_2 {
+        return false;
+    }
+
+    // Verify both signatures
+    let pk = match FalconPublicKey::from_bytes(public_key) {
+        Some(pk) => pk,
+        None => return false,
+    };
+
+    let sig_1 = FalconSignature::from_bytes(&evidence.signature_1);
+    let sig_2 = FalconSignature::from_bytes(&evidence.signature_2);
+
+    falcon_verify(&pk, &hash_1, &sig_1) && falcon_verify(&pk, &hash_2, &sig_2)
+}
+
+// ========== Slash Computation ==========
+
+/// Compute the slash amount and finder's fee for a given offense.
+fn compute_slash(stake: u128, offense: &SlashingOffense) -> (u128, u128) {
+    let slash_percent = match offense {
+        SlashingOffense::DoubleSigning => 100,
+        SlashingOffense::Equivocation => 100,
+        SlashingOffense::LivenessMinor => LIVENESS_SLASH_MINOR,
+        SlashingOffense::LivenessMajor => LIVENESS_SLASH_MAJOR,
+        SlashingOffense::LivenessAbsent => LIVENESS_SLASH_ABSENT,
+        SlashingOffense::InvalidProposal => INVALID_PROPOSAL_SLASH,
+        SlashingOffense::DecryptionWithholding => DECRYPTION_WITHHOLD_SLASH,
+        SlashingOffense::InvalidProof => 100, // 100% of prover bond
+    };
+
+    let slash_amount = stake * slash_percent / 100;
+    let finder_fee = slash_amount * FINDER_FEE_PERCENT / 100;
+    let burned = slash_amount - finder_fee;
+
+    (burned, finder_fee)
+}
+
+/// Process a double-sign slashing event.
+pub fn slash_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> Option<SlashResult> {
+    if !verify_double_sign(evidence, public_key) {
+        return None;
+    }
+
+    let (burned, finder_fee) = compute_slash(VALIDATOR_STAKE, &SlashingOffense::DoubleSigning);
+
+    Some(SlashResult {
+        offender: evidence.signer,
+        amount_burned: burned,
+        finder_fee,
+        ejected: true,
+        forced_unbonding: true,
+        offense: SlashingOffense::DoubleSigning,
+    })
+}
+
+/// Process liveness slashing based on participation rate.
+pub fn slash_liveness(report: &LivenessReport) -> Option<SlashResult> {
+    let pct = report.participation_percent();
+
+    let offense = if pct == 0 {
+        SlashingOffense::LivenessAbsent
+    } else if pct < 50 {
+        SlashingOffense::LivenessMajor
+    } else if pct < 90 {
+        SlashingOffense::LivenessMinor
+    } else {
+        return None; // >= 90% participation, no slash
+    };
+
+    let (burned, finder_fee) = compute_slash(VALIDATOR_STAKE, &offense);
+    let ejected = matches!(offense, SlashingOffense::LivenessMajor | SlashingOffense::LivenessAbsent);
+    let forced_unbonding = matches!(offense, SlashingOffense::LivenessAbsent);
+
+    Some(SlashResult {
+        offender: report.validator,
+        amount_burned: burned,
+        finder_fee,
+        ejected,
+        forced_unbonding,
+        offense,
+    })
+}
+
+/// Process invalid proof slashing (prover offense).
+pub fn slash_invalid_proof(evidence: &InvalidProofEvidence) -> SlashResult {
+    let (burned, finder_fee) = compute_slash(PROVER_BOND, &SlashingOffense::InvalidProof);
+
+    SlashResult {
+        offender: evidence.prover,
+        amount_burned: burned,
+        finder_fee,
+        ejected: true,
+        forced_unbonding: false,
+        offense: SlashingOffense::InvalidProof,
+    }
+}
+
+/// Apply a slash result to the validator set.
+///
+/// This actually modifies the validator's state:
+/// 1. Reduces the validator's stake by the slashed amount
+/// 2. Ejects the validator if required (status → Exited or Unbonding)
+/// 3. Returns the amounts for the caller to credit/burn
+///
+/// Note: balance transfers (finder's fee, burn) must be handled by the
+/// caller via the state/account layer, since this module only manages
+/// the validator set.
+pub fn apply_slash(
+    validator_set: &mut ValidatorSet,
+    result: &SlashResult,
+    current_block: u64,
+) -> bool {
+    let total_slash = result.amount_burned + result.finder_fee;
+
+    let validator = match validator_set
+        .validators
+        .iter_mut()
+        .find(|v| v.address == result.offender)
+    {
+        Some(v) => v,
+        None => return false,
+    };
+
+    // Reduce stake
+    if validator.stake >= total_slash {
+        validator.stake -= total_slash;
+    } else {
+        validator.stake = 0;
+    }
+
+    // Eject if required
+    if result.forced_unbonding {
+        validator.status = ValidatorStatus::Unbonding {
+            exit_block: current_block,
+        };
+    } else if result.ejected {
+        validator.status = ValidatorStatus::Exited;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::QuorumCert;
+    use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+
+    fn make_validator(seed: u8) -> (Address, Vec<u8>) {
+        let pk = vec![seed; 897];
+        let addr = derive_eoa_address(&pk);
+        (addr, pk)
+    }
+
+    fn make_header(slot: u64, timestamp: u64) -> BlockHeader {
+        BlockHeader {
+            slot,
+            epoch: slot / 1000,
+            parent_hash: [0xAA; 32],
+            proposer: derive_eoa_address(&[0x01; 897]),
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0; 32],
+            state_root: [0; 32],
+            timestamp,
+        }
+    }
+
+    // ========== Task 0512: Double-sign slashes validator ==========
+
+    #[test]
+    fn double_sign_detected_and_slashed() {
+        let (pk, sk) = falcon_keygen();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let header_1 = make_header(100, 1_000_000);
+        let header_2 = make_header(100, 2_000_000); // same slot, different timestamp → different hash
+
+        let sig_1 = falcon_sign(&sk, &header_1.hash());
+        let sig_2 = falcon_sign(&sk, &header_2.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header_1,
+            signature_1: sig_1.as_bytes().to_vec(),
+            block_2: header_2,
+            signature_2: sig_2.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        assert!(verify_double_sign(&evidence, &pk_bytes));
+
+        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        assert_eq!(result.offender, addr);
+        assert_eq!(result.offense, SlashingOffense::DoubleSigning);
+        assert!(result.ejected);
+        assert!(result.forced_unbonding);
+        // 100% slashed: 90% burned, 10% finder fee
+        assert_eq!(result.amount_burned + result.finder_fee, VALIDATOR_STAKE);
+        assert_eq!(result.finder_fee, VALIDATOR_STAKE / 10);
+    }
+
+    // ========== Task 0515: False evidence rejected ==========
+
+    #[test]
+    fn same_block_twice_rejected() {
+        let (pk, sk) = falcon_keygen();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let header = make_header(100, 1_000_000);
+        let sig = falcon_sign(&sk, &header.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header.clone(),
+            signature_1: sig.as_bytes().to_vec(),
+            block_2: header, // same block!
+            signature_2: sig.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        assert!(!verify_double_sign(&evidence, &pk_bytes));
+        assert!(slash_double_sign(&evidence, &pk_bytes).is_none());
+    }
+
+    #[test]
+    fn wrong_signer_key_rejected() {
+        let (pk1, sk1) = falcon_keygen();
+        let (pk2, _sk2) = falcon_keygen();
+        let addr = derive_eoa_address(pk1.as_bytes());
+
+        let header_1 = make_header(100, 1_000_000);
+        let header_2 = make_header(100, 2_000_000);
+
+        let sig_1 = falcon_sign(&sk1, &header_1.hash());
+        let sig_2 = falcon_sign(&sk1, &header_2.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header_1,
+            signature_1: sig_1.as_bytes().to_vec(),
+            block_2: header_2,
+            signature_2: sig_2.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        // Wrong key → reject
+        assert!(!verify_double_sign(&evidence, pk2.as_bytes()));
+    }
+
+    #[test]
+    fn wrong_slot_rejected() {
+        let (pk, sk) = falcon_keygen();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let header_1 = make_header(100, 1_000_000);
+        let header_2 = make_header(101, 2_000_000); // different slot!
+
+        let sig_1 = falcon_sign(&sk, &header_1.hash());
+        let sig_2 = falcon_sign(&sk, &header_2.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header_1,
+            signature_1: sig_1.as_bytes().to_vec(),
+            block_2: header_2,
+            signature_2: sig_2.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        assert!(!verify_double_sign(&evidence, &pk_bytes));
+    }
+
+    // ========== Task 0513: Liveness slashes proportionally ==========
+
+    #[test]
+    fn liveness_90_percent_no_slash() {
+        let report = LivenessReport {
+            validator: derive_eoa_address(b"val"),
+            slots_participated: 900,
+            total_slots: 1000,
+        };
+        assert!(slash_liveness(&report).is_none());
+    }
+
+    #[test]
+    fn liveness_89_percent_minor_slash() {
+        let report = LivenessReport {
+            validator: derive_eoa_address(b"val"),
+            slots_participated: 890,
+            total_slots: 1000,
+        };
+        let result = slash_liveness(&report).unwrap();
+        assert_eq!(result.offense, SlashingOffense::LivenessMinor);
+        assert!(!result.ejected);
+        // 1% of 10K PYDE
+        let expected_total = VALIDATOR_STAKE / 100;
+        assert_eq!(result.amount_burned + result.finder_fee, expected_total);
+    }
+
+    #[test]
+    fn liveness_49_percent_major_slash_and_eject() {
+        let report = LivenessReport {
+            validator: derive_eoa_address(b"val"),
+            slots_participated: 490,
+            total_slots: 1000,
+        };
+        let result = slash_liveness(&report).unwrap();
+        assert_eq!(result.offense, SlashingOffense::LivenessMajor);
+        assert!(result.ejected);
+        assert!(!result.forced_unbonding);
+        // 5% of 10K PYDE
+        let expected_total = VALIDATOR_STAKE * 5 / 100;
+        assert_eq!(result.amount_burned + result.finder_fee, expected_total);
+    }
+
+    #[test]
+    fn liveness_zero_absent_slash_and_forced_unbonding() {
+        let report = LivenessReport {
+            validator: derive_eoa_address(b"val"),
+            slots_participated: 0,
+            total_slots: 1000,
+        };
+        let result = slash_liveness(&report).unwrap();
+        assert_eq!(result.offense, SlashingOffense::LivenessAbsent);
+        assert!(result.ejected);
+        assert!(result.forced_unbonding);
+        // 10% of 10K PYDE
+        let expected_total = VALIDATOR_STAKE / 10;
+        assert_eq!(result.amount_burned + result.finder_fee, expected_total);
+    }
+
+    // ========== Task 0514: Invalid proof slashes prover ==========
+
+    #[test]
+    fn invalid_proof_slashes_prover_bond() {
+        let evidence = InvalidProofEvidence {
+            slot: 50,
+            block_hash: [0xAA; 32],
+            proof_hash: [0xBB; 32],
+            prover: derive_eoa_address(b"bad_prover"),
+            submitter: derive_eoa_address(b"finder"),
+        };
+
+        let result = slash_invalid_proof(&evidence);
+        assert_eq!(result.offense, SlashingOffense::InvalidProof);
+        assert!(result.ejected);
+        // 100% of 1K PYDE bond
+        assert_eq!(result.amount_burned + result.finder_fee, PROVER_BOND);
+        assert_eq!(result.finder_fee, PROVER_BOND / 10);
+    }
+
+    // ========== Finder's fee ==========
+
+    #[test]
+    fn finder_fee_is_10_percent() {
+        let (pk, sk) = falcon_keygen();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let header_1 = make_header(100, 1_000_000);
+        let header_2 = make_header(100, 2_000_000);
+
+        let sig_1 = falcon_sign(&sk, &header_1.hash());
+        let sig_2 = falcon_sign(&sk, &header_2.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header_1,
+            signature_1: sig_1.as_bytes().to_vec(),
+            block_2: header_2,
+            signature_2: sig_2.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"finder"),
+        };
+
+        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        assert_eq!(result.finder_fee, VALIDATOR_STAKE * 10 / 100);
+        assert_eq!(result.amount_burned, VALIDATOR_STAKE * 90 / 100);
+    }
+
+    // ========== apply_slash ==========
+
+    #[test]
+    fn apply_double_sign_slash_reduces_stake_and_ejects() {
+        let (pk, sk) = falcon_keygen();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let mut set = ValidatorSet::new();
+        set.register(addr, pk_bytes.clone(), VALIDATOR_STAKE, 0).unwrap();
+        assert_eq!(set.validators[0].stake, VALIDATOR_STAKE);
+
+        let header_1 = make_header(100, 1_000_000);
+        let header_2 = make_header(100, 2_000_000);
+        let sig_1 = falcon_sign(&sk, &header_1.hash());
+        let sig_2 = falcon_sign(&sk, &header_2.hash());
+
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_1: header_1,
+            signature_1: sig_1.as_bytes().to_vec(),
+            block_2: header_2,
+            signature_2: sig_2.as_bytes().to_vec(),
+            signer: addr,
+            submitter: derive_eoa_address(b"finder"),
+        };
+
+        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        assert!(apply_slash(&mut set, &result, 500));
+
+        // Stake reduced to 0 (100% slashed)
+        assert_eq!(set.validators[0].stake, 0);
+        // Forced unbonding
+        assert!(matches!(
+            set.validators[0].status,
+            ValidatorStatus::Unbonding { exit_block: 500 }
+        ));
+    }
+
+    #[test]
+    fn apply_liveness_slash_reduces_stake_partially() {
+        let mut set = ValidatorSet::new();
+        let (addr, pk) = make_validator(1);
+        set.register(addr, pk, VALIDATOR_STAKE, 0).unwrap();
+
+        let report = LivenessReport {
+            validator: addr,
+            slots_participated: 890,
+            total_slots: 1000,
+        };
+
+        let result = slash_liveness(&report).unwrap();
+        assert!(apply_slash(&mut set, &result, 1000));
+
+        // 1% slashed, 99% remains
+        let expected_remaining = VALIDATOR_STAKE - (VALIDATOR_STAKE / 100);
+        assert_eq!(set.validators[0].stake, expected_remaining);
+        // Not ejected for minor liveness
+        assert_eq!(set.validators[0].status, ValidatorStatus::Active);
+    }
+
+    #[test]
+    fn apply_slash_nonexistent_validator_returns_false() {
+        let mut set = ValidatorSet::new();
+        let result = SlashResult {
+            offender: derive_eoa_address(b"nobody"),
+            amount_burned: 1000,
+            finder_fee: 100,
+            ejected: true,
+            forced_unbonding: false,
+            offense: SlashingOffense::DoubleSigning,
+        };
+        assert!(!apply_slash(&mut set, &result, 0));
+    }
+}

--- a/crates/consensus/src/validator.rs
+++ b/crates/consensus/src/validator.rs
@@ -157,15 +157,36 @@ impl ValidatorSet {
         }
     }
 
-    /// Get all active (eligible) validators.
+    /// Get all active (eligible) validators with sufficient stake.
     pub fn active_validators(&self) -> Vec<&Validator> {
         self.validators
             .iter()
-            .filter(|v| v.status == ValidatorStatus::Active)
+            .filter(|v| v.status == ValidatorStatus::Active && v.stake >= VALIDATOR_STAKE)
             .collect()
     }
 
+    /// Get active validators with stake below the required minimum.
+    /// These validators should top up before the next epoch or be excluded.
+    pub fn underfunded_validators(&self) -> Vec<&Validator> {
+        self.validators
+            .iter()
+            .filter(|v| v.status == ValidatorStatus::Active && v.stake < VALIDATOR_STAKE)
+            .collect()
+    }
+
+    /// Top up a validator's stake (e.g., after partial slash).
+    pub fn top_up_stake(&mut self, address: &Address, amount: u128) -> Result<(), ValidatorError> {
+        let validator = self
+            .validators
+            .iter_mut()
+            .find(|v| v.address == *address)
+            .ok_or(ValidatorError::NotFound(*address))?;
+        validator.stake += amount;
+        Ok(())
+    }
+
     /// Select a committee of 128 validators for the given epoch.
+    /// Only validators with Active status AND sufficient stake are eligible.
     /// Uses VRF-seeded randomness for deterministic, unpredictable selection.
     pub fn select_committee(
         &self,
@@ -176,7 +197,7 @@ impl ValidatorSet {
         let eligible: Vec<Validator> = self
             .validators
             .iter()
-            .filter(|v| v.status == ValidatorStatus::Active)
+            .filter(|v| v.status == ValidatorStatus::Active && v.stake >= VALIDATOR_STAKE)
             .cloned()
             .collect();
 
@@ -427,5 +448,38 @@ mod tests {
         for m in &committee.members {
             assert!(committee.contains(&m.address));
         }
+    }
+
+    // ========== Underfunded after slash ==========
+
+    #[test]
+    fn underfunded_validator_excluded_from_committee() {
+        let mut set = ValidatorSet::new();
+        register_n(&mut set, 130);
+
+        // Slash one validator's stake below minimum
+        set.validators[0].stake = VALIDATOR_STAKE - 1;
+
+        // Underfunded detected
+        assert_eq!(set.underfunded_validators().len(), 1);
+
+        // Excluded from committee selection
+        let committee = set.select_committee(0, &[0xAA; 32], vec![]).unwrap();
+        assert!(!committee.contains(&set.validators[0].address));
+    }
+
+    #[test]
+    fn top_up_restores_eligibility() {
+        let mut set = ValidatorSet::new();
+        register_n(&mut set, 130);
+
+        // Slash below minimum
+        set.validators[0].stake = VALIDATOR_STAKE - 100;
+        assert_eq!(set.underfunded_validators().len(), 1);
+
+        // Top up
+        set.top_up_stake(&set.validators[0].address.clone(), 100).unwrap();
+        assert_eq!(set.underfunded_validators().len(), 0);
+        assert_eq!(set.validators[0].stake, VALIDATOR_STAKE);
     }
 }


### PR DESCRIPTION
## Summary
- DoubleSignEvidence: verify two different blocks signed for same slot
- Graduated liveness slashing: 1% (<90%), 5%+eject (<50%), 10%+forced unbond (absent)
- Invalid proof slashing: 100% of prover bond (prover registry deferred to Phase 8)
- 10% finder's fee paid to evidence submitter from slashed amount
- apply_slash: actually modifies validator set (reduce stake, eject/unbond)
- Underfunded validators (stake < 10K after slash) excluded from committee selection
- top_up_stake allows validators to restore eligibility

## Test plan
- [x] 717 tests pass across workspace
- [x] Double-sign detected, verified, slashed 100%
- [x] False evidence rejected (same block, wrong key, wrong slot)
- [x] Liveness: 90%+ no slash, <90% 1%, <50% 5%+eject, 0% 10%+forced unbond
- [x] Invalid proof slashes prover bond
- [x] Finder's fee is 10% of slash
- [x] apply_slash reduces stake and changes validator status
- [x] Underfunded validator excluded from committee
- [x] top_up restores eligibility