### PR TITLE
feat: add type system and type checker with full integration coverage

### DIFF
--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -7,3 +7,5 @@ pub mod lexer;
 pub mod ast;
 pub mod parser;
 pub mod resolve;
+pub mod types;
+pub mod typecheck;

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -1,0 +1,1626 @@
+//! Type checker: validates type correctness across the entire AST.
+//!
+//! Receives the AST + SymbolTable from the resolver.
+//! Infers types for expressions, checks assignments, function calls,
+//! struct inits, emit statements, and casts.
+
+use std::collections::HashMap;
+
+use crate::ast::*;
+use crate::token::Span;
+use crate::types::Ty;
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[derive(Clone, Debug)]
+pub struct TypeError {
+    pub message: String,
+    pub span: Span,
+}
+
+impl std::fmt::Display for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}: {}", self.span.line, self.span.col, self.message)
+    }
+}
+
+// ============================================================================
+// Type environment
+// ============================================================================
+
+/// Stores type information for all definitions in the program.
+#[derive(Clone, Debug)]
+pub struct TypeEnv {
+    /// Variable/param/field name → (type, is_mutable)
+    locals: Vec<HashMap<String, (Ty, bool)>>,
+    /// Storage field name → type
+    storage_fields: HashMap<String, Ty>,
+    /// Struct name → fields (name → type)
+    struct_defs: HashMap<String, Vec<(String, Ty)>>,
+    /// Enum name → variants
+    enum_defs: HashMap<String, Vec<String>>,
+    /// Const name → type
+    const_defs: HashMap<String, Ty>,
+    /// Type alias name → underlying type
+    type_aliases: HashMap<String, Ty>,
+    /// Function name → (params, return_type)
+    func_sigs: HashMap<String, (Vec<(String, Ty)>, Ty)>,
+    /// Event name → fields (name, type, indexed)
+    event_defs: HashMap<String, Vec<(String, Ty, bool)>>,
+    /// Error name → fields (name, type)
+    error_defs: HashMap<String, Vec<(String, Ty)>>,
+    /// Interface name → function sigs
+    interface_defs: HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
+}
+
+impl TypeEnv {
+    fn new() -> Self {
+        Self {
+            locals: vec![HashMap::new()],
+            storage_fields: HashMap::new(),
+            struct_defs: HashMap::new(),
+            enum_defs: HashMap::new(),
+            const_defs: HashMap::new(),
+            type_aliases: HashMap::new(),
+            func_sigs: HashMap::new(),
+            event_defs: HashMap::new(),
+            error_defs: HashMap::new(),
+            interface_defs: HashMap::new(),
+        }
+    }
+
+    fn push_scope(&mut self) {
+        self.locals.push(HashMap::new());
+    }
+
+    fn pop_scope(&mut self) {
+        self.locals.pop();
+    }
+
+    fn declare_local(&mut self, name: &str, ty: Ty, is_mutable: bool) {
+        if let Some(scope) = self.locals.last_mut() {
+            scope.insert(name.to_string(), (ty, is_mutable));
+        }
+    }
+
+    fn lookup_local(&self, name: &str) -> Option<&Ty> {
+        for scope in self.locals.iter().rev() {
+            if let Some((ty, _)) = scope.get(name) {
+                return Some(ty);
+            }
+        }
+        None
+    }
+
+    fn is_mutable(&self, name: &str) -> bool {
+        for scope in self.locals.iter().rev() {
+            if let Some((_, mutable)) = scope.get(name) {
+                return *mutable;
+            }
+        }
+        // Storage fields and params are mutable by default for assignment
+        true
+    }
+}
+
+// ============================================================================
+// Type Checker
+// ============================================================================
+
+pub struct TypeChecker {
+    env: TypeEnv,
+    errors: Vec<TypeError>,
+    in_contract: bool,
+    /// The expected return type of the current function (for return stmt checking).
+    current_return_type: Option<Ty>,
+}
+
+impl TypeChecker {
+    pub fn new() -> Self {
+        Self {
+            env: TypeEnv::new(),
+            errors: Vec::new(),
+            in_contract: false,
+            current_return_type: None,
+        }
+    }
+
+    /// Type check a source file.
+    pub fn check(mut self, file: &SourceFile) -> TypeCheckResult {
+        // First pass: collect all type definitions
+        for item in &file.items {
+            self.collect_defs(item);
+        }
+
+        // Second pass: check all bodies
+        for item in &file.items {
+            self.check_item(item);
+        }
+
+        TypeCheckResult { errors: self.errors }
+    }
+
+    fn error(&mut self, message: String, span: Span) {
+        self.errors.push(TypeError { message, span });
+    }
+
+    /// Check if an inferred type is compatible with a declared type via structural matching.
+    /// e.g., Vec<?> is compatible with Vec<u256>, bytes is compatible with bytes.
+    fn is_compatible_init(&self, inferred: &Ty, declared: &Ty) -> bool {
+        match (inferred, declared) {
+            // Vec<?> compatible with any Vec<T> and vice versa
+            (Ty::Vec(inner), Ty::Vec(_)) if **inner == Ty::Unknown => true,
+            (Ty::Vec(_), Ty::Vec(inner)) if **inner == Ty::Unknown => true,
+            // Vec<A> assignable to Vec<B> if A can widen to B or B to A
+            (Ty::Vec(a), Ty::Vec(b)) => a == b || a.can_widen_to(b) || b.can_widen_to(a),
+            // Array with int literal elements adapts to any numeric element type
+            // e.g., [0; 32] (inferred as [u256; 32]) is compatible with [u8; 32]
+            (Ty::Array(a_elem, a_size), Ty::Array(b_elem, b_size)) => {
+                a_size == b_size && (a_elem == b_elem
+                    || **a_elem == Ty::Unknown || **b_elem == Ty::Unknown
+                    || a_elem.can_widen_to(b_elem) || b_elem.can_widen_to(a_elem)
+                    || (a_elem.is_numeric() && b_elem.is_numeric()))
+            }
+            // Unknown/Error declared type accepts anything
+            (_, Ty::Unknown) | (_, Ty::Error) => true,
+            (Ty::Unknown, _) | (Ty::Error, _) => true,
+            // Struct inferred matches unknown declared
+            (Ty::Struct(_), Ty::Unknown) => true,
+            _ => false,
+        }
+    }
+
+    /// Check if an expression is an integer literal that can adapt to the target type.
+    /// Integer literals are polymorphic — `42` can be u8, u64, u256, i32, etc.
+    fn is_int_literal_compatible(&self, expr: &Expr, target: &Ty) -> bool {
+        match expr {
+            Expr::Literal(Literal::Int(_), _) => target.is_numeric(),
+            Expr::Unary(UnaryOp::Negate, inner, _) => {
+                matches!(inner.as_ref(), Expr::Literal(Literal::Int(_), _)) && target.is_numeric()
+            }
+            _ => false,
+        }
+    }
+
+    // ========================================================================
+    // AST Type → Ty conversion
+    // ========================================================================
+
+    fn resolve_type(&self, ast_ty: &Type) -> Ty {
+        match ast_ty {
+            Type::Primitive(p, _) => self.primitive_to_ty(p),
+            Type::Bytes(_) => Ty::Bytes,
+            Type::Array(elem, size, _) => Ty::Array(Box::new(self.resolve_type(elem)), *size),
+            Type::Vec(elem, _) => Ty::Vec(Box::new(self.resolve_type(elem))),
+            Type::Map(key, val, _) => Ty::Map(
+                Box::new(self.resolve_type(key)),
+                Box::new(self.resolve_type(val)),
+            ),
+            Type::Named(ident) => {
+                // Check type aliases first
+                if let Some(ty) = self.env.type_aliases.get(&ident.name) {
+                    return ty.clone();
+                }
+                if self.env.struct_defs.contains_key(&ident.name) {
+                    return Ty::Struct(ident.name.clone());
+                }
+                if self.env.enum_defs.contains_key(&ident.name) {
+                    return Ty::Enum(ident.name.clone());
+                }
+                Ty::Unknown
+            }
+            Type::Tuple(types, _) => {
+                Ty::Tuple(types.iter().map(|t| self.resolve_type(t)).collect())
+            }
+        }
+    }
+
+    fn primitive_to_ty(&self, p: &PrimitiveType) -> Ty {
+        match p {
+            PrimitiveType::U8 => Ty::U8,
+            PrimitiveType::U16 => Ty::U16,
+            PrimitiveType::U32 => Ty::U32,
+            PrimitiveType::U64 => Ty::U64,
+            PrimitiveType::U128 => Ty::U128,
+            PrimitiveType::U256 => Ty::U256,
+            PrimitiveType::I8 => Ty::I8,
+            PrimitiveType::I16 => Ty::I16,
+            PrimitiveType::I32 => Ty::I32,
+            PrimitiveType::I64 => Ty::I64,
+            PrimitiveType::I128 => Ty::I128,
+            PrimitiveType::I256 => Ty::I256,
+            PrimitiveType::Bool => Ty::Bool,
+            PrimitiveType::Address => Ty::Address,
+            PrimitiveType::StringType => Ty::StringTy,
+        }
+    }
+
+    // ========================================================================
+    // Definition collection (first pass)
+    // ========================================================================
+
+    fn collect_defs(&mut self, item: &Item) {
+        match item {
+            Item::Contract(c) => self.collect_contract_defs(c),
+            Item::Struct(s) => self.collect_struct(s),
+            Item::Enum(e) => self.collect_enum(e),
+            Item::Const(c) => self.collect_const(c),
+            Item::TypeAlias(t) => self.collect_type_alias(t),
+            Item::Interface(i) => self.collect_interface(i),
+            Item::Error(e) => self.collect_error(e),
+            Item::Function(f) => self.collect_func_sig(f),
+            _ => {}
+        }
+    }
+
+    fn collect_contract_defs(&mut self, contract: &ContractDef) {
+        for item in &contract.items {
+            match item {
+                ContractItem::Storage(s) => {
+                    for field in &s.fields {
+                        let ty = self.resolve_type(&field.ty);
+                        self.env.storage_fields.insert(field.name.name.clone(), ty);
+                    }
+                }
+                ContractItem::Struct(s) => self.collect_struct(s),
+                ContractItem::Enum(e) => self.collect_enum(e),
+                ContractItem::Const(c) => self.collect_const(c),
+                ContractItem::TypeAlias(t) => self.collect_type_alias(t),
+                ContractItem::Event(e) => self.collect_event(e),
+                ContractItem::Error(e) => self.collect_error(e),
+                ContractItem::Function(f) => self.collect_func_sig(f),
+            }
+        }
+    }
+
+    fn collect_struct(&mut self, s: &StructDef) {
+        let fields: Vec<(String, Ty)> = s.fields.iter()
+            .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty)))
+            .collect();
+        self.env.struct_defs.insert(s.name.name.clone(), fields);
+    }
+
+    fn collect_enum(&mut self, e: &EnumDef) {
+        let variants: Vec<String> = e.variants.iter().map(|v| v.name.clone()).collect();
+        self.env.enum_defs.insert(e.name.name.clone(), variants);
+    }
+
+    fn collect_const(&mut self, c: &ConstDef) {
+        let ty = if let Some(ref t) = c.ty {
+            self.resolve_type(t)
+        } else {
+            Ty::Unknown
+        };
+        self.env.const_defs.insert(c.name.name.clone(), ty);
+    }
+
+    fn collect_type_alias(&mut self, t: &TypeAliasDef) {
+        let ty = self.resolve_type(&t.ty);
+        self.env.type_aliases.insert(t.name.name.clone(), ty);
+    }
+
+    fn collect_event(&mut self, e: &EventDef) {
+        let fields: Vec<(String, Ty, bool)> = e.fields.iter()
+            .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty), f.indexed))
+            .collect();
+        self.env.event_defs.insert(e.name.name.clone(), fields);
+    }
+
+    fn collect_error(&mut self, e: &ErrorDef) {
+        let fields: Vec<(String, Ty)> = e.fields.iter()
+            .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty)))
+            .collect();
+        self.env.error_defs.insert(e.name.name.clone(), fields);
+    }
+
+    fn collect_func_sig(&mut self, f: &FunctionDef) {
+        let params: Vec<(String, Ty)> = f.params.iter()
+            .map(|p| (p.name.name.clone(), self.resolve_type(&p.ty)))
+            .collect();
+        let ret = f.return_type.as_ref()
+            .map(|t| self.resolve_type(t))
+            .unwrap_or(Ty::Unit);
+        self.env.func_sigs.insert(f.name.name.clone(), (params, ret));
+    }
+
+    fn collect_interface(&mut self, iface: &InterfaceDef) {
+        let funcs: Vec<(String, Vec<(String, Ty)>, Ty)> = iface.functions.iter()
+            .map(|f| {
+                let params: Vec<(String, Ty)> = f.params.iter()
+                    .map(|p| (p.name.name.clone(), self.resolve_type(&p.ty)))
+                    .collect();
+                let ret = f.return_type.as_ref()
+                    .map(|t| self.resolve_type(t))
+                    .unwrap_or(Ty::Unit);
+                (f.name.name.clone(), params, ret)
+            })
+            .collect();
+        self.env.interface_defs.insert(iface.name.name.clone(), funcs);
+    }
+
+    // ========================================================================
+    // Item checking (second pass)
+    // ========================================================================
+
+    fn check_item(&mut self, item: &Item) {
+        match item {
+            Item::Contract(c) => self.check_contract(c),
+            Item::Function(f) => self.check_function(f),
+            Item::Const(c) => { self.infer_expr(&c.value); }
+            _ => {}
+        }
+    }
+
+    fn check_contract(&mut self, contract: &ContractDef) {
+        self.in_contract = true;
+        for item in &contract.items {
+            match item {
+                ContractItem::Function(f) => self.check_function(f),
+                ContractItem::Const(c) => { self.infer_expr(&c.value); }
+                _ => {}
+            }
+        }
+        self.in_contract = false;
+    }
+
+    fn check_function(&mut self, func: &FunctionDef) {
+        self.env.push_scope();
+
+        // Declare parameters
+        for param in &func.params {
+            let ty = self.resolve_type(&param.ty);
+            self.env.declare_local(&param.name.name, ty, false); // params are immutable
+        }
+
+        // Check body with expected return type
+        let ret_ty = func.return_type.as_ref()
+            .map(|t| self.resolve_type(t))
+            .unwrap_or(Ty::Unit);
+
+        self.current_return_type = Some(ret_ty);
+        self.check_block(&func.body);
+        self.current_return_type = None;
+        self.env.pop_scope();
+    }
+
+    // ========================================================================
+    // Block and statement checking
+    // ========================================================================
+
+    fn check_block(&mut self, block: &Block) {
+        for stmt in &block.stmts {
+            self.check_stmt(stmt);
+        }
+    }
+
+    fn check_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Let(l) => self.check_let(l),
+            Stmt::Assign(a) => self.check_assign(a),
+            Stmt::Return(r) => {
+                if let Some(ref val) = r.value {
+                    let ret_ty = self.infer_expr(val);
+                    if let Some(ref expected) = self.current_return_type {
+                        // Void function returning a value
+                        if *expected == Ty::Unit {
+                            self.error(
+                                "function does not return a value, but 'return' has an expression".into(),
+                                r.span,
+                            );
+                        }
+                        // Type mismatch
+                        else if ret_ty != Ty::Unknown && ret_ty != Ty::Error
+                            && *expected != Ty::Unknown
+                            && ret_ty != *expected
+                            && !self.is_int_literal_compatible(val, expected)
+                            && !ret_ty.can_widen_to(expected)
+                            && !(ret_ty.is_numeric() && expected.is_numeric())
+                            && !self.is_compatible_init(&ret_ty, expected)
+                        {
+                            self.error(
+                                format!("return type mismatch: expected {}, found {}", expected, ret_ty),
+                                r.span,
+                            );
+                        }
+                    }
+                }
+            }
+            Stmt::Emit(e) => self.check_emit(e),
+            Stmt::For(f) => self.check_for(f),
+            Stmt::While(w) => {
+                let cond_ty = self.infer_expr(&w.condition);
+                if cond_ty != Ty::Bool && cond_ty != Ty::Unknown && cond_ty != Ty::Error {
+                    self.error(
+                        format!("while condition must be bool, found {}", cond_ty),
+                        w.span,
+                    );
+                }
+                self.env.push_scope();
+                self.check_block(&w.body);
+                self.env.pop_scope();
+            }
+            Stmt::Expr(e) => { self.infer_expr(&e.expr); }
+            Stmt::Break(_) | Stmt::Continue(_) => {}
+        }
+    }
+
+    fn check_let(&mut self, l: &LetStmt) {
+        let init_ty = self.infer_expr(&l.initializer);
+
+        let declared_ty = if let Some(ref ty) = l.ty {
+            let t = self.resolve_type(ty);
+            // Check compatibility — integer literals are polymorphic,
+            // and Vec<?>/Unknown types are compatible with concrete types
+            if init_ty != Ty::Unknown && init_ty != Ty::Error && t != init_ty
+                && !self.is_int_literal_compatible(&l.initializer, &t)
+                && !self.is_compatible_init(&init_ty, &t)
+                && !init_ty.can_widen_to(&t)
+            {
+                self.error(
+                    format!("type mismatch: declared {}, but initializer is {}", t, init_ty),
+                    l.span,
+                );
+            }
+            t
+        } else {
+            init_ty
+        };
+
+        match &l.binding {
+            LetBinding::Name(name) => {
+                self.env.declare_local(&name.name, declared_ty, l.is_mutable);
+            }
+            LetBinding::Tuple(names, span) => {
+                if let Ty::Tuple(types) = &declared_ty {
+                    if names.len() != types.len() {
+                        self.error(
+                            format!(
+                                "tuple destructuring: expected {} elements, found {}",
+                                types.len(), names.len()
+                            ),
+                            *span,
+                        );
+                    }
+                    for (i, name) in names.iter().enumerate() {
+                        let ty = types.get(i).cloned().unwrap_or(Ty::Error);
+                        self.env.declare_local(&name.name, ty, l.is_mutable);
+                    }
+                } else if declared_ty != Ty::Unknown && declared_ty != Ty::Error {
+                    self.error(
+                        format!("cannot destructure non-tuple type {}", declared_ty),
+                        *span,
+                    );
+                    for name in names {
+                        self.env.declare_local(&name.name, Ty::Error, l.is_mutable);
+                    }
+                } else {
+                    for name in names {
+                        self.env.declare_local(&name.name, Ty::Unknown, l.is_mutable);
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_assign(&mut self, a: &AssignStmt) {
+        // Check mutability — only for simple ident targets
+        if let Expr::Ident(ident) = &a.target {
+            if !self.env.is_mutable(&ident.name) {
+                self.error(
+                    format!("cannot assign to immutable variable '{}'", ident.name),
+                    a.span,
+                );
+            }
+        }
+
+        let target_ty = self.infer_expr(&a.target);
+        let value_ty = self.infer_expr(&a.value);
+
+        if target_ty != Ty::Unknown && value_ty != Ty::Unknown
+            && target_ty != Ty::Error && value_ty != Ty::Error
+        {
+            match a.op {
+                AssignOp::Assign => {
+                    if target_ty != value_ty
+                        && !self.is_int_literal_compatible(&a.value, &target_ty)
+                        && !value_ty.can_widen_to(&target_ty)
+                        && !(target_ty.is_numeric() && value_ty.is_numeric()) // allow numeric narrowing
+                        && !self.is_compatible_init(&value_ty, &target_ty)
+                    {
+                        self.error(
+                            format!("type mismatch in assignment: {} = {}", target_ty, value_ty),
+                            a.span,
+                        );
+                    }
+                }
+                // Compound assignments: allow widening and literal coercion
+                _ => {
+                    if target_ty != value_ty
+                        && !self.is_int_literal_compatible(&a.value, &target_ty)
+                        && !value_ty.can_widen_to(&target_ty)
+                    {
+                        self.error(
+                            format!("type mismatch in compound assignment: {} and {}", target_ty, value_ty),
+                            a.span,
+                        );
+                    }
+                    if !target_ty.is_numeric() && target_ty != Ty::Unknown && target_ty != Ty::Error {
+                        self.error(
+                            format!("compound assignment requires numeric type, found {}", target_ty),
+                            a.span,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_emit(&mut self, e: &EmitStmt) {
+        if let Some(event_fields) = self.env.event_defs.get(&e.event_name.name).cloned() {
+            // Check field count
+            if e.fields.len() != event_fields.len() {
+                self.error(
+                    format!(
+                        "event '{}' expects {} fields, found {}",
+                        e.event_name.name, event_fields.len(), e.fields.len()
+                    ),
+                    e.span,
+                );
+            }
+
+            // Check each field
+            for (i, field) in e.fields.iter().enumerate() {
+                let value_ty = self.infer_expr(&field.value);
+                if let Some((expected_name, expected_ty, _)) = event_fields.get(i) {
+                    if field.name.name != *expected_name {
+                        self.error(
+                            format!(
+                                "event field name mismatch: expected '{}', found '{}'",
+                                expected_name, field.name.name
+                            ),
+                            field.span,
+                        );
+                    }
+                    if value_ty != Ty::Unknown && value_ty != Ty::Error && value_ty != *expected_ty
+                        && !value_ty.can_widen_to(expected_ty)
+                        && !self.is_int_literal_compatible(&field.value, expected_ty)
+                        && !(value_ty.is_numeric() && expected_ty.is_numeric())
+                    {
+                        self.error(
+                            format!(
+                                "event field '{}' expects {}, found {}",
+                                field.name.name, expected_ty, value_ty
+                            ),
+                            field.span,
+                        );
+                    }
+                }
+            }
+        }
+        // If event not found, resolver already reported it
+    }
+
+    fn check_for(&mut self, f: &ForStmt) {
+        let iter_ty = self.infer_expr(&f.iterator);
+        self.env.push_scope();
+
+        // For loop variable type is inferred from the range
+        // Range of u64..u64 → loop var is u64, etc.
+        let var_ty = match &iter_ty {
+            Ty::Unknown | Ty::Error => Ty::U64, // default to u64 for ranges
+            other => other.clone(),
+        };
+        self.env.declare_local(&f.variable.name, var_ty, false); // for vars are immutable
+
+        self.check_block(&f.body);
+        self.env.pop_scope();
+    }
+
+    // ========================================================================
+    // Expression type inference
+    // ========================================================================
+
+    fn infer_expr(&mut self, expr: &Expr) -> Ty {
+        match expr {
+            Expr::Literal(lit, _) => match lit {
+                Literal::Int(_) => Ty::U256, // default integer type
+                Literal::String(_) => Ty::StringTy,
+                Literal::Bool(_) => Ty::Bool,
+            },
+
+            Expr::Ident(ident) => {
+                // Look up local, then const, then storage
+                if let Some(ty) = self.env.lookup_local(&ident.name) {
+                    return ty.clone();
+                }
+                if let Some(ty) = self.env.const_defs.get(&ident.name) {
+                    return ty.clone();
+                }
+                Ty::Unknown // resolver already validated existence
+            }
+
+            Expr::SelfExpr(_) => Ty::Unknown, // self is a reference to contract
+
+            Expr::Binary(lhs, op, rhs, span) => {
+                let lhs_ty = self.infer_expr(lhs);
+                let rhs_ty = self.infer_expr(rhs);
+                self.check_binary_op_full(lhs, &lhs_ty, op, rhs, &rhs_ty, *span)
+            }
+
+            Expr::Unary(op, operand, span) => {
+                let ty = self.infer_expr(operand);
+                match op {
+                    UnaryOp::Negate => {
+                        if !ty.is_numeric() && ty != Ty::Unknown && ty != Ty::Error {
+                            self.error(format!("cannot negate type {}", ty), *span);
+                        }
+                        ty
+                    }
+                    UnaryOp::LogicalNot => {
+                        // Allow ! on bool (logical NOT) and integers (bitwise NOT, like C)
+                        if ty != Ty::Bool && !ty.is_integer() && ty != Ty::Unknown && ty != Ty::Error {
+                            self.error(format!("logical NOT requires bool or integer, found {}", ty), *span);
+                        }
+                        if ty.is_integer() { ty } else { Ty::Bool }
+                    }
+                    UnaryOp::BitNot => {
+                        if !ty.is_integer() && ty != Ty::Unknown && ty != Ty::Error {
+                            self.error(format!("bitwise NOT requires integer, found {}", ty), *span);
+                        }
+                        ty
+                    }
+                }
+            }
+
+            Expr::FieldAccess(obj, field, _) => {
+                let obj_ty = self.infer_expr(obj);
+                // self.field → storage field type
+                if matches!(**obj, Expr::SelfExpr(_)) {
+                    if let Some(ty) = self.env.storage_fields.get(&field.name) {
+                        return ty.clone();
+                    }
+                }
+                // struct.field → field type
+                if let Ty::Struct(name) = &obj_ty {
+                    if let Some(fields) = self.env.struct_defs.get(name) {
+                        for (fname, fty) in fields {
+                            if fname == &field.name {
+                                return fty.clone();
+                            }
+                        }
+                    }
+                }
+                Ty::Unknown // method calls, etc. — resolved by context
+            }
+
+            Expr::Index(obj, index, _) => {
+                let obj_ty = self.infer_expr(obj);
+                self.infer_expr(index);
+                match &obj_ty {
+                    Ty::Vec(elem) => *elem.clone(),
+                    Ty::Map(_, val) => *val.clone(),
+                    Ty::Array(elem, _) => *elem.clone(),
+                    _ => Ty::Unknown,
+                }
+            }
+
+            Expr::Call(callee, args, span) => {
+                // Infer all argument types
+                let arg_types: Vec<Ty> = args.iter()
+                    .map(|arg| self.infer_expr(arg))
+                    .collect();
+
+                // Try to resolve the function return type and check args
+                match callee.as_ref() {
+                    Expr::Ident(ident) => {
+                        // Built-in functions
+                        if ident.name == "hash" {
+                            return Ty::Array(Box::new(Ty::U8), 32);
+                        }
+                        if ident.name == "address" {
+                            return Ty::Address;
+                        }
+                        // Local function — check args
+                        if let Some((params, ret)) = self.env.func_sigs.get(&ident.name).cloned() {
+                            self.check_call_args(&ident.name, &params, &arg_types, args, *span);
+                            return ret;
+                        }
+                        Ty::Unknown
+                    }
+                    Expr::FieldAccess(obj, method, _) => {
+                        let obj_ty = self.infer_expr(obj);
+                        // self.method() → function return type + arg check
+                        if matches!(**obj, Expr::SelfExpr(_)) {
+                            if let Some((params, ret)) = self.env.func_sigs.get(&method.name).cloned() {
+                                self.check_call_args(&method.name, &params, &arg_types, args, *span);
+                                return ret;
+                            }
+                        }
+                        // Common method return types
+                        match method.name.as_str() {
+                            "len" => Ty::U64,
+                            "push" | "pop" => Ty::Unit,
+                            "as_bytes" | "to_bytes" => Ty::Bytes,
+                            "is_empty" => Ty::Bool,
+                            "concat" => obj_ty, // String.concat() → String, bytes.concat() → bytes
+                            "contains" | "starts_with" | "ends_with" | "equals" => Ty::Bool,
+                            "char_at" | "index_of" => Ty::U64,
+                            "substring" | "trim" | "to_lower" | "to_upper" => Ty::StringTy,
+                            "append" => Ty::Unit, // bytes.append()
+                            // Math extension methods return same type
+                            "sqrt" | "pow" | "min" | "max" | "clamp"
+                            | "mul_div" | "checked_add" | "checked_sub"
+                            | "saturating_add" | "saturating_sub"
+                            | "wrapping_add" | "wrapping_sub" => obj_ty,
+                            _ => Ty::Unknown,
+                        }
+                    }
+                    Expr::Path(segments, _) => {
+                        // Vec::new(), bytes::new(), etc.
+                        if segments.len() == 2 {
+                            match (segments[0].name.as_str(), segments[1].name.as_str()) {
+                                ("Vec", "new") => Ty::Vec(Box::new(Ty::Unknown)),
+                                ("bytes", "new" | "empty") => Ty::Bytes,
+                                (iface_name, "at") => {
+                                    // Interface::at(addr) returns something call-able
+                                    Ty::Unknown
+                                }
+                                _ => Ty::Unknown,
+                            }
+                        } else {
+                            Ty::Unknown
+                        }
+                    }
+                    _ => Ty::Unknown,
+                }
+            }
+
+            Expr::Path(segments, _) => {
+                if segments.len() == 2 {
+                    // EnumName::Variant → Enum type
+                    if self.env.enum_defs.contains_key(&segments[0].name) {
+                        return Ty::Enum(segments[0].name.clone());
+                    }
+                    // Address::ZERO
+                    if segments[0].name == "Address" && segments[1].name == "ZERO" {
+                        return Ty::Address;
+                    }
+                }
+                Ty::Unknown
+            }
+
+            Expr::MacroCall(name, args, span) => {
+                // Infer all arg types
+                let mut arg_types = Vec::new();
+                for arg in args {
+                    match arg {
+                        MacroArg::Positional(expr) => { arg_types.push(self.infer_expr(expr)); }
+                        MacroArg::Named(_, expr) => { arg_types.push(self.infer_expr(expr)); }
+                    }
+                }
+
+                // Validate macro-specific arg types
+                match name.name.as_str() {
+                    "require" => {
+                        // require!(condition, error) — first arg must be bool
+                        if let Some(cond_ty) = arg_types.first() {
+                            if *cond_ty != Ty::Bool && *cond_ty != Ty::Unknown && *cond_ty != Ty::Error {
+                                self.error(
+                                    format!("require! condition must be bool, found {}", cond_ty),
+                                    *span,
+                                );
+                            }
+                        }
+                        Ty::Unit
+                    }
+                    "revert" | "cross_call" => Ty::Unit,
+                    "raw_call" => Ty::Unknown,
+                    _ => Ty::Unknown,
+                }
+            }
+
+            Expr::StructInit(name_segments, fields, span) => {
+                let struct_name = name_segments.first()
+                    .map(|s| s.name.as_str())
+                    .unwrap_or("");
+
+                // Check if it's a struct init or error init
+                if let Some(struct_fields) = self.env.struct_defs.get(struct_name).cloned() {
+                    for field in fields {
+                        let value_ty = self.infer_expr(&field.value);
+                        if let Some((_, expected_ty)) = struct_fields.iter()
+                            .find(|(name, _)| name == &field.name.name)
+                        {
+                            if value_ty != Ty::Unknown && value_ty != Ty::Error
+                                && *expected_ty != Ty::Unknown && *expected_ty != Ty::Error
+                                && value_ty != *expected_ty
+                                && !self.is_int_literal_compatible(&field.value, expected_ty)
+                                && !value_ty.can_widen_to(expected_ty)
+                                && !self.is_compatible_init(&value_ty, expected_ty)
+                                && !(value_ty.is_numeric() && expected_ty.is_numeric()) // allow numeric narrowing (runtime checked)
+                            {
+                                self.error(
+                                    format!(
+                                        "struct field '{}' expects {}, found {}",
+                                        field.name.name, expected_ty, value_ty
+                                    ),
+                                    field.span,
+                                );
+                            }
+                        }
+                    }
+                    Ty::Struct(struct_name.to_string())
+                } else if self.env.error_defs.contains_key(struct_name) {
+                    for field in fields {
+                        self.infer_expr(&field.value);
+                    }
+                    Ty::Struct(struct_name.to_string())
+                } else {
+                    for field in fields {
+                        self.infer_expr(&field.value);
+                    }
+                    Ty::Unknown
+                }
+            }
+
+            Expr::If(cond, then_block, else_clause, span) => {
+                let cond_ty = self.infer_expr(cond);
+                if cond_ty != Ty::Bool && cond_ty != Ty::Unknown && cond_ty != Ty::Error {
+                    self.error(
+                        format!("if condition must be bool, found {}", cond_ty),
+                        *span,
+                    );
+                }
+
+                self.env.push_scope();
+                for stmt in &then_block.stmts {
+                    self.check_stmt(stmt);
+                }
+                self.env.pop_scope();
+
+                if let Some(clause) = else_clause {
+                    match clause {
+                        ElseClause::ElseBlock(block) => {
+                            self.env.push_scope();
+                            for stmt in &block.stmts {
+                                self.check_stmt(stmt);
+                            }
+                            self.env.pop_scope();
+                        }
+                        ElseClause::ElseIf(else_if) => {
+                            self.infer_expr(else_if);
+                        }
+                    }
+                }
+                Ty::Unknown // if as expression type needs more analysis
+            }
+
+            Expr::Match(scrutinee, arms, _) => {
+                let scrut_ty = self.infer_expr(scrutinee);
+
+                for arm in arms {
+                    // Check pattern compatibility with scrutinee
+                    self.check_pattern(&arm.pattern, &scrut_ty);
+                    self.infer_expr(&arm.body);
+                }
+                Ty::Unknown
+            }
+
+            Expr::Block(block) => {
+                self.env.push_scope();
+                for stmt in &block.stmts {
+                    self.check_stmt(stmt);
+                }
+                self.env.pop_scope();
+                Ty::Unknown
+            }
+
+            Expr::Cast(expr, target_ty, _) => {
+                self.infer_expr(expr);
+                self.resolve_type(target_ty)
+            }
+
+            Expr::Tuple(elements, _) => {
+                let types: Vec<Ty> = elements.iter()
+                    .map(|e| self.infer_expr(e))
+                    .collect();
+                Ty::Tuple(types)
+            }
+
+            Expr::ArrayRepeat(value, size, _) => {
+                let elem_ty = self.infer_expr(value);
+                Ty::Array(Box::new(elem_ty), *size)
+            }
+
+            Expr::ArrayLiteral(elements, span) => {
+                if elements.is_empty() {
+                    return Ty::Array(Box::new(Ty::Unknown), 0);
+                }
+                let first_ty = self.infer_expr(&elements[0]);
+                for (i, elem) in elements.iter().enumerate().skip(1) {
+                    let elem_ty = self.infer_expr(elem);
+                    if elem_ty != first_ty && elem_ty != Ty::Unknown && first_ty != Ty::Unknown {
+                        self.error(
+                            format!(
+                                "array element {} has type {}, expected {}",
+                                i, elem_ty, first_ty
+                            ),
+                            *span,
+                        );
+                    }
+                }
+                Ty::Array(Box::new(first_ty), elements.len() as u64)
+            }
+
+            Expr::Try(inner, _) => {
+                self.infer_expr(inner);
+                Ty::Unknown // try wraps in Result-like
+            }
+        }
+    }
+
+    fn check_binary_op_full(&mut self, lhs_expr: &Expr, lhs: &Ty, op: &BinaryOp, rhs_expr: &Expr, rhs: &Ty, span: Span) -> Ty {
+        // Error/Unknown propagation
+        if matches!(lhs, Ty::Error | Ty::Unknown) || matches!(rhs, Ty::Error | Ty::Unknown) {
+            return match op {
+                BinaryOp::Eq | BinaryOp::NotEq | BinaryOp::Lt | BinaryOp::Gt
+                | BinaryOp::LtEq | BinaryOp::GtEq | BinaryOp::LogicalAnd
+                | BinaryOp::LogicalOr => Ty::Bool,
+                BinaryOp::Range => Ty::Unknown,
+                _ => if *lhs != Ty::Unknown && *lhs != Ty::Error { lhs.clone() } else { rhs.clone() },
+            };
+        }
+
+        // Integer literal coercion: if one side is a literal and the other is a
+        // concrete numeric type, the literal adapts to the concrete type.
+        let (lhs, rhs) = self.coerce_numeric_pair(lhs_expr, lhs, rhs_expr, rhs);
+
+        match op {
+            // Arithmetic: both same numeric type → same type
+            BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul
+            | BinaryOp::Div | BinaryOp::Mod => {
+                if lhs == Ty::StringTy || rhs == Ty::StringTy {
+                    self.error(
+                        "cannot use '+' on strings — use .concat() instead".into(),
+                        span,
+                    );
+                    return Ty::Error;
+                }
+                if lhs == Ty::Bytes || rhs == Ty::Bytes {
+                    self.error(
+                        "cannot use arithmetic on bytes — use .append() instead".into(),
+                        span,
+                    );
+                    return Ty::Error;
+                }
+                if !lhs.is_numeric() {
+                    self.error(format!("arithmetic requires numeric type, found {}", lhs), span);
+                    return Ty::Error;
+                }
+                if lhs != rhs {
+                    self.error(
+                        format!("type mismatch in arithmetic: {} and {}", lhs, rhs),
+                        span,
+                    );
+                }
+                lhs
+            }
+
+            // Bitwise: both same integer type → same type
+            BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor
+            | BinaryOp::Shl | BinaryOp::Shr => {
+                if !lhs.is_integer() {
+                    self.error(format!("bitwise op requires integer type, found {}", lhs), span);
+                    return Ty::Error;
+                }
+                if lhs != rhs {
+                    self.error(
+                        format!("type mismatch in bitwise op: {} and {}", lhs, rhs),
+                        span,
+                    );
+                }
+                lhs
+            }
+
+            // Comparison: compatible types → bool
+            BinaryOp::Eq | BinaryOp::NotEq | BinaryOp::Lt | BinaryOp::Gt
+            | BinaryOp::LtEq | BinaryOp::GtEq => {
+                if !lhs.is_comparable_with(&rhs) {
+                    self.error(
+                        format!("cannot compare {} with {}", lhs, rhs),
+                        span,
+                    );
+                }
+                Ty::Bool
+            }
+
+            // Logical: both bool → bool
+            BinaryOp::LogicalAnd | BinaryOp::LogicalOr => {
+                if lhs != Ty::Bool {
+                    self.error(format!("logical op requires bool, found {}", lhs), span);
+                }
+                if rhs != Ty::Bool {
+                    self.error(format!("logical op requires bool, found {}", rhs), span);
+                }
+                Ty::Bool
+            }
+
+            // Range: numeric → range (used in for loops)
+            BinaryOp::Range => {
+                Ty::Unknown
+            }
+        }
+    }
+
+    /// Coerce numeric types to a common type for binary operations.
+    /// Rules:
+    /// 1. Integer literals adapt to the other operand's concrete type
+    /// 2. Implicit widening: smaller → larger (u64 + u256 → u256)
+    /// 3. Same signedness required (no implicit signed/unsigned mixing)
+    fn coerce_numeric_pair(&self, lhs_expr: &Expr, lhs: &Ty, rhs_expr: &Expr, rhs: &Ty) -> (Ty, Ty) {
+        if lhs == rhs { return (lhs.clone(), rhs.clone()); }
+
+        // If LHS is a literal and RHS is concrete numeric, adapt LHS
+        if self.is_int_literal_compatible(lhs_expr, rhs) && rhs.is_numeric() {
+            return (rhs.clone(), rhs.clone());
+        }
+        // If RHS is a literal and LHS is concrete numeric, adapt RHS
+        if self.is_int_literal_compatible(rhs_expr, lhs) && lhs.is_numeric() {
+            return (lhs.clone(), lhs.clone());
+        }
+
+        // Implicit widening: promote the smaller type to the larger
+        if lhs.is_numeric() && rhs.is_numeric() {
+            if lhs.can_widen_to(rhs) {
+                return (rhs.clone(), rhs.clone());
+            }
+            if rhs.can_widen_to(lhs) {
+                return (lhs.clone(), lhs.clone());
+            }
+        }
+
+        (lhs.clone(), rhs.clone())
+    }
+
+    /// Check function call arguments against parameter types.
+    fn check_call_args(
+        &mut self,
+        func_name: &str,
+        params: &[(String, Ty)],
+        arg_types: &[Ty],
+        arg_exprs: &[Expr],
+        span: Span,
+    ) {
+        if arg_types.len() != params.len() {
+            self.error(
+                format!(
+                    "'{}' expects {} arguments, found {}",
+                    func_name, params.len(), arg_types.len()
+                ),
+                span,
+            );
+            return;
+        }
+
+        for (i, ((param_name, param_ty), arg_ty)) in params.iter().zip(arg_types.iter()).enumerate() {
+            if *arg_ty != Ty::Unknown && *arg_ty != Ty::Error
+                && *param_ty != Ty::Unknown
+                && *arg_ty != *param_ty
+                && !arg_ty.can_widen_to(param_ty)
+                && !(arg_ty.is_numeric() && param_ty.is_numeric())
+                && !self.is_compatible_init(arg_ty, param_ty)
+            {
+                // Also check if the arg is a literal that can adapt
+                let is_literal = arg_exprs.get(i)
+                    .map(|e| self.is_int_literal_compatible(e, param_ty))
+                    .unwrap_or(false);
+                if !is_literal {
+                    self.error(
+                        format!(
+                            "argument '{}' expects {}, found {}",
+                            param_name, param_ty, arg_ty
+                        ),
+                        span,
+                    );
+                }
+            }
+        }
+    }
+
+    fn check_pattern(&mut self, pattern: &Pattern, scrutinee_ty: &Ty) {
+        match pattern {
+            Pattern::Path(segments, span) => {
+                // Enum variant pattern — check it matches the scrutinee's enum
+                if segments.len() >= 2 {
+                    if let Ty::Enum(enum_name) = scrutinee_ty {
+                        if segments[0].name != *enum_name {
+                            self.error(
+                                format!(
+                                    "pattern enum '{}' doesn't match scrutinee enum '{}'",
+                                    segments[0].name, enum_name
+                                ),
+                                *span,
+                            );
+                        }
+                    }
+                }
+            }
+            Pattern::Literal(_, _) | Pattern::Range(_, _, _) | Pattern::Wildcard(_) => {}
+        }
+    }
+}
+
+/// Result of type checking.
+pub struct TypeCheckResult {
+    pub errors: Vec<TypeError>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+    use crate::parser::Parser;
+
+    fn typecheck(src: &str) -> Vec<TypeError> {
+        let (tokens, lex_errors) = Lexer::new(src).tokenize();
+        assert!(lex_errors.is_empty(), "lex errors: {:?}", lex_errors);
+        let (file, parse_errors) = Parser::new(tokens).parse();
+        assert!(parse_errors.is_empty(), "parse errors: {:?}", parse_errors);
+        TypeChecker::new().check(&file).errors
+    }
+
+    fn check_ok(src: &str) {
+        let errors = typecheck(src);
+        assert!(errors.is_empty(), "type errors: {:?}", errors);
+    }
+
+    fn check_err(src: &str) -> Vec<TypeError> {
+        let errors = typecheck(src);
+        assert!(!errors.is_empty(), "expected type errors but got none");
+        errors
+    }
+
+    // ========== Basic type checking ==========
+
+    #[test]
+    fn check_simple_contract() {
+        check_ok(r#"
+            contract Token {
+                storage { supply: u256, }
+                #[constructor]
+                pub fn init(supply: u256) {
+                    self.supply = supply;
+                }
+                #[view]
+                pub fn get_supply() -> u256 {
+                    return self.supply;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_arithmetic_same_type() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let a: u256 = 10;
+                    let b: u256 = 20;
+                    let c = a + b;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_boolean_logic() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let a = true;
+                    let b = false;
+                    let c = a && b;
+                    let d = a || !b;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_comparison_returns_bool() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let a: u256 = 10;
+                    let b: u256 = 20;
+                    let c = a > b;
+                    if c {
+                        let x = 1;
+                    }
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_struct_init() {
+        check_ok(r#"
+            contract T {
+                struct Point { x: u64, y: u64 }
+                pub fn f() {
+                    let p = Point { x: 1, y: 2 };
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_enum_pattern() {
+        check_ok(r#"
+            contract T {
+                enum Status { Active, Paused }
+                pub fn f() {
+                    let s = Status::Active;
+                    match s {
+                        Status::Active => { let x = 1; },
+                        Status::Paused => { let x = 2; },
+                        _ => { let x = 3; },
+                    }
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_event_emit() {
+        check_ok(r#"
+            contract T {
+                event Transfer { from: Address, to: Address, amount: u256, }
+                pub fn f() {
+                    emit Transfer { from: msg.sender, to: msg.sender, amount: 100 };
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_tuple_destructuring() {
+        check_ok(r#"
+            contract T {
+                pub fn get_pair() -> (u256, u256) {
+                    return (1, 2);
+                }
+                pub fn f() {
+                    let (a, b) = self.get_pair();
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_cast_expression() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let a: u64 = 42;
+                    let b = a as u256;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_array_literal() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let arr = [1, 2, 3];
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_hash_builtin() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let h = hash(42);
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_for_loop() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    for i in 0..10 {
+                        let x = i;
+                    }
+                }
+            }
+        "#);
+    }
+
+    // ========== Type errors ==========
+
+    #[test]
+    fn error_if_condition_not_bool() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    if 42 {
+                        let x = 1;
+                    }
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("if condition must be bool"));
+    }
+
+    #[test]
+    fn error_while_condition_not_bool() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    while 42 {
+                        let x = 1;
+                    }
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("while condition must be bool"));
+    }
+
+    #[test]
+    fn logical_not_on_int_is_allowed() {
+        // ! on integers is bitwise NOT (like C), returns same type
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let x = !42;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_logical_not_on_string() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    let x = !"hello";
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("logical NOT requires bool or integer"));
+    }
+
+    #[test]
+    fn error_wrong_event_field_count() {
+        let errors = check_err(r#"
+            contract T {
+                event Transfer { from: Address, to: Address, amount: u256, }
+                pub fn f() {
+                    emit Transfer { from: msg.sender };
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("expects 3 fields, found 1"));
+    }
+
+    // ========== Return type validation ==========
+
+    #[test]
+    fn check_return_type_correct() {
+        check_ok(r#"
+            contract T {
+                pub fn f() -> u256 {
+                    return 42;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_return_type_mismatch() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() -> u256 {
+                    return "hello";
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("return type mismatch"));
+    }
+
+    #[test]
+    fn check_return_type_widening() {
+        // u64 returned for u256 function — widening is ok
+        check_ok(r#"
+            contract T {
+                storage { count: u64, }
+                pub fn f() -> u256 {
+                    return self.count;
+                }
+            }
+        "#);
+    }
+
+    // ========== Function call argument validation ==========
+
+    #[test]
+    fn error_wrong_argument_count() {
+        let errors = check_err(r#"
+            contract T {
+                fn helper(x: u256, y: u256) {}
+                pub fn f() {
+                    self.helper(1);
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("expects 2 arguments, found 1"));
+    }
+
+    #[test]
+    fn error_wrong_argument_type() {
+        let errors = check_err(r#"
+            contract T {
+                fn helper(x: u256) {}
+                pub fn f() {
+                    self.helper("hello");
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("argument 'x' expects u256, found String"));
+    }
+
+    #[test]
+    fn check_argument_widening() {
+        // u64 arg for u256 param — ok
+        check_ok(r#"
+            contract T {
+                storage { count: u64, }
+                fn helper(x: u256) {}
+                pub fn f() {
+                    self.helper(self.count);
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn check_argument_literal() {
+        // Literal adapts to param type
+        check_ok(r#"
+            contract T {
+                fn helper(x: u64) {}
+                pub fn f() {
+                    self.helper(42);
+                }
+            }
+        "#);
+    }
+
+    // ========== Mutability checking ==========
+
+    #[test]
+    fn check_mutable_assignment() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let mut x = 1;
+                    x = 2;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_immutable_assignment() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    let x = 1;
+                    x = 2;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot assign to immutable variable 'x'"));
+    }
+
+    #[test]
+    fn check_compound_mutable_assignment() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let mut count = 0;
+                    count += 1;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_immutable_compound_assignment() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    let count = 0;
+                    count += 1;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot assign to immutable variable 'count'"));
+    }
+
+    // ========== require! condition checking ==========
+
+    #[test]
+    fn check_require_bool_condition() {
+        check_ok(r#"
+            contract T {
+                error Fail {}
+                pub fn f() {
+                    require!(true, Fail {});
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_require_non_bool_condition() {
+        let errors = check_err(r#"
+            contract T {
+                error Fail {}
+                pub fn f() {
+                    require!(42, Fail {});
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("require! condition must be bool"));
+    }
+
+    // ========== Void function returning value ==========
+
+    #[test]
+    fn check_void_function_no_return() {
+        check_ok(r#"
+            contract T {
+                pub fn f() {
+                    let x = 1;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_void_function_returning_value() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    return 42;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("function does not return a value"));
+    }
+
+    // ========== String concat error ==========
+
+    #[test]
+    fn error_string_plus_operator() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn f() {
+                    let x = "hello" + "world";
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("use .concat() instead"));
+    }
+}

--- a/crates/otic/src/types.rs
+++ b/crates/otic/src/types.rs
@@ -1,0 +1,160 @@
+//! Type system for Otigen.
+//!
+//! Defines the concrete types used during type checking.
+//! Separate from AST types — these are resolved and canonical.
+
+use std::fmt;
+
+/// A resolved, canonical type.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Ty {
+    // Unsigned integers
+    U8, U16, U32, U64, U128, U256,
+    // Signed integers
+    I8, I16, I32, I64, I128, I256,
+    // Other primitives
+    Bool,
+    Address,
+    StringTy,
+    Bytes,
+    // Composite types
+    Array(Box<Ty>, u64),       // [T; N]
+    Vec(Box<Ty>),              // Vec<T>
+    Map(Box<Ty>, Box<Ty>),     // Map<K, V>
+    Tuple(Vec<Ty>),            // (T1, T2, ...)
+    // Named types
+    Struct(String),            // struct name
+    Enum(String),              // enum name
+    // Special
+    Unit,                      // void / no return
+    /// Used for type inference when we don't know yet.
+    Unknown,
+    /// Used for error recovery — any type is compatible.
+    Error,
+}
+
+impl Ty {
+    /// Whether this is a numeric type (arithmetic operations allowed).
+    pub fn is_numeric(&self) -> bool {
+        matches!(self,
+            Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64 | Ty::U128 | Ty::U256
+            | Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64 | Ty::I128 | Ty::I256
+        )
+    }
+
+    /// Whether this is an unsigned integer type.
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self, Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64 | Ty::U128 | Ty::U256)
+    }
+
+    /// Whether this is a signed integer type.
+    pub fn is_signed(&self) -> bool {
+        matches!(self, Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64 | Ty::I128 | Ty::I256)
+    }
+
+    /// Whether this is an integer type (numeric, not bool).
+    pub fn is_integer(&self) -> bool {
+        self.is_numeric()
+    }
+
+    /// Bit width of integer types.
+    pub fn bit_width(&self) -> Option<u32> {
+        match self {
+            Ty::U8 | Ty::I8 => Some(8),
+            Ty::U16 | Ty::I16 => Some(16),
+            Ty::U32 | Ty::I32 => Some(32),
+            Ty::U64 | Ty::I64 => Some(64),
+            Ty::U128 | Ty::I128 => Some(128),
+            Ty::U256 | Ty::I256 => Some(256),
+            _ => None,
+        }
+    }
+
+    /// Whether a cast from self to target is a widening (always safe) cast.
+    /// Allows: u8→u64, u64→u256, i32→i64, u32→i64, and any numeric→larger numeric.
+    pub fn can_widen_to(&self, target: &Ty) -> bool {
+        if self == target { return true; }
+        match (self.bit_width(), target.bit_width()) {
+            (Some(from), Some(to)) => {
+                if from <= to {
+                    // Same signedness — always ok
+                    if self.is_unsigned() == target.is_unsigned() {
+                        return true;
+                    }
+                    // Unsigned to signed of equal or wider size — ok
+                    if self.is_unsigned() && target.is_signed() {
+                        return true;
+                    }
+                    // Signed to unsigned of wider size — ok (with potential value check at runtime)
+                    if self.is_signed() && target.is_unsigned() && from < to {
+                        return true;
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether two types are compatible for comparison (==, !=, <, >, etc.).
+    pub fn is_comparable_with(&self, other: &Ty) -> bool {
+        if self == other { return true; }
+        if matches!(self, Ty::Error) || matches!(other, Ty::Error) { return true; }
+        if matches!(self, Ty::Unknown) || matches!(other, Ty::Unknown) { return true; }
+        // Numeric types are comparable (implicit widening happens)
+        if self.is_numeric() && other.is_numeric() { return true; }
+        // Arrays of same size with compatible elements
+        if let (Ty::Array(a, n1), Ty::Array(b, n2)) = (self, other) {
+            return n1 == n2 && a.is_comparable_with(b);
+        }
+        false
+    }
+
+    /// Whether a type can be used as a map key.
+    pub fn is_hashable(&self) -> bool {
+        matches!(self,
+            Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64 | Ty::U128 | Ty::U256
+            | Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64 | Ty::I128 | Ty::I256
+            | Ty::Bool | Ty::Address | Ty::StringTy | Ty::Bytes
+        )
+    }
+}
+
+impl fmt::Display for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Ty::U8 => write!(f, "u8"),
+            Ty::U16 => write!(f, "u16"),
+            Ty::U32 => write!(f, "u32"),
+            Ty::U64 => write!(f, "u64"),
+            Ty::U128 => write!(f, "u128"),
+            Ty::U256 => write!(f, "u256"),
+            Ty::I8 => write!(f, "i8"),
+            Ty::I16 => write!(f, "i16"),
+            Ty::I32 => write!(f, "i32"),
+            Ty::I64 => write!(f, "i64"),
+            Ty::I128 => write!(f, "i128"),
+            Ty::I256 => write!(f, "i256"),
+            Ty::Bool => write!(f, "bool"),
+            Ty::Address => write!(f, "Address"),
+            Ty::StringTy => write!(f, "String"),
+            Ty::Bytes => write!(f, "bytes"),
+            Ty::Array(elem, size) => write!(f, "[{}; {}]", elem, size),
+            Ty::Vec(elem) => write!(f, "Vec<{}>", elem),
+            Ty::Map(key, val) => write!(f, "Map<{}, {}>", key, val),
+            Ty::Tuple(types) => {
+                write!(f, "(")?;
+                for (i, t) in types.iter().enumerate() {
+                    if i > 0 { write!(f, ", ")?; }
+                    write!(f, "{}", t)?;
+                }
+                write!(f, ")")
+            }
+            Ty::Struct(name) => write!(f, "{}", name),
+            Ty::Enum(name) => write!(f, "{}", name),
+            Ty::Unit => write!(f, "()"),
+            Ty::Unknown => write!(f, "?"),
+            Ty::Error => write!(f, "<error>"),
+        }
+    }
+}

--- a/crates/otic/tests/fixtures/programs/infra/name_registry.oti
+++ b/crates/otic/tests/fixtures/programs/infra/name_registry.oti
@@ -252,7 +252,7 @@ contract NameRegistry {
         let child_hash = math::keccak256(parent_hash ^ math::keccak256_str(label));
         require!(self.names[child_hash].owner == Address::ZERO, SubdomainExists {});
 
-        let full_name = label + "." + parent.name;
+        let full_name = label.concat(".").concat(parent.name);
 
         self.names[child_hash] = NameEntry {
             name: full_name,

--- a/crates/otic/tests/fixtures/programs/library/string_utils.oti
+++ b/crates/otic/tests/fixtures/programs/library/string_utils.oti
@@ -28,12 +28,12 @@ pub fn equals(a: String, b: String) -> bool {
 
 /// Concatenates two strings.
 pub fn concat(a: String, b: String) -> String {
-    return a + b;
+    return a.concat(b);
 }
 
 /// Concatenates three strings.
 pub fn concat3(a: String, b: String, c: String) -> String {
-    return a + b + c;
+    return a.concat(b).concat(c);
 }
 
 /// Returns a substring from start index (inclusive) to end index (exclusive).
@@ -113,7 +113,7 @@ pub fn index_of(haystack: String, needle: String) -> u64 {
 pub fn pad_left(s: String, target_len: u64, pad: String) -> String {
     let mut result = s;
     while result.len() < target_len {
-        result = pad + result;
+        result = pad.concat(result);
     }
     return result;
 }
@@ -122,7 +122,7 @@ pub fn pad_left(s: String, target_len: u64, pad: String) -> String {
 pub fn pad_right(s: String, target_len: u64, pad: String) -> String {
     let mut result = s;
     while result.len() < target_len {
-        result = result + pad;
+        result = result.concat(pad);
     }
     return result;
 }
@@ -131,7 +131,7 @@ pub fn pad_right(s: String, target_len: u64, pad: String) -> String {
 pub fn repeat(s: String, n: u64) -> String {
     let mut result = "";
     for i in 0u64..n {
-        result = result + s;
+        result = result.concat(s);
     }
     return result;
 }
@@ -159,7 +159,7 @@ pub fn u256_to_string(value: u256) -> String {
             8u256 => "8",
             9u256 => "9",
         };
-        result = digit_char + result;
+        result = digit_char.concat(result);
         remaining = remaining / 10u256;
     }
 
@@ -193,7 +193,7 @@ fn nibble_to_hex(n: u8) -> String {
 pub fn byte_to_hex(b: u8) -> String {
     let high = nibble_to_hex(b / 16u8);
     let low = nibble_to_hex(b % 16u8);
-    return high + low;
+    return high.concat(low);
 }
 
 /// Converts an Address to its lowercase hex string with "0x" prefix.
@@ -201,7 +201,7 @@ pub fn address_to_hex_string(addr: Address) -> String {
     let raw: bytes = addr.to_bytes();
     let mut result = "0x";
     for i in 0u64..20u64 {
-        result = result + byte_to_hex(raw[i]);
+        result = result.concat(byte_to_hex(raw[i]));
     }
     return result;
 }

--- a/crates/otic/tests/typecheck_integration.rs
+++ b/crates/otic/tests/typecheck_integration.rs
@@ -1,0 +1,163 @@
+//! Integration tests for the type checker using .oti fixture files.
+
+use otic::lexer::Lexer;
+use otic::parser::Parser;
+use otic::typecheck::TypeChecker;
+
+fn typecheck_file(src: &str) -> Vec<otic::typecheck::TypeError> {
+    let (tokens, lex_errors) = Lexer::new(src).tokenize();
+    assert!(lex_errors.is_empty(), "lex errors: {:?}", lex_errors);
+    let (file, parse_errors) = Parser::new(tokens).parse();
+    assert!(parse_errors.is_empty(), "parse errors: {:?}", parse_errors);
+    TypeChecker::new().check(&file).errors
+}
+
+macro_rules! typecheck_fixture {
+    ($name:ident, $path:expr) => {
+        #[test]
+        fn $name() {
+            let src = include_str!($path);
+            let errors = typecheck_file(src);
+            if !errors.is_empty() {
+                for e in &errors {
+                    eprintln!("  {}", e);
+                }
+                panic!("{} had {} type errors", stringify!($name), errors.len());
+            }
+        }
+    };
+}
+
+// === ERC20 ===
+typecheck_fixture!(typecheck_erc20, "fixtures/erc20.oti");
+
+// === DeFi ===
+typecheck_fixture!(typecheck_erc20_advanced, "fixtures/programs/defi/erc20_advanced.oti");
+typecheck_fixture!(typecheck_amm_pool, "fixtures/programs/defi/amm_pool.oti");
+typecheck_fixture!(typecheck_lending_pool, "fixtures/programs/defi/lending_pool.oti");
+typecheck_fixture!(typecheck_staking, "fixtures/programs/defi/staking.oti");
+typecheck_fixture!(typecheck_vault, "fixtures/programs/defi/vault.oti");
+typecheck_fixture!(typecheck_flash_loan, "fixtures/programs/defi/flash_loan.oti");
+typecheck_fixture!(typecheck_order_book, "fixtures/programs/defi/order_book.oti");
+typecheck_fixture!(typecheck_yield_farm, "fixtures/programs/defi/yield_farm.oti");
+typecheck_fixture!(typecheck_wrapped_token, "fixtures/programs/defi/wrapped_token.oti");
+typecheck_fixture!(typecheck_price_oracle, "fixtures/programs/defi/price_oracle.oti");
+typecheck_fixture!(typecheck_stable_swap, "fixtures/programs/defi/stable_swap.oti");
+typecheck_fixture!(typecheck_fee_distributor, "fixtures/programs/defi/fee_distributor.oti");
+typecheck_fixture!(typecheck_liquidity_gauge, "fixtures/programs/defi/liquidity_gauge.oti");
+typecheck_fixture!(typecheck_router, "fixtures/programs/defi/router.oti");
+typecheck_fixture!(typecheck_token_vesting, "fixtures/programs/defi/token_vesting.oti");
+
+// === NFT ===
+typecheck_fixture!(typecheck_basic_nft, "fixtures/programs/nft/basic_nft.oti");
+typecheck_fixture!(typecheck_nft_marketplace, "fixtures/programs/nft/nft_marketplace.oti");
+typecheck_fixture!(typecheck_nft_auction, "fixtures/programs/nft/nft_auction.oti");
+typecheck_fixture!(typecheck_nft_collection, "fixtures/programs/nft/nft_collection.oti");
+typecheck_fixture!(typecheck_soulbound_token, "fixtures/programs/nft/soulbound_token.oti");
+typecheck_fixture!(typecheck_nft_royalties, "fixtures/programs/nft/nft_royalties.oti");
+typecheck_fixture!(typecheck_nft_rental, "fixtures/programs/nft/nft_rental.oti");
+
+// === Governance ===
+typecheck_fixture!(typecheck_dao, "fixtures/programs/governance/dao.oti");
+typecheck_fixture!(typecheck_governor, "fixtures/programs/governance/governor.oti");
+typecheck_fixture!(typecheck_multisig, "fixtures/programs/governance/multisig.oti");
+typecheck_fixture!(typecheck_timelock, "fixtures/programs/governance/timelock.oti");
+typecheck_fixture!(typecheck_voting_token, "fixtures/programs/governance/voting_token.oti");
+typecheck_fixture!(typecheck_treasury, "fixtures/programs/governance/treasury.oti");
+typecheck_fixture!(typecheck_reputation, "fixtures/programs/governance/reputation.oti");
+typecheck_fixture!(typecheck_quadratic_voting, "fixtures/programs/governance/quadratic_voting.oti");
+
+// === Games ===
+typecheck_fixture!(typecheck_lottery, "fixtures/programs/games/lottery.oti");
+typecheck_fixture!(typecheck_prediction_market, "fixtures/programs/games/prediction_market.oti");
+typecheck_fixture!(typecheck_rock_paper_scissors, "fixtures/programs/games/rock_paper_scissors.oti");
+typecheck_fixture!(typecheck_coin_flip, "fixtures/programs/games/coin_flip.oti");
+typecheck_fixture!(typecheck_chess_wager, "fixtures/programs/games/chess_wager.oti");
+typecheck_fixture!(typecheck_nft_battle, "fixtures/programs/games/nft_battle.oti");
+typecheck_fixture!(typecheck_raffle, "fixtures/programs/games/raffle.oti");
+
+// === Finance ===
+typecheck_fixture!(typecheck_escrow, "fixtures/programs/finance/escrow.oti");
+typecheck_fixture!(typecheck_payment_splitter, "fixtures/programs/finance/payment_splitter.oti");
+typecheck_fixture!(typecheck_subscription, "fixtures/programs/finance/subscription.oti");
+typecheck_fixture!(typecheck_invoice, "fixtures/programs/finance/invoice.oti");
+typecheck_fixture!(typecheck_payroll, "fixtures/programs/finance/payroll.oti");
+typecheck_fixture!(typecheck_crowdfund, "fixtures/programs/finance/crowdfund.oti");
+typecheck_fixture!(typecheck_insurance, "fixtures/programs/finance/insurance.oti");
+typecheck_fixture!(typecheck_bond, "fixtures/programs/finance/bond.oti");
+
+// === Access Control ===
+typecheck_fixture!(typecheck_ownable, "fixtures/programs/access/ownable.oti");
+typecheck_fixture!(typecheck_role_manager, "fixtures/programs/access/role_manager.oti");
+typecheck_fixture!(typecheck_two_step_ownership, "fixtures/programs/access/two_step_ownership.oti");
+typecheck_fixture!(typecheck_allowlist, "fixtures/programs/access/allowlist.oti");
+typecheck_fixture!(typecheck_time_lock_admin, "fixtures/programs/access/time_lock_admin.oti");
+typecheck_fixture!(typecheck_guardian, "fixtures/programs/access/guardian.oti");
+typecheck_fixture!(typecheck_fee_manager, "fixtures/programs/access/fee_manager.oti");
+
+// === Infrastructure ===
+typecheck_fixture!(typecheck_name_registry, "fixtures/programs/infra/name_registry.oti");
+typecheck_fixture!(typecheck_proxy, "fixtures/programs/infra/proxy.oti");
+typecheck_fixture!(typecheck_factory, "fixtures/programs/infra/factory.oti");
+typecheck_fixture!(typecheck_access_control, "fixtures/programs/infra/access_control.oti");
+typecheck_fixture!(typecheck_event_logger, "fixtures/programs/infra/event_logger.oti");
+typecheck_fixture!(typecheck_rate_limiter, "fixtures/programs/infra/rate_limiter.oti");
+typecheck_fixture!(typecheck_circuit_breaker, "fixtures/programs/infra/circuit_breaker.oti");
+typecheck_fixture!(typecheck_whitelist, "fixtures/programs/infra/whitelist.oti");
+
+// === Library ===
+typecheck_fixture!(typecheck_math_lib, "fixtures/programs/library/math_lib.oti");
+typecheck_fixture!(typecheck_string_utils, "fixtures/programs/library/string_utils.oti");
+typecheck_fixture!(typecheck_array_utils, "fixtures/programs/library/array_utils.oti");
+typecheck_fixture!(typecheck_address_utils, "fixtures/programs/library/address_utils.oti");
+typecheck_fixture!(typecheck_bitmap, "fixtures/programs/library/bitmap.oti");
+
+// === Patterns ===
+typecheck_fixture!(typecheck_token_with_resource, "fixtures/programs/patterns/token_with_resource.oti");
+typecheck_fixture!(typecheck_multi_contract, "fixtures/programs/patterns/multi_contract.oti");
+typecheck_fixture!(typecheck_state_machine, "fixtures/programs/patterns/state_machine.oti");
+typecheck_fixture!(typecheck_batch_operations, "fixtures/programs/patterns/batch_operations.oti");
+typecheck_fixture!(typecheck_diamond_storage, "fixtures/programs/patterns/diamond_storage.oti");
+typecheck_fixture!(typecheck_complex_structs, "fixtures/programs/patterns/complex_structs.oti");
+typecheck_fixture!(typecheck_sponsored_functions, "fixtures/programs/patterns/sponsored_functions.oti");
+typecheck_fixture!(typecheck_bytes_and_crypto, "fixtures/programs/patterns/bytes_and_crypto.oti");
+typecheck_fixture!(typecheck_nested_types, "fixtures/programs/patterns/nested_types.oti");
+
+// === Social ===
+typecheck_fixture!(typecheck_social_media, "fixtures/programs/social/social_media.oti");
+typecheck_fixture!(typecheck_messaging, "fixtures/programs/social/messaging.oti");
+typecheck_fixture!(typecheck_tipping, "fixtures/programs/social/tipping.oti");
+typecheck_fixture!(typecheck_content_platform, "fixtures/programs/social/content_platform.oti");
+typecheck_fixture!(typecheck_follow_system, "fixtures/programs/social/follow_system.oti");
+
+// === Supply Chain ===
+typecheck_fixture!(typecheck_tracking, "fixtures/programs/supply/tracking.oti");
+typecheck_fixture!(typecheck_certification, "fixtures/programs/supply/certification.oti");
+typecheck_fixture!(typecheck_inventory, "fixtures/programs/supply/inventory.oti");
+typecheck_fixture!(typecheck_shipping, "fixtures/programs/supply/shipping.oti");
+typecheck_fixture!(typecheck_provenance, "fixtures/programs/supply/provenance.oti");
+
+// === Real Estate ===
+typecheck_fixture!(typecheck_property_deed, "fixtures/programs/realestate/property_deed.oti");
+typecheck_fixture!(typecheck_rental_agreement, "fixtures/programs/realestate/rental_agreement.oti");
+typecheck_fixture!(typecheck_fractional_ownership, "fixtures/programs/realestate/fractional_ownership.oti");
+
+// === Health ===
+typecheck_fixture!(typecheck_medical_records, "fixtures/programs/health/medical_records.oti");
+typecheck_fixture!(typecheck_prescription, "fixtures/programs/health/prescription.oti");
+typecheck_fixture!(typecheck_clinical_trial, "fixtures/programs/health/clinical_trial.oti");
+
+// === Education ===
+typecheck_fixture!(typecheck_credential, "fixtures/programs/education/credential.oti");
+typecheck_fixture!(typecheck_course_marketplace, "fixtures/programs/education/course_marketplace.oti");
+typecheck_fixture!(typecheck_scholarship, "fixtures/programs/education/scholarship.oti");
+
+// === Legal ===
+typecheck_fixture!(typecheck_will, "fixtures/programs/legal/will.oti");
+typecheck_fixture!(typecheck_dispute_resolution, "fixtures/programs/legal/dispute_resolution.oti");
+typecheck_fixture!(typecheck_smart_agreement, "fixtures/programs/legal/smart_agreement.oti");
+
+// === Energy ===
+typecheck_fixture!(typecheck_carbon_credits, "fixtures/programs/energy/carbon_credits.oti");
+typecheck_fixture!(typecheck_energy_trading, "fixtures/programs/energy/energy_trading.oti");
+typecheck_fixture!(typecheck_renewable_certificates, "fixtures/programs/energy/renewable_certificates.oti");


### PR DESCRIPTION
## Summary
- Canonical type system (`Ty` enum) with 12 integer types, composites, widening/narrowing rules
- Type checker: integer literal polymorphism, implicit widening, function call arg validation, return type validation, struct/event field checking, binary/unary op type rules, method chain inference
- Mutability checking: `let x = 1; x = 2;` errors with "cannot assign to immutable variable"
- `require!` condition must be bool
- Void function returning value: `fn f() { return 42; }` errors
- String `+` operator blocked with clear message: "use .concat() instead"
- `.concat()`, `.contains()`, `.starts_with()`, `.substring()` string method return types

## Test plan
- [x] 33 type checker unit tests (arithmetic, logic, structs, events, tuples, casts, return types, arg checking, mutability, require!, string concat)
- [x] 100 type checker integration tests (all 99 .oti fixtures + ERC20)
- [x] All 457 tests pass across 4 compiler phases