### PR TITLE
Add ZK prover crate with Plonky3, committee proving, and trace tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1024,6 +1024,12 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generic-array"
@@ -1513,6 +1519,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2314,6 +2329,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2341,6 +2357,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nums"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3c74f925fb8cfc49a8022f2afce48a0683b70f9e439885594e84c5edbf5b01"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,16 +2390,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "p3-air"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d47a7f2fbcbc8a086f14e8cf2fa27690db54b9e583e3811d629dd9915f66ba"
+dependencies = [
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34060cfb3a04c6ca61f6f5332e0f63e0727c339d4d6b11f70f8b080ce3e3e95d"
+dependencies = [
+ "p3-field 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-symmetric 0.2.0",
+ "p3-util 0.2.0",
+ "tracing",
+]
+
+[[package]]
 name = "p3-challenger"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20e42ba74a49c08c6e99f74cd9b343bfa31aa5721fea55079b18e3fd65f1dcbc"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
  "p3-monty-31",
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a12369ad2cea77f251436d55f39a104d5c34028e1ee286887f0e847297046b"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-challenger 0.2.0",
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-util 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51595e5196c92e17418c1757c8ec2f33b485a562fbd43231a99dc8824a6e3857"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-util 0.2.0",
  "tracing",
 ]
 
@@ -2382,12 +2461,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
  "spin 0.10.0",
  "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927218c608b033bfd3d193c8e2a7a3f8c291de04971e02bb61b807692d2c5cda"
+dependencies = [
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "nums",
+ "p3-util 0.2.0",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -2398,12 +2493,48 @@ checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
  "paste",
  "rand 0.9.2",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd34e2efd999c6c5318561f5ade1c53dafd0d4149b5ff5ba2fbcd781206d80"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-challenger 0.2.0",
+ "p3-commit",
+ "p3-dft 0.2.0",
+ "p3-field 0.2.0",
+ "p3-interpolation",
+ "p3-matrix 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-util 0.2.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bc5f4c1d47e22eb0cd6719389d5b02ba5b11305342f755d3ba7094deddb139"
+dependencies = [
+ "num-bigint",
+ "p3-dft 0.2.0",
+ "p3-field 0.2.0",
+ "p3-mds 0.2.0",
+ "p3-poseidon2 0.2.0",
+ "p3-symmetric 0.2.0",
+ "p3-util 0.2.0",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -2413,16 +2544,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64716244b5612622d4e78a4f48b74f6d3bb7b4085b7b6b25364b1dfca7198c66"
 dependencies = [
  "num-bigint",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-challenger 0.4.2",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
  "paste",
  "rand 0.9.2",
  "serde",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7911172855d0a9c7216c64a674a1a119ab2214b7451af843738626b3923e22f7"
+dependencies = [
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-util 0.2.0",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61af10867534e6516c71c918221781cb84165b852bff4568590c32f4b47edc86"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-field 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-util 0.2.0",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+ "transpose",
 ]
 
 [[package]]
@@ -2432,14 +2590,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
  "rand 0.9.2",
  "serde",
  "tracing",
  "transpose",
 ]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3925562a4c03183eafc92fd07b19f65ac6cb4b48d68c3920ce58d9bee6efe362"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -2449,15 +2613,47 @@ checksum = "0e5669ca75645f99cd001e9d0289a4eeff2bc2cd9dc3c6c3aaf22643966e83df"
 
 [[package]]
 name = "p3-mds"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75671b0c103f3be427823eacdb78e8a259aed03928cb349003ed0ace0736cf35"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft 0.2.0",
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-symmetric 0.2.0",
+ "p3-util 0.2.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-mds"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038763af23df9da653065867fd85b38626079031576c86fd537097e5be6a0da0"
 dependencies = [
- "p3-dft",
- "p3-field",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c291600d39bc355b7014bc6c72fa5062c7e57dfda5e20cc79e91c64e6268bd3d"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-commit",
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-symmetric 0.2.0",
+ "p3-util 0.2.0",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -2468,14 +2664,14 @@ checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
  "paste",
  "rand 0.9.2",
  "serde",
@@ -2486,15 +2682,39 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe2252b1ed041cfec362e4da3971df549f8b97f55d9f92b38a347934a4caca2"
+dependencies = [
+ "gcd",
+ "p3-field 0.2.0",
+ "p3-mds 0.2.0",
+ "p3-symmetric 0.2.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-poseidon2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903b73e4f9a7781a18561c74dc169cf03333497b57a8dd02aaeb130c0f386599"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5614190162fa38196a655a0ff1d6cb29c84c1b1f1cabaf686b7219fc667edf3"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-field 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -2504,7 +2724,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
+ "p3-field 0.4.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-uni-stark"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961760f74bc5f92207936da93d5c8828e617eca327c3697a1cc1119e96097a9b"
+dependencies = [
+ "itertools 0.13.0",
+ "p3-air",
+ "p3-challenger 0.2.0",
+ "p3-commit",
+ "p3-dft 0.2.0",
+ "p3-field 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-maybe-rayon 0.2.0",
+ "p3-util 0.2.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88dd5ca3eb6ff33cb20084778c32a6d68064a1913b4632437408c5a1098408b3"
+dependencies = [
  "serde",
 ]
 
@@ -2752,10 +3000,10 @@ version = "0.1.0"
 dependencies = [
  "falcon-rs",
  "ml-kem",
- "p3-field",
- "p3-goldilocks",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.4.2",
+ "p3-goldilocks 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
 ]
 
 [[package]]
@@ -2776,6 +3024,26 @@ dependencies = [
  "pyde-crypto",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "pyde-prover"
+version = "0.1.0"
+dependencies = [
+ "p3-air",
+ "p3-challenger 0.2.0",
+ "p3-commit",
+ "p3-field 0.2.0",
+ "p3-fri",
+ "p3-goldilocks 0.2.0",
+ "p3-matrix 0.2.0",
+ "p3-merkle-tree",
+ "p3-poseidon2 0.2.0",
+ "p3-symmetric 0.2.0",
+ "p3-uni-stark",
+ "pyde-account",
+ "pyde-crypto",
+ "pyde-vm",
 ]
 
 [[package]]
@@ -3146,7 +3414,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3486,7 +3754,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "crates/consensus",
     "crates/mempool",
     "crates/net",
+    "crates/prover",
 ]

--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -77,6 +77,9 @@ pub struct BlockHeader {
     /// Merkle root of the transactions in this block.
     pub tx_root: [u8; 32],
     /// State root after executing all transactions.
+    /// NOTE: Empty at proposal time (txs encrypted, can't compute).
+    /// Set by full nodes after optimistic execution at soft finality.
+    /// Proven correct by the STARK proof and committed in HardFinalityCert.
     pub state_root: [u8; 32],
     /// Block timestamp (Unix milliseconds).
     pub timestamp: u64,

--- a/crates/consensus/src/finality.rs
+++ b/crates/consensus/src/finality.rs
@@ -3,16 +3,62 @@
 //! **Soft finality (~400ms)**: block has a valid QC (86+ votes).
 //! - Content finality: transactions and ordering locked.
 //! - No rollback under honest majority (<1/3 malicious).
+//! - Full nodes execute optimistically → state changes applied here.
 //! - Use cases: payments, DEX orders, game state, social.
 //!
 //! **Hard finality (~2.5s)**: soft finality + STARK proof + 86+ finality signatures.
 //! - Execution correctness: mathematically proven state transition.
 //! - Irreversibility: cannot revert without breaking STARK assumptions.
+//! - State_root committed by the STARK proof, not the block proposer
+//!   (proposer can't compute state_root because txs are encrypted at proposal time).
 //! - Use cases: bridge transfers, large settlements, governance.
+//!
+//! **Proof failure does NOT mean state is wrong:**
+//! - Execution is deterministic — same inputs always produce same result.
+//! - A failed proof means the PROVER failed, not the state.
+//! - Full nodes computed state correctly at soft finality regardless.
+//! - The proof is for light clients, bridges, and hard finality anchor.
+//!
+//! **Unproven window:** if provers fall behind, block production adapts:
+//! - 0-100 unproven blocks: normal operation (400ms block time)
+//! - 100-500 unproven blocks: slowed production (800ms block time)
+//! - 500+ unproven blocks: empty blocks only (no new txs, chain liveness preserved)
+//! - Provers can catch up retroactively by proving backlog blocks.
 
 use crate::block::{QuorumCert, QUORUM_THRESHOLD};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey, FalconSignature};
+
+/// Max unproven blocks before production slows (doubled block time).
+pub const MAX_UNPROVEN_WINDOW: u64 = 100;
+
+/// Max unproven blocks before production pauses (empty blocks only).
+pub const MAX_UNPROVEN_CRITICAL: u64 = 500;
+
+/// Block time when in slowed mode (ms).
+pub const SLOWED_BLOCK_TIME_MS: u64 = 800;
+
+/// Production mode based on unproven backlog.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProductionMode {
+    /// Normal: 400ms block time, full transactions.
+    Normal,
+    /// Slowed: 800ms block time, full transactions. Provers catching up.
+    Slowed,
+    /// Paused: empty blocks only. Provers critically behind.
+    Paused,
+}
+
+/// Determine production mode from unproven block count.
+pub fn production_mode(unproven_count: u64) -> ProductionMode {
+    if unproven_count >= MAX_UNPROVEN_CRITICAL {
+        ProductionMode::Paused
+    } else if unproven_count >= MAX_UNPROVEN_WINDOW {
+        ProductionMode::Slowed
+    } else {
+        ProductionMode::Normal
+    }
+}
 
 /// Finality level for a block.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -222,6 +268,10 @@ pub struct FinalityTracker {
     pub latest_checkpoint: Option<FinalityCheckpoint>,
     /// Pending finality statuses for recent blocks.
     pub pending: Vec<FinalityStatus>,
+    /// Highest soft-finalized slot.
+    pub highest_soft_slot: u64,
+    /// Highest hard-finalized slot.
+    pub highest_hard_slot: u64,
 }
 
 impl FinalityTracker {
@@ -229,19 +279,38 @@ impl FinalityTracker {
         Self {
             latest_checkpoint: None,
             pending: Vec::new(),
+            highest_soft_slot: 0,
+            highest_hard_slot: 0,
         }
+    }
+
+    /// Number of blocks with soft finality but no hard finality.
+    pub fn unproven_count(&self) -> u64 {
+        self.highest_soft_slot.saturating_sub(self.highest_hard_slot)
+    }
+
+    /// Current production mode based on unproven backlog.
+    pub fn production_mode(&self) -> ProductionMode {
+        production_mode(self.unproven_count())
     }
 
     /// Record soft finality for a block.
     pub fn record_soft_finality(&mut self, slot: u64, block_hash: [u8; 32], qc: QuorumCert) {
         let status = soft_finality_status(slot, block_hash, &qc);
         if status.level == FinalityLevel::Soft {
+            if slot > self.highest_soft_slot {
+                self.highest_soft_slot = slot;
+            }
             self.pending.push(status);
         }
     }
 
     /// Record hard finality and create a checkpoint.
+    /// The state_root is committed by the STARK proof, not the block proposer.
     pub fn record_hard_finality(&mut self, cert: HardFinalityCert) {
+        if cert.slot > self.highest_hard_slot {
+            self.highest_hard_slot = cert.slot;
+        }
         let checkpoint = FinalityCheckpoint {
             slot: cert.slot,
             block_hash: cert.block_hash,
@@ -523,5 +592,73 @@ mod tests {
         // Only slot 15 remains pending
         assert_eq!(tracker.pending.len(), 1);
         assert_eq!(tracker.pending[0].slot, 15);
+    }
+
+    // ========== Unproven window ==========
+
+    #[test]
+    fn unproven_count_tracks_gap() {
+        let mut tracker = FinalityTracker::new();
+
+        // Soft finality for slots 1-50
+        for slot in 1..=50 {
+            tracker.record_soft_finality(slot, [slot as u8; 32], make_qc(slot, 90));
+        }
+        assert_eq!(tracker.unproven_count(), 50);
+
+        // Hard finality for slot 20
+        let cert = HardFinalityCert {
+            slot: 20,
+            block_hash: [20; 32],
+            proof_hash: [0xBB; 32],
+            state_root: [0xCC; 32],
+            voter_bitmap: (1u128 << 86) - 1,
+            signatures: vec![],
+        };
+        tracker.record_hard_finality(cert);
+        assert_eq!(tracker.unproven_count(), 30); // 50 - 20
+    }
+
+    #[test]
+    fn production_mode_normal() {
+        assert_eq!(production_mode(0), ProductionMode::Normal);
+        assert_eq!(production_mode(99), ProductionMode::Normal);
+    }
+
+    #[test]
+    fn production_mode_slowed() {
+        assert_eq!(production_mode(100), ProductionMode::Slowed);
+        assert_eq!(production_mode(499), ProductionMode::Slowed);
+    }
+
+    #[test]
+    fn production_mode_paused() {
+        assert_eq!(production_mode(500), ProductionMode::Paused);
+        assert_eq!(production_mode(1000), ProductionMode::Paused);
+    }
+
+    #[test]
+    fn tracker_production_mode() {
+        let mut tracker = FinalityTracker::new();
+        assert_eq!(tracker.production_mode(), ProductionMode::Normal);
+
+        // Soft finality races ahead
+        for slot in 1..=150 {
+            tracker.record_soft_finality(slot, [slot as u8; 32], make_qc(slot, 90));
+        }
+        assert_eq!(tracker.production_mode(), ProductionMode::Slowed);
+
+        // Hard finality catches up
+        let cert = HardFinalityCert {
+            slot: 100,
+            block_hash: [100; 32],
+            proof_hash: [0xBB; 32],
+            state_root: [0xCC; 32],
+            voter_bitmap: (1u128 << 86) - 1,
+            signatures: vec![],
+        };
+        tracker.record_hard_finality(cert);
+        assert_eq!(tracker.unproven_count(), 50); // 150 - 100
+        assert_eq!(tracker.production_mode(), ProductionMode::Normal);
     }
 }

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pyde-prover"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+pyde-crypto = { path = "../crypto" }
+pyde-account = { path = "../account" }
+pyde-vm = { path = "../pvm" }
+p3-field = "0.2"
+p3-air = "0.2"
+p3-matrix = "0.2"
+p3-uni-stark = "0.2"
+p3-goldilocks = "0.2"
+p3-challenger = "0.2"
+p3-commit = "0.2"
+p3-fri = "0.2"
+p3-merkle-tree = "0.2"
+p3-poseidon2 = "0.2"
+p3-symmetric = "0.2"

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1,0 +1,77 @@
+//! Pyde ZK Prover: STARK proof generation using Plonky3.
+//!
+//! ## Architecture: Committee-Based Proving
+//!
+//! Provers are organized into a **prover committee** (e.g., 16 members per epoch).
+//! When a ScheduledBlock arrives:
+//!
+//! 1. **All members execute independently** (no trust — each member executes
+//!    all txs using witnesses verified against the previous block's proven
+//!    state_root).
+//! 2. **Parallel groups divided among members** (round-robin assignment).
+//!    Each member generates STARK proofs for their assigned groups only.
+//! 3. **Rotating aggregator** (slot % committee_size) collects sub-proofs
+//!    and recursively combines them into a single block proof.
+//! 4. **Block proof submitted** to validator committee for hard finality.
+//!
+//! If a member fails to submit their sub-proof by the deadline (t=1500ms),
+//! the aggregator broadcasts unclaimed groups. First available member picks
+//! up the work. If aggregator fails, next member takes over.
+//!
+//! ## Group-Level Proving (Not Per-Transaction)
+//!
+//! Each parallel execution group produces one trace and one STARK proof.
+//! This keeps proof count manageable at high throughput:
+//!
+//! - Per-tx: 50K txs → 50K proofs (~5 GB, infeasible)
+//! - Per-group: ~50 groups → 50 proofs (~5 MB, practical)
+//!
+//! Group proofs are recursively composed into a single block proof.
+//!
+//! ## Proof and State Commitment
+//!
+//! The proposer cannot include a state_root in the block header because
+//! transactions are encrypted at proposal time. The state_root is committed
+//! by the STARK proof and included in the HardFinalityCert:
+//!
+//! - Proposal:     tx_root ✓, state_root unknown (txs encrypted)
+//! - Soft finality: ordering locked, full nodes execute optimistically
+//! - Hard finality: STARK proof commits state_root, proven correct
+//!
+//! Full nodes apply state changes at soft finality (optimistic execution).
+//! The proof CONFIRMS correctness — it doesn't cause execution. A proof
+//! failure means the prover failed, not the state. State reverts only
+//! happen in catastrophic consensus failures (43+ malicious validators).
+//!
+//! ## Witness Verification
+//!
+//! Provers receive state witnesses from full nodes. Each witness contains
+//! (key, value, merkle_proof) verified against the previous block's proven
+//! state_root. A rogue full node cannot corrupt execution because:
+//!
+//! - Calldata comes from the ScheduledBlock (signed by 86+ validators)
+//! - Witness values are bound to the proven state_root via Merkle proofs
+//! - Modified calldata or wrong state values fail Merkle verification
+//!
+//! ## Proving Failure Recovery
+//!
+//! If the prover committee fails to generate a proof:
+//!
+//! - Soft finality is unaffected (no proof needed, 400ms confirmation)
+//! - Hard finality is delayed until proof is submitted
+//! - Block production continues, unproven blocks accumulate
+//! - MAX_UNPROVEN_WINDOW (100 blocks): production slows (800ms block time)
+//! - MAX_UNPROVEN_CRITICAL (500 blocks): empty blocks only (no new txs)
+//! - Absent provers slashed (same graduated penalties as validators)
+//! - Provers can catch up retroactively (prove backlog blocks)
+//!
+//! ## Competitive vs Committee
+//!
+//! Unlike competitive proving (race to submit, wasteful), committee proving
+//! divides work efficiently. Market dynamics still apply: prover rewards
+//! incentivize fast hardware, and the committee is selected from registered
+//! provers each epoch.
+
+pub mod registry;
+pub mod trace;
+

--- a/crates/prover/src/registry.rs
+++ b/crates/prover/src/registry.rs
@@ -1,0 +1,521 @@
+//! Prover registry: bond management for ZK provers.
+//!
+//! Provers post a 1,000 PYDE bond (not stake). The bond is slashable
+//! for submitting invalid proofs. Registration, unbonding, and slash
+//! execution are handled here.
+
+use pyde_account::address::Address;
+
+/// Required bond to register as a prover (in quanta, 1,000 PYDE).
+pub const PROVER_BOND: u128 = 1_000_000_000_000;
+
+/// Minimum prover committee size.
+pub const MIN_PROVER_COMMITTEE: usize = 4;
+
+/// Maximum prover committee size (coordination overhead cap).
+pub const MAX_PROVER_COMMITTEE: usize = 32;
+
+/// Unbonding period in blocks (~7 days at 400ms blocks).
+pub const PROVER_UNBONDING_PERIOD: u64 = 1_512_000;
+
+/// Prover status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProverStatus {
+    /// Active and eligible to submit proofs.
+    Active,
+    /// Initiated exit, bond locked during unbonding.
+    Unbonding { exit_block: u64 },
+    /// Unbonding complete, bond returned.
+    Exited,
+    /// Slashed — bond partially or fully burned.
+    Slashed,
+}
+
+/// A registered prover.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Prover {
+    /// Prover's address.
+    pub address: Address,
+    /// Public key for proof verification.
+    pub public_key: Vec<u8>,
+    /// Bond amount (starts at PROVER_BOND, reduced by slashing).
+    pub bond: u128,
+    /// Current status.
+    pub status: ProverStatus,
+    /// Total proofs submitted.
+    pub proofs_submitted: u64,
+    /// Total invalid proofs (for reputation).
+    pub invalid_proofs: u64,
+}
+
+/// Prover registry error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProverError {
+    InsufficientBond { required: u128, provided: u128 },
+    AlreadyRegistered(Address),
+    NotFound(Address),
+    AlreadyUnbonding(Address),
+    NotActive(Address),
+}
+
+/// The prover registry.
+#[derive(Clone, Debug, Default)]
+pub struct ProverRegistry {
+    pub provers: Vec<Prover>,
+}
+
+impl ProverRegistry {
+    pub fn new() -> Self {
+        Self {
+            provers: Vec::new(),
+        }
+    }
+
+    /// Register a new prover with the required bond.
+    pub fn register(
+        &mut self,
+        address: Address,
+        public_key: Vec<u8>,
+        bond: u128,
+    ) -> Result<(), ProverError> {
+        if bond < PROVER_BOND {
+            return Err(ProverError::InsufficientBond {
+                required: PROVER_BOND,
+                provided: bond,
+            });
+        }
+
+        if self.provers.iter().any(|p| p.address == address && p.status == ProverStatus::Active) {
+            return Err(ProverError::AlreadyRegistered(address));
+        }
+
+        self.provers.push(Prover {
+            address,
+            public_key,
+            bond: PROVER_BOND,
+            status: ProverStatus::Active,
+            proofs_submitted: 0,
+            invalid_proofs: 0,
+        });
+
+        Ok(())
+    }
+
+    /// Initiate unbonding (exit).
+    pub fn unbond(&mut self, address: &Address, current_block: u64) -> Result<(), ProverError> {
+        let prover = self
+            .provers
+            .iter_mut()
+            .find(|p| p.address == *address && p.status == ProverStatus::Active)
+            .ok_or(ProverError::NotFound(*address))?;
+
+        prover.status = ProverStatus::Unbonding {
+            exit_block: current_block,
+        };
+        Ok(())
+    }
+
+    /// Process unbonding: release provers whose period has elapsed.
+    /// Returns list of (address, bond_to_return).
+    pub fn process_unbonding(&mut self, current_block: u64) -> Vec<(Address, u128)> {
+        let mut released = Vec::new();
+        for p in &mut self.provers {
+            if let ProverStatus::Unbonding { exit_block } = p.status {
+                if current_block >= exit_block + PROVER_UNBONDING_PERIOD {
+                    released.push((p.address, p.bond));
+                    p.status = ProverStatus::Exited;
+                }
+            }
+        }
+        released
+    }
+
+    /// Slash a prover's bond. Returns (amount_burned, finder_fee).
+    pub fn slash(
+        &mut self,
+        address: &Address,
+        slash_percent: u128,
+    ) -> Result<(u128, u128), ProverError> {
+        let prover = self
+            .provers
+            .iter_mut()
+            .find(|p| p.address == *address)
+            .ok_or(ProverError::NotFound(*address))?;
+
+        let slash_amount = prover.bond * slash_percent / 100;
+        let finder_fee = slash_amount * 10 / 100; // 10% finder's fee
+        let burned = slash_amount - finder_fee;
+
+        prover.bond -= slash_amount;
+        prover.invalid_proofs += 1;
+
+        if prover.bond == 0 {
+            prover.status = ProverStatus::Slashed;
+        }
+
+        Ok((burned, finder_fee))
+    }
+
+    /// Record a successful proof submission.
+    pub fn record_proof(&mut self, address: &Address) -> Result<(), ProverError> {
+        let prover = self
+            .provers
+            .iter_mut()
+            .find(|p| p.address == *address && p.status == ProverStatus::Active)
+            .ok_or(ProverError::NotActive(*address))?;
+
+        prover.proofs_submitted += 1;
+        Ok(())
+    }
+
+    /// Get active provers.
+    pub fn active_provers(&self) -> Vec<&Prover> {
+        self.provers.iter().filter(|p| p.status == ProverStatus::Active).collect()
+    }
+
+    /// Number of active provers.
+    pub fn active_count(&self) -> usize {
+        self.active_provers().len()
+    }
+
+    /// Get a prover by address.
+    pub fn get(&self, address: &Address) -> Option<&Prover> {
+        self.provers.iter().find(|p| p.address == *address)
+    }
+
+    /// Compute the prover committee size based on active provers and backlog.
+    ///
+    /// - Base: half of active provers (rest are backup)
+    /// - Scale up 1.5x if unproven backlog > 50
+    /// - Clamped to [MIN_PROVER_COMMITTEE, MAX_PROVER_COMMITTEE]
+    pub fn committee_size(&self, unproven_backlog: u64) -> usize {
+        compute_committee_size(self.active_count(), unproven_backlog)
+    }
+
+    /// Select a prover committee for an epoch.
+    ///
+    /// Uses all active provers up to MAX_PROVER_COMMITTEE (minimum viable).
+    /// Sorted by highest proof count (most reliable get priority if capped).
+    /// Overflow provers serve as backup (pick up unclaimed groups on failure).
+    pub fn select_committee(
+        &self,
+        unproven_backlog: u64,
+    ) -> ProverCommittee {
+        let size = self.committee_size(unproven_backlog);
+
+        let mut candidates: Vec<&Prover> = self.active_provers();
+        // Sort by most proofs submitted (most reliable first)
+        candidates.sort_by(|a, b| b.proofs_submitted.cmp(&a.proofs_submitted));
+
+        let members: Vec<Prover> = candidates
+            .iter()
+            .take(size)
+            .map(|p| (*p).clone())
+            .collect();
+
+        // Only overflow beyond MAX becomes backup
+        let backups: Vec<Prover> = candidates
+            .iter()
+            .skip(size)
+            .map(|p| (*p).clone())
+            .collect();
+
+        ProverCommittee {
+            members,
+            backups,
+        }
+    }
+}
+
+/// Compute committee size from active prover count and backlog.
+///
+/// Strategy: use all available provers (minimum viable), capped at MAX.
+/// Don't bench provers unnecessarily — more provers = faster proving.
+/// Backlog doesn't increase size (we use everyone already), it's a signal
+/// for the market to attract more prover registrations.
+pub fn compute_committee_size(active_provers: usize, _unproven_backlog: u64) -> usize {
+    active_provers.clamp(MIN_PROVER_COMMITTEE, MAX_PROVER_COMMITTEE)
+}
+
+/// A prover committee for an epoch.
+#[derive(Clone, Debug)]
+pub struct ProverCommittee {
+    /// Active committee members (assigned groups).
+    pub members: Vec<Prover>,
+    /// Backup provers (pick up unclaimed groups on failure).
+    pub backups: Vec<Prover>,
+}
+
+impl ProverCommittee {
+    /// Number of committee members.
+    pub fn size(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Get the aggregator for a given slot (rotating).
+    pub fn aggregator(&self, slot: u64) -> Option<&Prover> {
+        if self.members.is_empty() {
+            return None;
+        }
+        Some(&self.members[slot as usize % self.members.len()])
+    }
+
+    /// Assign parallel groups to committee members (round-robin).
+    pub fn assign_groups(&self, num_groups: usize) -> Vec<Vec<usize>> {
+        let mut assignments = vec![vec![]; self.members.len()];
+        if self.members.is_empty() {
+            return assignments;
+        }
+        for group_idx in 0..num_groups {
+            assignments[group_idx % self.members.len()].push(group_idx);
+        }
+        assignments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_account::address::derive_eoa_address;
+
+    fn prover_addr(seed: u8) -> (Address, Vec<u8>) {
+        let pk = vec![seed; 897];
+        let addr = derive_eoa_address(&pk);
+        (addr, pk)
+    }
+
+    // ========== Task 1210-1211: Prover registration ==========
+
+    #[test]
+    fn register_prover() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+        assert_eq!(reg.active_count(), 1);
+        assert_eq!(reg.get(&addr).unwrap().bond, PROVER_BOND);
+    }
+
+    #[test]
+    fn reject_insufficient_bond() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        let err = reg.register(addr, pk, PROVER_BOND - 1).unwrap_err();
+        assert!(matches!(err, ProverError::InsufficientBond { .. }));
+    }
+
+    #[test]
+    fn reject_duplicate_registration() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk.clone(), PROVER_BOND).unwrap();
+        let err = reg.register(addr, pk, PROVER_BOND).unwrap_err();
+        assert!(matches!(err, ProverError::AlreadyRegistered(_)));
+    }
+
+    // ========== Task 1212: Slash reduces bond ==========
+
+    #[test]
+    fn slash_reduces_bond() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+
+        let (burned, fee) = reg.slash(&addr, 100).unwrap(); // 100% slash
+        assert_eq!(burned + fee, PROVER_BOND);
+        assert_eq!(fee, PROVER_BOND / 10); // 10% finder's fee
+
+        let prover = reg.get(&addr).unwrap();
+        assert_eq!(prover.bond, 0);
+        assert_eq!(prover.status, ProverStatus::Slashed);
+        assert_eq!(prover.invalid_proofs, 1);
+    }
+
+    #[test]
+    fn partial_slash() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+
+        reg.slash(&addr, 50).unwrap(); // 50% slash
+        let prover = reg.get(&addr).unwrap();
+        assert_eq!(prover.bond, PROVER_BOND / 2);
+        assert_eq!(prover.status, ProverStatus::Active); // still active, has remaining bond
+    }
+
+    // ========== Task 1213: Unbond returns bond ==========
+
+    #[test]
+    fn unbond_and_release() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+
+        reg.unbond(&addr, 1000).unwrap();
+        assert!(matches!(
+            reg.get(&addr).unwrap().status,
+            ProverStatus::Unbonding { exit_block: 1000 }
+        ));
+
+        // Before period
+        let released = reg.process_unbonding(1000 + PROVER_UNBONDING_PERIOD - 1);
+        assert!(released.is_empty());
+
+        // After period
+        let released = reg.process_unbonding(1000 + PROVER_UNBONDING_PERIOD);
+        assert_eq!(released.len(), 1);
+        assert_eq!(released[0], (addr, PROVER_BOND));
+        assert_eq!(reg.get(&addr).unwrap().status, ProverStatus::Exited);
+    }
+
+    // ========== Proof tracking ==========
+
+    #[test]
+    fn record_proof() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+
+        reg.record_proof(&addr).unwrap();
+        reg.record_proof(&addr).unwrap();
+        assert_eq!(reg.get(&addr).unwrap().proofs_submitted, 2);
+    }
+
+    #[test]
+    fn inactive_prover_cannot_submit() {
+        let mut reg = ProverRegistry::new();
+        let (addr, pk) = prover_addr(1);
+        reg.register(addr, pk, PROVER_BOND).unwrap();
+        reg.unbond(&addr, 0).unwrap();
+
+        assert!(reg.record_proof(&addr).is_err());
+    }
+
+    // ========== Committee sizing ==========
+
+    fn register_n_provers(reg: &mut ProverRegistry, n: usize) {
+        for i in 0..n {
+            let (addr, pk) = prover_addr(i as u8);
+            reg.register(addr, pk, PROVER_BOND).unwrap();
+        }
+    }
+
+    #[test]
+    fn committee_size_minimum() {
+        // 2 provers → clamped to MIN = 4 (use all available anyway)
+        assert_eq!(compute_committee_size(2, 0), MIN_PROVER_COMMITTEE);
+        assert_eq!(compute_committee_size(4, 0), MIN_PROVER_COMMITTEE);
+    }
+
+    #[test]
+    fn committee_size_uses_all_provers() {
+        // 20 provers → all 20 in committee
+        assert_eq!(compute_committee_size(20, 0), 20);
+    }
+
+    #[test]
+    fn committee_size_backlog_doesnt_change_size() {
+        // All provers already in committee, backlog is market signal
+        assert_eq!(compute_committee_size(20, 0), 20);
+        assert_eq!(compute_committee_size(20, 100), 20);
+    }
+
+    #[test]
+    fn committee_size_maximum() {
+        // 100 provers → capped at MAX = 32
+        assert_eq!(compute_committee_size(100, 0), MAX_PROVER_COMMITTEE);
+    }
+
+    #[test]
+    fn committee_size_from_registry() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 20);
+        assert_eq!(reg.committee_size(0), 20); // all 20
+    }
+
+    // ========== Committee selection ==========
+
+    #[test]
+    fn select_committee_uses_all_provers() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 20);
+
+        let committee = reg.select_committee(0);
+        assert_eq!(committee.size(), 20);       // all provers in committee
+        assert_eq!(committee.backups.len(), 0);  // no overflow
+    }
+
+    #[test]
+    fn select_committee_overflow_becomes_backup() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 40); // exceeds MAX_PROVER_COMMITTEE (32)
+
+        let committee = reg.select_committee(0);
+        assert_eq!(committee.size(), MAX_PROVER_COMMITTEE); // capped at 32
+        assert_eq!(committee.backups.len(), 8);               // overflow as backup
+    }
+
+    #[test]
+    fn select_committee_sorted_by_reputation() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 10);
+
+        // Give prover 5 the most proofs
+        let addr5 = reg.provers[5].address;
+        for _ in 0..100 {
+            reg.record_proof(&addr5).unwrap();
+        }
+
+        let committee = reg.select_committee(0);
+        // Most prolific prover should be first member
+        assert_eq!(committee.members[0].address, addr5);
+    }
+
+    // ========== Group assignment ==========
+
+    #[test]
+    fn assign_groups_round_robin() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 8);
+        let committee = reg.select_committee(0);
+
+        let assignments = committee.assign_groups(10);
+        assert_eq!(assignments.len(), committee.size());
+
+        // All groups assigned
+        let total: usize = assignments.iter().map(|a| a.len()).sum();
+        assert_eq!(total, 10);
+
+        // Roughly equal distribution
+        for a in &assignments {
+            assert!(a.len() >= 1 && a.len() <= 3);
+        }
+    }
+
+    #[test]
+    fn assign_groups_fewer_than_members() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 20);
+        let committee = reg.select_committee(0); // 10 members
+
+        let assignments = committee.assign_groups(3); // only 3 groups
+        let assigned_members = assignments.iter().filter(|a| !a.is_empty()).count();
+        assert_eq!(assigned_members, 3); // only 3 members get work
+    }
+
+    // ========== Aggregator ==========
+
+    #[test]
+    fn aggregator_rotates() {
+        let mut reg = ProverRegistry::new();
+        register_n_provers(&mut reg, 10);
+        let committee = reg.select_committee(0);
+
+        let agg0 = committee.aggregator(0).unwrap().address;
+        let agg1 = committee.aggregator(1).unwrap().address;
+        assert_ne!(agg0, agg1); // different aggregators per slot
+
+        // Wraps around
+        let agg_wrap = committee.aggregator(committee.size() as u64).unwrap().address;
+        assert_eq!(agg_wrap, agg0); // back to first
+    }
+}

--- a/crates/prover/src/trace.rs
+++ b/crates/prover/src/trace.rs
@@ -1,0 +1,323 @@
+//! Execution trace table for STARK proof generation.
+//!
+//! The trace table captures every cycle of PVM execution. Each row
+//! represents one instruction execution with ~50-70 columns:
+//!
+//! - Program counter, opcode, decoded fields
+//! - 16 GP registers (r0-r15)
+//! - 8 wide registers (w0-w7), 4 limbs each = 32 columns
+//! - Memory read/write addresses and values
+//! - Storage read/write keys and values
+//! - Gas counter
+//! - Flags (overflow, zero, etc.)
+//!
+//! The Plonky3 AIR (Algebraic Intermediate Representation) defines
+//! constraints that each row must satisfy. The prover generates a
+//! STARK proof that the trace is valid.
+
+use p3_field::{AbstractField, PrimeField64};
+use p3_goldilocks::Goldilocks;
+
+/// Number of GP register columns (r0-r15).
+pub const NUM_GP_REGS: usize = 16;
+
+/// Number of wide register columns (w0-w7, 4 u64 limbs each).
+pub const NUM_WIDE_LIMBS: usize = 8 * 4; // 32
+
+/// Trace row: one PVM execution step.
+///
+/// All values are Goldilocks field elements (u64 mod p).
+#[derive(Clone, Debug)]
+pub struct TraceRow {
+    // === Control flow (5 columns) ===
+    /// Program counter.
+    pub pc: Goldilocks,
+    /// Opcode (as field element).
+    pub opcode: Goldilocks,
+    /// Decoded rd field.
+    pub rd: Goldilocks,
+    /// Decoded rs1 field.
+    pub rs1: Goldilocks,
+    /// Decoded rs2/imm field.
+    pub rs2_imm: Goldilocks,
+
+    // === GP registers (16 columns) ===
+    pub gp_regs: [Goldilocks; NUM_GP_REGS],
+
+    // === Wide registers (32 columns) ===
+    /// w0-w7, each split into 4 × u64 limbs for field compatibility.
+    pub wide_limbs: [Goldilocks; NUM_WIDE_LIMBS],
+
+    // === Memory (4 columns) ===
+    /// Memory read address (0 if no read).
+    pub mem_read_addr: Goldilocks,
+    /// Memory read value.
+    pub mem_read_val: Goldilocks,
+    /// Memory write address (0 if no write).
+    pub mem_write_addr: Goldilocks,
+    /// Memory write value.
+    pub mem_write_val: Goldilocks,
+
+    // === Storage (4 columns) ===
+    /// Storage key (hash, lower 64 bits).
+    pub storage_key_lo: Goldilocks,
+    /// Storage key (hash, upper 64 bits).
+    pub storage_key_hi: Goldilocks,
+    /// Storage value (lower 64 bits).
+    pub storage_val_lo: Goldilocks,
+    /// Storage value (upper 64 bits).
+    pub storage_val_hi: Goldilocks,
+
+    // === Gas (2 columns) ===
+    /// Gas used this step.
+    pub gas_step: Goldilocks,
+    /// Cumulative gas used.
+    pub gas_cumulative: Goldilocks,
+
+    // === Flags (3 columns) ===
+    /// Is this a memory instruction?
+    pub is_memory_op: Goldilocks,
+    /// Is this a storage instruction?
+    pub is_storage_op: Goldilocks,
+    /// Is this the last row (HALT/REVERT)?
+    pub is_final: Goldilocks,
+}
+
+impl TraceRow {
+    /// Total number of columns in the trace.
+    pub const NUM_COLUMNS: usize = 5 + NUM_GP_REGS + NUM_WIDE_LIMBS + 4 + 4 + 2 + 3;
+    // 5 + 16 + 32 + 4 + 4 + 2 + 3 = 66 columns
+
+    /// Create an empty trace row (all zeros).
+    pub fn zero() -> Self {
+        Self {
+            pc: Goldilocks::zero(),
+            opcode: Goldilocks::zero(),
+            rd: Goldilocks::zero(),
+            rs1: Goldilocks::zero(),
+            rs2_imm: Goldilocks::zero(),
+            gp_regs: [Goldilocks::zero(); NUM_GP_REGS],
+            wide_limbs: [Goldilocks::zero(); NUM_WIDE_LIMBS],
+            mem_read_addr: Goldilocks::zero(),
+            mem_read_val: Goldilocks::zero(),
+            mem_write_addr: Goldilocks::zero(),
+            mem_write_val: Goldilocks::zero(),
+            storage_key_lo: Goldilocks::zero(),
+            storage_key_hi: Goldilocks::zero(),
+            storage_val_lo: Goldilocks::zero(),
+            storage_val_hi: Goldilocks::zero(),
+            gas_step: Goldilocks::zero(),
+            gas_cumulative: Goldilocks::zero(),
+            is_memory_op: Goldilocks::zero(),
+            is_storage_op: Goldilocks::zero(),
+            is_final: Goldilocks::zero(),
+        }
+    }
+
+    /// Convert to a flat array of field elements (for Plonky3 matrix).
+    pub fn to_fields(&self) -> Vec<Goldilocks> {
+        let mut fields = Vec::with_capacity(Self::NUM_COLUMNS);
+        fields.push(self.pc);
+        fields.push(self.opcode);
+        fields.push(self.rd);
+        fields.push(self.rs1);
+        fields.push(self.rs2_imm);
+        fields.extend_from_slice(&self.gp_regs);
+        fields.extend_from_slice(&self.wide_limbs);
+        fields.push(self.mem_read_addr);
+        fields.push(self.mem_read_val);
+        fields.push(self.mem_write_addr);
+        fields.push(self.mem_write_val);
+        fields.push(self.storage_key_lo);
+        fields.push(self.storage_key_hi);
+        fields.push(self.storage_val_lo);
+        fields.push(self.storage_val_hi);
+        fields.push(self.gas_step);
+        fields.push(self.gas_cumulative);
+        fields.push(self.is_memory_op);
+        fields.push(self.is_storage_op);
+        fields.push(self.is_final);
+        fields
+    }
+}
+
+/// Helper: convert a u64 to a Goldilocks field element.
+pub fn to_field(val: u64) -> Goldilocks {
+    Goldilocks::from_canonical_u64(val)
+}
+
+/// The full execution trace: a list of rows.
+#[derive(Clone, Debug)]
+pub struct ExecutionTrace {
+    /// Trace rows in execution order.
+    pub rows: Vec<TraceRow>,
+}
+
+impl ExecutionTrace {
+    pub fn new() -> Self {
+        Self { rows: Vec::new() }
+    }
+
+    pub fn with_capacity(n: usize) -> Self {
+        Self {
+            rows: Vec::with_capacity(n),
+        }
+    }
+
+    /// Add a row to the trace.
+    pub fn push(&mut self, row: TraceRow) {
+        self.rows.push(row);
+    }
+
+    /// Number of execution steps.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Convert the trace to a flat column-major matrix for Plonky3.
+    /// Returns Vec of columns, each column is Vec<Goldilocks>.
+    pub fn to_column_major(&self) -> Vec<Vec<Goldilocks>> {
+        if self.rows.is_empty() {
+            return vec![vec![]; TraceRow::NUM_COLUMNS];
+        }
+
+        let num_rows = self.rows.len();
+        let mut columns = vec![Vec::with_capacity(num_rows); TraceRow::NUM_COLUMNS];
+
+        for row in &self.rows {
+            let fields = row.to_fields();
+            for (col_idx, val) in fields.into_iter().enumerate() {
+                columns[col_idx].push(val);
+            }
+        }
+
+        columns
+    }
+
+    /// Pad the trace to a power of 2 (required by STARK provers).
+    pub fn pad_to_power_of_two(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let target = self.rows.len().next_power_of_two();
+        while self.rows.len() < target {
+            self.rows.push(TraceRow::zero());
+        }
+    }
+}
+
+impl Default for ExecutionTrace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_row_column_count() {
+        assert_eq!(TraceRow::NUM_COLUMNS, 66);
+    }
+
+    #[test]
+    fn zero_row_all_zeros() {
+        let row = TraceRow::zero();
+        let fields = row.to_fields();
+        assert_eq!(fields.len(), 66);
+        for f in &fields {
+            assert_eq!(*f, Goldilocks::zero());
+        }
+    }
+
+    #[test]
+    fn to_fields_preserves_values() {
+        let mut row = TraceRow::zero();
+        row.pc = to_field(42);
+        row.opcode = to_field(7);
+        row.gp_regs[0] = to_field(100);
+        row.gas_cumulative = to_field(21000);
+
+        let fields = row.to_fields();
+        assert_eq!(fields[0], to_field(42)); // pc
+        assert_eq!(fields[1], to_field(7)); // opcode
+        assert_eq!(fields[5], to_field(100)); // gp_regs[0]
+                                              // gas_cumulative: 5 control + 16 gp + 32 wide + 4 mem + 4 storage + 1 gas_step = index 62
+        assert_eq!(fields[62], to_field(21000)); // gas_cumulative
+    }
+
+    #[test]
+    fn trace_push_and_len() {
+        let mut trace = ExecutionTrace::new();
+        assert!(trace.is_empty());
+
+        trace.push(TraceRow::zero());
+        trace.push(TraceRow::zero());
+        assert_eq!(trace.len(), 2);
+    }
+
+    #[test]
+    fn pad_to_power_of_two() {
+        let mut trace = ExecutionTrace::new();
+        for _ in 0..5 {
+            trace.push(TraceRow::zero());
+        }
+        assert_eq!(trace.len(), 5);
+
+        trace.pad_to_power_of_two();
+        assert_eq!(trace.len(), 8); // next power of 2
+    }
+
+    #[test]
+    fn pad_already_power_of_two() {
+        let mut trace = ExecutionTrace::new();
+        for _ in 0..4 {
+            trace.push(TraceRow::zero());
+        }
+        trace.pad_to_power_of_two();
+        assert_eq!(trace.len(), 4); // already power of 2
+    }
+
+    #[test]
+    fn column_major_conversion() {
+        let mut trace = ExecutionTrace::new();
+
+        let mut row1 = TraceRow::zero();
+        row1.pc = to_field(0);
+        row1.opcode = to_field(1);
+
+        let mut row2 = TraceRow::zero();
+        row2.pc = to_field(4);
+        row2.opcode = to_field(2);
+
+        trace.push(row1);
+        trace.push(row2);
+
+        let cols = trace.to_column_major();
+        assert_eq!(cols.len(), 66);
+        assert_eq!(cols[0].len(), 2); // 2 rows
+
+        // Column 0 = pc: [0, 4]
+        assert_eq!(cols[0][0], to_field(0));
+        assert_eq!(cols[0][1], to_field(4));
+
+        // Column 1 = opcode: [1, 2]
+        assert_eq!(cols[1][0], to_field(1));
+        assert_eq!(cols[1][1], to_field(2));
+    }
+
+    #[test]
+    fn empty_trace_column_major() {
+        let trace = ExecutionTrace::new();
+        let cols = trace.to_column_major();
+        assert_eq!(cols.len(), 66);
+        for col in &cols {
+            assert!(col.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Create pyde-prover crate with Plonky3 (Goldilocks field) integration
- ProverRegistry: 1K PYDE bond, register/unbond/slash, proof tracking
- ProverCommittee: dynamic sizing (MIN=4, MAX=32), minimum viable committee
  (all active provers participate, overflow becomes backup)
- Rotating aggregator (slot % members), round-robin group assignment
- TraceRow: 66 columns (5 control + 16 GP + 32 wide + 4 memory + 4 storage + 2 gas + 3 flags)
- ExecutionTrace: row collection, power-of-2 padding, column-major matrix
- Comprehensive architecture documentation:
  - Committee-based proving (group-level, not per-tx)
  - state_root committed by STARK proof, not proposer (txs encrypted at proposal)
  - Witness verification: Merkle proofs against proven state roots
  - Proof failure recovery: soft finality unaffected, hard finality delayed
  - Unproven window: Normal/Slowed/Paused production modes

## Test plan
- [x] 851 tests pass across 11 crates
- [x] Prover registration, insufficient bond rejected, duplicate rejected
- [x] Slash reduces bond, partial slash, full slash
- [x] Unbond with release after period
- [x] Committee sizing: min=4, uses all provers, max=32, overflow as backup
- [x] Selection sorted by reputation (most proofs first)
- [x] Round-robin group assignment, fewer groups than members handled
- [x] Rotating aggregator wraps around
- [x] Trace: 66 columns, zero row, field preservation, padding, column-major
- [x] Unproven window: Normal/Slowed/Paused thresholds
- [x] Production mode tracks soft-hard finality gap