### PR TITLE
Add execution trace recorder with full state capture

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -72,6 +72,7 @@
 //! incentivize fast hardware, and the committee is selected from registered
 //! provers each epoch.
 
+pub mod recorder;
 pub mod registry;
 pub mod trace;
 

--- a/crates/prover/src/recorder.rs
+++ b/crates/prover/src/recorder.rs
@@ -1,0 +1,613 @@
+//! Execution trace recorder: captures full PVM state per cycle for STARK proving.
+//!
+//! The recorder wraps a PVM VM and captures a TraceRow after each step:
+//! - Program counter, opcode, decoded fields
+//! - All 16 GP registers
+//! - All 8 wide registers (4 limbs each)
+//! - Memory read/write address and value (if applicable)
+//! - Storage key and value (if applicable)
+//! - Gas step cost and cumulative gas
+//! - Flags (is_memory_op, is_storage_op, is_final)
+//!
+//! Recording is opt-in: provers use `record_execution()`, normal nodes
+//! use the standard `vm.execute()` without overhead.
+
+use crate::trace::{to_field, ExecutionTrace, TraceRow, NUM_GP_REGS};
+use p3_field::AbstractField;
+use p3_goldilocks::Goldilocks;
+use pyde_vm::isa::Opcode;
+use pyde_vm::vm::{ExecResult, Outcome, Vm};
+use pyde_vm::cpu::Trap;
+
+/// Record a full execution trace from a loaded VM.
+///
+/// The VM must have bytecode loaded (via `vm.load()`).
+/// Returns the ExecutionTrace and the execution outcome.
+pub fn record_execution(vm: &mut Vm) -> (ExecutionTrace, Outcome) {
+    let mut trace = ExecutionTrace::new();
+    let logs_snapshot_len = vm.logs.len();
+
+    let outcome = loop {
+        let pc = vm.pc;
+        let idx = (pc / 4) as usize;
+
+        let decoded = match vm.decoded_cache().get(idx) {
+            Some(&d) => d,
+            None => break Outcome::Trap(Trap::MemoryFault),
+        };
+
+        // Capture pre-step gas for computing step cost
+        let gas_before = vm.gas_used_total;
+
+        // Determine if this is a memory/storage op (from opcode)
+        let is_mem = is_memory_opcode(decoded.opcode);
+        let is_storage = is_storage_opcode(decoded.opcode);
+
+        // Capture pre-step memory/storage access info from registers + opcode
+        let mem_access = if is_mem {
+            capture_memory_access(vm, decoded.opcode, decoded.rd, decoded.rs1, decoded.rs2_or_imm)
+        } else {
+            MemAccess::default()
+        };
+
+        let storage_access = if is_storage {
+            capture_storage_access(vm, decoded.opcode, decoded.rd, decoded.rs1, decoded.rs2_or_imm)
+        } else {
+            StorageAccess::default()
+        };
+
+        // Execute one step
+        let step_result = vm.step();
+
+        // Compute gas cost for this step
+        let gas_after = vm.gas_used_total;
+        let gas_step = gas_after - gas_before;
+
+        // Build trace row from post-step state
+        let is_final = matches!(
+            step_result,
+            Ok(Some(ExecResult::Halt)) | Ok(Some(ExecResult::Revert)) | Err(_)
+        );
+
+        let row = build_trace_row(vm, pc, decoded.opcode, decoded.rd, decoded.rs1,
+            decoded.rs2_or_imm, gas_step, gas_after, is_mem, is_storage, is_final,
+            &mem_access, &storage_access);
+        trace.push(row);
+
+        match step_result {
+            Ok(Some(ExecResult::Halt)) => break Outcome::Success,
+            Ok(Some(ExecResult::Revert)) => {
+                vm.rollback_storage_pub();
+                vm.logs.truncate(logs_snapshot_len);
+                vm.gas_refund = 0;
+                break Outcome::Revert;
+            }
+            Ok(None) => {} // continue
+            Err(Trap::OutOfGas) => {
+                vm.rollback_storage_pub();
+                vm.logs.truncate(logs_snapshot_len);
+                vm.gas_refund = 0;
+                break Outcome::OutOfGas;
+            }
+            Err(trap) => {
+                vm.rollback_storage_pub();
+                vm.logs.truncate(logs_snapshot_len);
+                vm.gas_refund = 0;
+                break Outcome::Trap(trap);
+            }
+        }
+    };
+
+    (trace, outcome)
+}
+
+/// Captured memory access for a single step.
+#[derive(Default)]
+struct MemAccess {
+    addr: u64,
+    /// Value: 4 × u64 limbs.
+    /// GP mode (≤8 bytes): val[0] = raw u64, rest = 0
+    /// Bulk mode (>8 bytes): val[0..3] = Poseidon2(raw_bytes) hash limbs
+    val: [u64; 4],
+    /// Access width in bytes (1-8 for GP, or N for bulk writes like checked_write_slice).
+    width: u64,
+    /// Is this a write (true) or read (false)?
+    is_write: bool,
+}
+
+/// Captured storage access for a single step.
+#[derive(Default)]
+struct StorageAccess {
+    /// Key: 4 × u64 limbs (U256).
+    key: [u64; 4],
+    /// Value: 4 × u64 limbs. Interpretation derived from val_len:
+    /// len ≤ 8:  val[0] = raw u64, rest = 0
+    /// len ≤ 32: val[0..3] = raw U256 limbs
+    /// len > 32: val[0..3] = Poseidon2(raw_bytes) hash limbs
+    val: [u64; 4],
+    /// Raw value length in bytes.
+    val_len: u64,
+    /// Is this a write?
+    is_write: bool,
+}
+
+/// Capture memory access info before step executes.
+/// Reads the address and value from registers based on the opcode.
+fn capture_memory_access(vm: &Vm, op: Opcode, rd: u8, rs1: u8, rs2_imm: u32) -> MemAccess {
+    let mut access = MemAccess::default();
+    match op {
+        Opcode::Load => {
+            let base = vm.cpu.read_gp(rs1);
+            let offset = pyde_vm::isa::decode_mem_offset(rs2_imm);
+            let width = pyde_vm::isa::decode_mem_width(rs2_imm);
+            access.addr = (base as i64 + offset as i64) as u64;
+            access.width = match width {
+                pyde_vm::isa::MemWidth::W8 => 1,
+                pyde_vm::isa::MemWidth::W16 => 2,
+                pyde_vm::isa::MemWidth::W32 => 4,
+                pyde_vm::isa::MemWidth::W64 => 8,
+            };
+            access.is_write = false;
+            // Value captured post-step from destination register
+        }
+        Opcode::Store => {
+            let base = vm.cpu.read_gp(rs1);
+            let offset = pyde_vm::isa::decode_mem_offset(rs2_imm);
+            let width = pyde_vm::isa::decode_mem_width(rs2_imm);
+            access.addr = (base as i64 + offset as i64) as u64;
+            access.val[0] = vm.cpu.read_gp(rd);
+            access.width = match width {
+                pyde_vm::isa::MemWidth::W8 => 1,
+                pyde_vm::isa::MemWidth::W16 => 2,
+                pyde_vm::isa::MemWidth::W32 => 4,
+                pyde_vm::isa::MemWidth::W64 => 8,
+            };
+            access.is_write = true;
+        }
+        Opcode::Push => {
+            access.val[0] = vm.cpu.read_gp(rd);
+            access.width = 8;
+            access.is_write = true;
+        }
+        Opcode::Pop => {
+            access.width = 8;
+            access.is_write = false;
+        }
+        Opcode::Wstore => {
+            // WSTORE: writes U256 (32 bytes) from wide register to memory
+            let base = vm.cpu.read_gp(rs1);
+            let offset = pyde_vm::isa::sign_extend_18(rs2_imm) as i64;
+            access.addr = (base as i64 + offset) as u64;
+            let val = vm.cpu.read_wide(rd);
+            let limbs = val.to_le_bytes();
+            for i in 0..4 {
+                access.val[i] = u64::from_le_bytes(
+                    limbs[i * 8..(i + 1) * 8].try_into().unwrap(),
+                );
+            }
+            access.width = 32;
+            access.is_write = true;
+        }
+        Opcode::Wload => {
+            // WLOAD: reads U256 (32 bytes) from memory to wide register
+            let base = vm.cpu.read_gp(rs1);
+            let offset = pyde_vm::isa::sign_extend_18(rs2_imm) as i64;
+            access.addr = (base as i64 + offset) as u64;
+            access.width = 32;
+            access.is_write = false;
+            // Value captured post-step from wide register
+        }
+        _ => {}
+    }
+    access
+}
+
+/// Compute Poseidon2 hash of raw bytes and return as 4 × u64 limbs.
+fn hash_value(data: &[u8]) -> [u64; 4] {
+    let hash = pyde_crypto::poseidon2::poseidon2_hash(data).to_bytes();
+    let mut limbs = [0u64; 4];
+    for i in 0..4 {
+        limbs[i] = u64::from_le_bytes(hash[i * 8..(i + 1) * 8].try_into().unwrap());
+    }
+    limbs
+}
+
+/// Capture storage access info before step executes.
+fn capture_storage_access(vm: &Vm, op: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> StorageAccess {
+    let mut access = StorageAccess::default();
+    let slot = vm.cpu.read_wide(rs1);
+    let key = vm.derive_storage_key(slot);
+    let key_bytes = key.to_le_bytes();
+
+    // Key: full U256 (4 × u64 limbs)
+    for i in 0..4 {
+        access.key[i] = u64::from_le_bytes(key_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+    }
+
+    if op == Opcode::Sload {
+        access.is_write = false;
+        if let Some(data) = vm.storage.get(&key) {
+            fill_storage_val(&mut access, data);
+        }
+    } else if op == Opcode::Sstore {
+        access.is_write = true;
+        let mode = rs2_or_imm & 0x3;
+        match mode {
+            0 => {
+                // Wide register mode: value = U256 from wide register rd
+                let val = vm.cpu.read_wide(rd);
+                let bytes = val.to_le_bytes();
+                access.val_len = 32;
+                for i in 0..4 {
+                    access.val[i] = u64::from_le_bytes(
+                        bytes[i * 8..(i + 1) * 8].try_into().unwrap(),
+                    );
+                }
+            }
+            2 => {
+                // GP register mode: value = u64 from GP register rd
+                access.val[0] = vm.cpu.read_gp(rd);
+                access.val_len = 8;
+            }
+            1 => {
+                // Memory mode: value = bytes from memory[ptr..ptr+len]
+                let ptr_reg = ((rs2_or_imm >> 2) & 0xF) as u8;
+                let len_reg = ((rs2_or_imm >> 6) & 0xF) as u8;
+                let ptr = vm.cpu.read_gp(ptr_reg) as u32;
+                let len = vm.cpu.read_gp(len_reg) as usize;
+                let data = vm.memory.read_slice(ptr, len);
+                fill_storage_val(&mut access, &data);
+            }
+            _ => {}
+        }
+    } else if op == Opcode::Sdelete {
+        // Delete: capture the key, value is the current value being deleted
+        access.is_write = true;
+        if let Some(data) = vm.storage.get(&key) {
+            fill_storage_val(&mut access, data);
+        }
+    }
+    access
+}
+
+/// Fill storage_val and storage_val_len from raw bytes.
+fn fill_storage_val(access: &mut StorageAccess, data: &[u8]) {
+    access.val_len = data.len() as u64;
+    if data.len() <= 8 {
+        let mut buf = [0u8; 8];
+        buf[..data.len()].copy_from_slice(data);
+        access.val[0] = u64::from_le_bytes(buf);
+    } else if data.len() <= 32 {
+        for i in 0..4 {
+            if data.len() >= (i + 1) * 8 {
+                access.val[i] = u64::from_le_bytes(
+                    data[i * 8..(i + 1) * 8].try_into().unwrap(),
+                );
+            }
+        }
+    } else {
+        access.val = hash_value(data);
+    }
+}
+
+/// Build a TraceRow from the current VM state.
+fn build_trace_row(
+    vm: &Vm,
+    pc: u32,
+    opcode: Opcode,
+    rd: u8,
+    rs1: u8,
+    rs2_imm: u32,
+    gas_step: u64,
+    gas_cumulative: u64,
+    is_mem: bool,
+    is_storage: bool,
+    is_final: bool,
+    mem_access: &MemAccess,
+    storage_access: &StorageAccess,
+) -> TraceRow {
+    let mut row = TraceRow::zero();
+
+    // Control flow
+    row.pc = to_field(pc as u64);
+    row.opcode = to_field(opcode.to_u8() as u64);
+    row.rd = to_field(rd as u64);
+    row.rs1 = to_field(rs1 as u64);
+    row.rs2_imm = to_field(rs2_imm as u64);
+
+    // GP registers (post-step state)
+    for i in 0..NUM_GP_REGS {
+        row.gp_regs[i] = to_field(vm.cpu.read_gp(i as u8));
+    }
+
+    // Wide registers (4 u64 limbs each, post-step state)
+    for w in 0..8 {
+        let val = vm.cpu.read_wide(w as u8);
+        let limbs = val.to_le_bytes();
+        for l in 0..4 {
+            let limb = u64::from_le_bytes(
+                limbs[l * 8..(l + 1) * 8].try_into().unwrap(),
+            );
+            row.wide_limbs[w * 4 + l] = to_field(limb);
+        }
+    }
+
+    // Memory access
+    row.mem_addr = to_field(mem_access.addr);
+    for i in 0..4 {
+        row.mem_val[i] = to_field(mem_access.val[i]);
+    }
+    row.mem_width = to_field(mem_access.width);
+    row.mem_is_write = if mem_access.is_write { Goldilocks::one() } else { Goldilocks::zero() };
+
+    // For reads: capture the value post-step from destination register
+    if is_mem && !mem_access.is_write {
+        if mem_access.width <= 8 {
+            // GP LOAD: value in GP register
+            row.mem_val[0] = to_field(vm.cpu.read_gp(rd));
+        } else if mem_access.width <= 32 {
+            // WLOAD: value in wide register (4 limbs)
+            let val = vm.cpu.read_wide(rd);
+            let limbs = val.to_le_bytes();
+            for i in 0..4 {
+                row.mem_val[i] = to_field(u64::from_le_bytes(
+                    limbs[i * 8..(i + 1) * 8].try_into().unwrap(),
+                ));
+            }
+        } else {
+            // Bulk read (>32 bytes): hash the memory region, raw in aux witness
+            let addr = mem_access.addr as u32;
+            let len = mem_access.width as usize;
+            let data = vm.memory.read_slice(addr, len);
+            let h = hash_value(&data);
+            for i in 0..4 {
+                row.mem_val[i] = to_field(h[i]);
+            }
+        }
+    }
+
+    // Storage access
+    for i in 0..4 {
+        row.storage_key[i] = to_field(storage_access.key[i]);
+        row.storage_val[i] = to_field(storage_access.val[i]);
+    }
+    row.storage_val_len = to_field(storage_access.val_len);
+    row.storage_is_write = if storage_access.is_write { Goldilocks::one() } else { Goldilocks::zero() };
+
+    // Gas
+    row.gas_step = to_field(gas_step);
+    row.gas_cumulative = to_field(gas_cumulative);
+
+    // Flags
+    row.is_memory_op = if is_mem { Goldilocks::one() } else { Goldilocks::zero() };
+    row.is_storage_op = if is_storage { Goldilocks::one() } else { Goldilocks::zero() };
+    row.is_final = if is_final { Goldilocks::one() } else { Goldilocks::zero() };
+
+    row
+}
+
+/// Check if an opcode is a memory operation.
+fn is_memory_opcode(op: Opcode) -> bool {
+    matches!(op, Opcode::Load | Opcode::Store | Opcode::Push | Opcode::Pop
+        | Opcode::Wload | Opcode::Wstore)
+}
+
+/// Check if an opcode is a storage operation.
+fn is_storage_opcode(op: Opcode) -> bool {
+    matches!(op, Opcode::Sload | Opcode::Sstore | Opcode::Sdelete)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_vm::isa::{encode, Opcode};
+    use pyde_vm::vm::Vm;
+
+    /// Helper: encode an instruction to 4 bytes.
+    fn instr(op: Opcode, rd: u8, rs1: u8, rs2_or_imm: u32) -> [u8; 4] {
+        encode(op, rd, rs1, rs2_or_imm).0.to_le_bytes()
+    }
+
+    fn build_bytecode(instrs: &[&[u8; 4]]) -> Vec<u8> {
+        instrs.iter().flat_map(|i| i.iter().copied()).collect()
+    }
+
+    // ========== Task 0601: Trace captures ADD ==========
+
+    #[test]
+    fn trace_captures_add() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 42),  // r1 = 42
+            &instr(Opcode::Addi, 2, 0, 58),  // r2 = 58
+            &instr(Opcode::Add, 3, 1, 2),     // r3 = r1 + r2 = 100
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (trace, outcome) = record_execution(&mut vm);
+        assert_eq!(outcome, Outcome::Success);
+        assert_eq!(trace.len(), 4); // 3 instructions + halt
+
+        // After ADD (row 2, 0-indexed), r3 should be 100
+        let add_row = &trace.rows[2];
+        assert_eq!(add_row.gp_regs[3], to_field(100));
+
+        // Final row is marked
+        assert_eq!(trace.rows[3].is_final, Goldilocks::one());
+        assert_eq!(trace.rows[0].is_final, Goldilocks::zero());
+    }
+
+    // ========== Task 0598: PC and opcode recorded ==========
+
+    #[test]
+    fn trace_captures_pc_and_opcode() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 10),
+            &instr(Opcode::Addi, 2, 0, 20),
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (trace, _) = record_execution(&mut vm);
+        assert_eq!(trace.len(), 3);
+
+        // PC advances by 4 each step
+        assert_eq!(trace.rows[0].pc, to_field(0));
+        assert_eq!(trace.rows[1].pc, to_field(4));
+        assert_eq!(trace.rows[2].pc, to_field(8));
+
+        // Opcodes recorded
+        assert_eq!(trace.rows[0].opcode, to_field(Opcode::Addi.to_u8() as u64));
+        assert_eq!(trace.rows[2].opcode, to_field(Opcode::Halt.to_u8() as u64));
+    }
+
+    // ========== Task 0595: Register state per cycle ==========
+
+    #[test]
+    fn trace_captures_registers_per_cycle() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 10), // r1 = 10
+            &instr(Opcode::Addi, 1, 1, 5),  // r1 = r1 + 5 = 15
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (trace, _) = record_execution(&mut vm);
+
+        // After step 0: r1 = 10
+        assert_eq!(trace.rows[0].gp_regs[1], to_field(10));
+        // After step 1: r1 = 15
+        assert_eq!(trace.rows[1].gp_regs[1], to_field(15));
+    }
+
+    // ========== Task 0599: Gas counter per cycle ==========
+
+    #[test]
+    fn trace_captures_gas() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 10),
+            &instr(Opcode::Add, 2, 1, 0),
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::with_gas_limit(100_000);
+        vm.load(&code).unwrap();
+
+        let (trace, _) = record_execution(&mut vm);
+
+        // Gas should be monotonically increasing
+        let gas_0 = trace.rows[0].gas_cumulative;
+        let gas_1 = trace.rows[1].gas_cumulative;
+        let gas_2 = trace.rows[2].gas_cumulative;
+        assert!(gas_0 < gas_1 || gas_0 == gas_1); // non-decreasing
+        assert!(gas_1 < gas_2 || gas_1 == gas_2);
+
+        // Step gas should be non-zero
+        assert_ne!(trace.rows[0].gas_step, Goldilocks::zero());
+    }
+
+    // ========== Flags ==========
+
+    #[test]
+    fn trace_flags_correct() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 10), // not memory, not storage
+            &instr(Opcode::Halt, 0, 0, 0),  // final
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (trace, _) = record_execution(&mut vm);
+
+        // First row: not final, not memory, not storage
+        assert_eq!(trace.rows[0].is_final, Goldilocks::zero());
+        assert_eq!(trace.rows[0].is_memory_op, Goldilocks::zero());
+        assert_eq!(trace.rows[0].is_storage_op, Goldilocks::zero());
+
+        // Last row: final
+        assert_eq!(trace.rows[1].is_final, Goldilocks::one());
+    }
+
+    // ========== Trace padded for STARK ==========
+
+    #[test]
+    fn trace_pads_to_power_of_two() {
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 1),
+            &instr(Opcode::Addi, 2, 0, 2),
+            &instr(Opcode::Addi, 3, 0, 3),
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (mut trace, _) = record_execution(&mut vm);
+        assert_eq!(trace.len(), 4); // already power of 2
+
+        // Add one more for non-power-of-2
+        trace.push(TraceRow::zero());
+        assert_eq!(trace.len(), 5);
+        trace.pad_to_power_of_two();
+        assert_eq!(trace.len(), 8);
+    }
+
+    // ========== Task 0596: Memory reads/writes recorded ==========
+
+    #[test]
+    fn trace_captures_memory_store() {
+        use pyde_vm::isa::{encode_mem_immediate, MemWidth};
+        let code = build_bytecode(&[
+            &instr(Opcode::Addi, 1, 0, 0x010000),                        // r1 = HEAP_START (address)
+            &instr(Opcode::Addi, 2, 0, 42),                             // r2 = 42 (value)
+            &instr(Opcode::Store, 2, 1, encode_mem_immediate(0, MemWidth::W64)), // store64(r1+0, r2)
+            &instr(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = Vm::new();
+        vm.load(&code).unwrap();
+
+        let (trace, outcome) = record_execution(&mut vm);
+        assert_eq!(outcome, Outcome::Success);
+
+        // Store instruction (row 2) should have memory flag
+        assert_eq!(trace.rows[2].is_memory_op, Goldilocks::one());
+        assert_eq!(trace.rows[2].mem_is_write, Goldilocks::one());
+        // Write address should be HEAP_START
+        assert_eq!(trace.rows[2].mem_addr, to_field(0x010000));
+        // Write value should be 42 (GP mode: raw value in limb 0)
+        assert_eq!(trace.rows[2].mem_val[0], to_field(42));
+        // Width should be 8 (W64)
+        assert_eq!(trace.rows[2].mem_width, to_field(8));
+    }
+
+    // ========== Task 0597: Storage flag recorded ==========
+
+    #[test]
+    fn trace_marks_storage_ops() {
+        // SSTORE requires wide register setup which is complex to encode.
+        // Verify the flag detection works for the opcode classification.
+        assert!(is_storage_opcode(Opcode::Sload));
+        assert!(is_storage_opcode(Opcode::Sstore));
+        assert!(is_storage_opcode(Opcode::Sdelete));
+        assert!(!is_storage_opcode(Opcode::Add));
+        assert!(!is_storage_opcode(Opcode::Load));
+    }
+
+    #[test]
+    fn trace_marks_memory_ops() {
+        assert!(is_memory_opcode(Opcode::Load));
+        assert!(is_memory_opcode(Opcode::Store));
+        assert!(is_memory_opcode(Opcode::Push));
+        assert!(is_memory_opcode(Opcode::Pop));
+        assert!(!is_memory_opcode(Opcode::Add));
+        assert!(!is_memory_opcode(Opcode::Sstore));
+    }
+}

--- a/crates/prover/src/trace.rs
+++ b/crates/prover/src/trace.rs
@@ -15,7 +15,7 @@
 //! constraints that each row must satisfy. The prover generates a
 //! STARK proof that the trace is valid.
 
-use p3_field::{AbstractField, PrimeField64};
+use p3_field::AbstractField;
 use p3_goldilocks::Goldilocks;
 
 /// Number of GP register columns (r0-r15).
@@ -48,25 +48,32 @@ pub struct TraceRow {
     /// w0-w7, each split into 4 × u64 limbs for field compatibility.
     pub wide_limbs: [Goldilocks; NUM_WIDE_LIMBS],
 
-    // === Memory (4 columns) ===
-    /// Memory read address (0 if no read).
-    pub mem_read_addr: Goldilocks,
-    /// Memory read value.
-    pub mem_read_val: Goldilocks,
-    /// Memory write address (0 if no write).
-    pub mem_write_addr: Goldilocks,
-    /// Memory write value.
-    pub mem_write_val: Goldilocks,
+    // === Memory (7 columns) ===
+    /// Memory address (read or write).
+    pub mem_addr: Goldilocks,
+    /// Memory value: 4 × u64 limbs.
+    /// - GP mode (width ≤ 8): val[0] = raw u64, val[1..3] = 0
+    /// - Bulk mode (width > 8): val[0..3] = Poseidon2(raw_bytes) hash limbs
+    ///   (actual bytes in auxiliary witness, AIR verifies hash)
+    pub mem_val: [Goldilocks; 4],
+    /// Memory access width in bytes (1, 2, 4, 8 for GP; or N for bulk writes).
+    pub mem_width: Goldilocks,
+    /// Memory is write (1) or read (0).
+    pub mem_is_write: Goldilocks,
 
-    // === Storage (4 columns) ===
-    /// Storage key (hash, lower 64 bits).
-    pub storage_key_lo: Goldilocks,
-    /// Storage key (hash, upper 64 bits).
-    pub storage_key_hi: Goldilocks,
-    /// Storage value (lower 64 bits).
-    pub storage_val_lo: Goldilocks,
-    /// Storage value (upper 64 bits).
-    pub storage_val_hi: Goldilocks,
+    // === Storage (10 columns) ===
+    /// Storage key: 4 × u64 limbs (U256, always fixed size).
+    pub storage_key: [Goldilocks; 4],
+    /// Storage value: 4 × u64 limbs. Interpretation derived from storage_val_len:
+    /// - len ≤ 8:  val[0] = raw u64, val[1..3] = 0
+    /// - len ≤ 32: val[0..3] = raw U256 limbs
+    /// - len > 32: val[0..3] = Poseidon2(raw_bytes) hash limbs
+    ///   (actual bytes in auxiliary witness, AIR verifies hash)
+    pub storage_val: [Goldilocks; 4],
+    /// Length of the raw storage value in bytes (same role as mem_width).
+    pub storage_val_len: Goldilocks,
+    /// Storage is write (1) or read (0).
+    pub storage_is_write: Goldilocks,
 
     // === Gas (2 columns) ===
     /// Gas used this step.
@@ -85,8 +92,8 @@ pub struct TraceRow {
 
 impl TraceRow {
     /// Total number of columns in the trace.
-    pub const NUM_COLUMNS: usize = 5 + NUM_GP_REGS + NUM_WIDE_LIMBS + 4 + 4 + 2 + 3;
-    // 5 + 16 + 32 + 4 + 4 + 2 + 3 = 66 columns
+    /// 5 control + 16 GP + 32 wide + 7 memory + 10 storage + 2 gas + 3 flags = 75
+    pub const NUM_COLUMNS: usize = 5 + NUM_GP_REGS + NUM_WIDE_LIMBS + 7 + 10 + 2 + 3;
 
     /// Create an empty trace row (all zeros).
     pub fn zero() -> Self {
@@ -98,14 +105,14 @@ impl TraceRow {
             rs2_imm: Goldilocks::zero(),
             gp_regs: [Goldilocks::zero(); NUM_GP_REGS],
             wide_limbs: [Goldilocks::zero(); NUM_WIDE_LIMBS],
-            mem_read_addr: Goldilocks::zero(),
-            mem_read_val: Goldilocks::zero(),
-            mem_write_addr: Goldilocks::zero(),
-            mem_write_val: Goldilocks::zero(),
-            storage_key_lo: Goldilocks::zero(),
-            storage_key_hi: Goldilocks::zero(),
-            storage_val_lo: Goldilocks::zero(),
-            storage_val_hi: Goldilocks::zero(),
+            mem_addr: Goldilocks::zero(),
+            mem_val: [Goldilocks::zero(); 4],
+            mem_width: Goldilocks::zero(),
+            mem_is_write: Goldilocks::zero(),
+            storage_key: [Goldilocks::zero(); 4],
+            storage_val: [Goldilocks::zero(); 4],
+            storage_val_len: Goldilocks::zero(),
+            storage_is_write: Goldilocks::zero(),
             gas_step: Goldilocks::zero(),
             gas_cumulative: Goldilocks::zero(),
             is_memory_op: Goldilocks::zero(),
@@ -124,14 +131,14 @@ impl TraceRow {
         fields.push(self.rs2_imm);
         fields.extend_from_slice(&self.gp_regs);
         fields.extend_from_slice(&self.wide_limbs);
-        fields.push(self.mem_read_addr);
-        fields.push(self.mem_read_val);
-        fields.push(self.mem_write_addr);
-        fields.push(self.mem_write_val);
-        fields.push(self.storage_key_lo);
-        fields.push(self.storage_key_hi);
-        fields.push(self.storage_val_lo);
-        fields.push(self.storage_val_hi);
+        fields.push(self.mem_addr);
+        fields.extend_from_slice(&self.mem_val);
+        fields.push(self.mem_width);
+        fields.push(self.mem_is_write);
+        fields.extend_from_slice(&self.storage_key);
+        fields.extend_from_slice(&self.storage_val);
+        fields.push(self.storage_val_len);
+        fields.push(self.storage_is_write);
         fields.push(self.gas_step);
         fields.push(self.gas_cumulative);
         fields.push(self.is_memory_op);
@@ -222,14 +229,14 @@ mod tests {
 
     #[test]
     fn trace_row_column_count() {
-        assert_eq!(TraceRow::NUM_COLUMNS, 66);
+        assert_eq!(TraceRow::NUM_COLUMNS, 75);
     }
 
     #[test]
     fn zero_row_all_zeros() {
         let row = TraceRow::zero();
         let fields = row.to_fields();
-        assert_eq!(fields.len(), 66);
+        assert_eq!(fields.len(), 75);
         for f in &fields {
             assert_eq!(*f, Goldilocks::zero());
         }
@@ -247,8 +254,8 @@ mod tests {
         assert_eq!(fields[0], to_field(42)); // pc
         assert_eq!(fields[1], to_field(7)); // opcode
         assert_eq!(fields[5], to_field(100)); // gp_regs[0]
-                                              // gas_cumulative: 5 control + 16 gp + 32 wide + 4 mem + 4 storage + 1 gas_step = index 62
-        assert_eq!(fields[62], to_field(21000)); // gas_cumulative
+                                              // gas_cumulative: 5 control + 16 gp + 32 wide + 7 mem + 10 storage + 1 gas_step = index 71
+        assert_eq!(fields[71], to_field(21000)); // gas_cumulative
     }
 
     #[test]
@@ -299,7 +306,7 @@ mod tests {
         trace.push(row2);
 
         let cols = trace.to_column_major();
-        assert_eq!(cols.len(), 66);
+        assert_eq!(cols.len(), 75);
         assert_eq!(cols[0].len(), 2); // 2 rows
 
         // Column 0 = pc: [0, 4]
@@ -315,7 +322,7 @@ mod tests {
     fn empty_trace_column_major() {
         let trace = ExecutionTrace::new();
         let cols = trace.to_column_major();
-        assert_eq!(cols.len(), 66);
+        assert_eq!(cols.len(), 75);
         for col in &cols {
             assert!(col.is_empty());
         }

--- a/crates/pvm/src/isa.rs
+++ b/crates/pvm/src/isa.rs
@@ -95,6 +95,26 @@ pub enum Opcode {
     FieldMul = 0x39, // rd = rs1 * rs2 (mod field prime)
     Commit = 0x3A,   // commit rd to public output
 
+    // --- Bulk Memory Copy (Phase 9) ---
+    //
+    // Problem: no Mcopy instruction, and all 64 opcode slots are used.
+    //
+    // Solution: turn opcode 0x00 (currently Weq) into a gateway for new
+    // instructions. When the VM sees opcode 0x00, it looks at the imm field
+    // to decide what to actually do:
+    //
+    //   0x00 + imm says "NOP"   → do nothing (all-zero instruction is safe)
+    //   0x00 + imm says "Weq"   → wide equal (same as current Weq)
+    //   0x00 + imm says "Mcopy" → bulk memory copy (new!)
+    //   0x00 + imm says "Mset"  → bulk memory set (new!)
+    //   ... room for 60 more future instructions
+    //
+    // This gives us 64 new instructions without changing the 32-bit encoding.
+    //
+    // Until Phase 9, bulk writes use a WSTORE loop:
+    //   for each 32-byte chunk: WSTORE to heap, advance pointer
+    //   ~N/32 instructions for N bytes (not N instructions)
+
     // --- Wide Comparisons (result → GP register) ---
     Weq = 0x00, // rd = (ws1 == ws2) ? 1 : 0
     Wlt = 0x3F, // rd = (ws1 < ws2) ? 1 : 0

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -137,18 +137,11 @@ pub enum Outcome {
     Trap(Trap),
 }
 
-/// A single step in the execution trace (for ZK prover).
-#[derive(Clone, Copy, Debug)]
-pub struct TraceStep {
-    /// Program counter before this step.
-    pub pc: u32,
-    /// Opcode executed.
-    pub opcode: Opcode,
-    /// Cumulative gas after this step.
-    pub gas_used: u64,
-}
-
 /// Full execution output returned by `execute()`.
+///
+/// No trace is captured here — full nodes don't need it.
+/// Provers use `pyde_prover::recorder::record_execution()` for full
+/// 66-column STARK trace capture.
 #[derive(Clone, Debug)]
 pub struct ExecutionOutput {
     /// High-level outcome.
@@ -161,8 +154,6 @@ pub struct ExecutionOutput {
     pub gas_refund: u64,
     /// Event logs (empty on revert/OOG).
     pub logs: Vec<EventLog>,
-    /// Execution trace for ZK prover.
-    pub trace: Vec<TraceStep>,
 }
 
 /// Two-dimensional gas tracker: execution + proving costs.
@@ -1001,59 +992,23 @@ impl Vm {
         self.storage_journal_keys.clear();
         let logs_snapshot_len = self.logs.len();
 
-        let mut trace = Vec::new();
         let outcome = loop {
-            let pc = self.pc;
-            let idx = (pc / 4) as usize;
-            let opcode = match self.decoded_cache.get(idx) {
-                Some(d) => d.opcode,
-                None => break Outcome::Trap(Trap::MemoryFault),
-            };
-
             match self.step() {
-                Ok(Some(ExecResult::Halt)) => {
-                    trace.push(TraceStep {
-                        pc,
-                        opcode,
-                        gas_used: self.gas_used_total,
-                    });
-                    break Outcome::Success;
-                }
+                Ok(Some(ExecResult::Halt)) => break Outcome::Success,
                 Ok(Some(ExecResult::Revert)) => {
-                    trace.push(TraceStep {
-                        pc,
-                        opcode,
-                        gas_used: self.gas_used_total,
-                    });
                     self.rollback_storage();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
                     break Outcome::Revert;
                 }
-                Ok(None) => {
-                    trace.push(TraceStep {
-                        pc,
-                        opcode,
-                        gas_used: self.gas_used_total,
-                    });
-                }
+                Ok(None) => {}
                 Err(Trap::OutOfGas) => {
-                    trace.push(TraceStep {
-                        pc,
-                        opcode,
-                        gas_used: self.gas_used_total,
-                    });
                     self.rollback_storage();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
                     break Outcome::OutOfGas;
                 }
                 Err(trap) => {
-                    trace.push(TraceStep {
-                        pc,
-                        opcode,
-                        gas_used: self.gas_used_total,
-                    });
                     self.rollback_storage();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
@@ -1071,7 +1026,6 @@ impl Vm {
             gas_raw: self.gas,
             gas_refund: self.gas_refund,
             logs: self.logs[logs_snapshot_len..].to_vec(),
-            trace,
         }
     }
 
@@ -1097,6 +1051,16 @@ impl Vm {
         buf[32..64].copy_from_slice(&self.ctx.self_address);
         let hash = pyde_crypto::poseidon2::poseidon2_hash(&buf);
         U256::from_le_bytes(hash.to_bytes())
+    }
+
+    /// Access the decoded instruction cache (for trace recording).
+    pub fn decoded_cache(&self) -> &[crate::isa::DecodedInstruction] {
+        &self.decoded_cache
+    }
+
+    /// Rollback storage to pre-execution state (public for trace recorder).
+    pub fn rollback_storage_pub(&mut self) {
+        self.rollback_storage();
     }
 
     /// Effective gas used after applying refund (capped at 50% of total used).
@@ -2981,8 +2945,6 @@ mod tests {
 
         assert_eq!(output.outcome, Outcome::Success);
         assert_eq!(vm.cpu.read_gp(3), 30);
-        assert!(!output.trace.is_empty());
-        assert_eq!(output.trace.last().unwrap().opcode, Opcode::Halt);
     }
 
     #[test]
@@ -3009,7 +2971,6 @@ mod tests {
 
         assert_eq!(output.outcome, Outcome::Success);
         assert_eq!(vm.cpu.read_gp(3), 55);
-        assert!(output.trace.len() > 10); // looped multiple times
     }
 
     #[test]
@@ -3163,30 +3124,8 @@ mod tests {
         assert_eq!(balance, 50);
     }
 
-    #[test]
-    fn execute_trace_records_all_steps() {
-        let code = bytecode(&[
-            instr_ri(Opcode::Addi, 1, 0, 5),
-            instr_ri(Opcode::Addi, 2, 0, 10),
-            instr_bytes(Opcode::Add, 3, 1, 2),
-            instr_bytes(Opcode::Halt, 0, 0, 0),
-        ]);
-        let mut vm = Vm::new();
-        vm.load(&code).unwrap();
-        let output = vm.execute();
-
-        assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(output.trace.len(), 4);
-        assert_eq!(output.trace[0].opcode, Opcode::Addi);
-        assert_eq!(output.trace[0].pc, 0);
-        assert_eq!(output.trace[1].pc, 4);
-        assert_eq!(output.trace[2].opcode, Opcode::Add);
-        assert_eq!(output.trace[3].opcode, Opcode::Halt);
-        // Gas should be monotonically increasing
-        for w in output.trace.windows(2) {
-            assert!(w[1].gas_used >= w[0].gas_used);
-        }
-    }
+    // Trace recording moved to pyde-prover::recorder (record_execution).
+    // Full nodes use lean execute() with no trace overhead.
 
     #[test]
     fn execute_success_preserves_storage_and_logs() {


### PR DESCRIPTION
## Summary
- Trace recorder: opt-in 75-column TraceRow capture per PVM step
- Captures all registers (16 GP + 32 wide limbs), PC, opcode, decoded fields
- Memory access: address, value (4 limbs), width, direction
  - GP (≤8 bytes): raw u64 in val[0]
  - Wide (≤32 bytes): raw U256 in val[0..3]
  - Bulk (>32 bytes): Poseidon2(data) hash in val[0..3], raw in aux witness
- Storage access: key (4 limbs), value (4 limbs), val_len, direction
  - All SSTORE modes captured: wide (mode 0), GP (mode 2), memory (mode 1)
  - SLOAD all modes, SDELETE captures current value being deleted
- Gas: step cost and cumulative per cycle
- Flags: is_memory_op, is_storage_op, is_final
- Remove TraceStep from VM execute() (full nodes don't need trace overhead)
- Add VM public accessors for trace recorder
- Document EXT opcode ISA extension for Phase 9 (Mcopy)

## Test plan
- [x] 36 prover tests pass
- [x] Trace captures ADD instruction correctly
- [x] PC and opcode recorded per cycle
- [x] Register state captured per cycle
- [x] Gas monotonically increasing
- [x] Memory STORE: address, value, width captured
- [x] Storage/memory opcode flags correct (including Sdelete)
- [x] Trace pads to power of 2
- [x] Column count verified (75)
- [x] Gas index verified (71)