### PR TITLE
Add peer discovery with banning and typed message channels

### DIFF
--- a/crates/net/src/channels.rs
+++ b/crates/net/src/channels.rs
@@ -1,0 +1,321 @@
+//! Message channels: typed gossipsub message handling with validation.
+//!
+//! 5 channels per spec:
+//! 1. Consensus — validator votes, view changes (validators only)
+//! 2. Transactions — encrypted transactions from users
+//! 3. Blocks — proposed blocks and scheduled blocks
+//! 4. Proofs — ZK proofs from provers
+//! 5. Sync — state sync and witness delivery
+//!
+//! Each channel has message validation and deduplication.
+
+use pyde_crypto::poseidon2::poseidon2_hash;
+use std::collections::HashSet;
+
+/// Message channel identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Channel {
+    Consensus,
+    Transactions,
+    Blocks,
+    Proofs,
+    Sync,
+}
+
+impl Channel {
+    /// Topic string for this channel.
+    pub fn topic(&self) -> &'static str {
+        match self {
+            Channel::Consensus => "pyde/consensus/1",
+            Channel::Transactions => "pyde/transactions/1",
+            Channel::Blocks => "pyde/blocks/1",
+            Channel::Proofs => "pyde/proofs/1",
+            Channel::Sync => "pyde/sync/1",
+        }
+    }
+
+    /// Whether this channel is validator-only.
+    pub fn validator_only(&self) -> bool {
+        matches!(self, Channel::Consensus | Channel::Proofs)
+    }
+
+    /// From topic string.
+    pub fn from_topic(topic: &str) -> Option<Self> {
+        match topic {
+            "pyde/consensus/1" => Some(Channel::Consensus),
+            "pyde/transactions/1" => Some(Channel::Transactions),
+            "pyde/blocks/1" => Some(Channel::Blocks),
+            "pyde/proofs/1" => Some(Channel::Proofs),
+            "pyde/sync/1" => Some(Channel::Sync),
+            _ => None,
+        }
+    }
+
+    /// All channels.
+    pub fn all() -> &'static [Channel] {
+        &[
+            Channel::Consensus,
+            Channel::Transactions,
+            Channel::Blocks,
+            Channel::Proofs,
+            Channel::Sync,
+        ]
+    }
+}
+
+/// A network message with channel routing.
+#[derive(Clone, Debug)]
+pub struct NetworkMessage {
+    /// Which channel this message belongs to.
+    pub channel: Channel,
+    /// Raw message bytes.
+    pub data: Vec<u8>,
+    /// Message ID (Poseidon2 hash of data).
+    pub id: [u8; 32],
+}
+
+impl NetworkMessage {
+    /// Create a new network message.
+    pub fn new(channel: Channel, data: Vec<u8>) -> Self {
+        let id = poseidon2_hash(&data).to_bytes();
+        Self { channel, data, id }
+    }
+}
+
+/// Message validation result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ValidationResult {
+    /// Message is valid, propagate to peers.
+    Accept,
+    /// Message is invalid, discard and penalize sender.
+    Reject(String),
+    /// Message should not be propagated but is not invalid.
+    Ignore,
+}
+
+/// Validate a message based on its channel.
+pub fn validate_message(msg: &NetworkMessage, is_validator_peer: bool) -> ValidationResult {
+    // Check channel access
+    if msg.channel.validator_only() && !is_validator_peer {
+        return ValidationResult::Reject("non-validator sending to validator-only channel".into());
+    }
+
+    // Check message size limits per channel
+    let max_size = match msg.channel {
+        Channel::Consensus => 64 * 1024,       // 64KB (votes, view changes)
+        Channel::Transactions => 128 * 1024,    // 128KB (encrypted txs)
+        Channel::Blocks => 4 * 1024 * 1024,     // 4MB (full blocks)
+        Channel::Proofs => 16 * 1024 * 1024,     // 16MB (ZK proofs)
+        Channel::Sync => 8 * 1024 * 1024,        // 8MB (state chunks)
+    };
+
+    if msg.data.len() > max_size {
+        return ValidationResult::Reject(format!(
+            "message too large: {} bytes, max {} for {:?}",
+            msg.data.len(),
+            max_size,
+            msg.channel
+        ));
+    }
+
+    // Empty messages are invalid
+    if msg.data.is_empty() {
+        return ValidationResult::Reject("empty message".into());
+    }
+
+    ValidationResult::Accept
+}
+
+/// Message deduplication using a bounded set of recently seen message IDs.
+#[derive(Debug)]
+pub struct MessageDedup {
+    /// Recently seen message IDs.
+    seen: HashSet<[u8; 32]>,
+    /// Maximum number of IDs to track.
+    max_size: usize,
+    /// Order of insertion for eviction.
+    order: Vec<[u8; 32]>,
+}
+
+impl MessageDedup {
+    /// Create a new dedup tracker.
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            seen: HashSet::with_capacity(max_size),
+            max_size,
+            order: Vec::with_capacity(max_size),
+        }
+    }
+
+    /// Check if a message has been seen before.
+    /// Returns true if this is a NEW message (not seen before).
+    pub fn check_and_insert(&mut self, id: &[u8; 32]) -> bool {
+        if self.seen.contains(id) {
+            return false; // duplicate
+        }
+
+        // Evict oldest if full
+        if self.seen.len() >= self.max_size {
+            if let Some(oldest) = self.order.first().copied() {
+                self.seen.remove(&oldest);
+                self.order.remove(0);
+            }
+        }
+
+        self.seen.insert(*id);
+        self.order.push(*id);
+        true // new message
+    }
+
+    /// Number of tracked message IDs.
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+
+    /// Clear all tracked IDs.
+    pub fn clear(&mut self) {
+        self.seen.clear();
+        self.order.clear();
+    }
+}
+
+/// Default dedup cache size (track last 100K messages).
+pub const DEFAULT_DEDUP_SIZE: usize = 100_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========== Channel ==========
+
+    #[test]
+    fn all_channels_count() {
+        assert_eq!(Channel::all().len(), 5);
+    }
+
+    #[test]
+    fn channel_from_topic_roundtrip() {
+        for ch in Channel::all() {
+            assert_eq!(Channel::from_topic(ch.topic()), Some(*ch));
+        }
+    }
+
+    #[test]
+    fn unknown_topic() {
+        assert_eq!(Channel::from_topic("pyde/unknown/1"), None);
+    }
+
+    #[test]
+    fn validator_only_channels() {
+        assert!(Channel::Consensus.validator_only());
+        assert!(Channel::Proofs.validator_only());
+        assert!(!Channel::Transactions.validator_only());
+        assert!(!Channel::Blocks.validator_only());
+        assert!(!Channel::Sync.validator_only());
+    }
+
+    // ========== Task 0564: Message reaches subscribers ==========
+
+    #[test]
+    fn message_creation() {
+        let msg = NetworkMessage::new(Channel::Transactions, vec![0xAA; 100]);
+        assert_eq!(msg.channel, Channel::Transactions);
+        assert_eq!(msg.data.len(), 100);
+        assert_ne!(msg.id, [0u8; 32]); // hash is non-zero
+    }
+
+    #[test]
+    fn message_id_deterministic() {
+        let data = vec![0xBB; 50];
+        let msg1 = NetworkMessage::new(Channel::Blocks, data.clone());
+        let msg2 = NetworkMessage::new(Channel::Blocks, data);
+        assert_eq!(msg1.id, msg2.id);
+    }
+
+    // ========== Task 0565: Validator-only channel rejects non-validator ==========
+
+    #[test]
+    fn validator_channel_rejects_non_validator() {
+        let msg = NetworkMessage::new(Channel::Consensus, vec![0x01; 10]);
+        assert_eq!(
+            validate_message(&msg, false),
+            ValidationResult::Reject("non-validator sending to validator-only channel".into())
+        );
+    }
+
+    #[test]
+    fn validator_channel_accepts_validator() {
+        let msg = NetworkMessage::new(Channel::Consensus, vec![0x01; 10]);
+        assert_eq!(validate_message(&msg, true), ValidationResult::Accept);
+    }
+
+    #[test]
+    fn non_validator_channel_accepts_anyone() {
+        let msg = NetworkMessage::new(Channel::Transactions, vec![0x01; 10]);
+        assert_eq!(validate_message(&msg, false), ValidationResult::Accept);
+    }
+
+    // ========== Message size limits ==========
+
+    #[test]
+    fn oversized_message_rejected() {
+        let msg = NetworkMessage::new(Channel::Consensus, vec![0x01; 65 * 1024]); // >64KB
+        assert!(matches!(
+            validate_message(&msg, true),
+            ValidationResult::Reject(_)
+        ));
+    }
+
+    #[test]
+    fn empty_message_rejected() {
+        let msg = NetworkMessage::new(Channel::Transactions, vec![]);
+        assert!(matches!(
+            validate_message(&msg, false),
+            ValidationResult::Reject(_)
+        ));
+    }
+
+    // ========== Task 0566: Duplicate messages filtered ==========
+
+    #[test]
+    fn dedup_new_message_accepted() {
+        let mut dedup = MessageDedup::new(100);
+        assert!(dedup.check_and_insert(&[0xAA; 32]));
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn dedup_duplicate_rejected() {
+        let mut dedup = MessageDedup::new(100);
+        let id = [0xBB; 32];
+        assert!(dedup.check_and_insert(&id));  // first time: new
+        assert!(!dedup.check_and_insert(&id)); // second time: duplicate
+        assert_eq!(dedup.len(), 1);
+    }
+
+    #[test]
+    fn dedup_evicts_oldest_when_full() {
+        let mut dedup = MessageDedup::new(3);
+
+        let id1 = [0x01; 32];
+        let id2 = [0x02; 32];
+        let id3 = [0x03; 32];
+        let id4 = [0x04; 32];
+
+        assert!(dedup.check_and_insert(&id1));
+        assert!(dedup.check_and_insert(&id2));
+        assert!(dedup.check_and_insert(&id3));
+        assert_eq!(dedup.len(), 3);
+
+        // Adding 4th evicts id1 (oldest)
+        assert!(dedup.check_and_insert(&id4));
+        assert_eq!(dedup.len(), 3);
+
+        // id1 is no longer tracked, so it looks "new" again
+        assert!(dedup.check_and_insert(&id1));
+    }
+}

--- a/crates/net/src/discovery.rs
+++ b/crates/net/src/discovery.rs
@@ -1,0 +1,364 @@
+//! Peer discovery via Kademlia DHT and bootstrap nodes.
+//!
+//! Discovery flow:
+//! 1. Node starts with a list of bootstrap peers (hardcoded or configured)
+//! 2. Connects to bootstrap peers and joins the Kademlia DHT
+//! 3. Performs random walks to discover more peers
+//! 4. Maintains a set of known peers for reconnection
+
+use libp2p::{Multiaddr, PeerId};
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+/// Default bootstrap peers for mainnet (empty until launch).
+pub const MAINNET_BOOTSTRAP: &[&str] = &[];
+
+/// Default bootstrap peers for testnet.
+pub const TESTNET_BOOTSTRAP: &[&str] = &[];
+
+/// Ban duration in seconds.
+pub const DEFAULT_BAN_DURATION_SECS: u64 = 3600; // 1 hour
+
+/// Ban reason.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BanReason {
+    /// Sent invalid consensus messages.
+    InvalidConsensusMessage,
+    /// Sent invalid or malformed transactions.
+    InvalidTransaction,
+    /// Exceeded rate limits repeatedly.
+    RateLimitAbuse,
+    /// Protocol violation (wrong message format, etc.).
+    ProtocolViolation,
+    /// Manual ban by operator.
+    Manual(String),
+}
+
+/// A banned peer entry.
+#[derive(Clone, Debug)]
+pub struct BanEntry {
+    pub peer_id: PeerId,
+    pub reason: BanReason,
+    pub banned_at: Instant,
+    pub duration_secs: u64,
+}
+
+impl BanEntry {
+    /// Whether the ban has expired.
+    pub fn is_expired(&self) -> bool {
+        self.banned_at.elapsed().as_secs() >= self.duration_secs
+    }
+}
+
+/// Known peer with address and discovery metadata.
+#[derive(Clone, Debug)]
+pub struct KnownPeer {
+    pub peer_id: PeerId,
+    pub addresses: Vec<Multiaddr>,
+    pub last_seen: Instant,
+    pub connection_failures: u32,
+}
+
+/// Peer discovery and ban management.
+#[derive(Debug)]
+pub struct Discovery {
+    /// Bootstrap peer addresses.
+    bootstrap_peers: Vec<(PeerId, Multiaddr)>,
+    /// Known peers discovered via DHT.
+    known_peers: HashMap<PeerId, KnownPeer>,
+    /// Banned peers.
+    banned: HashMap<PeerId, BanEntry>,
+    /// Ban duration in seconds.
+    ban_duration: u64,
+}
+
+impl Discovery {
+    pub fn new() -> Self {
+        Self {
+            bootstrap_peers: Vec::new(),
+            known_peers: HashMap::new(),
+            banned: HashMap::new(),
+            ban_duration: DEFAULT_BAN_DURATION_SECS,
+        }
+    }
+
+    /// Add bootstrap peers from multiaddr strings.
+    pub fn add_bootstrap_peers(&mut self, addrs: &[String]) {
+        for addr_str in addrs {
+            if let Ok(addr) = addr_str.parse::<Multiaddr>() {
+                // Extract PeerId from the multiaddr if present
+                if let Some(peer_id) = extract_peer_id(&addr) {
+                    self.bootstrap_peers.push((peer_id, addr));
+                }
+            }
+        }
+    }
+
+    /// Get bootstrap peers for initial connection.
+    pub fn bootstrap_peers(&self) -> &[(PeerId, Multiaddr)] {
+        &self.bootstrap_peers
+    }
+
+    /// Record a discovered peer from DHT or gossip.
+    pub fn add_known_peer(&mut self, peer_id: PeerId, addr: Multiaddr) {
+        if self.is_banned(&peer_id) {
+            return; // don't track banned peers
+        }
+
+        let entry = self.known_peers.entry(peer_id).or_insert_with(|| KnownPeer {
+            peer_id,
+            addresses: Vec::new(),
+            last_seen: Instant::now(),
+            connection_failures: 0,
+        });
+
+        entry.last_seen = Instant::now();
+        if !entry.addresses.contains(&addr) {
+            entry.addresses.push(addr);
+        }
+    }
+
+    /// Record a failed connection attempt.
+    pub fn record_failure(&mut self, peer_id: &PeerId) {
+        if let Some(peer) = self.known_peers.get_mut(peer_id) {
+            peer.connection_failures += 1;
+        }
+    }
+
+    /// Get peers to try connecting to, sorted by reliability.
+    pub fn peers_to_connect(&self, max: usize) -> Vec<&KnownPeer> {
+        let mut peers: Vec<&KnownPeer> = self
+            .known_peers
+            .values()
+            .filter(|p| !self.is_banned(&p.peer_id))
+            .collect();
+
+        // Sort by fewest failures, then most recently seen
+        peers.sort_by(|a, b| {
+            a.connection_failures
+                .cmp(&b.connection_failures)
+                .then_with(|| b.last_seen.cmp(&a.last_seen))
+        });
+
+        peers.into_iter().take(max).collect()
+    }
+
+    /// Number of known peers.
+    pub fn known_peer_count(&self) -> usize {
+        self.known_peers.len()
+    }
+
+    // ========== Banning ==========
+
+    /// Ban a peer.
+    pub fn ban_peer(&mut self, peer_id: PeerId, reason: BanReason) {
+        self.banned.insert(
+            peer_id,
+            BanEntry {
+                peer_id,
+                reason,
+                banned_at: Instant::now(),
+                duration_secs: self.ban_duration,
+            },
+        );
+        // Remove from known peers
+        self.known_peers.remove(&peer_id);
+    }
+
+    /// Ban a peer with a custom duration.
+    pub fn ban_peer_for(&mut self, peer_id: PeerId, reason: BanReason, duration_secs: u64) {
+        self.banned.insert(
+            peer_id,
+            BanEntry {
+                peer_id,
+                reason,
+                banned_at: Instant::now(),
+                duration_secs,
+            },
+        );
+        self.known_peers.remove(&peer_id);
+    }
+
+    /// Check if a peer is currently banned.
+    pub fn is_banned(&self, peer_id: &PeerId) -> bool {
+        if let Some(entry) = self.banned.get(peer_id) {
+            !entry.is_expired()
+        } else {
+            false
+        }
+    }
+
+    /// Unban a peer manually.
+    pub fn unban_peer(&mut self, peer_id: &PeerId) {
+        self.banned.remove(peer_id);
+    }
+
+    /// Remove expired bans.
+    pub fn prune_expired_bans(&mut self) {
+        self.banned.retain(|_, entry| !entry.is_expired());
+    }
+
+    /// Number of currently banned peers.
+    pub fn banned_count(&self) -> usize {
+        self.banned.values().filter(|e| !e.is_expired()).count()
+    }
+
+    /// Get all banned peer IDs.
+    pub fn banned_peers(&self) -> Vec<PeerId> {
+        self.banned
+            .iter()
+            .filter(|(_, e)| !e.is_expired())
+            .map(|(id, _)| *id)
+            .collect()
+    }
+}
+
+impl Default for Discovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract PeerId from a multiaddr (if it ends with /p2p/<peer_id>).
+fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
+    addr.iter().find_map(|proto| {
+        if let libp2p::multiaddr::Protocol::P2p(peer_id) = proto {
+            Some(peer_id)
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn random_peer() -> PeerId {
+        PeerId::random()
+    }
+
+    fn dummy_addr() -> Multiaddr {
+        "/ip4/127.0.0.1/tcp/30303".parse().unwrap()
+    }
+
+    // ========== Task 0554: Peer discovery ==========
+
+    #[test]
+    fn add_known_peer() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+
+        disco.add_known_peer(peer, dummy_addr());
+        assert_eq!(disco.known_peer_count(), 1);
+    }
+
+    #[test]
+    fn known_peer_dedup_addresses() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+        let addr = dummy_addr();
+
+        disco.add_known_peer(peer, addr.clone());
+        disco.add_known_peer(peer, addr); // same addr
+        assert_eq!(disco.known_peers[&peer].addresses.len(), 1);
+    }
+
+    #[test]
+    fn peers_sorted_by_reliability() {
+        let mut disco = Discovery::new();
+        let good = random_peer();
+        let bad = random_peer();
+
+        disco.add_known_peer(good, dummy_addr());
+        disco.add_known_peer(bad, dummy_addr());
+        disco.record_failure(&bad);
+        disco.record_failure(&bad);
+
+        let to_connect = disco.peers_to_connect(10);
+        assert_eq!(to_connect[0].peer_id, good); // fewer failures first
+    }
+
+    // ========== Task 0555: Banned peer cannot reconnect ==========
+
+    #[test]
+    fn ban_peer() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+
+        disco.add_known_peer(peer, dummy_addr());
+        assert_eq!(disco.known_peer_count(), 1);
+
+        disco.ban_peer(peer, BanReason::ProtocolViolation);
+        assert!(disco.is_banned(&peer));
+        assert_eq!(disco.known_peer_count(), 0); // removed from known
+        assert_eq!(disco.banned_count(), 1);
+    }
+
+    #[test]
+    fn banned_peer_not_added_to_known() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+
+        disco.ban_peer(peer, BanReason::InvalidTransaction);
+        disco.add_known_peer(peer, dummy_addr()); // should be ignored
+        assert_eq!(disco.known_peer_count(), 0);
+    }
+
+    #[test]
+    fn banned_peer_excluded_from_connect_list() {
+        let mut disco = Discovery::new();
+        let good = random_peer();
+        let bad = random_peer();
+
+        disco.add_known_peer(good, dummy_addr());
+        disco.add_known_peer(bad, dummy_addr());
+        disco.ban_peer(bad, BanReason::RateLimitAbuse);
+
+        let to_connect = disco.peers_to_connect(10);
+        assert_eq!(to_connect.len(), 1);
+        assert_eq!(to_connect[0].peer_id, good);
+    }
+
+    #[test]
+    fn unban_peer() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+
+        disco.ban_peer(peer, BanReason::Manual("test".into()));
+        assert!(disco.is_banned(&peer));
+
+        disco.unban_peer(&peer);
+        assert!(!disco.is_banned(&peer));
+    }
+
+    #[test]
+    fn ban_with_custom_duration() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+
+        // Ban for 0 seconds → immediately expired
+        disco.ban_peer_for(peer, BanReason::ProtocolViolation, 0);
+        assert!(!disco.is_banned(&peer)); // already expired
+    }
+
+    // ========== Bootstrap ==========
+
+    #[test]
+    fn bootstrap_peer_parsing() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+        let addr = format!("/ip4/1.2.3.4/tcp/30303/p2p/{}", peer);
+
+        disco.add_bootstrap_peers(&[addr]);
+        assert_eq!(disco.bootstrap_peers().len(), 1);
+        assert_eq!(disco.bootstrap_peers()[0].0, peer);
+    }
+
+    #[test]
+    fn invalid_bootstrap_ignored() {
+        let mut disco = Discovery::new();
+        disco.add_bootstrap_peers(&["not_a_valid_addr".to_string()]);
+        assert_eq!(disco.bootstrap_peers().len(), 0);
+    }
+}

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -11,6 +11,8 @@
 //! messages are already signed with FALCON-512 and encrypted with
 //! threshold Kyber. See ROADMAP tasks for upgrade path.
 
+pub mod channels;
 pub mod config;
+pub mod discovery;
 pub mod node;
 pub mod peer;


### PR DESCRIPTION
## Summary
- Discovery: bootstrap peer parsing, known peer tracking with reliability sorting
- Banning: per-peer with reason, custom duration, auto-expiry
- Banned peers excluded from known list and connect recommendations
- 5 typed message channels: Consensus, Transactions, Blocks, Proofs, Sync
- Validator-only enforcement on Consensus and Proofs channels
- Per-channel message size limits (64KB consensus → 16MB proofs)
- Message deduplication with bounded LRU eviction (100K message IDs)
- Deterministic message IDs via Poseidon2 hash

## Test plan
- [x] 39 net tests pass
- [x] Known peer tracking, address dedup, reliability sorting
- [x] Ban/unban, banned excluded from connect list, banned peer not re-added
- [x] Bootstrap peer parsing, invalid addrs ignored
- [x] Channel ↔ topic roundtrip, validator-only enforcement
- [x] Oversized/empty messages rejected
- [x] Dedup: new accepted, duplicate rejected, LRU eviction