### PR TITLE
Add threshold decryption coordinator and VRF transaction ordering

### DIFF
--- a/crates/mempool/src/decryption.rs
+++ b/crates/mempool/src/decryption.rs
@@ -1,0 +1,320 @@
+//! Threshold decryption coordinator per Chapter 6, Section 6.5 Step 3.
+//!
+//! After the proposer broadcasts the encrypted block and ordering is locked:
+//! 1. Each committee member generates a decryption share per tx
+//! 2. Shares are broadcast to ALL committee members (not just proposer)
+//! 3. Upon collecting 85+ shares → reconstruct and decrypt each tx
+//! 4. Decrypted txs are validated (full validation after decryption)
+//!
+//! The decryption happens AFTER ordering is committed (QC formed).
+
+use crate::encrypted::{decrypt_payload, EncryptedTx};
+use pyde_account::address::Address;
+use pyde_crypto::threshold::{
+    combine_shares, generate_decryption_share, DecryptionShare, KeyShare, ThresholdCiphertext,
+};
+use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
+
+/// Decryption state for a single block's worth of encrypted transactions.
+#[derive(Debug)]
+pub struct BlockDecryptor {
+    /// The encrypted transactions to decrypt.
+    pub encrypted_txs: Vec<EncryptedTx>,
+    /// Collected decryption shares per transaction: tx_index → shares.
+    shares: Vec<Vec<DecryptionShare>>,
+    /// Threshold required for decryption.
+    pub threshold: usize,
+    /// Whether each tx has been successfully decrypted.
+    decrypted: Vec<bool>,
+}
+
+impl BlockDecryptor {
+    /// Create a new decryptor for a set of encrypted transactions.
+    pub fn new(encrypted_txs: Vec<EncryptedTx>, threshold: usize) -> Self {
+        let n = encrypted_txs.len();
+        Self {
+            encrypted_txs,
+            shares: vec![Vec::new(); n],
+            threshold,
+            decrypted: vec![false; n],
+        }
+    }
+
+    /// Number of transactions to decrypt.
+    pub fn tx_count(&self) -> usize {
+        self.encrypted_txs.len()
+    }
+
+    /// Add a decryption share for a specific transaction.
+    /// Returns true if this share was new (not a duplicate index).
+    pub fn add_share(&mut self, tx_index: usize, share: DecryptionShare) -> bool {
+        if tx_index >= self.shares.len() {
+            return false;
+        }
+
+        // Check for duplicate share index
+        if self.shares[tx_index]
+            .iter()
+            .any(|s| s.index == share.index)
+        {
+            return false;
+        }
+
+        self.shares[tx_index].push(share);
+        true
+    }
+
+    /// Add decryption shares for ALL transactions from a single committee member.
+    /// This is the common case: one member generates one share per tx.
+    pub fn add_member_shares(&mut self, key_share: &KeyShare) {
+        // Generate all shares first to avoid borrow conflict
+        let shares: Vec<DecryptionShare> = self
+            .encrypted_txs
+            .iter()
+            .map(|tx| generate_decryption_share(key_share, &tx.ciphertext))
+            .collect();
+
+        for (i, share) in shares.into_iter().enumerate() {
+            self.add_share(i, share);
+        }
+    }
+
+    /// Number of shares collected for a specific transaction.
+    pub fn share_count(&self, tx_index: usize) -> usize {
+        self.shares.get(tx_index).map_or(0, |s| s.len())
+    }
+
+    /// Whether a specific transaction has enough shares to decrypt.
+    pub fn can_decrypt(&self, tx_index: usize) -> bool {
+        self.share_count(tx_index) >= self.threshold
+    }
+
+    /// Whether ALL transactions have enough shares.
+    pub fn all_ready(&self) -> bool {
+        (0..self.encrypted_txs.len()).all(|i| self.can_decrypt(i))
+    }
+
+    /// Decrypt a single transaction. Returns the full Transaction or error.
+    pub fn decrypt_tx(&mut self, tx_index: usize) -> Result<Transaction, String> {
+        if tx_index >= self.encrypted_txs.len() {
+            return Err("tx_index out of bounds".into());
+        }
+
+        let share_count = self.shares.get(tx_index).map_or(0, |s| s.len());
+        if share_count < self.threshold {
+            return Err(format!(
+                "insufficient shares: have {}, need {}",
+                share_count, self.threshold
+            ));
+        }
+
+        let (to, value, calldata) = decrypt_payload(
+            &self.encrypted_txs[tx_index].ciphertext,
+            &self.shares[tx_index],
+            self.threshold,
+        )?;
+
+        let enc_tx = &self.encrypted_txs[tx_index];
+        let tx = Transaction {
+            from: enc_tx.sender,
+            to,
+            value,
+            data: calldata,
+            gas_limit: enc_tx.gas_limit,
+            nonce: enc_tx.nonce,
+            signature: enc_tx.signature.clone(),
+            fee_payer: FeePayer::Sender,
+            access_list: enc_tx.access_list.clone(),
+            deadline: enc_tx.deadline,
+            chain_id: enc_tx.chain_id,
+            tx_type: TransactionType::Standard,
+        };
+
+        self.decrypted[tx_index] = true;
+        Ok(tx)
+    }
+
+    /// Decrypt all transactions. Returns the full list or stops at first error.
+    pub fn decrypt_all(&mut self) -> Result<Vec<Transaction>, String> {
+        let mut txs = Vec::with_capacity(self.encrypted_txs.len());
+        for i in 0..self.encrypted_txs.len() {
+            txs.push(self.decrypt_tx(i)?);
+        }
+        Ok(txs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encrypted::encrypt_transaction;
+    use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::threshold;
+    use pyde_tx::types::AccessEntry;
+
+    fn make_keys(n: usize, t: usize) -> (threshold::ThresholdPublicKey, Vec<KeyShare>) {
+        threshold::threshold_keygen(n, t)
+    }
+
+    fn dummy_access_list() -> Vec<AccessEntry> {
+        vec![AccessEntry {
+            address: derive_eoa_address(b"contract"),
+            reads: vec![[0x01; 32]],
+            writes: vec![],
+        }]
+    }
+
+    fn make_enc_tx(
+        pk: &threshold::ThresholdPublicKey,
+        to: Address,
+        value: u128,
+        calldata: &[u8],
+    ) -> EncryptedTx {
+        let sender = derive_eoa_address(b"sender");
+        encrypt_transaction(
+            sender, 0, 100_000, dummy_access_list(), None, 1,
+            vec![0xAA; 666], &to, value, calldata, pk,
+        )
+    }
+
+    // ========== Task 0526: Successful decryption with 85 shares ==========
+
+    #[test]
+    fn decrypt_with_threshold_shares() {
+        let (pk, key_shares) = make_keys(128, 85);
+        let to = derive_eoa_address(b"recipient");
+        let enc_tx = make_enc_tx(&pk, to, 5_000, b"transfer()");
+
+        let mut decryptor = BlockDecryptor::new(vec![enc_tx], 85);
+
+        // Add 85 shares
+        for ks in key_shares.iter().take(85) {
+            decryptor.add_member_shares(ks);
+        }
+
+        assert!(decryptor.can_decrypt(0));
+        let tx = decryptor.decrypt_tx(0).unwrap();
+        assert_eq!(tx.to, to);
+        assert_eq!(tx.value, 5_000);
+        assert_eq!(tx.data, b"transfer()");
+    }
+
+    // ========== Task 0527: Decryption fails with 84 shares ==========
+
+    #[test]
+    fn decrypt_fails_with_insufficient_shares() {
+        let (pk, key_shares) = make_keys(128, 85);
+        let to = derive_eoa_address(b"recipient");
+        let enc_tx = make_enc_tx(&pk, to, 100, b"");
+
+        let mut decryptor = BlockDecryptor::new(vec![enc_tx], 85);
+
+        // Only 84 shares
+        for ks in key_shares.iter().take(84) {
+            decryptor.add_member_shares(ks);
+        }
+
+        assert!(!decryptor.can_decrypt(0));
+        assert!(decryptor.decrypt_tx(0).is_err());
+    }
+
+    // ========== Task 0528: Invalid/duplicate share rejected ==========
+
+    #[test]
+    fn duplicate_share_rejected() {
+        let (pk, key_shares) = make_keys(3, 2);
+        let to = derive_eoa_address(b"recipient");
+        let enc_tx = make_enc_tx(&pk, to, 100, b"");
+
+        let mut decryptor = BlockDecryptor::new(vec![enc_tx.clone()], 2);
+
+        // Add same share twice
+        let share = generate_decryption_share(&key_shares[0], &enc_tx.ciphertext);
+        assert!(decryptor.add_share(0, share.clone()));
+        assert!(!decryptor.add_share(0, share)); // duplicate rejected
+
+        assert_eq!(decryptor.share_count(0), 1); // only counted once
+    }
+
+    // ========== Multiple transactions ==========
+
+    #[test]
+    fn decrypt_multiple_txs() {
+        let (pk, key_shares) = make_keys(3, 2);
+        let to1 = derive_eoa_address(b"alice");
+        let to2 = derive_eoa_address(b"bob");
+
+        let txs = vec![
+            make_enc_tx(&pk, to1, 1_000, b"call_a"),
+            make_enc_tx(&pk, to2, 2_000, b"call_b"),
+        ];
+
+        let mut decryptor = BlockDecryptor::new(txs, 2);
+
+        // Add 2 members' shares for all txs
+        for ks in key_shares.iter().take(2) {
+            decryptor.add_member_shares(ks);
+        }
+
+        assert!(decryptor.all_ready());
+
+        let decrypted = decryptor.decrypt_all().unwrap();
+        assert_eq!(decrypted.len(), 2);
+        assert_eq!(decrypted[0].to, to1);
+        assert_eq!(decrypted[0].value, 1_000);
+        assert_eq!(decrypted[0].data, b"call_a");
+        assert_eq!(decrypted[1].to, to2);
+        assert_eq!(decrypted[1].value, 2_000);
+        assert_eq!(decrypted[1].data, b"call_b");
+    }
+
+    // ========== Plaintext fields preserved ==========
+
+    #[test]
+    fn plaintext_fields_preserved_after_decrypt() {
+        let (pk, key_shares) = make_keys(3, 2);
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+
+        let enc_tx = encrypt_transaction(
+            sender, 42, 500_000, dummy_access_list(), Some(1_000_000), 7,
+            vec![0xAA; 666], &to, 999, b"data", &pk,
+        );
+
+        let mut decryptor = BlockDecryptor::new(vec![enc_tx], 2);
+        for ks in key_shares.iter().take(2) {
+            decryptor.add_member_shares(ks);
+        }
+
+        let tx = decryptor.decrypt_tx(0).unwrap();
+        assert_eq!(tx.from, sender);
+        assert_eq!(tx.nonce, 42);
+        assert_eq!(tx.gas_limit, 500_000);
+        assert_eq!(tx.deadline, Some(1_000_000));
+        assert_eq!(tx.chain_id, 7);
+        assert_eq!(tx.access_list.len(), 1);
+    }
+
+    // ========== Edge cases ==========
+
+    #[test]
+    fn out_of_bounds_tx_index() {
+        let decryptor = BlockDecryptor::new(vec![], 2);
+        assert!(!decryptor.can_decrypt(0));
+        assert_eq!(decryptor.share_count(99), 0);
+    }
+
+    #[test]
+    fn add_share_out_of_bounds() {
+        let (pk, key_shares) = make_keys(3, 2);
+        let to = derive_eoa_address(b"recipient");
+        let enc_tx = make_enc_tx(&pk, to, 100, b"");
+
+        // Create share from the tx's ciphertext
+        let share = generate_decryption_share(&key_shares[0], &enc_tx.ciphertext);
+
+        // Empty decryptor — index 0 is out of bounds
+        let mut decryptor = BlockDecryptor::new(vec![], 2);
+        assert!(!decryptor.add_share(0, share));
+    }
+}

--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -1,4 +1,6 @@
 //! Pyde Mempool: encrypted transaction pool with MEV protection.
 
+pub mod decryption;
 pub mod encrypted;
+pub mod ordering;
 pub mod pool;

--- a/crates/mempool/src/ordering.rs
+++ b/crates/mempool/src/ordering.rs
@@ -1,0 +1,173 @@
+//! VRF-based transaction ordering per Chapter 6, Section 6.5 Step 2.
+//!
+//! The proposer VRF-shuffles the selected transactions after collecting
+//! them from the mempool. This makes the final ordering unpredictable
+//! and unmanipulable — even by the proposer.
+//!
+//! Algorithm: Fisher-Yates shuffle seeded by VRF output.
+//! Verification: any node can reproduce the shuffle given the VRF output.
+
+use pyde_crypto::poseidon2::poseidon2_hash;
+
+/// Generate a deterministic shuffle seed from a VRF output.
+/// The VRF output is the proposer's VRF(sk, epoch_randomness || slot).
+pub fn shuffle_seed(vrf_output: &[u8; 32]) -> [u8; 32] {
+    // Domain-separate the shuffle seed from other VRF uses
+    let mut buf = Vec::with_capacity(44); // "vrf_shuffle"(11) + vrf_output(32)
+    buf.extend_from_slice(b"vrf_shuffle");
+    buf.extend_from_slice(vrf_output);
+    poseidon2_hash(&buf).to_bytes()
+}
+
+/// Derive a pseudo-random u64 from the seed at a given index.
+/// Used internally by the Fisher-Yates shuffle.
+fn prng_at(seed: &[u8; 32], index: usize) -> u64 {
+    let mut buf = Vec::with_capacity(40); // seed(32) + index(8)
+    buf.extend_from_slice(seed);
+    buf.extend_from_slice(&(index as u64).to_le_bytes());
+    let hash = poseidon2_hash(&buf).to_bytes();
+    u64::from_le_bytes(hash[..8].try_into().unwrap())
+}
+
+/// Fisher-Yates shuffle: deterministic, uniform, O(n).
+/// Shuffles indices [0..n) using the given seed.
+/// Returns the permutation as a vector of indices.
+pub fn vrf_shuffle(n: usize, seed: &[u8; 32]) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..n).collect();
+
+    // Fisher-Yates: iterate from last to first, swap with random earlier index
+    for i in (1..n).rev() {
+        let j = (prng_at(seed, i) as usize) % (i + 1);
+        indices.swap(i, j);
+    }
+
+    indices
+}
+
+/// Apply a shuffle permutation to a slice, returning a new Vec.
+pub fn apply_shuffle<T: Clone>(items: &[T], permutation: &[usize]) -> Vec<T> {
+    permutation.iter().map(|&i| items[i].clone()).collect()
+}
+
+/// Verify that a claimed ordering matches the VRF shuffle.
+/// Any node can reproduce the shuffle from the VRF output.
+pub fn verify_shuffle(n: usize, vrf_output: &[u8; 32], claimed_order: &[usize]) -> bool {
+    if claimed_order.len() != n {
+        return false;
+    }
+    let seed = shuffle_seed(vrf_output);
+    let expected = vrf_shuffle(n, &seed);
+    claimed_order == expected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========== Task 0532: Same seed → same ordering ==========
+
+    #[test]
+    fn same_seed_same_ordering() {
+        let seed = shuffle_seed(&[0xAA; 32]);
+        let perm1 = vrf_shuffle(100, &seed);
+        let perm2 = vrf_shuffle(100, &seed);
+        assert_eq!(perm1, perm2);
+    }
+
+    // ========== Task 0533: Different seed → different ordering ==========
+
+    #[test]
+    fn different_seed_different_ordering() {
+        let seed1 = shuffle_seed(&[0xAA; 32]);
+        let seed2 = shuffle_seed(&[0xBB; 32]);
+        let perm1 = vrf_shuffle(100, &seed1);
+        let perm2 = vrf_shuffle(100, &seed2);
+        assert_ne!(perm1, perm2);
+    }
+
+    // ========== Task 0534: Shuffle is statistically uniform ==========
+
+    #[test]
+    fn shuffle_is_permutation() {
+        let seed = shuffle_seed(&[0xCC; 32]);
+        let perm = vrf_shuffle(50, &seed);
+
+        // Every index appears exactly once
+        let mut sorted = perm.clone();
+        sorted.sort();
+        assert_eq!(sorted, (0..50).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn shuffle_distributes_uniformly() {
+        // Run 1000 shuffles with different seeds, check that index 0
+        // doesn't always end up in the same position
+        let mut first_positions = std::collections::HashSet::new();
+
+        for i in 0u64..1000 {
+            let mut vrf = [0u8; 32];
+            vrf[..8].copy_from_slice(&i.to_le_bytes());
+            let seed = shuffle_seed(&vrf);
+            let perm = vrf_shuffle(20, &seed);
+            first_positions.insert(perm[0]);
+        }
+
+        // With 1000 shuffles of 20 elements, index 0 should appear in
+        // many different positions (at least 15 of 20)
+        assert!(first_positions.len() >= 15);
+    }
+
+    // ========== Verification ==========
+
+    #[test]
+    fn verify_correct_shuffle() {
+        let vrf_output = [0xDD; 32];
+        let seed = shuffle_seed(&vrf_output);
+        let perm = vrf_shuffle(10, &seed);
+
+        assert!(verify_shuffle(10, &vrf_output, &perm));
+    }
+
+    #[test]
+    fn verify_wrong_shuffle_rejected() {
+        let vrf_output = [0xDD; 32];
+        let wrong_order: Vec<usize> = (0..10).rev().collect(); // reversed, not shuffled
+
+        assert!(!verify_shuffle(10, &vrf_output, &wrong_order));
+    }
+
+    #[test]
+    fn verify_wrong_length_rejected() {
+        let vrf_output = [0xDD; 32];
+        let perm = vrf_shuffle(10, &shuffle_seed(&vrf_output));
+
+        // Wrong n
+        assert!(!verify_shuffle(11, &vrf_output, &perm));
+    }
+
+    // ========== Apply shuffle ==========
+
+    #[test]
+    fn apply_shuffle_reorders() {
+        let items = vec!["a", "b", "c", "d"];
+        let perm = vec![2, 0, 3, 1]; // c, a, d, b
+        let shuffled = apply_shuffle(&items, &perm);
+        assert_eq!(shuffled, vec!["c", "a", "d", "b"]);
+    }
+
+    // ========== Edge cases ==========
+
+    #[test]
+    fn shuffle_single_element() {
+        let seed = shuffle_seed(&[0xFF; 32]);
+        let perm = vrf_shuffle(1, &seed);
+        assert_eq!(perm, vec![0]);
+    }
+
+    #[test]
+    fn shuffle_empty() {
+        let seed = shuffle_seed(&[0xFF; 32]);
+        let perm = vrf_shuffle(0, &seed);
+        assert!(perm.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- BlockDecryptor: collect per-tx decryption shares, decrypt when threshold met
- add_member_shares: bulk share generation from one committee member
- Duplicate share rejection, insufficient share detection
- decrypt_tx/decrypt_all: reconstruct plaintext Transaction from encrypted fields
- VRF Fisher-Yates shuffle with Poseidon2-seeded PRNG
- verify_shuffle: deterministic verification from VRF output
- Document serialization format decision point for Phase 7

## Test plan
- [x] 38 mempool tests pass
- [x] Decrypt with 85 shares (128-member keygen)
- [x] Decrypt fails with 84 shares
- [x] Duplicate share rejected
- [x] Multiple txs decrypted in batch
- [x] Plaintext fields preserved after decryption
- [x] Same seed → same ordering
- [x] Different seed → different ordering
- [x] Shuffle is valid permutation, statistically uniform
- [x] Verify correct/wrong shuffle
- [x] Edge cases: single element, empty, out of bounds