### PR TITLE
Add encrypted mempool with structural validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyde-mempool"
+version = "0.1.0"
+dependencies = [
+ "pyde-account",
+ "pyde-crypto",
+ "pyde-tx",
+]
+
+[[package]]
 name = "pyde-state"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "crates/account",
     "crates/tx",
     "crates/consensus",
+    "crates/mempool",
 ]

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -138,6 +138,23 @@ pub struct ThresholdCiphertext {
     mac: [u8; 32],
 }
 
+impl ThresholdCiphertext {
+    /// Length of the encrypted message.
+    pub fn encrypted_len(&self) -> usize {
+        self.encrypted_msg.len()
+    }
+
+    /// Serialize to bytes for hashing/transmission.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let ct_bytes = self.kyber_ct.as_bytes();
+        let mut buf = Vec::with_capacity(ct_bytes.len() + self.encrypted_msg.len() + 32);
+        buf.extend_from_slice(ct_bytes);
+        buf.extend_from_slice(&self.encrypted_msg);
+        buf.extend_from_slice(&self.mac);
+        buf
+    }
+}
+
 // --- Symmetric encryption using Poseidon2-derived keystream ---
 
 const SEED_ELEMENTS: usize = 8; // 64-byte seed = 8 × 8-byte elements
@@ -240,7 +257,23 @@ pub fn threshold_encrypt(tpk: &ThresholdPublicKey, msg: &[u8]) -> ThresholdCiphe
 }
 
 /// Generate a decryption share from a validator's key share.
-/// (In the reconstruct-then-decrypt model, the share is just passed through.)
+///
+/// ## SECURITY TODO (Production)
+///
+/// Current implementation uses reconstruct-then-decrypt: the share is the
+/// raw KeyShare, independent of the ciphertext. This means 85+ shares
+/// collected from ANY decryption round can reconstruct the full secret key
+/// and decrypt ALL transactions for the current epoch.
+///
+/// Production must upgrade to **per-ciphertext shares**:
+///   share_i = f(key_share_i, ciphertext)
+/// This binds each share to a specific ciphertext, preventing reuse across
+/// different transactions. Collecting shares from Block N would be useless
+/// for decrypting Block N+1's transactions.
+///
+/// Risk is bounded by BFT assumption: 85/128 colluding validators already
+/// exceeds the 43/128 Byzantine threshold. PSS epoch refresh limits exposure
+/// to a single epoch.
 pub fn generate_decryption_share(
     key_share: &KeyShare,
     _ct: &ThresholdCiphertext,

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pyde-mempool"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pyde-crypto = { path = "../crypto" }
+pyde-account = { path = "../account" }
+pyde-tx = { path = "../tx" }

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -1,0 +1,278 @@
+//! Encrypted transaction type per Chapter 9 (MEV Protection).
+//!
+//! Plaintext fields (visible to everyone):
+//!   sender, nonce, gas_limit, access_list, deadline, chain_id, signature
+//!
+//! Encrypted fields (hidden until threshold decryption):
+//!   to, value, calldata
+//!
+//! Encryption: threshold_encrypt(committee_pk, (to || value || calldata))
+//!             → ThresholdCiphertext (Kyber encaps + symmetric encryption + MAC)
+
+use pyde_account::address::Address;
+use pyde_crypto::poseidon2::poseidon2_hash;
+use pyde_crypto::threshold::{
+    self, DecryptionShare, KeyShare, ThresholdCiphertext, ThresholdPublicKey,
+};
+use pyde_tx::types::AccessEntry;
+
+/// Maximum transaction size (128 KB).
+pub const MAX_TX_SIZE: usize = 128 * 1024;
+
+/// An encrypted transaction in the mempool.
+/// Plaintext fields are visible for validation and scheduling.
+/// Encrypted fields are hidden until threshold decryption.
+#[derive(Clone, Debug)]
+pub struct EncryptedTx {
+    // === Plaintext fields (visible) ===
+    /// Sender address.
+    pub sender: Address,
+    /// Transaction nonce.
+    pub nonce: u64,
+    /// Gas limit.
+    pub gas_limit: u64,
+    /// Access list (which contracts/slots this tx touches).
+    pub access_list: Vec<AccessEntry>,
+    /// Deadline block height (tx expires after this).
+    pub deadline: Option<u64>,
+    /// Chain ID.
+    pub chain_id: u64,
+    /// FALCON-512 signature over all fields (plaintext + encrypted).
+    pub signature: Vec<u8>,
+
+    // === Encrypted fields (hidden) ===
+    /// Threshold-encrypted payload: contains to, value, calldata.
+    pub ciphertext: ThresholdCiphertext,
+
+    /// Cached hash (computed lazily).
+    hash_cache: Option<[u8; 32]>,
+}
+
+impl EncryptedTx {
+    /// Total size in bytes (rough estimate for MAX_TX_SIZE check).
+    pub fn size(&self) -> usize {
+        32 // sender
+        + 8 // nonce
+        + 8 // gas_limit
+        + self.access_list.len() * 68 // rough estimate per entry
+        + 8 // deadline
+        + 8 // chain_id
+        + self.signature.len()
+        + self.ciphertext.encrypted_len()
+    }
+
+    /// Hash of the encrypted transaction (for deduplication and tx_root).
+    pub fn hash(&self) -> [u8; 32] {
+        if let Some(h) = self.hash_cache {
+            return h;
+        }
+        let mut buf = Vec::with_capacity(96); // sender(32) + nonce(8) + gas(8) + chain(8) + ct_hash(32)
+        buf.extend_from_slice(&self.sender);
+        buf.extend_from_slice(&self.nonce.to_le_bytes());
+        buf.extend_from_slice(&self.gas_limit.to_le_bytes());
+        buf.extend_from_slice(&self.chain_id.to_le_bytes());
+        // Hash the ciphertext bytes for uniqueness
+        buf.extend_from_slice(&poseidon2_hash(&self.ciphertext.to_bytes()).to_bytes());
+        poseidon2_hash(&buf).to_bytes()
+    }
+
+    /// Check if the transaction has expired.
+    pub fn is_expired(&self, current_block: u64) -> bool {
+        match self.deadline {
+            Some(d) => current_block >= d,
+            None => false,
+        }
+    }
+
+    /// Check if the transaction exceeds the size limit.
+    pub fn is_oversized(&self) -> bool {
+        self.size() > MAX_TX_SIZE
+    }
+}
+
+/// Encrypt a transaction's sensitive fields using the committee's threshold public key.
+///
+/// Plaintext fields remain visible. The to/value/calldata are encrypted.
+pub fn encrypt_transaction(
+    sender: Address,
+    nonce: u64,
+    gas_limit: u64,
+    access_list: Vec<AccessEntry>,
+    deadline: Option<u64>,
+    chain_id: u64,
+    signature: Vec<u8>,
+    to: &Address,
+    value: u128,
+    calldata: &[u8],
+    committee_pk: &ThresholdPublicKey,
+) -> EncryptedTx {
+    // Build plaintext payload: to || value || calldata
+    let mut payload = Vec::with_capacity(48 + calldata.len()); // to(32) + value(16) + calldata
+    payload.extend_from_slice(to);
+    payload.extend_from_slice(&value.to_le_bytes());
+    payload.extend_from_slice(calldata);
+
+    // Encrypt using threshold Kyber
+    let ciphertext = threshold::threshold_encrypt(committee_pk, &payload);
+
+    EncryptedTx {
+        sender,
+        nonce,
+        gas_limit,
+        access_list,
+        deadline,
+        chain_id,
+        signature,
+        ciphertext,
+        hash_cache: None,
+    }
+}
+
+/// Decrypt an encrypted transaction's payload using combined decryption shares.
+/// Returns (to, value, calldata) or error.
+pub fn decrypt_payload(
+    ciphertext: &ThresholdCiphertext,
+    shares: &[DecryptionShare],
+    threshold: usize,
+) -> Result<(Address, u128, Vec<u8>), String> {
+    let plaintext = threshold::combine_shares(shares, threshold, ciphertext)
+        .map_err(|e| format!("decryption failed: {}", e))?;
+
+    if plaintext.len() < 48 {
+        return Err("decrypted payload too short".into());
+    }
+
+    let mut to = [0u8; 32];
+    to.copy_from_slice(&plaintext[..32]);
+
+    let value = u128::from_le_bytes(plaintext[32..48].try_into().unwrap());
+    let calldata = plaintext[48..].to_vec();
+
+    Ok((to, value, calldata))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_account::address::derive_eoa_address;
+
+    fn make_threshold_keys() -> (ThresholdPublicKey, Vec<KeyShare>) {
+        threshold::threshold_keygen(3, 2) // 2-of-3
+    }
+
+    #[test]
+    fn encrypt_and_decrypt_roundtrip() {
+        let (pk, key_shares) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender,
+            42,
+            500_000,
+            vec![],
+            Some(1_000_500),
+            1,
+            vec![0xAA; 64],
+            &to,
+            1_000_000,
+            b"swap(TOKEN_X, 500)",
+            &pk,
+        );
+
+        // Plaintext fields visible
+        assert_eq!(enc_tx.sender, sender);
+        assert_eq!(enc_tx.nonce, 42);
+        assert_eq!(enc_tx.gas_limit, 500_000);
+
+        // Generate decryption shares (need 2 of 3)
+        let dec_shares: Vec<DecryptionShare> = key_shares
+            .iter()
+            .take(2)
+            .map(|ks| threshold::generate_decryption_share(ks, &enc_tx.ciphertext))
+            .collect();
+
+        // Decrypt
+        let (dec_to, dec_value, dec_calldata) =
+            decrypt_payload(&enc_tx.ciphertext, &dec_shares, 2).unwrap();
+        assert_eq!(dec_to, to);
+        assert_eq!(dec_value, 1_000_000);
+        assert_eq!(dec_calldata, b"swap(TOKEN_X, 500)");
+    }
+
+    #[test]
+    fn insufficient_shares_fails() {
+        let (pk, key_shares) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], None, 1, vec![], &to, 100, b"", &pk,
+        );
+
+        // Only 1 share (need 2)
+        let dec_shares = vec![
+            threshold::generate_decryption_share(&key_shares[0], &enc_tx.ciphertext),
+        ];
+
+        assert!(decrypt_payload(&enc_tx.ciphertext, &dec_shares, 2).is_err());
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        let (pk, _) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], None, 1, vec![], &to, 100, b"", &pk,
+        );
+
+        assert_eq!(enc_tx.hash(), enc_tx.hash());
+    }
+
+    #[test]
+    fn expired_check() {
+        let (pk, _) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], Some(100), 1, vec![], &to, 0, b"", &pk,
+        );
+
+        assert!(!enc_tx.is_expired(99));
+        assert!(enc_tx.is_expired(100));
+        assert!(enc_tx.is_expired(200));
+    }
+
+    #[test]
+    fn no_deadline_never_expires() {
+        let (pk, _) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, b"", &pk,
+        );
+
+        assert!(!enc_tx.is_expired(u64::MAX));
+    }
+
+    #[test]
+    fn size_check() {
+        let (pk, _) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let small_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, b"", &pk,
+        );
+        assert!(!small_tx.is_oversized());
+
+        let big_tx = encrypt_transaction(
+            sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, &vec![0xFF; 200_000], &pk,
+        );
+        assert!(big_tx.is_oversized());
+    }
+}

--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -1,0 +1,4 @@
+//! Pyde Mempool: encrypted transaction pool with MEV protection.
+
+pub mod encrypted;
+pub mod pool;

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -1,0 +1,540 @@
+//! Encrypted mempool: stores and manages encrypted transactions.
+//!
+//! - FCFS ordering (no tips in Pyde, everyone pays same base fee)
+//! - Eviction: oldest first when pool is full
+//! - Deduplication: reject transactions with same hash
+//! - Expiry: remove transactions past their deadline
+//!
+//! Mempool validation (structural, no state access):
+//!   1. FALCON-512 signature valid
+//!   2. Gas limit in [21_000, block_gas_limit]
+//!   3. Ciphertext non-empty (well-formed)
+//!   4. Access list non-empty
+//!   5. Tx size within limit
+//!   6. Deadline not expired
+//!   7. No duplicate hash
+//!
+//! State-dependent checks (nonce, balance) deferred to Phase 7
+//! when mempool connects to full node state.
+
+use crate::encrypted::EncryptedTx;
+use pyde_account::address::Address;
+use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
+use std::collections::{HashMap, HashSet};
+
+/// Default maximum mempool capacity (number of transactions).
+/// Sized for ~100 blocks at sustained throughput (12,500 TPS × 0.4s × 100).
+pub const DEFAULT_MAX_POOL_SIZE: usize = 500_000;
+
+/// Mempool validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MempoolError {
+    /// Transaction is a duplicate (same hash already in pool).
+    Duplicate,
+    /// Transaction has expired (past deadline).
+    Expired,
+    /// Transaction exceeds size limit.
+    Oversized,
+    /// Transaction signature is invalid or missing.
+    InvalidSignature,
+    /// Gas limit too low (below minimum 21,000).
+    GasTooLow,
+    /// Gas limit exceeds block gas limit.
+    GasTooHigh,
+    /// Ciphertext is empty or malformed.
+    MalformedEncryption,
+    /// Access list is empty (required for parallel scheduling).
+    MissingAccessList,
+}
+
+/// The encrypted mempool.
+#[derive(Debug)]
+pub struct Mempool {
+    /// All transactions in arrival order.
+    txs: Vec<EncryptedTx>,
+    /// Set of tx hashes for deduplication.
+    seen_hashes: HashSet<[u8; 32]>,
+    /// Per-sender nonce tracking (sender → highest nonce seen).
+    sender_nonces: HashMap<Address, u64>,
+    /// Maximum pool size.
+    max_size: usize,
+    /// Current block height (for expiry checks).
+    current_block: u64,
+    /// Block gas limit (for gas_limit upper bound check).
+    block_gas_limit: u64,
+}
+
+impl Mempool {
+    pub fn new() -> Self {
+        Self {
+            txs: Vec::new(),
+            seen_hashes: HashSet::new(),
+            sender_nonces: HashMap::new(),
+            max_size: DEFAULT_MAX_POOL_SIZE,
+            current_block: 0,
+            block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+        }
+    }
+
+    pub fn with_capacity(max_size: usize) -> Self {
+        Self {
+            txs: Vec::with_capacity(max_size),
+            seen_hashes: HashSet::with_capacity(max_size),
+            sender_nonces: HashMap::new(),
+            max_size,
+            current_block: 0,
+            block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+        }
+    }
+
+    /// Update the current block height (for expiry checks).
+    pub fn set_current_block(&mut self, block: u64) {
+        self.current_block = block;
+    }
+
+    /// Update the block gas limit.
+    pub fn set_block_gas_limit(&mut self, limit: u64) {
+        self.block_gas_limit = limit;
+    }
+
+    /// Number of transactions in the pool.
+    pub fn len(&self) -> usize {
+        self.txs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    /// Add an encrypted transaction to the mempool.
+    ///
+    /// Structural validation (no state access required):
+    /// 1. Signature valid (FALCON-512)
+    /// 2. Gas limit in bounds [21K, block_gas_limit]
+    /// 3. Ciphertext non-empty
+    /// 4. Access list non-empty
+    /// 5. Size within limit
+    /// 6. Not expired
+    /// 7. Not duplicate
+    pub fn add(&mut self, tx: EncryptedTx) -> Result<(), MempoolError> {
+        // 1. Signature check
+        self.verify_signature(&tx)?;
+
+        // 2. Gas limit bounds
+        if tx.gas_limit < 21_000 {
+            return Err(MempoolError::GasTooLow);
+        }
+        if tx.gas_limit > self.block_gas_limit {
+            return Err(MempoolError::GasTooHigh);
+        }
+
+        // 3. Ciphertext well-formed
+        if tx.ciphertext.encrypted_len() == 0 {
+            return Err(MempoolError::MalformedEncryption);
+        }
+
+        // 4. Access list non-empty
+        if tx.access_list.is_empty() {
+            return Err(MempoolError::MissingAccessList);
+        }
+
+        // 5. Size limit
+        if tx.is_oversized() {
+            return Err(MempoolError::Oversized);
+        }
+
+        // 6. Expiry
+        if tx.is_expired(self.current_block) {
+            return Err(MempoolError::Expired);
+        }
+
+        // 7. Duplicate
+        let hash = tx.hash();
+        if self.seen_hashes.contains(&hash) {
+            return Err(MempoolError::Duplicate);
+        }
+
+        // Evict if full: drop oldest transaction (FCFS — newest survive)
+        if self.txs.len() >= self.max_size {
+            self.evict_oldest();
+        }
+
+        // Track sender nonce
+        let entry = self.sender_nonces.entry(tx.sender).or_insert(0);
+        if tx.nonce > *entry {
+            *entry = tx.nonce;
+        }
+
+        self.seen_hashes.insert(hash);
+        self.txs.push(tx);
+
+        Ok(())
+    }
+
+    /// Evict the oldest transaction (first in the list).
+    fn evict_oldest(&mut self) {
+        if self.txs.is_empty() {
+            return;
+        }
+        let evicted = self.txs.remove(0);
+        self.seen_hashes.remove(&evicted.hash());
+    }
+
+    /// Verify the FALCON-512 signature on an encrypted transaction.
+    ///
+    /// Full cryptographic verification requires the sender's public key,
+    /// which needs state access (deferred to Phase 7). For now, we check
+    /// that the signature is structurally valid (non-empty, correct size
+    /// range for FALCON-512 signatures).
+    fn verify_signature(&self, tx: &EncryptedTx) -> Result<(), MempoolError> {
+        // FALCON-512 signatures are typically 617-690 bytes (variable due to compression)
+        if tx.signature.is_empty() {
+            return Err(MempoolError::InvalidSignature);
+        }
+        // FALCON-512 compressed signatures range: ~600-700 bytes
+        if tx.signature.len() < 500 || tx.signature.len() > 1000 {
+            return Err(MempoolError::InvalidSignature);
+        }
+        Ok(())
+    }
+
+    /// Verify a signature with a known public key (called when state is available).
+    pub fn verify_signature_with_key(tx: &EncryptedTx, public_key: &[u8]) -> bool {
+        let pk = match FalconPublicKey::from_bytes(public_key) {
+            Some(pk) => pk,
+            None => return false,
+        };
+        let sig = FalconSignature::from_bytes(&tx.signature);
+        falcon_verify(&pk, &tx.hash(), &sig)
+    }
+
+    /// Remove expired transactions.
+    pub fn prune_expired(&mut self) {
+        let current = self.current_block;
+        let before = self.txs.len();
+        self.txs.retain(|tx| !tx.is_expired(current));
+
+        // Rebuild hash set if we pruned anything
+        if self.txs.len() != before {
+            self.seen_hashes.clear();
+            for tx in &self.txs {
+                self.seen_hashes.insert(tx.hash());
+            }
+        }
+    }
+
+    /// Get transactions in arrival order (FCFS).
+    /// No fee-based priority — Pyde has no tips, everyone pays the same base fee.
+    pub fn in_arrival_order(&self) -> &[EncryptedTx] {
+        &self.txs
+    }
+
+    /// Select transactions for a block in arrival order, respecting gas limit.
+    /// The proposer VRF-shuffles the selected set after this.
+    pub fn select_for_block(
+        &self,
+        block_gas_limit: u64,
+        current_slot: u64,
+    ) -> Vec<&EncryptedTx> {
+        let mut selected = Vec::new();
+        let mut gas_used = 0u64;
+
+        for tx in &self.txs {
+            if tx.is_expired(current_slot) {
+                continue;
+            }
+            if gas_used.saturating_add(tx.gas_limit) > block_gas_limit {
+                continue; // skip this tx, try next (might fit)
+            }
+            gas_used += tx.gas_limit;
+            selected.push(tx);
+        }
+
+        selected
+    }
+
+    /// Remove transactions that were included in a block.
+    pub fn remove_included(&mut self, hashes: &[[u8; 32]]) {
+        let hash_set: HashSet<[u8; 32]> = hashes.iter().copied().collect();
+        self.txs.retain(|tx| !hash_set.contains(&tx.hash()));
+
+        for hash in hashes {
+            self.seen_hashes.remove(hash);
+        }
+    }
+
+    /// Check if a transaction hash is already in the pool.
+    pub fn contains(&self, hash: &[u8; 32]) -> bool {
+        self.seen_hashes.contains(hash)
+    }
+}
+
+/// Validate that a block's transaction list has no duplicates.
+/// Called by validators when receiving a proposed block.
+pub fn check_no_duplicate_txs(txs: &[EncryptedTx]) -> Result<(), [u8; 32]> {
+    let mut seen = HashSet::with_capacity(txs.len());
+    for tx in txs {
+        let hash = tx.hash();
+        if !seen.insert(hash) {
+            return Err(hash); // return the duplicate hash
+        }
+    }
+    Ok(())
+}
+
+impl Default for Mempool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encrypted::encrypt_transaction;
+    use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::threshold;
+
+    fn make_pk() -> threshold::ThresholdPublicKey {
+        let (pk, _) = threshold::threshold_keygen(3, 2);
+        pk
+    }
+
+    use pyde_tx::types::AccessEntry;
+
+    fn dummy_access_list() -> Vec<AccessEntry> {
+        vec![AccessEntry {
+            address: derive_eoa_address(b"contract"),
+            reads: vec![[0x01; 32]],
+            writes: vec![],
+        }]
+    }
+
+    fn dummy_signature() -> Vec<u8> {
+        vec![0xAA; 666] // FALCON-512 signature range (~600-700 bytes)
+    }
+
+    fn make_enc_tx(pk: &threshold::ThresholdPublicKey, gas: u64, nonce: u64) -> EncryptedTx {
+        let sender = derive_eoa_address(&nonce.to_le_bytes());
+        let to = derive_eoa_address(b"to");
+        encrypt_transaction(sender, nonce, gas, dummy_access_list(), None, 1, dummy_signature(), &to, 0, b"", pk)
+    }
+
+    fn make_enc_tx_with_deadline(
+        pk: &threshold::ThresholdPublicKey,
+        gas: u64,
+        nonce: u64,
+        deadline: u64,
+    ) -> EncryptedTx {
+        let sender = derive_eoa_address(&nonce.to_le_bytes());
+        let to = derive_eoa_address(b"to");
+        encrypt_transaction(sender, nonce, gas, dummy_access_list(), Some(deadline), 1, dummy_signature(), &to, 0, b"", pk)
+    }
+
+    // ========== Task 0520: Encrypted tx stored in mempool ==========
+
+    #[test]
+    fn add_encrypted_tx() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        let tx = make_enc_tx(&pk, 50_000, 0);
+        pool.add(tx).unwrap();
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn reject_duplicate() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        let tx = make_enc_tx(&pk, 50_000, 0);
+        pool.add(tx.clone()).unwrap();
+        assert_eq!(pool.add(tx), Err(MempoolError::Duplicate));
+    }
+
+    #[test]
+    fn reject_expired() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_current_block(200);
+
+        let tx = make_enc_tx_with_deadline(&pk, 50_000, 0, 100); // expired
+        assert_eq!(pool.add(tx), Err(MempoolError::Expired));
+    }
+
+    #[test]
+    fn reject_gas_too_low() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        let tx = make_enc_tx(&pk, 20_999, 0); // below 21K
+        assert_eq!(pool.add(tx), Err(MempoolError::GasTooLow));
+    }
+
+    #[test]
+    fn reject_gas_too_high() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        let tx = make_enc_tx(&pk, 2_000_000_000, 0); // exceeds GAS_CEILING
+        assert_eq!(pool.add(tx), Err(MempoolError::GasTooHigh));
+    }
+
+    #[test]
+    fn reject_empty_signature() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"to");
+
+        let tx = encrypt_transaction(
+            sender, 0, 50_000, dummy_access_list(), None, 1,
+            vec![], // empty sig
+            &to, 0, b"", &pk,
+        );
+        assert_eq!(pool.add(tx), Err(MempoolError::InvalidSignature));
+    }
+
+    #[test]
+    fn reject_empty_access_list() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"to");
+
+        let tx = encrypt_transaction(
+            sender, 0, 50_000, vec![], None, 1, // empty access list
+            dummy_signature(), &to, 0, b"", &pk,
+        );
+        assert_eq!(pool.add(tx), Err(MempoolError::MissingAccessList));
+    }
+
+    // ========== Task 0521: Eviction when full ==========
+
+    #[test]
+    fn evict_oldest_when_full() {
+        let pk = make_pk();
+        let mut pool = Mempool::with_capacity(3);
+
+        // Fill pool: nonce 0 (oldest), 1, 2
+        pool.add(make_enc_tx(&pk, 30_000, 0)).unwrap();
+        pool.add(make_enc_tx(&pk, 40_000, 1)).unwrap();
+        pool.add(make_enc_tx(&pk, 50_000, 2)).unwrap();
+        assert_eq!(pool.len(), 3);
+
+        // Add new tx → evicts oldest (nonce 0, gas 30K)
+        pool.add(make_enc_tx(&pk, 60_000, 3)).unwrap();
+        assert_eq!(pool.len(), 3);
+
+        // Oldest (30K) should be gone, newest (60K) should be present
+        assert!(pool.txs.iter().any(|t| t.gas_limit == 60_000));
+        assert!(!pool.txs.iter().any(|t| t.gas_limit == 30_000));
+    }
+
+    // ========== FCFS ordering ==========
+
+    #[test]
+    fn arrival_order_preserved() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        pool.add(make_enc_tx(&pk, 30_000, 0)).unwrap();
+        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        pool.add(make_enc_tx(&pk, 45_000, 2)).unwrap();
+
+        let txs = pool.in_arrival_order();
+        assert_eq!(txs[0].gas_limit, 30_000); // first in
+        assert_eq!(txs[1].gas_limit, 60_000);
+        assert_eq!(txs[2].gas_limit, 45_000); // last in
+    }
+
+    // ========== Block selection ==========
+
+    #[test]
+    fn select_for_block_respects_gas_limit() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        pool.add(make_enc_tx(&pk, 50_000, 0)).unwrap();
+        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        pool.add(make_enc_tx(&pk, 40_000, 2)).unwrap();
+
+        // Block gas limit of 100K → picks 60K + 40K (or 60K + 50K... highest first)
+        let selected = pool.select_for_block(100_000, 0);
+        let total_gas: u64 = selected.iter().map(|t| t.gas_limit).sum();
+        assert!(total_gas <= 100_000);
+        assert!(selected.len() >= 1);
+    }
+
+    #[test]
+    fn select_skips_expired() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        pool.add(make_enc_tx_with_deadline(&pk, 50_000, 0, 200)).unwrap();
+        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap(); // no deadline
+
+        // At slot 300, first tx is expired
+        let selected = pool.select_for_block(1_000_000, 300);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].gas_limit, 60_000);
+    }
+
+    // ========== Prune expired ==========
+
+    #[test]
+    fn prune_removes_expired() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        pool.add(make_enc_tx_with_deadline(&pk, 50_000, 0, 100)).unwrap();
+        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        assert_eq!(pool.len(), 2);
+
+        pool.set_current_block(200);
+        pool.prune_expired();
+        assert_eq!(pool.len(), 1);
+    }
+
+    // ========== Remove included ==========
+
+    #[test]
+    fn remove_included_txs() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+
+        let tx1 = make_enc_tx(&pk, 50_000, 0);
+        let tx2 = make_enc_tx(&pk, 60_000, 1);
+        let hash1 = tx1.hash();
+
+        pool.add(tx1).unwrap();
+        pool.add(tx2).unwrap();
+        assert_eq!(pool.len(), 2);
+
+        pool.remove_included(&[hash1]);
+        assert_eq!(pool.len(), 1);
+        assert!(!pool.contains(&hash1));
+    }
+
+    // ========== Block-level duplicate check ==========
+
+    #[test]
+    fn no_duplicates_passes() {
+        let pk = make_pk();
+        let txs = vec![
+            make_enc_tx(&pk, 50_000, 0),
+            make_enc_tx(&pk, 60_000, 1),
+        ];
+        assert!(check_no_duplicate_txs(&txs).is_ok());
+    }
+
+    #[test]
+    fn duplicate_tx_detected() {
+        let pk = make_pk();
+        let tx = make_enc_tx(&pk, 50_000, 0);
+        let dup = tx.clone();
+        let txs = vec![tx, dup];
+        assert!(check_no_duplicate_txs(&txs).is_err());
+    }
+}

--- a/crates/pvm/src/cpu.rs
+++ b/crates/pvm/src/cpu.rs
@@ -29,6 +29,8 @@ pub enum Trap {
     StaticModeViolation,
     #[error("reentrancy detected")]
     Reentrancy,
+    #[error("storage access not in access list")]
+    AccessListViolation,
 }
 
 /// The CPU register file and minimal execution state.

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -246,6 +246,10 @@ pub struct Vm {
     reentrancy_set: std::collections::HashSet<Address>,
     /// Current external call depth.
     ext_call_depth: usize,
+    /// Allowed storage keys from the access list. If Some, SLOAD/SSTORE
+    /// on unlisted keys will trap (strict access list enforcement).
+    /// If None, all keys are allowed (no enforcement).
+    pub allowed_storage_keys: Option<std::collections::HashSet<U256>>,
 }
 
 /// Safe address calculation: base (u64) + offset (i64) → u32, or MemoryFault.
@@ -283,6 +287,7 @@ impl Vm {
             static_mode: false,
             reentrancy_set: std::collections::HashSet::new(),
             ext_call_depth: 0,
+            allowed_storage_keys: None,
         }
     }
 
@@ -661,6 +666,12 @@ impl Vm {
             Opcode::Sload => {
                 let slot = self.cpu.read_wide(d.rs1);
                 let key = self.derive_storage_key(slot);
+                // Strict access list enforcement: revert if key not in allowed set
+                if let Some(ref allowed) = self.allowed_storage_keys {
+                    if !allowed.contains(&key) {
+                        return Err(Trap::AccessListViolation);
+                    }
+                }
                 let mode = d.rs2_or_imm & 0x3;
                 match mode {
                     0 => {
@@ -704,6 +715,12 @@ impl Vm {
                 }
                 let slot = self.cpu.read_wide(d.rs1);
                 let key = self.derive_storage_key(slot);
+                // Strict access list enforcement: revert if key not in allowed set
+                if let Some(ref allowed) = self.allowed_storage_keys {
+                    if !allowed.contains(&key) {
+                        return Err(Trap::AccessListViolation);
+                    }
+                }
                 self.journal_storage_write(&key);
                 let mode = d.rs2_or_imm & 0x3;
                 match mode {

--- a/crates/tx/src/parallel.rs
+++ b/crates/tx/src/parallel.rs
@@ -154,6 +154,89 @@ pub fn schedule(txs: &[Transaction]) -> ExecutionSchedule {
     }
 }
 
+/// Check if two access lists conflict (shared key with at least one write).
+pub fn access_lists_conflict(a: &[AccessEntry], b: &[AccessEntry]) -> bool {
+    let writes_a: HashSet<(Address, [u8; 32])> = a
+        .iter()
+        .flat_map(|entry| entry.writes.iter().map(move |k| (entry.address, *k)))
+        .collect();
+
+    let writes_b: HashSet<(Address, [u8; 32])> = b
+        .iter()
+        .flat_map(|entry| entry.writes.iter().map(move |k| (entry.address, *k)))
+        .collect();
+
+    let all_a: HashSet<(Address, [u8; 32])> = a
+        .iter()
+        .flat_map(|entry| {
+            entry.reads.iter().chain(entry.writes.iter())
+                .map(move |k| (entry.address, *k))
+        })
+        .collect();
+
+    let all_b: HashSet<(Address, [u8; 32])> = b
+        .iter()
+        .flat_map(|entry| {
+            entry.reads.iter().chain(entry.writes.iter())
+                .map(move |k| (entry.address, *k))
+        })
+        .collect();
+
+    for wk in &writes_a {
+        if all_b.contains(wk) {
+            return true;
+        }
+    }
+    for wk in &writes_b {
+        if all_a.contains(wk) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Schedule from raw access lists (works for both Transaction and EncryptedTx).
+/// Each element in `access_lists` is the access list for one transaction.
+pub fn schedule_from_access_lists(access_lists: &[Vec<AccessEntry>]) -> ExecutionSchedule {
+    let n = access_lists.len();
+    if n == 0 {
+        return ExecutionSchedule {
+            groups: vec![],
+            total_txs: 0,
+        };
+    }
+
+    let mut groups: Vec<ExecutionGroup> = Vec::new();
+
+    for i in 0..n {
+        let mut assigned = false;
+
+        for group in groups.iter_mut() {
+            let has_conflict = group
+                .tx_indices
+                .iter()
+                .any(|&j| access_lists_conflict(&access_lists[i], &access_lists[j]));
+
+            if !has_conflict {
+                group.tx_indices.push(i);
+                assigned = true;
+                break;
+            }
+        }
+
+        if !assigned {
+            groups.push(ExecutionGroup {
+                tx_indices: vec![i],
+            });
+        }
+    }
+
+    ExecutionSchedule {
+        groups,
+        total_txs: n,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- Create pyde-mempool crate with encrypted transaction pool
- EncryptedTx: plaintext fields visible for scheduling, payload threshold-encrypted
- Mempool: 500K capacity, FCFS ordering (no tips), oldest-first eviction
- 7 structural validations: FALCON sig structure, gas bounds [21K, ceiling],
  ciphertext non-empty, access list non-empty, size limit, expiry, dedup
- Block-level duplicate detection for validators
- PVM AccessListViolation trap on SLOAD/SSTORE of unlisted keys
- schedule_from_access_lists: generic scheduler for proposer step (step 2)
- ThresholdCiphertext: to_bytes() and encrypted_len() methods
- Document per-ciphertext decryption share upgrade for production security

## Test plan
- [x] 21 mempool tests pass
- [x] Encrypt/decrypt roundtrip with 2-of-3 threshold shares
- [x] Insufficient shares fails decryption
- [x] Reject: duplicate, expired, oversized, gas too low/high,
  empty sig, empty access list
- [x] FCFS arrival order preserved
- [x] Oldest evicted when full
- [x] Block selection respects gas limit, skips expired
- [x] Block-level duplicate detection
- [x] 734 total tests pass across workspace