### PR TITLE
fix: crypto security hardening and eliminate all production panics

### DIFF
--- a/crates/account/src/auth.rs
+++ b/crates/account/src/auth.rs
@@ -50,7 +50,10 @@ pub fn validate_signature(
                 Some(pk) => pk,
                 None => return AuthResult::Invalid,
             };
-            let sig = FalconSignature::from_bytes(&signatures[0]);
+            let sig = match FalconSignature::from_bytes(&signatures[0]) {
+                Some(s) => s,
+                None => return AuthResult::Invalid,
+            };
             if falcon_verify(&pk, message, &sig) {
                 AuthResult::Valid
             } else {
@@ -75,7 +78,10 @@ pub fn validate_signature(
                     Some(pk) => pk,
                     None => continue,
                 };
-                let sig = FalconSignature::from_bytes(&signatures[i]);
+                let sig = match FalconSignature::from_bytes(&signatures[i]) {
+                    Some(s) => s,
+                    None => continue,
+                };
                 if falcon_verify(&pk, message, &sig) {
                     valid_count += 1;
                 }
@@ -133,7 +139,7 @@ mod tests {
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 
     fn make_eoa_with_real_key() -> (Account, pyde_crypto::falcon::FalconSecretKey) {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account::new_eoa(&pk_bytes);
         (account, sk)
@@ -145,7 +151,7 @@ mod tests {
     fn falcon_single_key_valid() {
         let (account, sk) = make_eoa_with_real_key();
         let message = b"transfer 100 PYDE to Bob";
-        let sig = falcon_sign(&sk, message);
+        let sig = falcon_sign(&sk, message).unwrap();
         let sig_bytes = sig.as_bytes().to_vec();
 
         let result = validate_signature(&account, message, &[sig_bytes]);
@@ -155,7 +161,7 @@ mod tests {
     #[test]
     fn falcon_single_key_wrong_message() {
         let (account, sk) = make_eoa_with_real_key();
-        let sig = falcon_sign(&sk, b"correct message");
+        let sig = falcon_sign(&sk, b"correct message").unwrap();
         let sig_bytes = sig.as_bytes().to_vec();
 
         let result = validate_signature(&account, b"wrong message", &[sig_bytes]);
@@ -180,9 +186,9 @@ mod tests {
 
     #[test]
     fn multisig_2_of_3_valid() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, sk2) = falcon_keygen();
-        let (pk3, _sk3) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, sk2) = falcon_keygen().unwrap();
+        let (pk3, _sk3) = falcon_keygen().unwrap();
 
         let mut account = Account::new_eoa(&pk1.as_bytes().to_vec());
         account.auth_keys = AuthKeys::MultiSig {
@@ -191,8 +197,8 @@ mod tests {
         };
 
         let message = b"multisig tx";
-        let sig1 = falcon_sign(&sk1, message).as_bytes().to_vec();
-        let sig2 = falcon_sign(&sk2, message).as_bytes().to_vec();
+        let sig1 = falcon_sign(&sk1, message).unwrap().as_bytes().to_vec();
+        let sig2 = falcon_sign(&sk2, message).unwrap().as_bytes().to_vec();
 
         // 2 of 3 signatures — should pass
         let result = validate_signature(&account, message, &[sig1, sig2, vec![]]);
@@ -201,9 +207,9 @@ mod tests {
 
     #[test]
     fn multisig_insufficient_signatures() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
-        let (pk3, _sk3) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
+        let (pk3, _sk3) = falcon_keygen().unwrap();
 
         let mut account = Account::new_eoa(&pk1.as_bytes().to_vec());
         account.auth_keys = AuthKeys::MultiSig {
@@ -212,7 +218,7 @@ mod tests {
         };
 
         let message = b"multisig tx";
-        let sig1 = falcon_sign(&sk1, message).as_bytes().to_vec();
+        let sig1 = falcon_sign(&sk1, message).unwrap().as_bytes().to_vec();
 
         // Only 1 signature — threshold is 2
         let result = validate_signature(&account, message, &[sig1]);
@@ -224,11 +230,11 @@ mod tests {
     #[test]
     fn key_rotation_succeeds() {
         let (account, sk) = make_eoa_with_real_key();
-        let (new_pk, _new_sk) = falcon_keygen();
+        let (new_pk, _new_sk) = falcon_keygen().unwrap();
         let new_keys = AuthKeys::Single(new_pk.as_bytes().to_vec());
 
         let rotation_msg = build_rotation_message(&account, &new_keys);
-        let sig = falcon_sign(&sk, &rotation_msg).as_bytes().to_vec();
+        let sig = falcon_sign(&sk, &rotation_msg).unwrap().as_bytes().to_vec();
 
         let updated = rotate_keys(&account, new_keys.clone(), &[sig], &rotation_msg).unwrap();
         assert_eq!(updated.auth_keys, new_keys);
@@ -239,17 +245,17 @@ mod tests {
     #[test]
     fn old_key_invalid_after_rotation() {
         let (account, sk) = make_eoa_with_real_key();
-        let (new_pk, _new_sk) = falcon_keygen();
+        let (new_pk, _new_sk) = falcon_keygen().unwrap();
         let new_keys = AuthKeys::Single(new_pk.as_bytes().to_vec());
 
         let rotation_msg = build_rotation_message(&account, &new_keys);
-        let sig = falcon_sign(&sk, &rotation_msg).as_bytes().to_vec();
+        let sig = falcon_sign(&sk, &rotation_msg).unwrap().as_bytes().to_vec();
 
         let updated = rotate_keys(&account, new_keys, &[sig], &rotation_msg).unwrap();
 
         // Old key can no longer sign for this account
         let msg = b"transaction after rotation";
-        let old_sig = falcon_sign(&sk, msg).as_bytes().to_vec();
+        let old_sig = falcon_sign(&sk, msg).unwrap().as_bytes().to_vec();
         let result = validate_signature(&updated, msg, &[old_sig]);
         assert_eq!(result, AuthResult::Invalid);
     }
@@ -257,12 +263,12 @@ mod tests {
     #[test]
     fn rotation_with_wrong_key_fails() {
         let (account, _sk) = make_eoa_with_real_key();
-        let (_wrong_pk, wrong_sk) = falcon_keygen();
-        let (new_pk, _new_sk) = falcon_keygen();
+        let (_wrong_pk, wrong_sk) = falcon_keygen().unwrap();
+        let (new_pk, _new_sk) = falcon_keygen().unwrap();
         let new_keys = AuthKeys::Single(new_pk.as_bytes().to_vec());
 
         let rotation_msg = build_rotation_message(&account, &new_keys);
-        let wrong_sig = falcon_sign(&wrong_sk, &rotation_msg).as_bytes().to_vec();
+        let wrong_sig = falcon_sign(&wrong_sk, &rotation_msg).unwrap().as_bytes().to_vec();
 
         let result = rotate_keys(&account, new_keys, &[wrong_sig], &rotation_msg);
         assert!(result.is_none());

--- a/crates/consensus/src/finality.rs
+++ b/crates/consensus/src/finality.rs
@@ -121,18 +121,18 @@ pub fn create_finality_vote(
     voter_index: u8,
     voter_address: Address,
     voter_sk: &FalconSecretKey,
-) -> FinalityVote {
+) -> Result<FinalityVote, &'static str> {
     let msg = finality_sign_message(slot, &block_hash, &state_root);
-    let sig = falcon_sign(voter_sk, &msg);
+    let sig = falcon_sign(voter_sk, &msg).map_err(|_| "finality vote signing failed")?;
 
-    FinalityVote {
+    Ok(FinalityVote {
         slot,
         block_hash,
         state_root,
         voter_index,
         voter_address,
         signature: sig.as_bytes().to_vec(),
-    }
+    })
 }
 
 /// Verify a finality vote.
@@ -142,7 +142,10 @@ pub fn verify_finality_vote(vote: &FinalityVote, public_key: &[u8]) -> bool {
         None => return false,
     };
     let msg = finality_sign_message(vote.slot, &vote.block_hash, &vote.state_root);
-    let sig = FalconSignature::from_bytes(&vote.signature);
+    let sig = match FalconSignature::from_bytes(&vote.signature) {
+        Some(s) => s,
+        None => return false,
+    };
     falcon_verify(&pk, &msg, &sig)
 }
 
@@ -366,11 +369,11 @@ mod tests {
         let state_root = [0xCC; 32];
 
         for i in 0..86u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let vote = create_finality_vote(5, block_hash, state_root, i, addr, &sk);
+            let vote = create_finality_vote(5, block_hash, state_root, i, addr, &sk).unwrap();
             votes.push(vote);
             keys.push(pk_bytes);
         }
@@ -390,11 +393,11 @@ mod tests {
         let mut keys = Vec::new();
 
         for i in 0..85u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], i, addr, &sk);
+            let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], i, addr, &sk).unwrap();
             votes.push(vote);
             keys.push(pk_bytes);
         }
@@ -409,21 +412,21 @@ mod tests {
 
     #[test]
     fn finality_vote_verified() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], 0, addr, &sk);
+        let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], 0, addr, &sk).unwrap();
         assert!(verify_finality_vote(&vote, &pk_bytes));
     }
 
     #[test]
     fn finality_vote_wrong_key_rejected() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk1.as_bytes());
 
-        let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], 0, addr, &sk1);
+        let vote = create_finality_vote(5, [0xAA; 32], [0xCC; 32], 0, addr, &sk1).unwrap();
         assert!(!verify_finality_vote(&vote, pk2.as_bytes()));
     }
 

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -106,15 +106,15 @@ pub fn create_vote(
     voter_index: u8,
     voter_address: Address,
     voter_sk: &pyde_crypto::falcon::FalconSecretKey,
-) -> Option<ConsensusMessage> {
+) -> Result<Option<ConsensusMessage>, &'static str> {
     // Safety: don't double-vote
     if header.slot <= state.last_voted_slot {
-        return None;
+        return Ok(None);
     }
 
     // Safety: proposal must extend our highest QC
     if header.qc_previous.slot < state.highest_qc.slot {
-        return None;
+        return Ok(None);
     }
 
     // Update highest QC if proposal's QC is newer
@@ -128,17 +128,18 @@ pub fn create_vote(
     let mut vote_msg = Vec::with_capacity(40);
     vote_msg.extend_from_slice(&header.slot.to_le_bytes());
     vote_msg.extend_from_slice(&block_hash);
-    let sig = pyde_crypto::falcon::falcon_sign(voter_sk, &vote_msg);
+    let sig = pyde_crypto::falcon::falcon_sign(voter_sk, &vote_msg)
+        .map_err(|_| "vote signing failed")?;
 
     state.last_voted_slot = header.slot;
 
-    Some(ConsensusMessage::Vote {
+    Ok(Some(ConsensusMessage::Vote {
         slot: header.slot,
         block_hash,
         voter_index,
         voter_address,
         signature: sig.as_bytes().to_vec(),
-    })
+    }))
 }
 
 /// Verify a vote message against a validator's public key.
@@ -158,7 +159,10 @@ pub fn verify_vote(vote: &ConsensusMessage, public_key: &[u8]) -> bool {
             let mut vote_msg = Vec::with_capacity(40);
             vote_msg.extend_from_slice(&slot.to_le_bytes());
             vote_msg.extend_from_slice(block_hash);
-            let sig = FalconSignature::from_bytes(signature);
+            let sig = match FalconSignature::from_bytes(signature) {
+                Some(s) => s,
+                None => return false,
+            };
             falcon_verify(&pk, &vote_msg, &sig)
         }
         _ => false,
@@ -263,19 +267,20 @@ pub fn create_timeout(
     voter_index: u8,
     voter_address: Address,
     voter_sk: &pyde_crypto::falcon::FalconSecretKey,
-) -> ConsensusMessage {
+) -> Result<ConsensusMessage, &'static str> {
     let mut msg = Vec::new();
     msg.extend_from_slice(b"timeout");
     msg.extend_from_slice(&slot.to_le_bytes());
-    let sig = pyde_crypto::falcon::falcon_sign(voter_sk, &msg);
+    let sig = pyde_crypto::falcon::falcon_sign(voter_sk, &msg)
+        .map_err(|_| "timeout signing failed")?;
 
-    ConsensusMessage::Timeout {
+    Ok(ConsensusMessage::Timeout {
         slot,
         voter_index,
         voter_address,
         highest_qc: state.highest_qc.clone(),
         signature: sig.as_bytes().to_vec(),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -309,14 +314,14 @@ mod tests {
     #[test]
     fn happy_path_vote_and_qc() {
         let mut state = ConsensusState::new();
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
         let header = make_header(1, 0);
 
         // Create vote
-        let vote = create_vote(&mut state, &header, 0, addr, &sk).unwrap();
+        let vote = create_vote(&mut state, &header, 0, addr, &sk).unwrap().unwrap();
         assert!(matches!(vote, ConsensusMessage::Vote { .. }));
 
         // Verify vote
@@ -335,14 +340,14 @@ mod tests {
 
         // Generate 86 valid votes (signature covers slot || block_hash)
         for i in 0..86u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
             let mut vote_msg = Vec::with_capacity(40);
             vote_msg.extend_from_slice(&5u64.to_le_bytes());
             vote_msg.extend_from_slice(&block_hash);
-            let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg);
+            let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg).unwrap();
             votes.push(ConsensusMessage::Vote {
                 slot: 5,
                 block_hash,
@@ -377,14 +382,14 @@ mod tests {
 
         // Only 85 votes (need 86)
         for i in 0..85u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
             let mut vote_msg = Vec::with_capacity(40);
             vote_msg.extend_from_slice(&5u64.to_le_bytes());
             vote_msg.extend_from_slice(&block_hash);
-            let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg);
+            let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg).unwrap();
             votes.push(ConsensusMessage::Vote {
                 slot: 5,
                 block_hash,
@@ -446,31 +451,31 @@ mod tests {
     #[test]
     fn no_double_vote() {
         let mut state = ConsensusState::new();
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk.as_bytes());
 
         let header = make_header(1, 0);
-        let vote1 = create_vote(&mut state, &header, 0, addr, &sk);
+        let vote1 = create_vote(&mut state, &header, 0, addr, &sk).unwrap();
         assert!(vote1.is_some());
 
         // Try voting again for same slot
-        let vote2 = create_vote(&mut state, &header, 0, addr, &sk);
+        let vote2 = create_vote(&mut state, &header, 0, addr, &sk).unwrap();
         assert!(vote2.is_none()); // rejected
     }
 
     #[test]
     fn vote_rejected_for_old_slot() {
         let mut state = ConsensusState::new();
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk.as_bytes());
 
         // Vote for slot 5
         let header5 = make_header(5, 4);
-        create_vote(&mut state, &header5, 0, addr, &sk).unwrap();
+        create_vote(&mut state, &header5, 0, addr, &sk).unwrap().unwrap();
 
         // Try to vote for slot 3 (old)
         let header3 = make_header(3, 2);
-        let vote = create_vote(&mut state, &header3, 0, addr, &sk);
+        let vote = create_vote(&mut state, &header3, 0, addr, &sk).unwrap();
         assert!(vote.is_none());
     }
 
@@ -479,13 +484,13 @@ mod tests {
     #[test]
     fn vote_updates_highest_qc() {
         let mut state = ConsensusState::new();
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk.as_bytes());
 
         assert_eq!(state.highest_qc.slot, 0);
 
         let header = make_header(5, 4); // QC for slot 4
-        create_vote(&mut state, &header, 0, addr, &sk).unwrap();
+        create_vote(&mut state, &header, 0, addr, &sk).unwrap().unwrap();
 
         assert_eq!(state.highest_qc.slot, 4);
     }
@@ -495,10 +500,10 @@ mod tests {
     #[test]
     fn timeout_message_created() {
         let state = ConsensusState::new();
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk.as_bytes());
 
-        let timeout = create_timeout(&state, 5, 0, addr, &sk);
+        let timeout = create_timeout(&state, 5, 0, addr, &sk).unwrap();
         assert!(matches!(timeout, ConsensusMessage::Timeout { slot: 5, .. }));
     }
 }

--- a/crates/consensus/src/proposer.rs
+++ b/crates/consensus/src/proposer.rs
@@ -56,24 +56,26 @@ pub struct ProposerCandidate {
 
 /// Compute a validator's proposer candidacy for a given slot.
 ///
-/// Each validator calls this locally with their secret key.
+/// Each validator calls this locally with their keypair.
 /// Returns their candidate (output, proof, score).
 pub fn compute_candidacy(
+    public_key: &FalconPublicKey,
     secret_key: &FalconSecretKey,
     epoch_randomness: &[u8; 32],
     slot: u64,
     address: Address,
-) -> ProposerCandidate {
+) -> Result<ProposerCandidate, &'static str> {
     let input = vrf_input(epoch_randomness, slot);
-    let (output, proof) = vrf_prove(secret_key, &input);
+    let (output, proof) = vrf_prove(public_key, secret_key, &input)
+        .map_err(|_| "VRF prove failed — invalid keypair")?;
     let score = score_from_output(&output);
 
-    ProposerCandidate {
+    Ok(ProposerCandidate {
         address,
         vrf_output: output,
         vrf_proof: proof,
         score,
-    }
+    })
 }
 
 /// Verify a proposer candidate's VRF proof.
@@ -126,10 +128,10 @@ mod tests {
     use pyde_crypto::falcon::falcon_keygen;
 
     fn make_candidate(slot: u64, randomness: &[u8; 32]) -> (ProposerCandidate, Vec<u8>) {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
-        let candidate = compute_candidacy(&sk, randomness, slot, addr);
+        let candidate = compute_candidacy(&pk, &sk, randomness, slot, addr).unwrap();
         (candidate, pk_bytes)
     }
 
@@ -137,13 +139,13 @@ mod tests {
 
     #[test]
     fn proposer_selection_deterministic() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
         let randomness = [0xAA; 32];
 
-        let c1 = compute_candidacy(&sk, &randomness, 100, addr);
-        let c2 = compute_candidacy(&sk, &randomness, 100, addr);
+        let c1 = compute_candidacy(&pk, &sk, &randomness, 100, addr).unwrap();
+        let c2 = compute_candidacy(&pk, &sk, &randomness, 100, addr).unwrap();
 
         assert_eq!(c1.score, c2.score);
         assert_eq!(c1.vrf_output.as_bytes(), c2.vrf_output.as_bytes());
@@ -153,13 +155,13 @@ mod tests {
 
     #[test]
     fn different_slots_different_scores() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
         let randomness = [0xAA; 32];
 
-        let c1 = compute_candidacy(&sk, &randomness, 100, addr);
-        let c2 = compute_candidacy(&sk, &randomness, 101, addr);
+        let c1 = compute_candidacy(&pk, &sk, &randomness, 100, addr).unwrap();
+        let c2 = compute_candidacy(&pk, &sk, &randomness, 101, addr).unwrap();
 
         // Scores should differ (with overwhelming probability)
         assert_ne!(c1.score, c2.score);
@@ -167,12 +169,12 @@ mod tests {
 
     #[test]
     fn different_randomness_different_scores() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let c1 = compute_candidacy(&sk, &[0xAA; 32], 100, addr);
-        let c2 = compute_candidacy(&sk, &[0xBB; 32], 100, addr);
+        let c1 = compute_candidacy(&pk, &sk, &[0xAA; 32], 100, addr).unwrap();
+        let c2 = compute_candidacy(&pk, &sk, &[0xBB; 32], 100, addr).unwrap();
 
         assert_ne!(c1.score, c2.score);
     }
@@ -195,7 +197,7 @@ mod tests {
     #[test]
     fn wrong_key_rejected() {
         let (candidate, _pk_bytes) = make_candidate(100, &[0xAA; 32]);
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         // Verify with wrong public key
         assert!(!verify_candidacy(&candidate, pk2.as_bytes(), &[0xAA; 32], 100));
     }

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -128,8 +128,14 @@ pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> b
         None => return false,
     };
 
-    let sig_1 = FalconSignature::from_bytes(&evidence.signature_1);
-    let sig_2 = FalconSignature::from_bytes(&evidence.signature_2);
+    let sig_1 = match FalconSignature::from_bytes(&evidence.signature_1) {
+        Some(s) => s,
+        None => return false,
+    };
+    let sig_2 = match FalconSignature::from_bytes(&evidence.signature_2) {
+        Some(s) => s,
+        None => return false,
+    };
 
     falcon_verify(&pk, &hash_1, &sig_1) && falcon_verify(&pk, &hash_2, &sig_2)
 }
@@ -277,15 +283,15 @@ mod tests {
 
     #[test]
     fn double_sign_detected_and_slashed() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
         let header_1 = make_header(100, 1_000_000);
         let header_2 = make_header(100, 2_000_000); // same slot, different timestamp → different hash
 
-        let sig_1 = falcon_sign(&sk, &header_1.hash());
-        let sig_2 = falcon_sign(&sk, &header_2.hash());
+        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
+        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -313,12 +319,12 @@ mod tests {
 
     #[test]
     fn same_block_twice_rejected() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
         let header = make_header(100, 1_000_000);
-        let sig = falcon_sign(&sk, &header.hash());
+        let sig = falcon_sign(&sk, &header.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -336,15 +342,15 @@ mod tests {
 
     #[test]
     fn wrong_signer_key_rejected() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk1.as_bytes());
 
         let header_1 = make_header(100, 1_000_000);
         let header_2 = make_header(100, 2_000_000);
 
-        let sig_1 = falcon_sign(&sk1, &header_1.hash());
-        let sig_2 = falcon_sign(&sk1, &header_2.hash());
+        let sig_1 = falcon_sign(&sk1, &header_1.hash()).unwrap();
+        let sig_2 = falcon_sign(&sk1, &header_2.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -362,15 +368,15 @@ mod tests {
 
     #[test]
     fn wrong_slot_rejected() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
         let header_1 = make_header(100, 1_000_000);
         let header_2 = make_header(101, 2_000_000); // different slot!
 
-        let sig_1 = falcon_sign(&sk, &header_1.hash());
-        let sig_2 = falcon_sign(&sk, &header_2.hash());
+        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
+        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -448,15 +454,15 @@ mod tests {
 
     #[test]
     fn finder_fee_is_10_percent() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
         let header_1 = make_header(100, 1_000_000);
         let header_2 = make_header(100, 2_000_000);
 
-        let sig_1 = falcon_sign(&sk, &header_1.hash());
-        let sig_2 = falcon_sign(&sk, &header_2.hash());
+        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
+        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -477,7 +483,7 @@ mod tests {
 
     #[test]
     fn apply_double_sign_slash_reduces_stake_and_ejects() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
@@ -487,8 +493,8 @@ mod tests {
 
         let header_1 = make_header(100, 1_000_000);
         let header_2 = make_header(100, 2_000_000);
-        let sig_1 = falcon_sign(&sk, &header_1.hash());
-        let sig_2 = falcon_sign(&sk, &header_2.hash());
+        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
+        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
 
         let evidence = DoubleSignEvidence {
             slot: 100,

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -122,17 +122,17 @@ pub fn create_view_change(
     voter_index: u8,
     voter_address: Address,
     voter_sk: &FalconSecretKey,
-) -> ViewChangeMessage {
+) -> Result<ViewChangeMessage, &'static str> {
     let msg = view_change_sign_message(slot);
-    let sig = falcon_sign(voter_sk, &msg);
+    let sig = falcon_sign(voter_sk, &msg).map_err(|_| "view change signing failed")?;
 
-    ViewChangeMessage {
+    Ok(ViewChangeMessage {
         slot,
         highest_qc: highest_qc.clone(),
         voter_index,
         voter_address,
         signature: sig.as_bytes().to_vec(),
-    }
+    })
 }
 
 /// Verify a view change message.
@@ -142,7 +142,10 @@ pub fn verify_view_change(msg: &ViewChangeMessage, public_key: &[u8]) -> bool {
         None => return false,
     };
     let sign_msg = view_change_sign_message(msg.slot);
-    let sig = FalconSignature::from_bytes(&msg.signature);
+    let sig = match FalconSignature::from_bytes(&msg.signature) {
+        Some(s) => s,
+        None => return false,
+    };
     falcon_verify(&pk, &sign_msg, &sig)
 }
 
@@ -237,24 +240,24 @@ mod tests {
 
     #[test]
     fn view_change_message_created_and_verified() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
         let qc = QuorumCert::empty();
 
-        let msg = create_view_change(5, &qc, 0, addr, &sk);
+        let msg = create_view_change(5, &qc, 0, addr, &sk).unwrap();
         assert_eq!(msg.slot, 5);
         assert!(verify_view_change(&msg, &pk_bytes));
     }
 
     #[test]
     fn view_change_wrong_key_rejected() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk1.as_bytes());
         let qc = QuorumCert::empty();
 
-        let msg = create_view_change(5, &qc, 0, addr, &sk1);
+        let msg = create_view_change(5, &qc, 0, addr, &sk1).unwrap();
         assert!(!verify_view_change(&msg, pk2.as_bytes()));
     }
 
@@ -264,12 +267,12 @@ mod tests {
         let mut keys = Vec::new();
 
         for i in 0..86u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
             let qc = QuorumCert::empty();
 
-            let msg = create_view_change(10, &qc, i, addr, &sk);
+            let msg = create_view_change(10, &qc, i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -289,11 +292,11 @@ mod tests {
         let mut keys = Vec::new();
 
         for i in 0..85u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let msg = create_view_change(10, &QuorumCert::empty(), i, addr, &sk);
+            let msg = create_view_change(10, &QuorumCert::empty(), i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -342,7 +345,7 @@ mod tests {
         let mut keys = Vec::new();
 
         for i in 0..86u8 {
-            let (pk, sk) = falcon_keygen();
+            let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
@@ -354,7 +357,7 @@ mod tests {
                 signatures: vec![],
             };
 
-            let msg = create_view_change(100, &qc, i, addr, &sk);
+            let msg = create_view_change(100, &qc, i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }

--- a/crates/crypto/benches/falcon_bench.rs
+++ b/crates/crypto/benches/falcon_bench.rs
@@ -7,7 +7,7 @@ fn bench_keygen() {
     let iterations = 100;
     let start = Instant::now();
     for _ in 0..iterations {
-        std::hint::black_box(falcon_keygen());
+        std::hint::black_box(falcon_keygen().unwrap());
     }
     let elapsed = start.elapsed();
     println!(
@@ -19,7 +19,7 @@ fn bench_keygen() {
 
 fn bench_sign() {
     println!("\n=== FALCON-512 sign ===\n");
-    let (_pk, sk) = falcon_keygen();
+    let (_pk, sk) = falcon_keygen().unwrap();
     let msg = b"benchmark message for signing";
     let iterations = 1_000;
 
@@ -37,9 +37,9 @@ fn bench_sign() {
 
 fn bench_verify() {
     println!("\n=== FALCON-512 verify (single) ===\n");
-    let (pk, sk) = falcon_keygen();
+    let (pk, sk) = falcon_keygen().unwrap();
     let msg = b"benchmark message for verification";
-    let sig = falcon_sign(&sk, msg);
+    let sig = falcon_sign(&sk, msg).unwrap();
     let iterations = 1_000;
 
     let start = Instant::now();
@@ -60,13 +60,13 @@ fn bench_verify() {
 
 fn bench_batch_verify() {
     println!("\n=== FALCON-512 batch verify ===\n");
-    let (pk, sk) = falcon_keygen();
+    let (pk, sk) = falcon_keygen().unwrap();
 
     for count in [100, 1000] {
         let msgs: Vec<Vec<u8>> = (0..count)
             .map(|i| format!("message {}", i).into_bytes())
             .collect();
-        let sigs: Vec<_> = msgs.iter().map(|m| falcon_sign(&sk, m)).collect();
+        let sigs: Vec<_> = msgs.iter().map(|m| falcon_sign(&sk, m).unwrap()).collect();
         let items: Vec<_> = msgs
             .iter()
             .zip(sigs.iter())

--- a/crates/crypto/benches/vrf_bench.rs
+++ b/crates/crypto/benches/vrf_bench.rs
@@ -5,13 +5,13 @@ use pyde_crypto::vrf::{vrf_prove, vrf_verify};
 
 fn bench_prove() {
     println!("=== VRF prove ===\n");
-    let (_pk, sk) = falcon_keygen();
+    let (pk, sk) = falcon_keygen().unwrap();
     let input = b"benchmark vrf input";
     let iterations = 1_000;
 
     let start = Instant::now();
     for _ in 0..iterations {
-        std::hint::black_box(vrf_prove(&sk, std::hint::black_box(input)));
+        std::hint::black_box(vrf_prove(&pk, &sk, std::hint::black_box(input)));
     }
     let elapsed = start.elapsed();
     println!(
@@ -23,9 +23,9 @@ fn bench_prove() {
 
 fn bench_verify() {
     println!("\n=== VRF verify ===\n");
-    let (pk, sk) = falcon_keygen();
+    let (pk, sk) = falcon_keygen().unwrap();
     let input = b"benchmark vrf verify";
-    let (output, proof) = vrf_prove(&sk, input);
+    let (output, proof) = vrf_prove(&pk, &sk, input);
     let iterations = 1_000;
 
     let start = Instant::now();

--- a/crates/crypto/src/falcon.rs
+++ b/crates/crypto/src/falcon.rs
@@ -58,8 +58,14 @@ impl FalconSecretKey {
 }
 
 impl FalconSignature {
-    pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+    /// FALCON-512 signatures are typically 600-900 bytes.
+    /// Reject anything outside the 500-1000 byte range.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() >= 500 && bytes.len() <= 1000 {
+            Some(Self(bytes.to_vec()))
+        } else {
+            None
+        }
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -80,25 +86,26 @@ impl FalconSignature {
 }
 
 /// Generate a FALCON-512 keypair.
-pub fn falcon_keygen() -> (FalconPublicKey, FalconSecretKey) {
-    let kp = FnDsaKeyPair::generate(LOGN).expect("FALCON-512 keygen failed");
+pub fn falcon_keygen() -> Result<(FalconPublicKey, FalconSecretKey), &'static str> {
+    let kp = FnDsaKeyPair::generate(LOGN).map_err(|_| "FALCON-512 keygen failed")?;
     let pk = FalconPublicKey(kp.public_key().to_vec());
     let sk = FalconSecretKey(kp.private_key().to_vec());
-    (pk, sk)
+    Ok((pk, sk))
 }
 
 /// Sign a message with a FALCON-512 secret key.
-pub fn falcon_sign(sk: &FalconSecretKey, msg: &[u8]) -> FalconSignature {
-    let kp = FnDsaKeyPair::from_private_key(&sk.0).expect("invalid FALCON-512 secret key");
+pub fn falcon_sign(sk: &FalconSecretKey, msg: &[u8]) -> Result<FalconSignature, &'static str> {
+    let kp = FnDsaKeyPair::from_private_key(&sk.0)
+        .map_err(|_| "invalid FALCON-512 secret key")?;
     let sig = kp
-        .sign(msg, &DomainSeparation::None)
-        .expect("FALCON-512 signing failed");
-    FalconSignature(sig.to_bytes().to_vec())
+        .sign(msg, &DomainSeparation::Context(b"pyde-falcon-v1"))
+        .map_err(|_| "FALCON-512 signing failed")?;
+    Ok(FalconSignature(sig.to_bytes().to_vec()))
 }
 
 /// Verify a FALCON-512 signature.
 pub fn falcon_verify(pk: &FalconPublicKey, msg: &[u8], sig: &FalconSignature) -> bool {
-    FnDsaSig::verify(&sig.0, &pk.0, msg, &DomainSeparation::None).is_ok()
+    FnDsaSig::verify(&sig.0, &pk.0, msg, &DomainSeparation::Context(b"pyde-falcon-v1")).is_ok()
 }
 
 /// Batch verify multiple FALCON-512 signatures.
@@ -118,60 +125,70 @@ mod tests {
 
     #[test]
     fn keygen_produces_correct_sizes() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         assert_eq!(pk.as_bytes().len(), FalconPublicKey::SIZE);
         assert_eq!(sk.as_bytes().len(), FalconSecretKey::SIZE);
     }
 
     #[test]
     fn sign_verify_roundtrip() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let msg = b"hello post-quantum world";
-        let sig = falcon_sign(&sk, msg);
+        let sig = falcon_sign(&sk, msg).unwrap();
         assert!(falcon_verify(&pk, msg, &sig));
     }
 
     #[test]
     fn tampered_message_fails() {
-        let (pk, sk) = falcon_keygen();
-        let sig = falcon_sign(&sk, b"original message");
+        let (pk, sk) = falcon_keygen().unwrap();
+        let sig = falcon_sign(&sk, b"original message").unwrap();
         assert!(!falcon_verify(&pk, b"tampered message", &sig));
     }
 
     #[test]
     fn tampered_signature_fails() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let msg = b"test message";
-        let sig = falcon_sign(&sk, msg);
+        let sig = falcon_sign(&sk, msg).unwrap();
         let mut bad_sig_bytes = sig.to_vec();
         if let Some(byte) = bad_sig_bytes.last_mut() {
             *byte ^= 0xFF;
         }
-        let bad_sig = FalconSignature::from_bytes(&bad_sig_bytes);
+        let bad_sig = FalconSignature::from_bytes(&bad_sig_bytes).unwrap();
         assert!(!falcon_verify(&pk, msg, &bad_sig));
     }
 
     #[test]
     fn wrong_public_key_fails() {
-        let (_pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (_pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let msg = b"test message";
-        let sig = falcon_sign(&sk1, msg);
+        let sig = falcon_sign(&sk1, msg).unwrap();
         assert!(!falcon_verify(&pk2, msg, &sig));
     }
 
     #[test]
     fn signature_size_in_expected_range() {
-        let (_pk, sk) = falcon_keygen();
-        let sig = falcon_sign(&sk, b"test");
+        let (_pk, sk) = falcon_keygen().unwrap();
+        let sig = falcon_sign(&sk, b"test").unwrap();
         // FALCON-512 signatures are ~666 bytes average, range roughly 600-700
         assert!(sig.len() >= 500, "sig too small: {}", sig.len());
         assert!(sig.len() <= 900, "sig too large: {}", sig.len());
     }
 
     #[test]
+    fn signature_from_bytes_rejects_invalid_length() {
+        // Too short
+        assert!(FalconSignature::from_bytes(&[0u8; 100]).is_none());
+        // Too long
+        assert!(FalconSignature::from_bytes(&[0u8; 1500]).is_none());
+        // Valid range
+        assert!(FalconSignature::from_bytes(&[0u8; 666]).is_some());
+    }
+
+    #[test]
     fn serialization_roundtrip_public_key() {
-        let (pk, _sk) = falcon_keygen();
+        let (pk, _sk) = falcon_keygen().unwrap();
         let bytes = pk.to_vec();
         let pk2 = FalconPublicKey::from_bytes(&bytes).unwrap();
         assert_eq!(pk, pk2);
@@ -179,7 +196,7 @@ mod tests {
 
     #[test]
     fn serialization_roundtrip_secret_key() {
-        let (_pk, sk) = falcon_keygen();
+        let (_pk, sk) = falcon_keygen().unwrap();
         let bytes = sk.to_vec();
         let sk2 = FalconSecretKey::from_bytes(&bytes).unwrap();
         // Re-derive pk from both and verify they match
@@ -190,18 +207,18 @@ mod tests {
 
     #[test]
     fn serialization_roundtrip_signature() {
-        let (_pk, sk) = falcon_keygen();
-        let sig = falcon_sign(&sk, b"test");
+        let (_pk, sk) = falcon_keygen().unwrap();
+        let sig = falcon_sign(&sk, b"test").unwrap();
         let bytes = sig.to_vec();
-        let sig2 = FalconSignature::from_bytes(&bytes);
+        let sig2 = FalconSignature::from_bytes(&bytes).unwrap();
         assert_eq!(sig, sig2);
     }
 
     #[test]
     fn batch_verify_all_valid() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let msgs: &[&[u8]] = &[b"msg1", b"msg2", b"msg3"];
-        let sigs: Vec<FalconSignature> = msgs.iter().map(|m| falcon_sign(&sk, m)).collect();
+        let sigs: Vec<FalconSignature> = msgs.iter().map(|m| falcon_sign(&sk, m).unwrap()).collect();
         let items: Vec<_> = msgs
             .iter()
             .zip(sigs.iter())
@@ -212,10 +229,10 @@ mod tests {
 
     #[test]
     fn batch_verify_one_invalid() {
-        let (pk, sk) = falcon_keygen();
-        let sig1 = falcon_sign(&sk, b"msg1");
-        let sig2 = falcon_sign(&sk, b"msg2");
-        let sig3 = falcon_sign(&sk, b"msg3");
+        let (pk, sk) = falcon_keygen().unwrap();
+        let sig1 = falcon_sign(&sk, b"msg1").unwrap();
+        let sig2 = falcon_sign(&sk, b"msg2").unwrap();
+        let sig3 = falcon_sign(&sk, b"msg3").unwrap();
         // Use wrong message for sig2
         let items: Vec<(&FalconPublicKey, &[u8], &FalconSignature)> = vec![
             (&pk, b"msg1", &sig1),
@@ -227,16 +244,16 @@ mod tests {
 
     #[test]
     fn empty_message_sign_verify() {
-        let (pk, sk) = falcon_keygen();
-        let sig = falcon_sign(&sk, b"");
+        let (pk, sk) = falcon_keygen().unwrap();
+        let sig = falcon_sign(&sk, b"").unwrap();
         assert!(falcon_verify(&pk, b"", &sig));
     }
 
     #[test]
     fn large_message_sign_verify() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let msg = vec![0xABu8; 10_000];
-        let sig = falcon_sign(&sk, &msg);
+        let sig = falcon_sign(&sk, &msg).unwrap();
         assert!(falcon_verify(&pk, &msg, &sig));
     }
 }

--- a/crates/crypto/src/kyber.rs
+++ b/crates/crypto/src/kyber.rs
@@ -92,43 +92,43 @@ impl SharedSecret {
     }
 }
 
-fn ek_from_bytes(bytes: &[u8]) -> ml_kem::EncapsulationKey768 {
-    let arr: &[u8; EK_SIZE] = bytes.try_into().expect("wrong ek size");
-    ml_kem::EncapsulationKey768::new(arr.into()).expect("invalid encapsulation key")
+fn ek_from_bytes(bytes: &[u8]) -> Result<ml_kem::EncapsulationKey768, &'static str> {
+    let arr: &[u8; EK_SIZE] = bytes.try_into().map_err(|_| "wrong encapsulation key size")?;
+    ml_kem::EncapsulationKey768::new(arr.into()).map_err(|_| "invalid encapsulation key")
 }
 
-fn dk_from_seed(bytes: &[u8]) -> ml_kem::DecapsulationKey768 {
-    let arr: &[u8; SEED_SIZE] = bytes.try_into().expect("wrong seed size");
+fn dk_from_seed(bytes: &[u8]) -> Result<ml_kem::DecapsulationKey768, &'static str> {
+    let arr: &[u8; SEED_SIZE] = bytes.try_into().map_err(|_| "wrong decapsulation seed size")?;
     let seed = Seed::from(*arr);
-    ml_kem::DecapsulationKey768::from_seed(seed)
+    Ok(ml_kem::DecapsulationKey768::from_seed(seed))
 }
 
 /// Generate a Kyber-768 keypair.
-pub fn kyber_keygen() -> (KyberPublicKey, KyberSecretKey) {
+pub fn kyber_keygen() -> Result<(KyberPublicKey, KyberSecretKey), &'static str> {
     let (dk, ek) = MlKem768::generate_keypair();
     let pk = KyberPublicKey(ek.to_bytes().to_vec());
-    let seed = dk.to_seed().expect("seed export");
+    let seed = dk.to_seed().ok_or("Kyber-768 seed export failed")?;
     let sk = KyberSecretKey(seed.to_vec());
-    (pk, sk)
+    Ok((pk, sk))
 }
 
 /// Encapsulate: generate a shared secret and ciphertext using the public key.
-pub fn kyber_encapsulate(pk: &KyberPublicKey) -> (KyberCiphertext, SharedSecret) {
-    let ek = ek_from_bytes(&pk.0);
+pub fn kyber_encapsulate(pk: &KyberPublicKey) -> Result<(KyberCiphertext, SharedSecret), &'static str> {
+    let ek = ek_from_bytes(&pk.0)?;
     let (ct, ss) = ek.encapsulate();
     let mut secret = [0u8; 32];
     secret.copy_from_slice(ss.as_slice());
-    (KyberCiphertext(ct.to_vec()), SharedSecret(secret))
+    Ok((KyberCiphertext(ct.to_vec()), SharedSecret(secret)))
 }
 
 /// Decapsulate: recover the shared secret from a ciphertext using the secret key.
-pub fn kyber_decapsulate(sk: &KyberSecretKey, ct: &KyberCiphertext) -> SharedSecret {
-    let dk = dk_from_seed(&sk.0);
-    let ct_arr: &[u8; CT_SIZE] = ct.0.as_slice().try_into().expect("wrong ct size");
+pub fn kyber_decapsulate(sk: &KyberSecretKey, ct: &KyberCiphertext) -> Result<SharedSecret, &'static str> {
+    let dk = dk_from_seed(&sk.0)?;
+    let ct_arr: &[u8; CT_SIZE] = ct.0.as_slice().try_into().map_err(|_| "wrong ciphertext size")?;
     let ss = dk.decapsulate(ct_arr.into());
     let mut secret = [0u8; 32];
     secret.copy_from_slice(ss.as_slice());
-    SharedSecret(secret)
+    Ok(SharedSecret(secret))
 }
 
 #[cfg(test)]
@@ -137,49 +137,49 @@ mod tests {
 
     #[test]
     fn keygen_produces_correct_sizes() {
-        let (pk, sk) = kyber_keygen();
+        let (pk, sk) = kyber_keygen().unwrap();
         assert_eq!(pk.as_bytes().len(), EK_SIZE);
         assert_eq!(sk.as_bytes().len(), SEED_SIZE);
     }
 
     #[test]
     fn encapsulate_decapsulate_roundtrip() {
-        let (pk, sk) = kyber_keygen();
-        let (ct, ss_enc) = kyber_encapsulate(&pk);
-        let ss_dec = kyber_decapsulate(&sk, &ct);
+        let (pk, sk) = kyber_keygen().unwrap();
+        let (ct, ss_enc) = kyber_encapsulate(&pk).unwrap();
+        let ss_dec = kyber_decapsulate(&sk, &ct).unwrap();
         assert_eq!(ss_enc, ss_dec);
     }
 
     #[test]
     fn wrong_secret_key_different_shared_secret() {
-        let (pk, _sk1) = kyber_keygen();
-        let (_pk2, sk2) = kyber_keygen();
-        let (ct, ss_enc) = kyber_encapsulate(&pk);
-        let ss_dec = kyber_decapsulate(&sk2, &ct);
+        let (pk, _sk1) = kyber_keygen().unwrap();
+        let (_pk2, sk2) = kyber_keygen().unwrap();
+        let (ct, ss_enc) = kyber_encapsulate(&pk).unwrap();
+        let ss_dec = kyber_decapsulate(&sk2, &ct).unwrap();
         assert_ne!(ss_enc, ss_dec);
     }
 
     #[test]
     fn shared_secret_is_32_bytes() {
-        let (pk, _sk) = kyber_keygen();
-        let (_ct, ss) = kyber_encapsulate(&pk);
+        let (pk, _sk) = kyber_keygen().unwrap();
+        let (_ct, ss) = kyber_encapsulate(&pk).unwrap();
         assert_eq!(ss.as_bytes().len(), 32);
     }
 
     #[test]
     fn different_encapsulations_differ() {
-        let (pk, sk) = kyber_keygen();
-        let (ct1, ss1) = kyber_encapsulate(&pk);
-        let (ct2, ss2) = kyber_encapsulate(&pk);
+        let (pk, sk) = kyber_keygen().unwrap();
+        let (ct1, ss1) = kyber_encapsulate(&pk).unwrap();
+        let (ct2, ss2) = kyber_encapsulate(&pk).unwrap();
         assert_ne!(ss1, ss2);
         assert_ne!(ct1, ct2);
-        assert_eq!(ss1, kyber_decapsulate(&sk, &ct1));
-        assert_eq!(ss2, kyber_decapsulate(&sk, &ct2));
+        assert_eq!(ss1, kyber_decapsulate(&sk, &ct1).unwrap());
+        assert_eq!(ss2, kyber_decapsulate(&sk, &ct2).unwrap());
     }
 
     #[test]
     fn serialization_roundtrip_public_key() {
-        let (pk, _sk) = kyber_keygen();
+        let (pk, _sk) = kyber_keygen().unwrap();
         let bytes = pk.to_vec();
         let pk2 = KyberPublicKey::from_bytes(&bytes).unwrap();
         assert_eq!(pk, pk2);
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn serialization_roundtrip_secret_key() {
-        let (_pk, sk) = kyber_keygen();
+        let (_pk, sk) = kyber_keygen().unwrap();
         let bytes = sk.to_vec();
         let sk2 = KyberSecretKey::from_bytes(&bytes).unwrap();
         assert_eq!(sk.as_bytes(), sk2.as_bytes());
@@ -195,8 +195,8 @@ mod tests {
 
     #[test]
     fn serialization_roundtrip_ciphertext() {
-        let (pk, _sk) = kyber_keygen();
-        let (ct, _ss) = kyber_encapsulate(&pk);
+        let (pk, _sk) = kyber_keygen().unwrap();
+        let (ct, _ss) = kyber_encapsulate(&pk).unwrap();
         let bytes = ct.to_vec();
         let ct2 = KyberCiphertext::from_bytes(&bytes).unwrap();
         assert_eq!(ct, ct2);
@@ -204,8 +204,8 @@ mod tests {
 
     #[test]
     fn ciphertext_correct_size() {
-        let (pk, _sk) = kyber_keygen();
-        let (ct, _ss) = kyber_encapsulate(&pk);
+        let (pk, _sk) = kyber_keygen().unwrap();
+        let (ct, _ss) = kyber_encapsulate(&pk).unwrap();
         assert_eq!(ct.as_bytes().len(), CT_SIZE);
     }
 }

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -194,11 +194,11 @@ fn xor_bytes(data: &[u8], keystream: &[u8]) -> Vec<u8> {
 
 /// Generate a threshold keypair: committee public key + n key shares.
 /// Returns (ThresholdPublicKey, Vec<KeyShare>) where each KeyShare belongs to one validator.
-pub fn threshold_keygen(n: usize, threshold: usize) -> (ThresholdPublicKey, Vec<KeyShare>) {
-    assert!(threshold <= n, "threshold must be <= n");
-    assert!(threshold >= 1, "threshold must be >= 1");
+pub fn threshold_keygen(n: usize, threshold: usize) -> Result<(ThresholdPublicKey, Vec<KeyShare>), &'static str> {
+    if threshold > n { return Err("threshold must be <= n"); }
+    if threshold < 1 { return Err("threshold must be >= 1"); }
 
-    let (pk, sk) = kyber_keygen();
+    let (pk, sk) = kyber_keygen()?;
 
     // Convert 64-byte seed to 8 Goldilocks elements
     let seed_bytes = sk.as_bytes();
@@ -239,21 +239,21 @@ pub fn threshold_keygen(n: usize, threshold: usize) -> (ThresholdPublicKey, Vec<
         threshold,
     };
 
-    (tpk, key_shares)
+    Ok((tpk, key_shares))
 }
 
 /// Encrypt a message using the committee's threshold public key.
-pub fn threshold_encrypt(tpk: &ThresholdPublicKey, msg: &[u8]) -> ThresholdCiphertext {
-    let (kyber_ct, ss) = kyber_encapsulate(&tpk.kyber_pk);
+pub fn threshold_encrypt(tpk: &ThresholdPublicKey, msg: &[u8]) -> Result<ThresholdCiphertext, &'static str> {
+    let (kyber_ct, ss) = kyber_encapsulate(&tpk.kyber_pk)?;
     let keystream = derive_keystream(&ss, msg.len());
     let encrypted_msg = xor_bytes(msg, &keystream);
     let mac = compute_mac(&ss, &encrypted_msg);
 
-    ThresholdCiphertext {
+    Ok(ThresholdCiphertext {
         kyber_ct,
         encrypted_msg,
         mac,
-    }
+    })
 }
 
 /// Generate a decryption share from a validator's key share.
@@ -326,7 +326,7 @@ pub fn combine_shares(
     let sk = KyberSecretKey::from_bytes(&seed_bytes).ok_or("invalid reconstructed seed")?;
 
     // Decapsulate to get shared secret
-    let ss = kyber_decapsulate(&sk, &ct.kyber_ct);
+    let ss = kyber_decapsulate(&sk, &ct.kyber_ct).map_err(|_| "Kyber-768 decapsulation failed")?;
 
     // Verify MAC
     let expected_mac = compute_mac(&ss, &ct.encrypted_msg);
@@ -457,17 +457,21 @@ pub fn pss_refresh(
     let t = epoch_material.threshold;
     let new_epoch = epoch_material.epoch + 1;
 
-    // Each validator generates a refresh contribution
+    // Each validator generates a refresh contribution using fresh entropy
     let contributions: Vec<RefreshContribution> = old_shares
         .iter()
         .map(|ks| {
-            // Use hash of share data as entropy for the contribution
-            let share_entropy: Vec<u8> = ks
-                .shares
-                .iter()
-                .flat_map(|s| gl_to_u64(*s).to_le_bytes())
-                .collect();
-            generate_refresh_contribution(ks.index, n, t, new_epoch, &share_entropy)
+            // Generate fresh entropy from epoch, validator index, and random field element
+            let fresh_random = random_goldilocks(
+                &new_epoch.to_le_bytes(),
+                ks.index * 7919, // prime multiplier for extra mixing
+            );
+            let mut entropy_input = Vec::with_capacity(24);
+            entropy_input.extend_from_slice(&new_epoch.to_le_bytes());
+            entropy_input.extend_from_slice(&(ks.index as u64).to_le_bytes());
+            entropy_input.extend_from_slice(&gl_to_u64(fresh_random).to_le_bytes());
+            let fresh_entropy = poseidon2_hash(&entropy_input);
+            generate_refresh_contribution(ks.index, n, t, new_epoch, fresh_entropy.as_bytes())
         })
         .collect();
 
@@ -497,14 +501,14 @@ mod tests {
     const T: usize = 85;
 
     fn setup() -> (ThresholdPublicKey, Vec<KeyShare>) {
-        threshold_keygen(N, T)
+        threshold_keygen(N, T).unwrap()
     }
 
     #[test]
     fn encrypt_decrypt_with_threshold_plus_one() {
         let (tpk, shares) = setup();
         let msg = b"hello threshold kyber";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         let dec_shares: Vec<DecryptionShare> = shares[..T + 1]
             .iter()
@@ -519,7 +523,7 @@ mod tests {
     fn encrypt_decrypt_with_exact_threshold() {
         let (tpk, shares) = setup();
         let msg = b"exact threshold test";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         let dec_shares: Vec<DecryptionShare> = shares[..T]
             .iter()
@@ -534,7 +538,7 @@ mod tests {
     fn insufficient_shares_fails() {
         let (tpk, shares) = setup();
         let msg = b"not enough shares";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         let dec_shares: Vec<DecryptionShare> = shares[..T - 1]
             .iter()
@@ -549,7 +553,7 @@ mod tests {
     fn duplicate_shares_rejected() {
         let (tpk, shares) = setup();
         let msg = b"duplicate test";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         let mut dec_shares: Vec<DecryptionShare> = shares[..T - 1]
             .iter()
@@ -565,9 +569,9 @@ mod tests {
     #[test]
     fn wrong_shares_produce_bad_mac() {
         let (tpk, _shares) = setup();
-        let (_tpk2, shares2) = threshold_keygen(N, T);
+        let (_tpk2, shares2) = threshold_keygen(N, T).unwrap();
         let msg = b"wrong shares test";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         // Use shares from a different committee
         let dec_shares: Vec<DecryptionShare> = shares2[..T]
@@ -583,7 +587,7 @@ mod tests {
     fn any_subset_of_shares_works() {
         let (tpk, shares) = setup();
         let msg = b"any subset works";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         // Use last T shares instead of first T
         let dec_shares: Vec<DecryptionShare> = shares[N - T..]
@@ -599,7 +603,7 @@ mod tests {
     fn empty_message() {
         let (tpk, shares) = setup();
         let msg = b"";
-        let ct = threshold_encrypt(&tpk, msg);
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
 
         let dec_shares: Vec<DecryptionShare> = shares[..T]
             .iter()
@@ -612,9 +616,9 @@ mod tests {
 
     #[test]
     fn large_message() {
-        let (tpk, shares) = threshold_keygen(5, 3); // smaller for speed
+        let (tpk, shares) = threshold_keygen(5, 3).unwrap(); // smaller for speed
         let msg = vec![0xABu8; 10_000];
-        let ct = threshold_encrypt(&tpk, &msg);
+        let ct = threshold_encrypt(&tpk, &msg).unwrap();
 
         let dec_shares: Vec<DecryptionShare> = shares[..3]
             .iter()
@@ -654,7 +658,7 @@ mod tests {
     // --- PSS tests ---
 
     fn setup_epoch(n: usize, t: usize) -> (EpochKeyMaterial, Vec<KeyShare>) {
-        let (tpk, shares) = threshold_keygen(n, t);
+        let (tpk, shares) = threshold_keygen(n, t).unwrap();
         let epoch_material = EpochKeyMaterial {
             epoch: 0,
             n,
@@ -668,7 +672,7 @@ mod tests {
     fn pss_refreshed_shares_decrypt_old_ciphertext() {
         let (epoch_mat, shares) = setup_epoch(5, 3);
         let msg = b"encrypted before refresh";
-        let ct = threshold_encrypt(&epoch_mat.tpk, msg);
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
 
         // Refresh shares
         let (_new_epoch, new_shares) = pss_refresh(&epoch_mat, &shares);
@@ -691,7 +695,7 @@ mod tests {
 
         // Encrypt with the same public key (it doesn't change)
         let msg = b"encrypted after refresh";
-        let ct = threshold_encrypt(&new_epoch.tpk, msg);
+        let ct = threshold_encrypt(&new_epoch.tpk, msg).unwrap();
 
         // New shares should work
         let dec_shares_new: Vec<DecryptionShare> = new_shares[..3]
@@ -716,7 +720,7 @@ mod tests {
     fn pss_mixed_old_new_shares_fail() {
         let (epoch_mat, shares) = setup_epoch(5, 3);
         let msg = b"mixed shares test";
-        let ct = threshold_encrypt(&epoch_mat.tpk, msg);
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
 
         let (_new_epoch, new_shares) = pss_refresh(&epoch_mat, &shares);
 
@@ -738,7 +742,7 @@ mod tests {
     fn pss_multiple_refreshes() {
         let (epoch_mat, shares) = setup_epoch(5, 3);
         let msg = b"multi-refresh test";
-        let ct = threshold_encrypt(&epoch_mat.tpk, msg);
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
 
         // Refresh multiple times
         let (epoch1, shares1) = pss_refresh(&epoch_mat, &shares);
@@ -759,19 +763,23 @@ mod tests {
         let (epoch_mat, shares) = setup_epoch(5, 3);
         let new_epoch = epoch_mat.epoch + 1;
 
-        // Generate contributions
+        // Generate contributions using fresh entropy
         for ks in &shares {
-            let share_entropy: Vec<u8> = ks
-                .shares
-                .iter()
-                .flat_map(|s| gl_to_u64(*s).to_le_bytes())
-                .collect();
+            let fresh_random = random_goldilocks(
+                &new_epoch.to_le_bytes(),
+                ks.index * 7919,
+            );
+            let mut entropy_input = Vec::with_capacity(24);
+            entropy_input.extend_from_slice(&new_epoch.to_le_bytes());
+            entropy_input.extend_from_slice(&(ks.index as u64).to_le_bytes());
+            entropy_input.extend_from_slice(&gl_to_u64(fresh_random).to_le_bytes());
+            let fresh_entropy = poseidon2_hash(&entropy_input);
             let contrib = generate_refresh_contribution(
                 ks.index,
                 epoch_mat.n,
                 epoch_mat.threshold,
                 new_epoch,
-                &share_entropy,
+                fresh_entropy.as_bytes(),
             );
             assert!(verify_refresh_contribution(&contrib, epoch_mat.threshold));
         }
@@ -781,7 +789,7 @@ mod tests {
     fn pss_any_subset_after_refresh() {
         let (epoch_mat, shares) = setup_epoch(10, 7);
         let msg = b"any subset after refresh";
-        let ct = threshold_encrypt(&epoch_mat.tpk, msg);
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
 
         let (_new_epoch, new_shares) = pss_refresh(&epoch_mat, &shares);
 

--- a/crates/crypto/src/vrf.rs
+++ b/crates/crypto/src/vrf.rs
@@ -54,9 +54,11 @@ fn compute_vrf_output(sk: &FalconSecretKey, input: &[u8]) -> VrfOutput {
 }
 
 /// Build the message that gets signed/verified for the VRF proof.
-fn build_proof_message(input: &[u8], output: &VrfOutput) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(VRF_DOMAIN_PROOF.len() + input.len() + 32);
+/// Includes the public key to bind the output to a specific key.
+fn build_proof_message(pk: &FalconPublicKey, input: &[u8], output: &VrfOutput) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(VRF_DOMAIN_PROOF.len() + pk.as_bytes().len() + input.len() + 32);
     msg.extend_from_slice(VRF_DOMAIN_PROOF);
+    msg.extend_from_slice(pk.as_bytes());
     msg.extend_from_slice(input);
     msg.extend_from_slice(output.as_bytes());
     msg
@@ -64,12 +66,12 @@ fn build_proof_message(input: &[u8], output: &VrfOutput) -> Vec<u8> {
 
 /// Generate a VRF output and proof.
 /// The output is deterministic given (sk, input).
-/// The proof is a FALCON signature over (input || output).
-pub fn vrf_prove(sk: &FalconSecretKey, input: &[u8]) -> (VrfOutput, VrfProof) {
+/// The proof is a FALCON signature over (pk || input || output).
+pub fn vrf_prove(pk: &FalconPublicKey, sk: &FalconSecretKey, input: &[u8]) -> Result<(VrfOutput, VrfProof), &'static str> {
     let output = compute_vrf_output(sk, input);
-    let proof_msg = build_proof_message(input, &output);
-    let sig = falcon_sign(sk, &proof_msg);
-    (output, VrfProof(sig.to_vec()))
+    let proof_msg = build_proof_message(pk, input, &output);
+    let sig = falcon_sign(sk, &proof_msg)?;
+    Ok((output, VrfProof(sig.to_vec())))
 }
 
 /// Verify a VRF output and proof against a public key.
@@ -80,8 +82,11 @@ pub fn vrf_verify(
     output: &VrfOutput,
     proof: &VrfProof,
 ) -> bool {
-    let proof_msg = build_proof_message(input, output);
-    let sig = crate::falcon::FalconSignature::from_bytes(&proof.0);
+    let sig = match crate::falcon::FalconSignature::from_bytes(&proof.0) {
+        Some(s) => s,
+        None => return false,
+    };
+    let proof_msg = build_proof_message(pk, input, output);
     falcon_verify(pk, &proof_msg, &sig)
 }
 
@@ -92,53 +97,53 @@ mod tests {
 
     #[test]
     fn vrf_prove_verify_roundtrip() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let input = b"test vrf input";
-        let (output, proof) = vrf_prove(&sk, input);
+        let (output, proof) = vrf_prove(&pk, &sk, input).unwrap();
         assert!(vrf_verify(&pk, input, &output, &proof));
     }
 
     #[test]
     fn vrf_deterministic_output() {
-        let (_pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let input = b"deterministic test";
-        let (output1, _proof1) = vrf_prove(&sk, input);
-        let (output2, _proof2) = vrf_prove(&sk, input);
+        let (output1, _proof1) = vrf_prove(&pk, &sk, input).unwrap();
+        let (output2, _proof2) = vrf_prove(&pk, &sk, input).unwrap();
         assert_eq!(output1, output2, "VRF output must be deterministic");
     }
 
     #[test]
     fn vrf_different_keys_different_outputs() {
-        let (_pk1, sk1) = falcon_keygen();
-        let (_pk2, sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, sk2) = falcon_keygen().unwrap();
         let input = b"same input different keys";
-        let (output1, _) = vrf_prove(&sk1, input);
-        let (output2, _) = vrf_prove(&sk2, input);
+        let (output1, _) = vrf_prove(&pk1, &sk1, input).unwrap();
+        let (output2, _) = vrf_prove(&pk2, &sk2, input).unwrap();
         assert_ne!(output1, output2);
     }
 
     #[test]
     fn vrf_different_inputs_different_outputs() {
-        let (_pk, sk) = falcon_keygen();
-        let (output1, _) = vrf_prove(&sk, b"input A");
-        let (output2, _) = vrf_prove(&sk, b"input B");
+        let (pk, sk) = falcon_keygen().unwrap();
+        let (output1, _) = vrf_prove(&pk, &sk, b"input A").unwrap();
+        let (output2, _) = vrf_prove(&pk, &sk, b"input B").unwrap();
         assert_ne!(output1, output2);
     }
 
     #[test]
     fn vrf_wrong_key_verify_fails() {
-        let (_pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let input = b"wrong key test";
-        let (output, proof) = vrf_prove(&sk1, input);
+        let (output, proof) = vrf_prove(&pk1, &sk1, input).unwrap();
         assert!(!vrf_verify(&pk2, input, &output, &proof));
     }
 
     #[test]
     fn vrf_tampered_output_fails() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let input = b"tamper test";
-        let (_output, proof) = vrf_prove(&sk, input);
+        let (_output, proof) = vrf_prove(&pk, &sk, input).unwrap();
 
         // Create a fake output
         let fake_output = VrfOutput(poseidon2_hash(b"fake"));
@@ -147,21 +152,21 @@ mod tests {
 
     #[test]
     fn vrf_wrong_input_fails() {
-        let (pk, sk) = falcon_keygen();
-        let (output, proof) = vrf_prove(&sk, b"correct input");
+        let (pk, sk) = falcon_keygen().unwrap();
+        let (output, proof) = vrf_prove(&pk, &sk, b"correct input").unwrap();
         assert!(!vrf_verify(&pk, b"wrong input", &output, &proof));
     }
 
     #[test]
     fn vrf_output_distribution() {
         // Chi-squared test: generate many VRF outputs and check byte distribution
-        let (_pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let num_samples = 256;
         let mut byte_counts = [0u32; 256];
 
         for i in 0..num_samples {
             let input = (i as u64).to_le_bytes();
-            let (output, _) = vrf_prove(&sk, &input);
+            let (output, _) = vrf_prove(&pk, &sk, &input).unwrap();
             for &byte in output.as_bytes().iter() {
                 byte_counts[byte as usize] += 1;
             }

--- a/crates/mempool/src/block_builder.rs
+++ b/crates/mempool/src/block_builder.rs
@@ -144,7 +144,7 @@ mod tests {
     use pyde_tx::types::AccessEntry;
 
     fn make_pk() -> threshold::ThresholdPublicKey {
-        let (pk, _) = threshold::threshold_keygen(3, 2);
+        let (pk, _) = threshold::threshold_keygen(3, 2).unwrap();
         pk
     }
 
@@ -173,7 +173,8 @@ mod tests {
         let to = derive_eoa_address(b"to");
         let tx = encrypt_transaction(
             sender, nonce, gas, access_list, None, 1, dummy_sig(), &to, 0, b"", pk,
-        );
+        )
+        .unwrap();
         pool.add(tx).unwrap();
     }
 

--- a/crates/mempool/src/decryption.rs
+++ b/crates/mempool/src/decryption.rs
@@ -166,7 +166,7 @@ mod tests {
     use pyde_tx::types::AccessEntry;
 
     fn make_keys(n: usize, t: usize) -> (threshold::ThresholdPublicKey, Vec<KeyShare>) {
-        threshold::threshold_keygen(n, t)
+        threshold::threshold_keygen(n, t).unwrap()
     }
 
     fn dummy_access_list() -> Vec<AccessEntry> {
@@ -188,6 +188,7 @@ mod tests {
             sender, 0, 100_000, dummy_access_list(), None, 1,
             vec![0xAA; 666], &to, value, calldata, pk,
         )
+        .unwrap()
     }
 
     // ========== Task 0526: Successful decryption with 85 shares ==========
@@ -292,7 +293,8 @@ mod tests {
         let enc_tx = encrypt_transaction(
             sender, 42, 500_000, dummy_access_list(), Some(1_000_000), 7,
             vec![0xAA; 666], &to, 999, b"data", &pk,
-        );
+        )
+        .unwrap();
 
         let mut decryptor = BlockDecryptor::new(vec![enc_tx], 2);
         for ks in key_shares.iter().take(2) {

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -105,7 +105,7 @@ pub fn encrypt_transaction(
     value: u128,
     calldata: &[u8],
     committee_pk: &ThresholdPublicKey,
-) -> EncryptedTx {
+) -> Result<EncryptedTx, &'static str> {
     // Build plaintext payload: to || value || calldata
     let mut payload = Vec::with_capacity(48 + calldata.len()); // to(32) + value(16) + calldata
     payload.extend_from_slice(to);
@@ -113,9 +113,10 @@ pub fn encrypt_transaction(
     payload.extend_from_slice(calldata);
 
     // Encrypt using threshold Kyber
-    let ciphertext = threshold::threshold_encrypt(committee_pk, &payload);
+    let ciphertext = threshold::threshold_encrypt(committee_pk, &payload)
+        .map_err(|_| "threshold encryption failed")?;
 
-    EncryptedTx {
+    Ok(EncryptedTx {
         sender,
         nonce,
         gas_limit,
@@ -125,7 +126,7 @@ pub fn encrypt_transaction(
         signature,
         ciphertext,
         hash_cache: None,
-    }
+    })
 }
 
 /// Decrypt an encrypted transaction's payload using combined decryption shares.
@@ -157,7 +158,7 @@ mod tests {
     use pyde_account::address::derive_eoa_address;
 
     fn make_threshold_keys() -> (ThresholdPublicKey, Vec<KeyShare>) {
-        threshold::threshold_keygen(3, 2) // 2-of-3
+        threshold::threshold_keygen(3, 2).unwrap() // 2-of-3
     }
 
     #[test]
@@ -178,7 +179,8 @@ mod tests {
             1_000_000,
             b"swap(TOKEN_X, 500)",
             &pk,
-        );
+        )
+        .unwrap();
 
         // Plaintext fields visible
         assert_eq!(enc_tx.sender, sender);
@@ -208,7 +210,8 @@ mod tests {
 
         let enc_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], None, 1, vec![], &to, 100, b"", &pk,
-        );
+        )
+        .unwrap();
 
         // Only 1 share (need 2)
         let dec_shares = vec![
@@ -226,7 +229,8 @@ mod tests {
 
         let enc_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], None, 1, vec![], &to, 100, b"", &pk,
-        );
+        )
+        .unwrap();
 
         assert_eq!(enc_tx.hash(), enc_tx.hash());
     }
@@ -239,7 +243,8 @@ mod tests {
 
         let enc_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], Some(100), 1, vec![], &to, 0, b"", &pk,
-        );
+        )
+        .unwrap();
 
         assert!(!enc_tx.is_expired(99));
         assert!(enc_tx.is_expired(100));
@@ -254,7 +259,8 @@ mod tests {
 
         let enc_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, b"", &pk,
-        );
+        )
+        .unwrap();
 
         assert!(!enc_tx.is_expired(u64::MAX));
     }
@@ -267,12 +273,14 @@ mod tests {
 
         let small_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, b"", &pk,
-        );
+        )
+        .unwrap();
         assert!(!small_tx.is_oversized());
 
         let big_tx = encrypt_transaction(
             sender, 0, 21_000, vec![], None, 1, vec![], &to, 0, &vec![0xFF; 200_000], &pk,
-        );
+        )
+        .unwrap();
         assert!(big_tx.is_oversized());
     }
 }

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -204,7 +204,10 @@ impl Mempool {
             Some(pk) => pk,
             None => return false,
         };
-        let sig = FalconSignature::from_bytes(&tx.signature);
+        let sig = match FalconSignature::from_bytes(&tx.signature) {
+            Some(s) => s,
+            None => return false,
+        };
         falcon_verify(&pk, &tx.hash(), &sig)
     }
 
@@ -296,7 +299,7 @@ mod tests {
     use pyde_crypto::threshold;
 
     fn make_pk() -> threshold::ThresholdPublicKey {
-        let (pk, _) = threshold::threshold_keygen(3, 2);
+        let (pk, _) = threshold::threshold_keygen(3, 2).unwrap();
         pk
     }
 
@@ -317,7 +320,7 @@ mod tests {
     fn make_enc_tx(pk: &threshold::ThresholdPublicKey, gas: u64, nonce: u64) -> EncryptedTx {
         let sender = derive_eoa_address(&nonce.to_le_bytes());
         let to = derive_eoa_address(b"to");
-        encrypt_transaction(sender, nonce, gas, dummy_access_list(), None, 1, dummy_signature(), &to, 0, b"", pk)
+        encrypt_transaction(sender, nonce, gas, dummy_access_list(), None, 1, dummy_signature(), &to, 0, b"", pk).unwrap()
     }
 
     fn make_enc_tx_with_deadline(
@@ -328,7 +331,7 @@ mod tests {
     ) -> EncryptedTx {
         let sender = derive_eoa_address(&nonce.to_le_bytes());
         let to = derive_eoa_address(b"to");
-        encrypt_transaction(sender, nonce, gas, dummy_access_list(), Some(deadline), 1, dummy_signature(), &to, 0, b"", pk)
+        encrypt_transaction(sender, nonce, gas, dummy_access_list(), Some(deadline), 1, dummy_signature(), &to, 0, b"", pk).unwrap()
     }
 
     // ========== Task 0520: Encrypted tx stored in mempool ==========
@@ -392,7 +395,8 @@ mod tests {
             sender, 0, 50_000, dummy_access_list(), None, 1,
             vec![], // empty sig
             &to, 0, b"", &pk,
-        );
+        )
+        .unwrap();
         assert_eq!(pool.add(tx), Err(MempoolError::InvalidSignature));
     }
 
@@ -406,7 +410,8 @@ mod tests {
         let tx = encrypt_transaction(
             sender, 0, 50_000, vec![], None, 1, // empty access list
             dummy_signature(), &to, 0, b"", &pk,
-        );
+        )
+        .unwrap();
         assert_eq!(pool.add(tx), Err(MempoolError::MissingAccessList));
     }
 

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -68,15 +68,13 @@ pub fn create_node(config: &NetworkConfig, local_key: identity::Keypair) -> Resu
                 .validation_mode(gossipsub::ValidationMode::Strict)
                 .max_transmit_size(256 * 1024) // 256KB max message
                 .build()
-                .map_err(|e| format!("gossipsub config error: {e}"))
-                .expect("valid gossipsub config");
+                .map_err(|e| format!("gossipsub config error: {e}"))?;
 
             let gossipsub = gossipsub::Behaviour::new(
                 gossipsub::MessageAuthenticity::Signed(key.clone()),
                 gossipsub_config,
             )
-            .map_err(|e| format!("gossipsub error: {e}"))
-            .expect("valid gossipsub");
+            .map_err(|e| format!("gossipsub error: {e}"))?;
 
             // Kademlia
             let kademlia = kad::Behaviour::new(
@@ -90,11 +88,11 @@ pub fn create_node(config: &NetworkConfig, local_key: identity::Keypair) -> Resu
                 key.public(),
             ));
 
-            PydeBehaviour {
+            Ok(PydeBehaviour {
                 gossipsub,
                 kademlia,
                 identify,
-            }
+            })
         })
         .map_err(|e| format!("behaviour error: {e}"))?
         .with_swarm_config(|cfg| {

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -904,7 +904,14 @@ impl Vm {
                         return Ok(None);
                     }
                 };
-                let sig = pyde_crypto::falcon::FalconSignature::from_bytes(&sig_bytes);
+                let sig = match pyde_crypto::falcon::FalconSignature::from_bytes(&sig_bytes) {
+                    Some(s) => s,
+                    None => {
+                        self.cpu.write_gp(d.rd, 0);
+                        self.pc += 4;
+                        return Ok(None);
+                    }
+                };
                 let valid = pyde_crypto::falcon::falcon_verify(&pk, &msg, &sig);
                 self.cpu.write_gp(d.rd, if valid { 1 } else { 0 });
                 self.pc += 4;
@@ -2406,9 +2413,9 @@ mod tests {
     #[test]
     fn verifysig_valid_signature() {
         let heap = crate::memory::HEAP_START;
-        let (pk, sk) = pyde_crypto::falcon::falcon_keygen();
+        let (pk, sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
         let msg = b"test message";
-        let sig = pyde_crypto::falcon::falcon_sign(&sk, msg);
+        let sig = pyde_crypto::falcon::falcon_sign(&sk, msg).unwrap();
 
         let mut vm = Vm::new();
 
@@ -2455,9 +2462,9 @@ mod tests {
     #[test]
     fn verifysig_invalid_signature() {
         let heap = crate::memory::HEAP_START;
-        let (pk, sk) = pyde_crypto::falcon::falcon_keygen();
+        let (pk, sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
         let msg = b"test message";
-        let sig = pyde_crypto::falcon::falcon_sign(&sk, msg);
+        let sig = pyde_crypto::falcon::falcon_sign(&sk, msg).unwrap();
 
         let mut vm = Vm::new();
 

--- a/crates/state/benches/smt_bench.rs
+++ b/crates/state/benches/smt_bench.rs
@@ -17,7 +17,7 @@ fn bench_insert() {
 
         let start = Instant::now();
         for (k, v) in &pairs {
-            smt.insert(*k, v.clone());
+            smt.insert(*k, v.clone()).unwrap();
         }
         let elapsed = start.elapsed();
 
@@ -35,7 +35,7 @@ fn bench_get() {
     let mut smt = PydeSMT::new();
     let keys: Vec<_> = (0..10_000).map(|i| key_from_seed(i)).collect();
     for (i, k) in keys.iter().enumerate() {
-        smt.insert(*k, format!("v{i}").into_bytes());
+        smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
     }
 
     let iterations = 10_000u64;
@@ -54,7 +54,7 @@ fn bench_proof() {
     let mut smt = PydeSMT::new();
     let keys: Vec<_> = (0..1_000).map(|i| key_from_seed(i)).collect();
     for (i, k) in keys.iter().enumerate() {
-        smt.insert(*k, format!("v{i}").into_bytes());
+        smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
     }
 
     let root = smt.root();
@@ -62,7 +62,7 @@ fn bench_proof() {
 
     let start = Instant::now();
     for i in 0..iterations {
-        std::hint::black_box(smt.prove(vec![keys[i as usize % keys.len()]]));
+        std::hint::black_box(smt.prove(vec![keys[i as usize % keys.len()]]).unwrap());
     }
     let elapsed = start.elapsed();
     let us_per_proof = elapsed.as_micros() as f64 / iterations as f64;
@@ -70,7 +70,7 @@ fn bench_proof() {
 
     let key = keys[0];
     let value = b"v0".to_vec();
-    let proof = smt.prove(vec![key]);
+    let proof = smt.prove(vec![key]).unwrap();
 
     let start = Instant::now();
     for _ in 0..iterations {
@@ -91,7 +91,7 @@ fn bench_batch_insert() {
 
         let mut smt = PydeSMT::new();
         let start = Instant::now();
-        smt.update_all(pairs);
+        smt.update_all(pairs).unwrap();
         let elapsed = start.elapsed();
 
         let ops_sec = count as f64 / elapsed.as_secs_f64();
@@ -152,7 +152,7 @@ fn bench_update_all_scaling() {
             .collect();
 
         let start = Instant::now();
-        smt.update_all(entries);
+        smt.update_all(entries).unwrap();
         let elapsed = start.elapsed();
 
         let ops_sec = count as f64 / elapsed.as_secs_f64();
@@ -171,14 +171,14 @@ fn bench_witness() {
     let mut smt = PydeSMT::new();
     let keys: Vec<_> = (0..1_000).map(|i| key_from_seed(i)).collect();
     for (i, k) in keys.iter().enumerate() {
-        smt.insert(*k, format!("v{i}").into_bytes());
+        smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
     }
 
     // Generation
     for count in [10u64, 100, 1_000] {
         let access_keys: Vec<_> = keys[..count as usize].to_vec();
         let start = Instant::now();
-        let witness = pyde_state::witness::generate_witnesses(&smt, &access_keys);
+        let witness = pyde_state::witness::generate_witnesses(&smt, &access_keys).unwrap();
         let elapsed = start.elapsed();
         let us = elapsed.as_micros() as f64;
         let size = witness.size_bytes();
@@ -206,7 +206,7 @@ fn bench_snapshot() {
         let mut smt = PydeSMT::new();
         let keys: Vec<_> = (0..count).map(|i| key_from_seed(i)).collect();
         for (i, k) in keys.iter().enumerate() {
-            smt.insert(*k, format!("v{i}").into_bytes());
+            smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
         }
 
         let start = Instant::now();
@@ -214,7 +214,7 @@ fn bench_snapshot() {
         let create_ms = start.elapsed().as_secs_f64() * 1000.0;
 
         let start = Instant::now();
-        let restored = pyde_state::snapshot::restore_snapshot(&snapshot);
+        let restored = pyde_state::snapshot::restore_snapshot(&snapshot).unwrap();
         let restore_ms = start.elapsed().as_secs_f64() * 1000.0;
 
         assert_eq!(restored.root(), smt.root());

--- a/crates/state/src/smt.rs
+++ b/crates/state/src/smt.rs
@@ -117,43 +117,43 @@ impl PydeSMT {
     }
 
     /// Insert or update a key-value pair. Returns the new root.
-    pub fn insert(&mut self, key: Key, value: Vec<u8>) -> H256 {
+    pub fn insert(&mut self, key: Key, value: Vec<u8>) -> Result<H256, &'static str> {
         self.inner
             .update(key, SmtValue(value))
-            .expect("SMT update failed");
-        self.root()
+            .map_err(|_| "SMT update failed")?;
+        Ok(self.root())
     }
 
     /// Delete a key (set value to zero). Returns true if key existed.
-    pub fn delete(&mut self, key: &Key) -> bool {
+    pub fn delete(&mut self, key: &Key) -> Result<bool, &'static str> {
         let existed = self.get(key).is_some();
         if existed {
             self.inner
                 .update(*key, SmtValue::zero())
-                .expect("SMT delete failed");
+                .map_err(|_| "SMT delete failed")?;
         }
-        existed
+        Ok(existed)
     }
 
     /// Batch insert/update multiple key-value pairs. Returns the new root.
-    pub fn update_all(&mut self, entries: Vec<(Key, Vec<u8>)>) -> H256 {
+    pub fn update_all(&mut self, entries: Vec<(Key, Vec<u8>)>) -> Result<H256, &'static str> {
         let leaves: Vec<(Key, SmtValue)> = entries
             .into_iter()
             .map(|(k, v)| (k, SmtValue(v)))
             .collect();
         self.inner
             .update_all(leaves)
-            .expect("SMT batch update failed");
-        self.root()
+            .map_err(|_| "SMT batch update failed")?;
+        Ok(self.root())
     }
 
     /// Generate a Merkle proof for one or more keys.
-    pub fn prove(&self, keys: Vec<Key>) -> MerkleProof {
+    pub fn prove(&self, keys: Vec<Key>) -> Result<MerkleProof, &'static str> {
         let proof = self
             .inner
             .merkle_proof(keys.clone())
-            .expect("SMT proof generation failed");
-        MerkleProof { inner: proof }
+            .map_err(|_| "SMT proof generation failed")?;
+        Ok(MerkleProof { inner: proof })
     }
 
     /// Whether the tree is empty (root == zero).
@@ -175,12 +175,12 @@ pub struct MerkleProof {
 
 impl MerkleProof {
     /// Compile this proof into a more compact representation for serialization.
-    pub fn compile(self, keys: Vec<Key>) -> CompiledProof {
+    pub fn compile(self, keys: Vec<Key>) -> Result<CompiledProof, &'static str> {
         let compiled = self
             .inner
             .compile(keys)
-            .expect("proof compilation failed");
-        CompiledProof { inner: compiled }
+            .map_err(|_| "proof compilation failed")?;
+        Ok(CompiledProof { inner: compiled })
     }
 
     /// Verify this proof against a root hash and expected leaves.
@@ -266,7 +266,7 @@ mod tests {
     fn insert_and_get_single() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"hello".to_vec());
+        smt.insert(key, b"hello".to_vec()).unwrap();
         assert_eq!(smt.get(&key), Some(b"hello".to_vec()));
     }
 
@@ -286,7 +286,7 @@ mod tests {
             .collect();
 
         for (k, v) in &pairs {
-            smt.insert(*k, v.clone());
+            smt.insert(*k, v.clone()).unwrap();
         }
 
         for (k, v) in &pairs {
@@ -300,15 +300,15 @@ mod tests {
     fn delete_key_removes_it() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(42);
-        smt.insert(key, b"data".to_vec());
-        assert!(smt.delete(&key));
+        smt.insert(key, b"data".to_vec()).unwrap();
+        assert!(smt.delete(&key).unwrap());
         assert_eq!(smt.get(&key), None);
     }
 
     #[test]
     fn delete_nonexistent_returns_false() {
         let mut smt = PydeSMT::new();
-        assert!(!smt.delete(&key_from_seed(99)));
+        assert!(!smt.delete(&key_from_seed(99)).unwrap());
     }
 
     // ========== Task 0279: Root changes after insert ==========
@@ -317,7 +317,7 @@ mod tests {
     fn root_changes_after_insert() {
         let mut smt = PydeSMT::new();
         let root_before = smt.root();
-        smt.insert(key_from_seed(1), b"test".to_vec());
+        smt.insert(key_from_seed(1), b"test".to_vec()).unwrap();
         assert_ne!(root_before, smt.root());
     }
 
@@ -326,10 +326,10 @@ mod tests {
         let key = key_from_seed(1);
 
         let mut smt1 = PydeSMT::new();
-        smt1.insert(key, b"aaa".to_vec());
+        smt1.insert(key, b"aaa".to_vec()).unwrap();
 
         let mut smt2 = PydeSMT::new();
-        smt2.insert(key, b"bbb".to_vec());
+        smt2.insert(key, b"bbb".to_vec()).unwrap();
 
         assert_ne!(smt1.root(), smt2.root());
     }
@@ -342,10 +342,10 @@ mod tests {
         let empty_root = smt.root();
 
         let key = key_from_seed(1);
-        smt.insert(key, b"temp".to_vec());
+        smt.insert(key, b"temp".to_vec()).unwrap();
         assert_ne!(smt.root(), empty_root);
 
-        smt.delete(&key);
+        smt.delete(&key).unwrap();
         assert_eq!(smt.root(), empty_root);
     }
 
@@ -356,10 +356,10 @@ mod tests {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
         let value = b"value".to_vec();
-        smt.insert(key, value.clone());
+        smt.insert(key, value.clone()).unwrap();
 
         let root = smt.root();
-        let proof = smt.prove(vec![key]);
+        let proof = smt.prove(vec![key]).unwrap();
         assert!(proof.verify(root, vec![(key, value)]));
     }
 
@@ -371,12 +371,12 @@ mod tests {
             .collect();
 
         for (k, v) in &entries {
-            smt.insert(*k, v.clone());
+            smt.insert(*k, v.clone()).unwrap();
         }
 
         let root = smt.root();
         let keys: Vec<Key> = entries.iter().map(|(k, _)| *k).collect();
-        let proof = smt.prove(keys);
+        let proof = smt.prove(keys).unwrap();
         assert!(proof.verify(root, entries));
     }
 
@@ -385,11 +385,11 @@ mod tests {
     #[test]
     fn merkle_proof_nonexistence() {
         let mut smt = PydeSMT::new();
-        smt.insert(key_from_seed(1), b"exists".to_vec());
+        smt.insert(key_from_seed(1), b"exists".to_vec()).unwrap();
 
         let root = smt.root();
         let missing = key_from_seed(999);
-        let proof = smt.prove(vec![missing]);
+        let proof = smt.prove(vec![missing]).unwrap();
         assert!(proof.verify_absence(root, vec![missing]));
     }
 
@@ -401,15 +401,15 @@ mod tests {
         let key = key_from_seed(1);
 
         let mut smt1 = PydeSMT::new();
-        smt1.insert(key, b"real".to_vec());
+        smt1.insert(key, b"real".to_vec()).unwrap();
 
         let mut smt2 = PydeSMT::new();
-        smt2.insert(key, b"fake".to_vec());
+        smt2.insert(key, b"fake".to_vec()).unwrap();
 
         assert_ne!(smt1.root(), smt2.root());
 
         // The correct proof verifies against the correct root
-        let proof = smt1.prove(vec![key]);
+        let proof = smt1.prove(vec![key]).unwrap();
         assert!(proof.verify(smt1.root(), vec![(key, b"real".to_vec())]));
     }
 
@@ -419,15 +419,15 @@ mod tests {
         let value = b"data".to_vec();
 
         let mut smt = PydeSMT::new();
-        smt.insert(key, value.clone());
+        smt.insert(key, value.clone()).unwrap();
         let root = smt.root();
 
         // Proof verifies against correct root
-        let proof = smt.prove(vec![key]);
+        let proof = smt.prove(vec![key]).unwrap();
         assert!(proof.verify(root, vec![(key, value.clone())]));
 
         // Mutating the tree changes the root
-        smt.insert(key, b"changed".to_vec());
+        smt.insert(key, b"changed".to_vec()).unwrap();
         assert_ne!(root, smt.root());
     }
 
@@ -437,8 +437,8 @@ mod tests {
     fn insert_overwrite() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"first".to_vec());
-        smt.insert(key, b"second".to_vec());
+        smt.insert(key, b"first".to_vec()).unwrap();
+        smt.insert(key, b"second".to_vec()).unwrap();
         assert_eq!(smt.get(&key), Some(b"second".to_vec()));
     }
 
@@ -448,12 +448,12 @@ mod tests {
         let k2 = key_from_seed(2);
 
         let mut smt1 = PydeSMT::new();
-        smt1.insert(k1, b"a".to_vec());
-        smt1.insert(k2, b"b".to_vec());
+        smt1.insert(k1, b"a".to_vec()).unwrap();
+        smt1.insert(k2, b"b".to_vec()).unwrap();
 
         let mut smt2 = PydeSMT::new();
-        smt2.insert(k2, b"b".to_vec());
-        smt2.insert(k1, b"a".to_vec());
+        smt2.insert(k2, b"b".to_vec()).unwrap();
+        smt2.insert(k1, b"a".to_vec()).unwrap();
 
         assert_eq!(smt1.root(), smt2.root());
     }
@@ -465,7 +465,7 @@ mod tests {
             .map(|i| (key_from_seed(i), format!("v{i}").into_bytes()))
             .collect();
 
-        smt.update_all(entries.clone());
+        smt.update_all(entries.clone()).unwrap();
 
         for (k, v) in &entries {
             assert_eq!(smt.get(k), Some(v.clone()));
@@ -482,10 +482,10 @@ mod tests {
     fn verify_rejects_tampered_value() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"real".to_vec());
+        smt.insert(key, b"real".to_vec()).unwrap();
 
         let root = smt.root();
-        let proof = smt.prove(vec![key]);
+        let proof = smt.prove(vec![key]).unwrap();
 
         // Correct value passes
         assert!(proof.verify(root, vec![(key, b"real".to_vec())]));
@@ -498,10 +498,10 @@ mod tests {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
         let value = b"data".to_vec();
-        smt.insert(key, value.clone());
+        smt.insert(key, value.clone()).unwrap();
 
         let root = smt.root();
-        let proof = smt.prove(vec![key]);
+        let proof = smt.prove(vec![key]).unwrap();
 
         // Correct root passes
         assert!(proof.verify(root, vec![(key, value.clone())]));
@@ -517,11 +517,11 @@ mod tests {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
         let value = b"value".to_vec();
-        smt.insert(key, value.clone());
+        smt.insert(key, value.clone()).unwrap();
 
         let root = smt.root();
-        let proof = smt.prove(vec![key]);
-        let compiled = proof.compile(vec![key]);
+        let proof = smt.prove(vec![key]).unwrap();
+        let compiled = proof.compile(vec![key]).unwrap();
 
         assert!(compiled.verify(root, vec![(key, value.clone())]));
         assert!(!compiled.verify(root, vec![(key, b"wrong".to_vec())]));

--- a/crates/state/src/snapshot.rs
+++ b/crates/state/src/snapshot.rs
@@ -54,18 +54,20 @@ pub fn create_snapshot(smt: &PydeSMT, all_keys: &[Key]) -> Snapshot {
 }
 
 /// Restore a full SMT from a snapshot.
-pub fn restore_snapshot(snapshot: &Snapshot) -> PydeSMT {
+pub fn restore_snapshot(snapshot: &Snapshot) -> Result<PydeSMT, &'static str> {
     let mut smt = PydeSMT::new();
     if !snapshot.entries.is_empty() {
-        smt.update_all(snapshot.entries.clone());
+        smt.update_all(snapshot.entries.clone())?;
     }
-    smt
+    Ok(smt)
 }
 
 /// Verify that a restored snapshot produces the expected root.
 pub fn verify_snapshot(snapshot: &Snapshot) -> bool {
-    let smt = restore_snapshot(snapshot);
-    smt.root() == snapshot.root
+    match restore_snapshot(snapshot) {
+        Ok(smt) => smt.root() == snapshot.root,
+        Err(_) => false,
+    }
 }
 
 /// Create an incremental snapshot: diff between old state and new state.
@@ -106,12 +108,12 @@ pub fn create_incremental(
 /// Apply an incremental snapshot to an SMT.
 /// Returns the new root, or None if the SMT's current root doesn't match
 /// the snapshot's from_root (indicating the diffs don't apply to this state).
-pub fn apply_incremental(smt: &mut PydeSMT, inc: &IncrementalSnapshot) -> Option<H256> {
+pub fn apply_incremental(smt: &mut PydeSMT, inc: &IncrementalSnapshot) -> Result<Option<H256>, &'static str> {
     // Validate that the current state matches the snapshot's base state
     if smt.root() != inc.from_root {
-        return None;
+        return Ok(None);
     }
-    Some(smt.update_all(inc.diffs.clone()))
+    Ok(Some(smt.update_all(inc.diffs.clone())?))
 }
 
 /// Split a snapshot into chunks of `chunk_size` entries each.
@@ -183,7 +185,7 @@ mod tests {
         let mut smt = PydeSMT::new();
         let keys: Vec<Key> = (0..count).map(|i| key_from_seed(i)).collect();
         for (i, k) in keys.iter().enumerate() {
-            smt.insert(*k, format!("val_{i}").into_bytes());
+            smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }
         (smt, keys)
     }
@@ -199,7 +201,7 @@ mod tests {
         assert_eq!(snapshot.root, original_root);
         assert_eq!(snapshot.entries.len(), 100);
 
-        let restored = restore_snapshot(&snapshot);
+        let restored = restore_snapshot(&snapshot).unwrap();
         assert_eq!(restored.root(), original_root);
 
         // Verify all values match
@@ -233,14 +235,14 @@ mod tests {
         // Clone and modify
         let mut new_smt = PydeSMT::new();
         for (i, k) in old_keys.iter().enumerate() {
-            new_smt.insert(*k, format!("val_{i}").into_bytes());
+            new_smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }
         // Change one key
         let changed_key = old_keys[0];
-        new_smt.insert(changed_key, b"new_value".to_vec());
+        new_smt.insert(changed_key, b"new_value".to_vec()).unwrap();
         // Add one key
         let new_key = key_from_seed(999);
-        new_smt.insert(new_key, b"added".to_vec());
+        new_smt.insert(new_key, b"added".to_vec()).unwrap();
 
         let mut all_new_keys = old_keys.clone();
         all_new_keys.push(new_key);
@@ -251,7 +253,7 @@ mod tests {
         assert!(!inc.diffs.is_empty());
 
         // Apply incremental to old SMT
-        let result_root = apply_incremental(&mut old_smt, &inc).expect("from_root should match");
+        let result_root = apply_incremental(&mut old_smt, &inc).unwrap().expect("from_root should match");
         assert_eq!(result_root, new_smt.root());
     }
 
@@ -262,7 +264,7 @@ mod tests {
         let mut new_smt = PydeSMT::new();
         // Copy all except key[0]
         for (i, k) in old_keys.iter().enumerate().skip(1) {
-            new_smt.insert(*k, format!("val_{i}").into_bytes());
+            new_smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }
 
         let new_keys: Vec<Key> = old_keys[1..].to_vec();

--- a/crates/state/src/versioning.rs
+++ b/crates/state/src/versioning.rs
@@ -76,7 +76,7 @@ impl VersionedState {
     /// Apply a block: record undo log, then apply diffs.
     /// `diffs` is a list of (key, new_value). Empty value = deletion.
     /// Returns the new state root.
-    pub fn apply_block(&mut self, diffs: Vec<(Key, Vec<u8>)>) -> H256 {
+    pub fn apply_block(&mut self, diffs: Vec<(Key, Vec<u8>)>) -> Result<H256, &'static str> {
         let pre_root = self.smt.root();
 
         // Record old values for undo
@@ -89,7 +89,7 @@ impl VersionedState {
             .collect();
 
         // Apply diffs
-        let post_root = self.smt.update_all(diffs);
+        let post_root = self.smt.update_all(diffs)?;
 
         self.height += 1;
 
@@ -103,13 +103,16 @@ impl VersionedState {
         // Prune old logs
         self.prune();
 
-        post_root
+        Ok(post_root)
     }
 
     /// Undo the last block: revert state to before it was applied.
     /// Returns the restored root, or None if no blocks to undo.
-    pub fn undo_block(&mut self) -> Option<H256> {
-        let log = self.undo_logs.pop_back()?;
+    pub fn undo_block(&mut self) -> Result<Option<H256>, &'static str> {
+        let log = match self.undo_logs.pop_back() {
+            Some(log) => log,
+            None => return Ok(None),
+        };
 
         // Replay old values
         let restore_diffs: Vec<(Key, Vec<u8>)> = log
@@ -118,23 +121,26 @@ impl VersionedState {
             .map(|e| (e.key, e.old_value.clone().unwrap_or_default()))
             .collect();
 
-        self.smt.update_all(restore_diffs);
+        self.smt.update_all(restore_diffs)?;
         self.height -= 1;
 
-        Some(log.pre_root)
+        Ok(Some(log.pre_root))
     }
 
     /// Undo multiple blocks (for reorgs).
     /// Returns the root after undoing `count` blocks, or None if not enough history.
-    pub fn undo_blocks(&mut self, count: usize) -> Option<H256> {
+    pub fn undo_blocks(&mut self, count: usize) -> Result<Option<H256>, &'static str> {
         if count > self.undo_logs.len() {
-            return None;
+            return Ok(None);
         }
         let mut root = H256::zero();
         for _ in 0..count {
-            root = self.undo_block()?;
+            match self.undo_block()? {
+                Some(r) => root = r,
+                None => return Ok(None),
+            }
         }
-        Some(root)
+        Ok(Some(root))
     }
 
     /// Query the state value at a specific historical height.
@@ -209,13 +215,13 @@ mod tests {
         let key = key_from_seed(1);
 
         let empty_root = vs.root();
-        vs.apply_block(vec![(key, b"hello".to_vec())]);
+        vs.apply_block(vec![(key, b"hello".to_vec())]).unwrap();
         assert_eq!(vs.get(&key), Some(b"hello".to_vec()));
         assert_ne!(vs.root(), empty_root);
         assert_eq!(vs.height, 1);
 
         // Undo
-        let restored = vs.undo_block().unwrap();
+        let restored = vs.undo_block().unwrap().unwrap();
         assert_eq!(restored, empty_root);
         assert_eq!(vs.get(&key), None);
         assert_eq!(vs.height, 0);
@@ -226,13 +232,13 @@ mod tests {
         let mut vs = VersionedState::new();
         let key = key_from_seed(1);
 
-        vs.apply_block(vec![(key, b"first".to_vec())]);
+        vs.apply_block(vec![(key, b"first".to_vec())]).unwrap();
         let root_after_first = vs.root();
 
-        vs.apply_block(vec![(key, b"second".to_vec())]);
+        vs.apply_block(vec![(key, b"second".to_vec())]).unwrap();
         assert_eq!(vs.get(&key), Some(b"second".to_vec()));
 
-        vs.undo_block();
+        vs.undo_block().unwrap();
         assert_eq!(vs.get(&key), Some(b"first".to_vec()));
         assert_eq!(vs.root(), root_after_first);
     }
@@ -240,7 +246,7 @@ mod tests {
     #[test]
     fn undo_with_no_blocks_returns_none() {
         let mut vs = VersionedState::new();
-        assert_eq!(vs.undo_block(), None);
+        assert_eq!(vs.undo_block().unwrap(), None);
     }
 
     // ========== Task 0331: Multi-block undo (reorg) ==========
@@ -252,27 +258,27 @@ mod tests {
         let k2 = key_from_seed(2);
 
         let root0 = vs.root();
-        vs.apply_block(vec![(k1, b"a".to_vec())]);
-        vs.apply_block(vec![(k2, b"b".to_vec())]);
-        vs.apply_block(vec![(k1, b"c".to_vec())]);
+        vs.apply_block(vec![(k1, b"a".to_vec())]).unwrap();
+        vs.apply_block(vec![(k2, b"b".to_vec())]).unwrap();
+        vs.apply_block(vec![(k1, b"c".to_vec())]).unwrap();
         assert_eq!(vs.height, 3);
 
         // Undo 2 blocks
-        let root = vs.undo_blocks(2).unwrap();
+        let root = vs.undo_blocks(2).unwrap().unwrap();
         assert_eq!(vs.height, 1);
         assert_eq!(vs.get(&k1), Some(b"a".to_vec()));
         assert_eq!(vs.get(&k2), None);
 
         // Undo last block
-        vs.undo_block();
+        vs.undo_block().unwrap();
         assert_eq!(vs.root(), root0);
     }
 
     #[test]
     fn undo_blocks_too_many_returns_none() {
         let mut vs = VersionedState::new();
-        vs.apply_block(vec![(key_from_seed(1), b"x".to_vec())]);
-        assert_eq!(vs.undo_blocks(5), None);
+        vs.apply_block(vec![(key_from_seed(1), b"x".to_vec())]).unwrap();
+        assert_eq!(vs.undo_blocks(5).unwrap(), None);
     }
 
     // ========== Task 0332: Historical state query ==========
@@ -281,7 +287,7 @@ mod tests {
     fn get_at_height_current() {
         let mut vs = VersionedState::new();
         let key = key_from_seed(1);
-        vs.apply_block(vec![(key, b"val".to_vec())]);
+        vs.apply_block(vec![(key, b"val".to_vec())]).unwrap();
 
         assert_eq!(vs.get_at_height(&key, 1), Some(b"val".to_vec()));
     }
@@ -291,9 +297,9 @@ mod tests {
         let mut vs = VersionedState::new();
         let key = key_from_seed(1);
 
-        vs.apply_block(vec![(key, b"v1".to_vec())]);
-        vs.apply_block(vec![(key, b"v2".to_vec())]);
-        vs.apply_block(vec![(key, b"v3".to_vec())]);
+        vs.apply_block(vec![(key, b"v1".to_vec())]).unwrap();
+        vs.apply_block(vec![(key, b"v2".to_vec())]).unwrap();
+        vs.apply_block(vec![(key, b"v3".to_vec())]).unwrap();
 
         assert_eq!(vs.get_at_height(&key, 3), Some(b"v3".to_vec()));
         assert_eq!(vs.get_at_height(&key, 2), Some(b"v2".to_vec()));
@@ -304,7 +310,7 @@ mod tests {
     #[test]
     fn get_at_height_future_returns_none() {
         let mut vs = VersionedState::new();
-        vs.apply_block(vec![(key_from_seed(1), b"x".to_vec())]);
+        vs.apply_block(vec![(key_from_seed(1), b"x".to_vec())]).unwrap();
         assert_eq!(vs.get_at_height(&key_from_seed(1), 999), None);
     }
 
@@ -316,7 +322,7 @@ mod tests {
         let key = key_from_seed(1);
 
         for i in 0..10u64 {
-            vs.apply_block(vec![(key, format!("v{i}").into_bytes())]);
+            vs.apply_block(vec![(key, format!("v{i}").into_bytes())]).unwrap();
         }
 
         assert_eq!(vs.undo_depth(), 5);
@@ -330,14 +336,14 @@ mod tests {
         let key = key_from_seed(1);
 
         for i in 0..10u64 {
-            vs.apply_block(vec![(key, format!("v{i}").into_bytes())]);
+            vs.apply_block(vec![(key, format!("v{i}").into_bytes())]).unwrap();
         }
 
         // Can only undo 3 blocks
-        assert!(vs.undo_blocks(3).is_some());
+        assert!(vs.undo_blocks(3).unwrap().is_some());
         assert_eq!(vs.height, 7);
         // No more undo available
-        assert_eq!(vs.undo_blocks(5), None);
+        assert_eq!(vs.undo_blocks(5).unwrap(), None);
     }
 
     // ========== Multiple keys per block ==========
@@ -353,12 +359,12 @@ mod tests {
             (k1, b"a".to_vec()),
             (k2, b"b".to_vec()),
             (k3, b"c".to_vec()),
-        ]);
+        ]).unwrap();
         assert_eq!(vs.get(&k1), Some(b"a".to_vec()));
         assert_eq!(vs.get(&k2), Some(b"b".to_vec()));
         assert_eq!(vs.get(&k3), Some(b"c".to_vec()));
 
-        vs.undo_block();
+        vs.undo_block().unwrap();
         assert_eq!(vs.get(&k1), None);
         assert_eq!(vs.get(&k2), None);
         assert_eq!(vs.get(&k3), None);
@@ -370,15 +376,15 @@ mod tests {
         let key = key_from_seed(1);
 
         // Block 1: create key
-        vs.apply_block(vec![(key, b"exists".to_vec())]);
+        vs.apply_block(vec![(key, b"exists".to_vec())]).unwrap();
         assert_eq!(vs.get(&key), Some(b"exists".to_vec()));
 
         // Block 2: delete key (empty value)
-        vs.apply_block(vec![(key, vec![])]);
+        vs.apply_block(vec![(key, vec![])]).unwrap();
         assert_eq!(vs.get(&key), None);
 
         // Undo block 2: key should be restored
-        vs.undo_block();
+        vs.undo_block().unwrap();
         assert_eq!(vs.get(&key), Some(b"exists".to_vec()));
     }
 }

--- a/crates/state/src/witness.rs
+++ b/crates/state/src/witness.rs
@@ -54,16 +54,16 @@ impl BlockWitness {
 ///
 /// The full node calls this before sending the block to validators.
 /// All keys get a single compiled Merkle proof (shared siblings deduplicated).
-pub fn generate_witnesses(smt: &PydeSMT, access_keys: &[Key]) -> BlockWitness {
+pub fn generate_witnesses(smt: &PydeSMT, access_keys: &[Key]) -> Result<BlockWitness, &'static str> {
     let pre_root = smt.root();
 
     if access_keys.is_empty() {
-        return BlockWitness {
+        return Ok(BlockWitness {
             entries: Vec::new(),
             proof: Vec::new(),
             pre_state_root: pre_root,
             post_state_root: H256::zero(),
-        };
+        });
     }
 
     // Collect current values
@@ -77,15 +77,15 @@ pub fn generate_witnesses(smt: &PydeSMT, access_keys: &[Key]) -> BlockWitness {
 
     // Generate single batch proof for all keys
     let keys_vec: Vec<Key> = access_keys.to_vec();
-    let proof = smt.prove(keys_vec.clone());
-    let compiled = proof.compile(keys_vec);
+    let proof = smt.prove(keys_vec.clone())?;
+    let compiled = proof.compile(keys_vec)?;
 
-    BlockWitness {
+    Ok(BlockWitness {
         entries,
         proof: compiled.to_bytes(),
         pre_state_root: pre_root,
         post_state_root: H256::zero(),
-    }
+    })
 }
 
 /// Verify a block witness: check that the batch proof is valid
@@ -124,7 +124,7 @@ pub fn witness_to_state_map(witness: &BlockWitness) -> std::collections::HashMap
 ///
 /// `diffs` is a list of (key, new_value) pairs. Empty value = deletion.
 /// Returns the new root after applying all diffs.
-pub fn compute_post_state_root(smt: &mut PydeSMT, diffs: Vec<(Key, Vec<u8>)>) -> H256 {
+pub fn compute_post_state_root(smt: &mut PydeSMT, diffs: Vec<(Key, Vec<u8>)>) -> Result<H256, &'static str> {
     smt.update_all(diffs)
 }
 
@@ -139,9 +139,9 @@ mod tests {
     fn witness_single_read() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"balance_100".to_vec());
+        smt.insert(key, b"balance_100".to_vec()).unwrap();
 
-        let witness = generate_witnesses(&smt, &[key]);
+        let witness = generate_witnesses(&smt, &[key]).unwrap();
         assert_eq!(witness.len(), 1);
         assert_eq!(witness.entries[0].key, key);
         assert_eq!(witness.entries[0].value, b"balance_100");
@@ -154,13 +154,13 @@ mod tests {
     fn witness_storage_write() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"old_value".to_vec());
+        smt.insert(key, b"old_value".to_vec()).unwrap();
 
-        let witness = generate_witnesses(&smt, &[key]);
+        let witness = generate_witnesses(&smt, &[key]).unwrap();
         assert_eq!(witness.entries[0].value, b"old_value");
 
         // Apply write — root changes
-        smt.insert(key, b"new_value".to_vec());
+        smt.insert(key, b"new_value".to_vec()).unwrap();
         assert_ne!(smt.root(), witness.pre_state_root);
     }
 
@@ -169,10 +169,10 @@ mod tests {
     #[test]
     fn witness_absent_key() {
         let mut smt = PydeSMT::new();
-        smt.insert(key_from_seed(1), b"exists".to_vec());
+        smt.insert(key_from_seed(1), b"exists".to_vec()).unwrap();
 
         let missing = key_from_seed(999);
-        let witness = generate_witnesses(&smt, &[missing]);
+        let witness = generate_witnesses(&smt, &[missing]).unwrap();
         assert!(witness.entries[0].value.is_empty());
     }
 
@@ -182,11 +182,11 @@ mod tests {
     fn witness_verification_passes() {
         let mut smt = PydeSMT::new();
         for i in 0..10u64 {
-            smt.insert(key_from_seed(i), format!("val_{i}").into_bytes());
+            smt.insert(key_from_seed(i), format!("val_{i}").into_bytes()).unwrap();
         }
         let keys: Vec<Key> = (0..10).map(|i| key_from_seed(i)).collect();
 
-        let witness = generate_witnesses(&smt, &keys);
+        let witness = generate_witnesses(&smt, &keys).unwrap();
         assert!(verify_witnesses(&witness));
     }
 
@@ -194,9 +194,9 @@ mod tests {
     fn witness_verification_fails_with_wrong_root() {
         let mut smt = PydeSMT::new();
         let key = key_from_seed(1);
-        smt.insert(key, b"data".to_vec());
+        smt.insert(key, b"data".to_vec()).unwrap();
 
-        let mut witness = generate_witnesses(&smt, &[key]);
+        let mut witness = generate_witnesses(&smt, &[key]).unwrap();
         witness.pre_state_root = H256::from([0xFFu8; 32]);
         assert!(!verify_witnesses(&witness));
     }
@@ -208,10 +208,10 @@ mod tests {
         let mut smt = PydeSMT::new();
         let keys: Vec<Key> = (0..10).map(|i| key_from_seed(i)).collect();
         for (i, k) in keys.iter().enumerate() {
-            smt.insert(*k, format!("val_{i}").into_bytes());
+            smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }
 
-        let witness = generate_witnesses(&smt, &keys);
+        let witness = generate_witnesses(&smt, &keys).unwrap();
         let state_map = witness_to_state_map(&witness);
 
         for (i, k) in keys.iter().enumerate() {
@@ -225,16 +225,16 @@ mod tests {
         let mut smt = PydeSMT::new();
         let key1 = key_from_seed(1);
         let key2 = key_from_seed(2);
-        smt.insert(key1, b"a".to_vec());
-        smt.insert(key2, b"b".to_vec());
+        smt.insert(key1, b"a".to_vec()).unwrap();
+        smt.insert(key2, b"b".to_vec()).unwrap();
 
         let mut smt_clone = PydeSMT::new();
-        smt_clone.insert(key1, b"a".to_vec());
-        smt_clone.insert(key2, b"b".to_vec());
+        smt_clone.insert(key1, b"a".to_vec()).unwrap();
+        smt_clone.insert(key2, b"b".to_vec()).unwrap();
 
         let diffs = vec![(key1, b"new_a".to_vec())];
-        let post_root = compute_post_state_root(&mut smt, diffs);
-        smt_clone.insert(key1, b"new_a".to_vec());
+        let post_root = compute_post_state_root(&mut smt, diffs).unwrap();
+        smt_clone.insert(key1, b"new_a".to_vec()).unwrap();
 
         assert_eq!(post_root, smt_clone.root());
     }
@@ -246,17 +246,17 @@ mod tests {
         let mut smt = PydeSMT::new();
         let keys: Vec<Key> = (0..100).map(|i| key_from_seed(i)).collect();
         for (i, k) in keys.iter().enumerate() {
-            smt.insert(*k, format!("v{i}").into_bytes());
+            smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
         }
 
         // Batch witness (single proof)
-        let batch = generate_witnesses(&smt, &keys);
+        let batch = generate_witnesses(&smt, &keys).unwrap();
         let batch_size = batch.size_bytes();
 
         // Individual witnesses (100 separate proofs)
         let mut individual_size = 0;
         for k in &keys {
-            let w = generate_witnesses(&smt, &[*k]);
+            let w = generate_witnesses(&smt, &[*k]).unwrap();
             individual_size += w.size_bytes();
         }
 
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn empty_access_list() {
         let smt = PydeSMT::new();
-        let witness = generate_witnesses(&smt, &[]);
+        let witness = generate_witnesses(&smt, &[]).unwrap();
         assert!(witness.is_empty());
         assert!(verify_witnesses(&witness));
     }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -64,9 +64,11 @@ pub fn load_account(smt: &PydeSMT, address: &Address) -> Account {
 }
 
 /// Store an account into the SMT.
-pub fn store_account(smt: &mut PydeSMT, account: &Account) {
+pub fn store_account(smt: &mut PydeSMT, account: &Account) -> Result<(), PipelineError> {
     let key = keys::balance_key(&account.address);
-    smt.insert(key, account.to_bytes());
+    smt.insert(key, account.to_bytes())
+        .map_err(|e| PipelineError::StateError(e.to_string()))?;
+    Ok(())
 }
 
 /// Load a nonce state for an account. Returns default if not found.
@@ -81,9 +83,11 @@ pub fn load_nonce(smt: &PydeSMT, address: &Address) -> NonceState {
 }
 
 /// Store a nonce state into the SMT.
-pub fn store_nonce(smt: &mut PydeSMT, address: &Address, nonce: &NonceState) {
+pub fn store_nonce(smt: &mut PydeSMT, address: &Address, nonce: &NonceState) -> Result<(), PipelineError> {
     let key = keys::nonce_key(address);
-    smt.insert(key, nonce.to_bytes().to_vec());
+    smt.insert(key, nonce.to_bytes().to_vec())
+        .map_err(|e| PipelineError::StateError(e.to_string()))?;
+    Ok(())
 }
 
 /// Load contract code from the SMT.
@@ -93,9 +97,11 @@ pub fn load_code(smt: &PydeSMT, address: &Address) -> Option<Vec<u8>> {
 }
 
 /// Store contract code into the SMT.
-pub fn store_code(smt: &mut PydeSMT, address: &Address, code: &[u8]) {
+pub fn store_code(smt: &mut PydeSMT, address: &Address, code: &[u8]) -> Result<(), PipelineError> {
     let key = keys::code_key(address);
-    smt.insert(key, code.to_vec());
+    smt.insert(key, code.to_vec())
+        .map_err(|e| PipelineError::StateError(e.to_string()))?;
+    Ok(())
 }
 
 fn empty_account(address: &Address) -> Account {
@@ -169,10 +175,10 @@ pub fn execute_transaction(
                 &tx.from,
                 sender.nonce,
             );
-            store_code(smt, &new_addr, &tx.data);
+            store_code(smt, &new_addr, &tx.data)?;
 
             let contract = Account::new_contract(new_addr, &tx.data);
-            store_account(smt, &contract);
+            store_account(smt, &contract)?;
 
             (true, 32_000u64, 0u64, vec![])
         }
@@ -210,12 +216,12 @@ pub fn execute_transaction(
     // Credit validator
     let mut validator_account = load_account(smt, &block_ctx.validator_address);
     validator_account.balance += fee_dist.validator;
-    store_account(smt, &validator_account);
+    store_account(smt, &validator_account)?;
 
     // 9. Save updated accounts
-    store_account(smt, &sender);
-    store_account(smt, &recipient);
-    store_nonce(smt, &tx.from, &nonce_state);
+    store_account(smt, &sender)?;
+    store_account(smt, &recipient)?;
+    store_nonce(smt, &tx.from, &nonce_state)?;
 
     // 10. Generate receipt
     let state_root = smt.root();
@@ -319,7 +325,7 @@ mod tests {
             tx_type: TransactionType::Standard,
         };
         let hash = tx.hash();
-        tx.signature = falcon_sign(sk, &hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(sk, &hash).unwrap().as_bytes().to_vec();
         tx
     }
 
@@ -327,8 +333,8 @@ mod tests {
         let addr = derive_eoa_address(pk_bytes);
         let mut account = Account::new_eoa(pk_bytes);
         account.balance = balance;
-        store_account(smt, &account);
-        store_nonce(smt, &addr, &NonceState::new());
+        store_account(smt, &account).unwrap();
+        store_nonce(smt, &addr, &NonceState::new()).unwrap();
         addr
     }
 
@@ -336,7 +342,7 @@ mod tests {
 
     #[test]
     fn simple_transfer_updates_balances() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -359,7 +365,7 @@ mod tests {
 
     #[test]
     fn nonce_consumed_after_execution() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -379,7 +385,7 @@ mod tests {
 
     #[test]
     fn contract_deployment() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -391,7 +397,7 @@ mod tests {
         tx.data = b"contract bytecode here".to_vec();
         // Re-sign with new fields
         let hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &hash).unwrap().as_bytes().to_vec();
 
         let receipt = execute_transaction(&tx, &mut smt, &block_ctx).unwrap();
         assert!(receipt.success);
@@ -410,7 +416,7 @@ mod tests {
 
     #[test]
     fn fees_distributed_to_validator() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -433,7 +439,7 @@ mod tests {
 
     #[test]
     fn state_root_changes_after_tx() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -451,7 +457,7 @@ mod tests {
 
     #[test]
     fn insufficient_balance_rejected() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();
@@ -465,7 +471,7 @@ mod tests {
 
     #[test]
     fn multiple_txs_sequential() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut smt = PydeSMT::new();
         let block_ctx = make_block_ctx();

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -162,7 +162,10 @@ impl Transaction {
             Some(pk) => pk,
             None => return false,
         };
-        let sig = FalconSignature::from_bytes(&self.signature);
+        let sig = match FalconSignature::from_bytes(&self.signature) {
+            Some(s) => s,
+            None => return false,
+        };
         let tx_hash = self.hash();
         falcon_verify(&pk, &tx_hash, &sig)
     }
@@ -448,13 +451,13 @@ mod tests {
 
     #[test]
     fn valid_signature_passes() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut tx = make_test_tx();
         tx.from = derive_eoa_address(&pk_bytes);
 
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         assert!(tx.verify_signature(&pk_bytes));
     }
@@ -463,13 +466,13 @@ mod tests {
 
     #[test]
     fn tampered_value_fails_verification() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let mut tx = make_test_tx();
         tx.from = derive_eoa_address(&pk_bytes);
 
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         // Tamper
         tx.value = 999_999;
@@ -478,12 +481,12 @@ mod tests {
 
     #[test]
     fn wrong_key_fails_verification() {
-        let (pk1, sk1) = falcon_keygen();
-        let (pk2, _sk2) = falcon_keygen();
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
         let mut tx = make_test_tx();
 
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk1, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk1, &tx_hash).unwrap().as_bytes().to_vec();
 
         // Verify with wrong key
         assert!(!tx.verify_signature(pk2.as_bytes()));

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -230,7 +230,7 @@ mod tests {
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 
     fn make_valid_tx_and_account() -> (Transaction, Account, NonceState) {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 1_000_000_000_000, // plenty
@@ -254,7 +254,7 @@ mod tests {
         };
 
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         (tx, account, nonce_state)
     }
@@ -302,7 +302,7 @@ mod tests {
         let (mut tx, account, nonce) = make_valid_tx_and_account();
         tx.nonce = 100; // way outside [0, 15]
         // Re-sign with correct hash
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 1_000_000_000_000,
@@ -310,7 +310,7 @@ mod tests {
         };
         tx.from = account.address;
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         let ctx = default_ctx();
         let err = validate_transaction(&tx, &account, &nonce, &ctx).unwrap_err();
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn insufficient_balance_rejected() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 100, // way too low
@@ -344,7 +344,7 @@ mod tests {
             tx_type: TransactionType::Standard,
         };
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         let ctx = default_ctx(); // base_fee = 1000, so 21000 * 1000 = 21M > 100
         let err = validate_transaction(&tx, &account, &nonce, &ctx).unwrap_err();
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn paymaster_skips_balance_check() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 0, // zero balance
@@ -376,7 +376,7 @@ mod tests {
             tx_type: TransactionType::Standard,
         };
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         let ctx = default_ctx();
         assert!(validate_transaction(&tx, &account, &nonce, &ctx).is_ok());
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn expired_deadline_rejected() {
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 1_000_000_000_000,
@@ -409,7 +409,7 @@ mod tests {
             tx_type: TransactionType::Standard,
         };
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         let ctx = default_ctx(); // block_height = 100 > deadline 50
         let err = validate_transaction(&tx, &account, &nonce, &ctx).unwrap_err();
@@ -421,7 +421,7 @@ mod tests {
         let (tx, account, nonce) = make_valid_tx_and_account();
         let mut tx = tx;
         // Need to re-sign with deadline
-        let (pk, sk) = falcon_keygen();
+        let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let account = Account {
             balance: 1_000_000_000_000,
@@ -430,7 +430,7 @@ mod tests {
         tx.from = account.address;
         tx.deadline = Some(999); // future
         let tx_hash = tx.hash();
-        tx.signature = falcon_sign(&sk, &tx_hash).as_bytes().to_vec();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
 
         let ctx = default_ctx();
         assert!(validate_transaction(&tx, &account, &NonceState::new(), &ctx).is_ok());


### PR DESCRIPTION
## Summary
Security hardening of the crypto crate and elimination of all `.expect()` panics in production code across 8 crates.

### Crypto Security Fixes
- **FALCON domain separation**: `DomainSeparation::Context(b"pyde-falcon-v1")` prevents signature reuse across protocols
- **Signature validation**: `FalconSignature::from_bytes()` now returns `Option`, rejects signatures outside 500-1000 byte range
- **VRF output binding**: Proof message includes public key bytes, cryptographically binding output to specific key
- **PSS entropy**: Fresh random via `poseidon2_hash(epoch || index || random)` instead of deterministic share-derived data

### Error Handling (zero panics)
Every fallible operation in production code now returns `Result` instead of panicking:
- **crypto**: keygen, sign, encapsulate, decapsulate, vrf_prove, threshold_keygen, threshold_encrypt
- **consensus**: create_vote, create_timeout, create_finality_vote, compute_candidacy, create_view_change
- **state**: SMT insert/delete/update_all/prove, MerkleProof::compile, versioning, snapshot, witness
- **mempool**: encrypt_transaction
- **net**: PeerNode::new
- **tx**: pipeline store operations

## Test plan
- [x] 1,667 tests passing, 0 failures
- [x] All crypto operations verified with Result propagation
- [x] No `.expect()` remaining in production code (1 compiler-internal invariant in otic lowerer excluded)