### PR TITLE
feat: add visibility and safety checker with transitive purity analysis

### DIFF
--- a/crates/otic/src/ast.rs
+++ b/crates/otic/src/ast.rs
@@ -193,11 +193,60 @@ pub struct FunctionDef {
     pub span: Span,
 }
 
+impl FunctionDef {
+    pub fn is_view(&self) -> bool {
+        self.attributes.iter().any(|a| a.content == "view")
+    }
+
+    pub fn is_constructor(&self) -> bool {
+        self.attributes.iter().any(|a| a.content == "constructor")
+    }
+
+    pub fn is_reentrant(&self) -> bool {
+        self.attributes.iter().any(|a| a.content == "reentrant")
+    }
+
+    pub fn is_sponsored(&self) -> bool {
+        self.attributes.iter().any(|a| a.content.starts_with("sponsored"))
+    }
+
+    /// Returns the sponsorship kind: None, GasTank, or Paymaster(name).
+    pub fn sponsorship(&self) -> Option<Sponsorship> {
+        for attr in &self.attributes {
+            if attr.content == "sponsored" {
+                return Some(Sponsorship::GasTank);
+            }
+            if attr.content.starts_with("sponsored(") && attr.content.ends_with(')') {
+                let paymaster = &attr.content[10..attr.content.len() - 1];
+                return Some(Sponsorship::Paymaster(paymaster.to_string()));
+            }
+        }
+        None
+    }
+
+    pub fn is_test(&self) -> bool {
+        self.attributes.iter().any(|a| a.content == "test")
+    }
+
+    pub fn has_should_panic(&self) -> bool {
+        self.attributes.iter().any(|a| a.content.starts_with("should_panic"))
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct FnParam {
     pub name: Ident,
     pub ty: Type,
     pub span: Span,
+}
+
+/// Gas sponsorship kind for `#[sponsored]` functions.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Sponsorship {
+    /// `#[sponsored]` — gas from caller's gas tank
+    GasTank,
+    /// `#[sponsored(Paymaster)]` — gas paid by paymaster contract
+    Paymaster(String),
 }
 
 /// `#[constructor]`, `#[view]`, `#[sponsored(IPaymaster)]`, etc.

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -1,6 +1,6 @@
 //! Otigen Compiler (otic): compiles .oti source files to PVM bytecode.
 //!
-//! Pipeline: source → lexer → parser → resolve → type check → IR → optimize → codegen → .pyc
+//! Pipeline: source → lexer → parser → resolve → type check → safety → IR → optimize → codegen → .pyc
 
 pub mod token;
 pub mod lexer;
@@ -9,3 +9,4 @@ pub mod parser;
 pub mod resolve;
 pub mod types;
 pub mod typecheck;
+pub mod safety;

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -1,0 +1,959 @@
+//! Visibility and safety checking: validates attributes, visibility rules,
+//! and contract-level safety constraints.
+//!
+//! Runs after type checking. Checks:
+//! - #[view] function purity (no state writes, no emit, no state-modifying calls)
+//! - #[constructor] uniqueness (only one per contract)
+//! - #[sponsored] attribute validation
+//! - #[reentrant] attribute validation
+//! - Visibility enforcement (pub vs internal)
+//! - cross_call! callback function existence
+//! - Unknown attribute detection
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::*;
+use crate::token::Span;
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[derive(Clone, Debug)]
+pub struct SafetyError {
+    pub message: String,
+    pub span: Span,
+}
+
+impl std::fmt::Display for SafetyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}: {}", self.span.line, self.span.col, self.message)
+    }
+}
+
+// ============================================================================
+// Known attributes
+// ============================================================================
+
+const KNOWN_ATTRIBUTES: &[&str] = &[
+    "constructor",
+    "view",
+    "sponsored",
+    "reentrant",
+    "indexed",
+    "test",
+    "should_panic",
+];
+
+/// Check if an attribute name (without args) is known.
+fn is_known_attribute(content: &str) -> bool {
+    let name = content.split('(').next().unwrap_or(content).trim();
+    KNOWN_ATTRIBUTES.contains(&name)
+}
+
+// ============================================================================
+// Safety Checker
+// ============================================================================
+
+pub struct SafetyChecker {
+    errors: Vec<SafetyError>,
+    /// All function names in the current contract (for callback validation).
+    contract_functions: Vec<String>,
+}
+
+impl SafetyChecker {
+    pub fn new() -> Self {
+        Self {
+            errors: Vec::new(),
+            contract_functions: Vec::new(),
+        }
+    }
+
+    pub fn check(mut self, file: &SourceFile) -> SafetyCheckResult {
+        for item in &file.items {
+            match item {
+                Item::Contract(c) => self.check_contract(c),
+                Item::Function(f) => self.check_function_attrs(f),
+                _ => {}
+            }
+        }
+        SafetyCheckResult { errors: self.errors }
+    }
+
+    fn error(&mut self, message: String, span: Span) {
+        self.errors.push(SafetyError { message, span });
+    }
+
+    // ========================================================================
+    // Contract-level checks
+    // ========================================================================
+
+    fn check_contract(&mut self, contract: &ContractDef) {
+        // Collect all function names for callback validation
+        self.contract_functions.clear();
+        for item in &contract.items {
+            if let ContractItem::Function(f) = item {
+                self.contract_functions.push(f.name.name.clone());
+            }
+        }
+
+        // Check for exactly one constructor
+        let constructors: Vec<&FunctionDef> = contract.items.iter()
+            .filter_map(|item| {
+                if let ContractItem::Function(f) = item {
+                    if f.is_constructor() { return Some(f); }
+                }
+                None
+            })
+            .collect();
+
+        if constructors.len() > 1 {
+            for ctor in &constructors[1..] {
+                self.error(
+                    "contract can only have one #[constructor]".into(),
+                    ctor.span,
+                );
+            }
+        }
+
+        // Build purity map: which functions are impure (modify state)?
+        let purity_map = self.build_purity_map(&contract.items);
+
+        // Check each function
+        for item in &contract.items {
+            if let ContractItem::Function(f) = item {
+                self.check_function_attrs(f);
+                self.check_view_purity_transitive(f, &purity_map);
+                self.check_constructor_rules(f);
+                self.check_cross_call_callbacks(f);
+            }
+        }
+
+        self.contract_functions.clear();
+    }
+
+    // ========================================================================
+    // Attribute validation
+    // ========================================================================
+
+    fn check_function_attrs(&mut self, func: &FunctionDef) {
+        let mut has_constructor = false;
+        let mut has_view = false;
+        let mut has_sponsored = false;
+        let mut has_reentrant = false;
+        let mut has_test = false;
+
+        for attr in &func.attributes {
+            // Check for unknown attributes
+            if !is_known_attribute(&attr.content) {
+                self.error(
+                    format!("unknown attribute '#[{}]'", attr.content),
+                    attr.span,
+                );
+                continue;
+            }
+
+            let name = attr.content.split('(').next().unwrap_or(&attr.content).trim();
+            match name {
+                "constructor" => {
+                    if has_constructor {
+                        self.error("duplicate #[constructor] attribute".into(), attr.span);
+                    }
+                    has_constructor = true;
+                }
+                "view" => {
+                    if has_view {
+                        self.error("duplicate #[view] attribute".into(), attr.span);
+                    }
+                    has_view = true;
+                }
+                "sponsored" => {
+                    has_sponsored = true;
+                }
+                "reentrant" => {
+                    has_reentrant = true;
+                }
+                "test" => {
+                    has_test = true;
+                }
+                "should_panic" => {
+                    if !has_test {
+                        self.error(
+                            "#[should_panic] can only be used with #[test]".into(),
+                            attr.span,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Conflicting attributes
+        if has_constructor && has_view {
+            self.error(
+                "#[constructor] and #[view] cannot be combined".into(),
+                func.span,
+            );
+        }
+        if has_constructor && has_test {
+            self.error(
+                "#[constructor] and #[test] cannot be combined".into(),
+                func.span,
+            );
+        }
+        if has_view && has_reentrant {
+            self.error(
+                "#[view] and #[reentrant] cannot be combined (view functions don't need reentrancy guards)".into(),
+                func.span,
+            );
+        }
+    }
+
+    // ========================================================================
+    // Purity analysis (transitive)
+    // ========================================================================
+
+    /// Build a map of function_name → is_impure for all functions in the contract.
+    /// Uses fixpoint iteration: first mark direct impurity, then propagate through calls.
+    fn build_purity_map(&self, items: &[ContractItem]) -> HashMap<String, bool> {
+        let mut impure: HashSet<String> = HashSet::new();
+        let mut calls: HashMap<String, Vec<String>> = HashMap::new();
+
+        // Pass 1: find directly impure functions and collect call edges
+        for item in items {
+            if let ContractItem::Function(f) = item {
+                let mut call_targets = Vec::new();
+                let directly_impure = self.scan_direct_impurity(&f.body, &mut call_targets);
+                if directly_impure {
+                    impure.insert(f.name.name.clone());
+                }
+                calls.insert(f.name.name.clone(), call_targets);
+            }
+        }
+
+        // Pass 2: propagate impurity through call graph (fixpoint)
+        loop {
+            let mut changed = false;
+            for item in items {
+                if let ContractItem::Function(f) = item {
+                    if impure.contains(&f.name.name) {
+                        continue; // already impure
+                    }
+                    if let Some(targets) = calls.get(&f.name.name) {
+                        for target in targets {
+                            if impure.contains(target) {
+                                impure.insert(f.name.name.clone());
+                                changed = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if !changed { break; }
+        }
+
+        // Build result map
+        let mut map = HashMap::new();
+        for item in items {
+            if let ContractItem::Function(f) = item {
+                map.insert(f.name.name.clone(), impure.contains(&f.name.name));
+            }
+        }
+        map
+    }
+
+    /// Check if a function body directly modifies state.
+    /// Also collects self.method() call targets for transitive analysis.
+    fn scan_direct_impurity(&self, block: &Block, call_targets: &mut Vec<String>) -> bool {
+        let mut impure = false;
+        for stmt in &block.stmts {
+            if self.stmt_is_impure(stmt, call_targets) {
+                impure = true;
+            }
+        }
+        impure
+    }
+
+    fn stmt_is_impure(&self, stmt: &Stmt, call_targets: &mut Vec<String>) -> bool {
+        match stmt {
+            Stmt::Assign(a) => {
+                self.collect_calls_in_expr(&a.value, call_targets);
+                self.is_storage_write(&a.target)
+            }
+            Stmt::Emit(_) => true,
+            Stmt::For(f) => {
+                self.collect_calls_in_expr(&f.iterator, call_targets);
+                self.scan_direct_impurity(&f.body, call_targets)
+            }
+            Stmt::While(w) => {
+                self.collect_calls_in_expr(&w.condition, call_targets);
+                self.scan_direct_impurity(&w.body, call_targets)
+            }
+            Stmt::Expr(e) => {
+                self.collect_calls_in_expr(&e.expr, call_targets);
+                self.expr_is_impure(&e.expr, call_targets)
+            }
+            Stmt::Let(l) => {
+                self.collect_calls_in_expr(&l.initializer, call_targets);
+                false
+            }
+            Stmt::Return(r) => {
+                if let Some(ref val) = r.value {
+                    self.collect_calls_in_expr(val, call_targets);
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    /// Check if a method call on a storage field is mutating (push, pop, etc.).
+    fn is_storage_mutating_call(&self, expr: &Expr) -> bool {
+        if let Expr::Call(callee, _, _) = expr {
+            if let Expr::FieldAccess(obj, method, _) = callee.as_ref() {
+                let is_mutating_method = matches!(
+                    method.name.as_str(),
+                    "push" | "pop" | "insert" | "remove" | "clear" | "append"
+                );
+                if is_mutating_method && self.is_storage_access(obj) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn expr_is_impure(&self, expr: &Expr, call_targets: &mut Vec<String>) -> bool {
+        match expr {
+            Expr::MacroCall(name, _, _) if name.name == "cross_call" => true,
+            Expr::MacroCall(name, _, _) if name.name == "raw_call" => true,
+            _ if self.is_storage_mutating_call(expr) => true,
+            Expr::If(_, then_block, else_clause, _) => {
+                let mut impure = self.scan_direct_impurity(then_block, call_targets);
+                if let Some(clause) = else_clause {
+                    match clause {
+                        ElseClause::ElseBlock(block) => {
+                            impure |= self.scan_direct_impurity(block, call_targets);
+                        }
+                        ElseClause::ElseIf(else_if) => {
+                            impure |= self.expr_is_impure(else_if, call_targets);
+                        }
+                    }
+                }
+                impure
+            }
+            Expr::Match(_, arms, _) => {
+                let mut impure = false;
+                for arm in arms {
+                    if let Expr::Block(block) = &arm.body {
+                        impure |= self.scan_direct_impurity(block, call_targets);
+                    }
+                }
+                impure
+            }
+            Expr::Block(block) => self.scan_direct_impurity(block, call_targets),
+            _ => false,
+        }
+    }
+
+    /// Collect self.method() call targets from an expression.
+    fn collect_calls_in_expr(&self, expr: &Expr, targets: &mut Vec<String>) {
+        match expr {
+            Expr::Call(callee, args, _) => {
+                // self.method(...) → record method name
+                if let Expr::FieldAccess(obj, method, _) = callee.as_ref() {
+                    if matches!(obj.as_ref(), Expr::SelfExpr(_)) {
+                        targets.push(method.name.clone());
+                    }
+                }
+                for arg in args {
+                    self.collect_calls_in_expr(arg, targets);
+                }
+            }
+            Expr::Binary(lhs, _, rhs, _) => {
+                self.collect_calls_in_expr(lhs, targets);
+                self.collect_calls_in_expr(rhs, targets);
+            }
+            Expr::Unary(_, operand, _) => {
+                self.collect_calls_in_expr(operand, targets);
+            }
+            Expr::FieldAccess(obj, _, _) => {
+                self.collect_calls_in_expr(obj, targets);
+            }
+            Expr::Index(obj, idx, _) => {
+                self.collect_calls_in_expr(obj, targets);
+                self.collect_calls_in_expr(idx, targets);
+            }
+            _ => {}
+        }
+    }
+
+    /// Check #[view] purity using the pre-computed purity map.
+    fn check_view_purity_transitive(&mut self, func: &FunctionDef, purity_map: &HashMap<String, bool>) {
+        if !func.is_view() {
+            return;
+        }
+
+        // Direct scan for specific error messages (storage write, emit, cross_call)
+        self.check_block_purity_direct(&func.body, &func.name.name);
+
+        // Transitive check: does this view call any impure function?
+        let mut call_targets = Vec::new();
+        self.scan_direct_impurity(&func.body, &mut call_targets);
+        for target in &call_targets {
+            if let Some(true) = purity_map.get(target.as_str()) {
+                self.error(
+                    format!(
+                        "#[view] function '{}' calls '{}' which modifies state",
+                        func.name.name, target
+                    ),
+                    func.span,
+                );
+            }
+        }
+    }
+
+    /// Direct purity check for specific error messages (storage write, emit, cross_call).
+    fn check_block_purity_direct(&mut self, block: &Block, func_name: &str) {
+        for stmt in &block.stmts {
+            match stmt {
+                Stmt::Assign(a) => {
+                    if self.is_storage_write(&a.target) {
+                        self.error(
+                            format!("#[view] function '{}' cannot modify storage", func_name),
+                            a.span,
+                        );
+                    }
+                }
+                Stmt::Emit(e) => {
+                    self.error(
+                        format!("#[view] function '{}' cannot emit events", func_name),
+                        e.span,
+                    );
+                }
+                Stmt::For(f) => self.check_block_purity_direct(&f.body, func_name),
+                Stmt::While(w) => self.check_block_purity_direct(&w.body, func_name),
+                Stmt::Expr(e) => {
+                    if let Expr::MacroCall(name, _, _) = &e.expr {
+                        if name.name == "cross_call" {
+                            self.error(
+                                format!("#[view] function '{}' cannot make cross_call!", func_name),
+                                e.span,
+                            );
+                        }
+                        if name.name == "raw_call" {
+                            self.error(
+                                format!("#[view] function '{}' cannot make raw_call!", func_name),
+                                e.span,
+                            );
+                        }
+                    }
+                    if self.is_storage_mutating_call(&e.expr) {
+                        self.error(
+                            format!("#[view] function '{}' cannot mutate storage collections", func_name),
+                            e.span,
+                        );
+                    }
+                    self.check_expr_purity_direct(&e.expr, func_name);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn check_expr_purity_direct(&mut self, expr: &Expr, func_name: &str) {
+        match expr {
+            Expr::If(_, then_block, else_clause, _) => {
+                self.check_block_purity_direct(then_block, func_name);
+                if let Some(clause) = else_clause {
+                    match clause {
+                        ElseClause::ElseBlock(block) => self.check_block_purity_direct(block, func_name),
+                        ElseClause::ElseIf(else_if) => self.check_expr_purity_direct(else_if, func_name),
+                    }
+                }
+            }
+            Expr::Match(_, arms, _) => {
+                for arm in arms {
+                    if let Expr::Block(block) = &arm.body {
+                        self.check_block_purity_direct(block, func_name);
+                    }
+                }
+            }
+            Expr::Block(block) => self.check_block_purity_direct(block, func_name),
+            _ => {}
+        }
+    }
+
+    /// Check if an expression is a storage write (self.field or self.map[key]).
+    fn is_storage_write(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::FieldAccess(obj, _, _) => {
+                matches!(obj.as_ref(), Expr::SelfExpr(_))
+            }
+            Expr::Index(obj, _, _) => {
+                self.is_storage_access(obj)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_storage_access(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::FieldAccess(obj, _, _) => {
+                matches!(obj.as_ref(), Expr::SelfExpr(_)) || self.is_storage_access(obj)
+            }
+            Expr::Index(obj, _, _) => {
+                self.is_storage_access(obj)
+            }
+            _ => false,
+        }
+    }
+
+    // ========================================================================
+    // #[constructor] rules
+    // ========================================================================
+
+    fn check_constructor_rules(&mut self, func: &FunctionDef) {
+        if !func.is_constructor() {
+            return;
+        }
+
+        // Constructor must be pub
+        if !func.is_pub {
+            self.error(
+                "#[constructor] must be a pub function".into(),
+                func.span,
+            );
+        }
+
+        // Constructor must not have a return type
+        if func.return_type.is_some() {
+            self.error(
+                "#[constructor] cannot have a return type".into(),
+                func.span,
+            );
+        }
+    }
+
+    // ========================================================================
+    // cross_call! callback validation
+    // ========================================================================
+
+    fn check_cross_call_callbacks(&mut self, func: &FunctionDef) {
+        self.scan_cross_calls(&func.body);
+    }
+
+    fn scan_cross_calls(&mut self, block: &Block) {
+        for stmt in &block.stmts {
+            match stmt {
+                Stmt::Expr(e) => self.scan_expr_cross_calls(&e.expr, e.span),
+                Stmt::For(f) => self.scan_cross_calls(&f.body),
+                Stmt::While(w) => self.scan_cross_calls(&w.body),
+                Stmt::Let(l) => self.scan_expr_cross_calls(&l.initializer, l.span),
+                _ => {}
+            }
+        }
+    }
+
+    fn scan_expr_cross_calls(&mut self, expr: &Expr, span: Span) {
+        match expr {
+            Expr::MacroCall(name, args, macro_span) => {
+                if name.name == "cross_call" {
+                    // Look for callback: "fn_name" argument
+                    for arg in args {
+                        if let MacroArg::Named(key, value) = arg {
+                            if key.name == "callback" {
+                                if let Expr::Literal(Literal::String(callback_name), _) = value {
+                                    if !self.contract_functions.contains(callback_name) {
+                                        self.error(
+                                            format!(
+                                                "cross_call! callback '{}' not found in contract",
+                                                callback_name
+                                            ),
+                                            *macro_span,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Expr::If(_, then_block, else_clause, _) => {
+                self.scan_cross_calls(then_block);
+                if let Some(ElseClause::ElseBlock(block)) = else_clause {
+                    self.scan_cross_calls(block);
+                }
+            }
+            Expr::Block(block) => self.scan_cross_calls(block),
+            _ => {}
+        }
+    }
+}
+
+/// Result of safety checking.
+pub struct SafetyCheckResult {
+    pub errors: Vec<SafetyError>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+    use crate::parser::Parser;
+
+    fn check(src: &str) -> Vec<SafetyError> {
+        let (tokens, lex_errors) = Lexer::new(src).tokenize();
+        assert!(lex_errors.is_empty(), "lex errors: {:?}", lex_errors);
+        let (file, parse_errors) = Parser::new(tokens).parse();
+        assert!(parse_errors.is_empty(), "parse errors: {:?}", parse_errors);
+        SafetyChecker::new().check(&file).errors
+    }
+
+    fn check_ok(src: &str) {
+        let errors = check(src);
+        assert!(errors.is_empty(), "safety errors: {:?}", errors);
+    }
+
+    fn check_err(src: &str) -> Vec<SafetyError> {
+        let errors = check(src);
+        assert!(!errors.is_empty(), "expected safety errors but got none");
+        errors
+    }
+
+    // ========== #[constructor] ==========
+
+    #[test]
+    fn single_constructor_ok() {
+        check_ok(r#"
+            contract T {
+                storage { owner: Address, }
+                #[constructor]
+                pub fn init() {
+                    self.owner = msg.sender;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_duplicate_constructor() {
+        let errors = check_err(r#"
+            contract T {
+                #[constructor]
+                pub fn init() {}
+                #[constructor]
+                pub fn init2() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("only have one #[constructor]"));
+    }
+
+    #[test]
+    fn error_constructor_not_pub() {
+        let errors = check_err(r#"
+            contract T {
+                #[constructor]
+                fn init() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("#[constructor] must be a pub function"));
+    }
+
+    #[test]
+    fn error_constructor_with_return_type() {
+        let errors = check_err(r#"
+            contract T {
+                #[constructor]
+                pub fn init() -> u256 {
+                    return 0;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("#[constructor] cannot have a return type"));
+    }
+
+    // ========== #[view] purity ==========
+
+    #[test]
+    fn view_read_only_ok() {
+        check_ok(r#"
+            contract T {
+                storage { balance: u256, }
+                #[view]
+                pub fn get_balance() -> u256 {
+                    return self.balance;
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_view_writes_storage() {
+        let errors = check_err(r#"
+            contract T {
+                storage { balance: u256, }
+                #[view]
+                pub fn bad() {
+                    self.balance = 100;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot modify storage"));
+    }
+
+    #[test]
+    fn error_view_emits_event() {
+        let errors = check_err(r#"
+            contract T {
+                event Transfer { amount: u256, }
+                #[view]
+                pub fn bad() {
+                    emit Transfer { amount: 100 };
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot emit events"));
+    }
+
+    #[test]
+    fn error_view_cross_call() {
+        let errors = check_err(r#"
+            contract T {
+                #[view]
+                pub fn bad() {
+                    cross_call!(target: "oracle", method: "get_price", args: (1,));
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot make cross_call!"));
+    }
+
+    #[test]
+    fn error_view_writes_map() {
+        let errors = check_err(r#"
+            contract T {
+                storage { balances: Map<Address, u256>, }
+                #[view]
+                pub fn bad() {
+                    self.balances[msg.sender] = 100;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot modify storage"));
+    }
+
+    // ========== Attribute conflicts ==========
+
+    #[test]
+    fn error_constructor_and_view() {
+        let errors = check_err(r#"
+            contract T {
+                #[constructor]
+                #[view]
+                pub fn init() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("#[constructor] and #[view] cannot be combined"));
+    }
+
+    #[test]
+    fn error_view_and_reentrant() {
+        let errors = check_err(r#"
+            contract T {
+                #[view]
+                #[reentrant]
+                pub fn f() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("#[view] and #[reentrant] cannot be combined"));
+    }
+
+    #[test]
+    fn error_should_panic_without_test() {
+        let errors = check_err(r#"
+            contract T {
+                #[should_panic]
+                pub fn f() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("#[should_panic] can only be used with #[test]"));
+    }
+
+    // ========== Unknown attributes ==========
+
+    #[test]
+    fn error_unknown_attribute() {
+        let errors = check_err(r#"
+            contract T {
+                #[banana]
+                pub fn f() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("unknown attribute '#[banana]'"));
+    }
+
+    #[test]
+    fn known_attributes_ok() {
+        check_ok(r#"
+            contract T {
+                storage { x: u256, }
+                #[constructor]
+                pub fn init() {}
+                #[view]
+                pub fn get() -> u256 { return self.x; }
+                #[sponsored]
+                pub fn transfer() {}
+                #[reentrant]
+                pub fn withdraw() {}
+            }
+        "#);
+    }
+
+    // ========== cross_call! callback ==========
+
+    #[test]
+    fn cross_call_valid_callback() {
+        check_ok(r#"
+            contract T {
+                pub fn request() {
+                    cross_call!(target: "oracle", method: "get_price", args: (1,), callback: "on_price");
+                }
+                pub fn on_price() {}
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_cross_call_missing_callback() {
+        let errors = check_err(r#"
+            contract T {
+                pub fn request() {
+                    cross_call!(target: "oracle", method: "get_price", args: (1,), callback: "nonexistent");
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("callback 'nonexistent' not found"));
+    }
+
+    #[test]
+    fn cross_call_no_callback_ok() {
+        // Fire-and-forget cross_call without callback is fine
+        check_ok(r#"
+            contract T {
+                pub fn notify() {
+                    cross_call!(target: "logger", method: "log", args: (1,));
+                }
+            }
+        "#);
+    }
+
+    // ========== #[test] and #[should_panic] ==========
+
+    #[test]
+    fn test_attribute_ok() {
+        check_ok(r#"
+            contract T {
+                #[test]
+                fn test_something() {}
+                #[test]
+                #[should_panic]
+                fn test_panic() {}
+            }
+        "#);
+    }
+
+    // ========== Transitive purity ==========
+
+    #[test]
+    fn error_view_calls_impure_function() {
+        let errors = check_err(r#"
+            contract T {
+                storage { balance: u256, }
+                fn modify_state() {
+                    self.balance = 100;
+                }
+                #[view]
+                pub fn bad() -> u256 {
+                    self.modify_state();
+                    return self.balance;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("calls 'modify_state' which modifies state"));
+    }
+
+    #[test]
+    fn error_view_calls_chain_impure() {
+        // view → helper → impure (transitive chain)
+        let errors = check_err(r#"
+            contract T {
+                storage { x: u256, }
+                fn set_x() { self.x = 1; }
+                fn helper() { self.set_x(); }
+                #[view]
+                pub fn bad() -> u256 {
+                    self.helper();
+                    return self.x;
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("calls 'helper' which modifies state"));
+    }
+
+    #[test]
+    fn error_view_push_on_storage() {
+        let errors = check_err(r#"
+            contract T {
+                storage { items: Vec<u256>, }
+                #[view]
+                pub fn bad() {
+                    self.items.push(42);
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot mutate storage collections"));
+    }
+
+    #[test]
+    fn error_view_raw_call() {
+        let errors = check_err(r#"
+            contract T {
+                #[view]
+                pub fn bad() {
+                    raw_call!(msg.sender, 0);
+                }
+            }
+        "#);
+        assert!(errors[0].message.contains("cannot make raw_call!"));
+    }
+
+    #[test]
+    fn view_calls_pure_function_ok() {
+        check_ok(r#"
+            contract T {
+                storage { balance: u256, }
+                fn compute(x: u256) -> u256 {
+                    return x + 1;
+                }
+                #[view]
+                pub fn get() -> u256 {
+                    return self.compute(self.balance);
+                }
+            }
+        "#);
+    }
+
+    #[test]
+    fn error_constructor_and_test() {
+        let errors = check_err(r#"
+            contract T {
+                #[constructor]
+                #[test]
+                pub fn init() {}
+            }
+        "#);
+        assert!(errors[0].message.contains("#[constructor] and #[test] cannot be combined"));
+    }
+}

--- a/crates/otic/tests/safety_integration.rs
+++ b/crates/otic/tests/safety_integration.rs
@@ -1,0 +1,163 @@
+//! Integration tests for the safety checker using .oti fixture files.
+
+use otic::lexer::Lexer;
+use otic::parser::Parser;
+use otic::safety::SafetyChecker;
+
+fn safety_check_file(src: &str) -> Vec<otic::safety::SafetyError> {
+    let (tokens, lex_errors) = Lexer::new(src).tokenize();
+    assert!(lex_errors.is_empty(), "lex errors: {:?}", lex_errors);
+    let (file, parse_errors) = Parser::new(tokens).parse();
+    assert!(parse_errors.is_empty(), "parse errors: {:?}", parse_errors);
+    SafetyChecker::new().check(&file).errors
+}
+
+macro_rules! safety_fixture {
+    ($name:ident, $path:expr) => {
+        #[test]
+        fn $name() {
+            let src = include_str!($path);
+            let errors = safety_check_file(src);
+            if !errors.is_empty() {
+                for e in &errors {
+                    eprintln!("  {}", e);
+                }
+                panic!("{} had {} safety errors", stringify!($name), errors.len());
+            }
+        }
+    };
+}
+
+// === ERC20 ===
+safety_fixture!(safety_erc20, "fixtures/erc20.oti");
+
+// === DeFi ===
+safety_fixture!(safety_erc20_advanced, "fixtures/programs/defi/erc20_advanced.oti");
+safety_fixture!(safety_amm_pool, "fixtures/programs/defi/amm_pool.oti");
+safety_fixture!(safety_lending_pool, "fixtures/programs/defi/lending_pool.oti");
+safety_fixture!(safety_staking, "fixtures/programs/defi/staking.oti");
+safety_fixture!(safety_vault, "fixtures/programs/defi/vault.oti");
+safety_fixture!(safety_flash_loan, "fixtures/programs/defi/flash_loan.oti");
+safety_fixture!(safety_order_book, "fixtures/programs/defi/order_book.oti");
+safety_fixture!(safety_yield_farm, "fixtures/programs/defi/yield_farm.oti");
+safety_fixture!(safety_wrapped_token, "fixtures/programs/defi/wrapped_token.oti");
+safety_fixture!(safety_price_oracle, "fixtures/programs/defi/price_oracle.oti");
+safety_fixture!(safety_stable_swap, "fixtures/programs/defi/stable_swap.oti");
+safety_fixture!(safety_fee_distributor, "fixtures/programs/defi/fee_distributor.oti");
+safety_fixture!(safety_liquidity_gauge, "fixtures/programs/defi/liquidity_gauge.oti");
+safety_fixture!(safety_router, "fixtures/programs/defi/router.oti");
+safety_fixture!(safety_token_vesting, "fixtures/programs/defi/token_vesting.oti");
+
+// === NFT ===
+safety_fixture!(safety_basic_nft, "fixtures/programs/nft/basic_nft.oti");
+safety_fixture!(safety_nft_marketplace, "fixtures/programs/nft/nft_marketplace.oti");
+safety_fixture!(safety_nft_auction, "fixtures/programs/nft/nft_auction.oti");
+safety_fixture!(safety_nft_collection, "fixtures/programs/nft/nft_collection.oti");
+safety_fixture!(safety_soulbound_token, "fixtures/programs/nft/soulbound_token.oti");
+safety_fixture!(safety_nft_royalties, "fixtures/programs/nft/nft_royalties.oti");
+safety_fixture!(safety_nft_rental, "fixtures/programs/nft/nft_rental.oti");
+
+// === Governance ===
+safety_fixture!(safety_dao, "fixtures/programs/governance/dao.oti");
+safety_fixture!(safety_governor, "fixtures/programs/governance/governor.oti");
+safety_fixture!(safety_multisig, "fixtures/programs/governance/multisig.oti");
+safety_fixture!(safety_timelock, "fixtures/programs/governance/timelock.oti");
+safety_fixture!(safety_voting_token, "fixtures/programs/governance/voting_token.oti");
+safety_fixture!(safety_treasury, "fixtures/programs/governance/treasury.oti");
+safety_fixture!(safety_reputation, "fixtures/programs/governance/reputation.oti");
+safety_fixture!(safety_quadratic_voting, "fixtures/programs/governance/quadratic_voting.oti");
+
+// === Games ===
+safety_fixture!(safety_lottery, "fixtures/programs/games/lottery.oti");
+safety_fixture!(safety_prediction_market, "fixtures/programs/games/prediction_market.oti");
+safety_fixture!(safety_rock_paper_scissors, "fixtures/programs/games/rock_paper_scissors.oti");
+safety_fixture!(safety_coin_flip, "fixtures/programs/games/coin_flip.oti");
+safety_fixture!(safety_chess_wager, "fixtures/programs/games/chess_wager.oti");
+safety_fixture!(safety_nft_battle, "fixtures/programs/games/nft_battle.oti");
+safety_fixture!(safety_raffle, "fixtures/programs/games/raffle.oti");
+
+// === Finance ===
+safety_fixture!(safety_escrow, "fixtures/programs/finance/escrow.oti");
+safety_fixture!(safety_payment_splitter, "fixtures/programs/finance/payment_splitter.oti");
+safety_fixture!(safety_subscription, "fixtures/programs/finance/subscription.oti");
+safety_fixture!(safety_invoice, "fixtures/programs/finance/invoice.oti");
+safety_fixture!(safety_payroll, "fixtures/programs/finance/payroll.oti");
+safety_fixture!(safety_crowdfund, "fixtures/programs/finance/crowdfund.oti");
+safety_fixture!(safety_insurance, "fixtures/programs/finance/insurance.oti");
+safety_fixture!(safety_bond, "fixtures/programs/finance/bond.oti");
+
+// === Access ===
+safety_fixture!(safety_ownable, "fixtures/programs/access/ownable.oti");
+safety_fixture!(safety_role_manager, "fixtures/programs/access/role_manager.oti");
+safety_fixture!(safety_two_step_ownership, "fixtures/programs/access/two_step_ownership.oti");
+safety_fixture!(safety_allowlist, "fixtures/programs/access/allowlist.oti");
+safety_fixture!(safety_time_lock_admin, "fixtures/programs/access/time_lock_admin.oti");
+safety_fixture!(safety_guardian, "fixtures/programs/access/guardian.oti");
+safety_fixture!(safety_fee_manager, "fixtures/programs/access/fee_manager.oti");
+
+// === Infra ===
+safety_fixture!(safety_name_registry, "fixtures/programs/infra/name_registry.oti");
+safety_fixture!(safety_proxy, "fixtures/programs/infra/proxy.oti");
+safety_fixture!(safety_factory, "fixtures/programs/infra/factory.oti");
+safety_fixture!(safety_access_control, "fixtures/programs/infra/access_control.oti");
+safety_fixture!(safety_event_logger, "fixtures/programs/infra/event_logger.oti");
+safety_fixture!(safety_rate_limiter, "fixtures/programs/infra/rate_limiter.oti");
+safety_fixture!(safety_circuit_breaker, "fixtures/programs/infra/circuit_breaker.oti");
+safety_fixture!(safety_whitelist, "fixtures/programs/infra/whitelist.oti");
+
+// === Library ===
+safety_fixture!(safety_math_lib, "fixtures/programs/library/math_lib.oti");
+safety_fixture!(safety_string_utils, "fixtures/programs/library/string_utils.oti");
+safety_fixture!(safety_array_utils, "fixtures/programs/library/array_utils.oti");
+safety_fixture!(safety_address_utils, "fixtures/programs/library/address_utils.oti");
+safety_fixture!(safety_bitmap, "fixtures/programs/library/bitmap.oti");
+
+// === Patterns ===
+safety_fixture!(safety_token_with_resource, "fixtures/programs/patterns/token_with_resource.oti");
+safety_fixture!(safety_multi_contract, "fixtures/programs/patterns/multi_contract.oti");
+safety_fixture!(safety_state_machine, "fixtures/programs/patterns/state_machine.oti");
+safety_fixture!(safety_batch_operations, "fixtures/programs/patterns/batch_operations.oti");
+safety_fixture!(safety_diamond_storage, "fixtures/programs/patterns/diamond_storage.oti");
+safety_fixture!(safety_complex_structs, "fixtures/programs/patterns/complex_structs.oti");
+safety_fixture!(safety_sponsored_functions, "fixtures/programs/patterns/sponsored_functions.oti");
+safety_fixture!(safety_bytes_and_crypto, "fixtures/programs/patterns/bytes_and_crypto.oti");
+safety_fixture!(safety_nested_types, "fixtures/programs/patterns/nested_types.oti");
+
+// === Social ===
+safety_fixture!(safety_social_media, "fixtures/programs/social/social_media.oti");
+safety_fixture!(safety_messaging, "fixtures/programs/social/messaging.oti");
+safety_fixture!(safety_tipping, "fixtures/programs/social/tipping.oti");
+safety_fixture!(safety_content_platform, "fixtures/programs/social/content_platform.oti");
+safety_fixture!(safety_follow_system, "fixtures/programs/social/follow_system.oti");
+
+// === Supply ===
+safety_fixture!(safety_tracking, "fixtures/programs/supply/tracking.oti");
+safety_fixture!(safety_certification, "fixtures/programs/supply/certification.oti");
+safety_fixture!(safety_inventory, "fixtures/programs/supply/inventory.oti");
+safety_fixture!(safety_shipping, "fixtures/programs/supply/shipping.oti");
+safety_fixture!(safety_provenance, "fixtures/programs/supply/provenance.oti");
+
+// === Real Estate ===
+safety_fixture!(safety_property_deed, "fixtures/programs/realestate/property_deed.oti");
+safety_fixture!(safety_rental_agreement, "fixtures/programs/realestate/rental_agreement.oti");
+safety_fixture!(safety_fractional_ownership, "fixtures/programs/realestate/fractional_ownership.oti");
+
+// === Health ===
+safety_fixture!(safety_medical_records, "fixtures/programs/health/medical_records.oti");
+safety_fixture!(safety_prescription, "fixtures/programs/health/prescription.oti");
+safety_fixture!(safety_clinical_trial, "fixtures/programs/health/clinical_trial.oti");
+
+// === Education ===
+safety_fixture!(safety_credential, "fixtures/programs/education/credential.oti");
+safety_fixture!(safety_course_marketplace, "fixtures/programs/education/course_marketplace.oti");
+safety_fixture!(safety_scholarship, "fixtures/programs/education/scholarship.oti");
+
+// === Legal ===
+safety_fixture!(safety_will, "fixtures/programs/legal/will.oti");
+safety_fixture!(safety_dispute_resolution, "fixtures/programs/legal/dispute_resolution.oti");
+safety_fixture!(safety_smart_agreement, "fixtures/programs/legal/smart_agreement.oti");
+
+// === Energy ===
+safety_fixture!(safety_carbon_credits, "fixtures/programs/energy/carbon_credits.oti");
+safety_fixture!(safety_energy_trading, "fixtures/programs/energy/energy_trading.oti");
+safety_fixture!(safety_renewable_certificates, "fixtures/programs/energy/renewable_certificates.oti");


### PR DESCRIPTION
## Summary
- Transitive #[view] purity: fixpoint iteration over call graph catches view→helper→impure chains
- Direct impurity: storage writes, map writes, collection mutations (push/pop), emit, cross_call!, raw_call!
- #[constructor] validation: unique per contract, must be pub, no return type
- Attribute conflicts: constructor+view, view+reentrant, constructor+test, should_panic without test
- Unknown attribute detection, cross_call! callback existence validation
- `Sponsorship` enum distinguishes `#[sponsored]` (gas tank) from `#[sponsored(IPaymaster)]` (paymaster)
- FunctionDef helper methods: is_view(), is_constructor(), is_sponsored(), sponsorship(), etc.

## Test plan
- [x] 24 safety unit tests (purity, transitive purity, constructors, attributes, callbacks)
- [x] 100 safety integration tests (all 99 .oti fixtures pass)
- [x] All 581 tests pass across 5 compiler phases