### PR TITLE
chore: update fixtures to use built-in sig_verify/sig_recover

### DIFF
--- a/crates/otic/tests/fixtures/programs/library/math_lib.oti
+++ b/crates/otic/tests/fixtures/programs/library/math_lib.oti
@@ -191,7 +191,7 @@ pub fn log10(x: u256) -> u256 {
 
 #[test]
 fn test_sqrt_perfect_square() {
-    let result = sqrt(25u256);
+    let result = 25u256.sqrt();
     require!(result == 5u256, Overflow {});
 }
 

--- a/crates/otic/tests/fixtures/programs/patterns/bytes_and_crypto.oti
+++ b/crates/otic/tests/fixtures/programs/patterns/bytes_and_crypto.oti
@@ -1,8 +1,6 @@
 // Exercises bytes manipulation, hash operations, signature verification,
 // fixed arrays, and complex type compositions
 
-use std::signature;
-
 contract VerifiedMessaging {
     struct Message {
         id: u256,
@@ -139,7 +137,7 @@ contract VerifiedMessaging {
         rotation_message.append(identity.key_rotation_nonce.to_bytes());
 
         let message_hash = hash(rotation_message);
-        let valid = signature::verify(message_hash, rotation_sig, identity.public_key);
+        let valid = sig_verify(message_hash, rotation_sig, identity.public_key);
         require!(valid, InvalidSignature { signer: msg.sender });
 
         self.identities[msg.sender].public_key = new_public_key;
@@ -188,7 +186,7 @@ contract VerifiedMessaging {
         sig_message.append(self.nonces[msg.sender].to_bytes());
 
         let sig_hash = hash(sig_message);
-        let valid = signature::verify(sig_hash, sig, identity.public_key);
+        let valid = sig_verify(sig_hash, sig, identity.public_key);
         require!(valid, InvalidSignature { signer: msg.sender });
 
         let id = self.next_message_id;

--- a/crates/otic/tests/fixtures/programs/patterns/complex_structs.oti
+++ b/crates/otic/tests/fixtures/programs/patterns/complex_structs.oti
@@ -1,7 +1,5 @@
 // Complex struct patterns: nested structs, arrays, bytes, strings
 
-use std::signature;
-
 contract DocumentVault {
     struct Document {
         id: u256,
@@ -167,8 +165,8 @@ contract DocumentVault {
 
         // Verify the signature over the content hash
         let message = doc.content_hash;
-        let valid = signature::verify(message, sig, public_key);
-        let signer = signature::recover(message, sig);
+        let valid = sig_verify(message, sig, public_key);
+        let signer = sig_recover(message, sig);
         require!(valid, InvalidSignature { signer: msg.sender });
 
         // Check no duplicate signature from same signer
@@ -272,7 +270,7 @@ contract DocumentVault {
         for i in 0..doc.signatures.len() {
             if doc.signatures[i].signer == signer {
                 let record = doc.signatures[i];
-                let valid = signature::verify(
+                let valid = sig_verify(
                     doc.content_hash,
                     record.signature,
                     record.public_key,

--- a/crates/otic/tests/fixtures/programs/patterns/sponsored_functions.oti
+++ b/crates/otic/tests/fixtures/programs/patterns/sponsored_functions.oti
@@ -2,8 +2,6 @@
 // Gas sponsorship for gasless UX
 
 use std::token::IERC20;
-use std::signature;
-
 interface IPaymaster {
     fn validate_and_pay(user: Address, function_sig: bytes, gas_cost: u256) -> bool;
     fn balance_of(user: Address) -> u256;
@@ -217,8 +215,8 @@ contract GaslessToken {
         let message_hash = hash(message_bytes);
 
         // Verify signature
-        let valid = signature::verify(message_hash, meta.signature, meta.public_key);
-        let recovered = signature::recover(message_hash, meta.signature);
+        let valid = sig_verify(message_hash, meta.signature, meta.public_key);
+        let recovered = sig_recover(message_hash, meta.signature);
         require!(valid && recovered == meta.from, InvalidSignature {});
 
         // Execute transfer
@@ -256,7 +254,7 @@ contract GaslessToken {
         message_bytes.append(data.deadline.to_bytes());
 
         let message_hash = hash(message_bytes);
-        let valid = signature::verify(message_hash, data.signature, bytes::new());
+        let valid = sig_verify(message_hash, data.signature, bytes::new());
         require!(valid, InvalidSignature {});
 
         self.allowances[data.owner][data.spender] = data.value;


### PR DESCRIPTION
## Summary
- Replace `signature::verify()` → `sig_verify()` and `signature::recover()` → `sig_recover()` (built-in, no import needed)
- Remove `use std::signature;` imports from 3 pattern fixtures
- Replace standalone `sqrt()` → `value.sqrt()` in math_lib fixture

## Test plan
- [x] All 725 tests pass