### PR TITLE
feat: add chain sync protocol over libp2p request-response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -397,6 +400,15 @@ checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "cbor4ii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472931dd4dfcc785075b09be910147f9c6258883fc4591d0dac6116392b2daa6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1949,6 +1961,7 @@ dependencies = [
  "libp2p-metrics",
  "libp2p-noise",
  "libp2p-quic",
+ "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
@@ -2003,6 +2016,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
+ "serde",
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
@@ -2051,6 +2065,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
+ "serde",
  "sha2",
  "smallvec",
  "tracing",
@@ -2093,6 +2108,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2",
  "thiserror 2.0.18",
  "tracing",
@@ -2119,6 +2135,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
+ "serde",
  "sha2",
  "smallvec",
  "thiserror 1.0.69",
@@ -2215,6 +2232,28 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+dependencies = [
+ "async-trait",
+ "cbor4ii",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]
@@ -2593,6 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
+ "serde",
  "unsigned-varint 0.8.0",
 ]
 
@@ -3201,6 +3241,8 @@ dependencies = [
  "libp2p",
  "pyde-account",
  "pyde-crypto",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]
@@ -3225,6 +3267,7 @@ dependencies = [
  "pyde-tx",
  "pyde-vm",
  "serde",
+ "serde_json",
  "tokio",
  "toml",
  "tracing",

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 pyde-crypto = { path = "../crypto" }
 pyde-account = { path = "../account" }
-libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify"] }
+libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify", "request-response", "cbor", "serde"] }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+serde_json = "1"

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -18,3 +18,4 @@ pub mod node;
 pub mod peer;
 pub mod propagation;
 pub mod sync;
+pub mod sync_protocol;

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -11,10 +11,11 @@
 //! Both are isolated to this module — no changes needed above transport layer.
 
 use crate::config::NetworkConfig;
+use crate::sync_protocol::{self, SyncReq, SyncResp};
 use libp2p::{
     gossipsub, identify, identity,
     kad::{self, store::MemoryStore},
-    noise,
+    noise, request_response,
     swarm::NetworkBehaviour,
     Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
@@ -29,6 +30,8 @@ pub struct PydeBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
     /// Identify protocol (exchange peer info on connect).
     pub identify: identify::Behaviour,
+    /// Request-response for sync protocol (block download, chain tip queries).
+    pub sync: request_response::cbor::Behaviour<SyncReq, SyncResp>,
 }
 
 /// Generate a new node keypair. Call once on first run, then persist.
@@ -88,10 +91,14 @@ pub fn create_node(config: &NetworkConfig, local_key: identity::Keypair) -> Resu
                 key.public(),
             ));
 
+            // Sync request-response protocol
+            let sync = sync_protocol::sync_behaviour();
+
             Ok(PydeBehaviour {
                 gossipsub,
                 kademlia,
                 identify,
+                sync,
             })
         })
         .map_err(|e| format!("behaviour error: {e}"))?

--- a/crates/net/src/sync_protocol.rs
+++ b/crates/net/src/sync_protocol.rs
@@ -1,0 +1,78 @@
+//! Sync request-response protocol over libp2p.
+//!
+//! Uses CBOR encoding over the `/pyde/sync/1` protocol.
+//! Peers exchange block headers, block bodies, and chain tip info.
+
+use libp2p::request_response;
+use libp2p::StreamProtocol;
+use serde::{Deserialize, Serialize};
+
+/// Protocol name for sync requests.
+pub const SYNC_PROTOCOL: StreamProtocol = StreamProtocol::new("/pyde/sync/1");
+
+/// Sync request sent from syncing node to a peer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SyncReq {
+    /// Ask the peer for their chain tip (highest slot).
+    GetChainTip,
+    /// Request block data for a range of slots.
+    GetBlocks {
+        start_slot: u64,
+        count: u32,
+    },
+    /// Request block headers only for a range of slots.
+    GetHeaders {
+        start_slot: u64,
+        count: u32,
+    },
+}
+
+/// Sync response from peer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SyncResp {
+    /// Peer's chain tip.
+    ChainTip {
+        slot: u64,
+        block_hash: [u8; 32],
+    },
+    /// Block data (serialized blocks).
+    Blocks(Vec<Vec<u8>>),
+    /// Block headers only.
+    Headers(Vec<Vec<u8>>),
+    /// Peer doesn't have the requested data.
+    NotFound,
+}
+
+/// Create the request-response behaviour for sync.
+pub fn sync_behaviour() -> request_response::cbor::Behaviour<SyncReq, SyncResp> {
+    request_response::cbor::Behaviour::new(
+        [(SYNC_PROTOCOL, request_response::ProtocolSupport::Full)],
+        request_response::Config::default(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_req_serializes() {
+        let req = SyncReq::GetBlocks { start_slot: 100, count: 50 };
+        let bytes = serde_json::to_vec(&req).unwrap();
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn sync_resp_serializes() {
+        let resp = SyncResp::ChainTip { slot: 42, block_hash: [0xAA; 32] };
+        let bytes = serde_json::to_vec(&resp).unwrap();
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn not_found_serializes() {
+        let resp = SyncResp::NotFound;
+        let bytes = serde_json::to_vec(&resp).unwrap();
+        assert!(!bytes.is_empty());
+    }
+}

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,7 +18,8 @@ pyde-tx = { path = "../tx" }
 pyde-consensus = { path = "../consensus" }
 pyde-mempool = { path = "../mempool" }
 pyde-net = { path = "../net" }
-libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify"] }
+libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify", "request-response", "cbor", "serde"] }
+serde_json = "1"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -7,6 +7,7 @@ mod metrics;
 mod node;
 mod shutdown;
 mod state_manager;
+mod sync;
 mod tx_relay;
 mod validator;
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3,16 +3,19 @@ use crate::chain::ChainState;
 use crate::config::NodeConfig;
 use crate::shutdown::ShutdownSignal;
 use crate::state_manager::StateManager;
+use crate::sync::ChainSync;
 use crate::tx_relay::TxRelay;
 use crate::validator::{ValidatorEngine, ValidatorIdentity, verify_stake};
 use libp2p::futures::StreamExt;
 use libp2p::gossipsub;
+use libp2p::request_response;
 use libp2p::swarm::SwarmEvent;
+use libp2p::PeerId;
 use pyde_net::channels::Channel;
 use pyde_net::config::NetworkConfig;
 use pyde_net::node::{
     create_node, generate_keypair, keypair_from_bytes, keypair_to_bytes, subscribe_topics,
-    PydeBehaviourEvent,
+    PydeBehaviour, PydeBehaviourEvent,
 };
 use std::path::Path;
 use tracing::{debug, info, warn};
@@ -65,7 +68,11 @@ impl PydeNode {
         // 3. Transaction relay / mempool
         let mut tx_relay = TxRelay::new();
 
-        // 4. Validator engine (only for validator role)
+        // 4. Chain sync
+        let mut chain_sync = ChainSync::new();
+        chain_sync.manager.local_tip = chain.head_slot;
+
+        // 5. Validator engine (only for validator role)
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
             // Load validator FALCON signing key (required for validator role)
             let identity = load_validator_identity(datadir)?;
@@ -155,19 +162,42 @@ impl PydeNode {
         // --- Main event loop ---
         let mut shutdown_rx = self.shutdown.subscribe();
 
-        // Periodic maintenance timer (every 10 seconds)
+        // Periodic timers
         let mut maintenance_interval = tokio::time::interval(std::time::Duration::from_secs(10));
+        let mut sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
 
         loop {
             tokio::select! {
                 event = swarm.select_next_some() => {
-                    handle_swarm_event(
+                    // Process event, collecting any actions that need the swarm
+                    let action = handle_swarm_event(
                         event,
                         &mut chain,
                         &mut state,
                         &mut tx_relay,
+                        &mut chain_sync,
                         &mut validator_engine,
                     );
+
+                    // Execute post-event actions that need swarm access
+                    match action {
+                        PostEventAction::None => {}
+                        PostEventAction::RequestChainTip(peer) => {
+                            chain_sync.request_chain_tip(&mut swarm, peer);
+                        }
+                        PostEventAction::SendSyncResponse(channel, response) => {
+                            let _ = swarm.behaviour_mut().sync.send_response(channel, response);
+                        }
+                        PostEventAction::ContinueSync => {
+                            chain_sync.request_next_batch(&mut swarm);
+                        }
+                    }
+                }
+                _ = sync_interval.tick() => {
+                    // Try to sync if we're behind
+                    if chain_sync.is_syncing() {
+                        chain_sync.request_next_batch(&mut swarm);
+                    }
                 }
                 _ = maintenance_interval.tick() => {
                     // Periodic maintenance
@@ -179,6 +209,8 @@ impl PydeNode {
                         peers = peer_count,
                         mempool = tx_relay.mempool_size(),
                         head = chain.head_slot,
+                        syncing = chain_sync.is_syncing(),
+                        behind = chain_sync.manager.slots_behind(),
                         "maintenance tick"
                     );
                 }
@@ -198,14 +230,25 @@ impl PydeNode {
     }
 }
 
-/// Handle a libp2p swarm event.
+use pyde_net::sync_protocol::{SyncReq, SyncResp};
+
+/// Action to take after processing a swarm event (avoids borrow conflicts with swarm).
+enum PostEventAction {
+    None,
+    RequestChainTip(PeerId),
+    SendSyncResponse(request_response::ResponseChannel<SyncResp>, SyncResp),
+    ContinueSync,
+}
+
+/// Handle a libp2p swarm event. Returns an action that may need swarm access.
 fn handle_swarm_event(
     event: SwarmEvent<PydeBehaviourEvent>,
     chain: &mut ChainState,
     state: &mut StateManager,
     tx_relay: &mut TxRelay,
+    chain_sync: &mut ChainSync,
     validator_engine: &mut Option<ValidatorEngine>,
-) {
+) -> PostEventAction {
     match event {
         // --- Gossipsub message received ---
         SwarmEvent::Behaviour(PydeBehaviourEvent::Gossipsub(
@@ -217,23 +260,13 @@ fn handle_swarm_event(
             match channel {
                 Some(Channel::Transactions) => {
                     debug!(bytes = message.data.len(), "received tx gossip");
-                    // Tx deserialization will be wired when we have a wire format
-                    // for EncryptedTx. For now, log receipt.
                 }
                 Some(Channel::Blocks) => {
                     debug!(bytes = message.data.len(), "received block gossip");
-                    // Block deserialization and processing will be wired when we have
-                    // a wire format for blocks.
                 }
                 Some(Channel::Consensus) => {
-                    if let Some(engine) = validator_engine.as_mut() {
+                    if let Some(_engine) = validator_engine.as_mut() {
                         debug!(bytes = message.data.len(), "received consensus message");
-                        // Consensus message deserialization and dispatch:
-                        // - Proposal → engine.on_proposal()
-                        // - Vote → engine.on_vote()
-                        // - ViewChange → engine.on_view_change()
-                        // - FinalityVote → engine.on_finality_vote()
-                        // Wire format serialization is a Phase 10 integration task.
                     }
                 }
                 Some(Channel::Sync) => {
@@ -243,9 +276,45 @@ fn handle_swarm_event(
                     debug!(topic, "received message on unknown topic");
                 }
             }
+            PostEventAction::None
         }
 
-        // --- Peer connected ---
+        // --- Sync: inbound request from peer ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Sync(
+            request_response::Event::Message {
+                message: request_response::Message::Request { request, channel, .. },
+                peer,
+            },
+        )) => {
+            debug!(%peer, "inbound sync request");
+            let response = ChainSync::handle_inbound_request(&request, chain);
+            PostEventAction::SendSyncResponse(channel, response)
+        }
+
+        // --- Sync: response to our outbound request ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Sync(
+            request_response::Event::Message {
+                message: request_response::Message::Response { request_id, response },
+                ..
+            },
+        )) => {
+            chain_sync.on_response(request_id, response, chain, state);
+            if chain_sync.is_syncing() {
+                PostEventAction::ContinueSync
+            } else {
+                PostEventAction::None
+            }
+        }
+
+        // --- Sync request failed ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Sync(
+            request_response::Event::OutboundFailure { peer, error, .. },
+        )) => {
+            warn!(%peer, ?error, "sync request failed");
+            PostEventAction::None
+        }
+
+        // --- Peer connected: ask for their chain tip ---
         SwarmEvent::ConnectionEstablished {
             peer_id, endpoint, ..
         } => {
@@ -254,6 +323,7 @@ fn handle_swarm_event(
                 addr = %endpoint.get_remote_address(),
                 "peer connected"
             );
+            PostEventAction::RequestChainTip(peer_id)
         }
 
         // --- Peer disconnected ---
@@ -265,15 +335,17 @@ fn handle_swarm_event(
                 cause = ?cause,
                 "peer disconnected"
             );
+            PostEventAction::None
         }
 
         // --- Listening on address ---
         SwarmEvent::NewListenAddr { address, .. } => {
             info!(%address, "listening on");
+            PostEventAction::None
         }
 
         // All other events
-        _ => {}
+        _ => PostEventAction::None,
     }
 }
 

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -1,0 +1,418 @@
+//! Chain sync: header-first sync over libp2p request-response.
+//!
+//! ## Current Limitations
+//!
+//! This is a header-only sync skeleton. A fully synced node currently has:
+//! - Chain head tracking (slot, epoch, parent hashes)
+//! - Block header history for finality verification
+//!
+//! What's NOT synced yet (requires block wire format + tx execution):
+//! - Block bodies (transactions, execution schedules)
+//! - State trie (account balances, storage, contract code)
+//! - Transaction execution / state replay from genesis
+//!
+//! ## TODO: Full Sync
+//!
+//! 1. Block serialization format (header + body + signatures)
+//! 2. Download full blocks (not just headers) during sync
+//! 3. Execute transactions per block to rebuild state from genesis
+//! 4. State snapshot sync (download trie at checkpoint, replay recent blocks)
+//! 5. Parallel block download with sequential execution
+
+use crate::block_processor::BlockProcessor;
+use crate::chain::ChainState;
+use crate::state_manager::StateManager;
+use libp2p::request_response::{self, OutboundRequestId, ResponseChannel};
+use libp2p::{PeerId, Swarm};
+use pyde_net::node::PydeBehaviour;
+use pyde_net::sync::SyncManager;
+use pyde_net::sync_protocol::{SyncReq, SyncResp};
+use std::collections::HashMap;
+use tracing::{debug, info, warn};
+
+/// Chain sync coordinator.
+/// Manages the sync state machine and dispatches requests to peers.
+pub struct ChainSync {
+    /// Sync state tracker from the net crate.
+    pub manager: SyncManager,
+    /// Outstanding outbound requests: request_id → peer.
+    pending: HashMap<OutboundRequestId, PeerId>,
+    /// Whether initial sync has completed at least once.
+    pub initial_sync_done: bool,
+}
+
+impl ChainSync {
+    pub fn new() -> Self {
+        Self {
+            manager: SyncManager::new(),
+            pending: HashMap::new(),
+            initial_sync_done: false,
+        }
+    }
+
+    /// Called when we learn a peer's chain tip (from ChainTip response or identify).
+    pub fn on_peer_tip(&mut self, peer: PeerId, tip_slot: u64) {
+        let old_tip = self.manager.network_tip;
+        self.manager.update_network_tip(tip_slot);
+        if tip_slot > old_tip {
+            info!(
+                %peer,
+                network_tip = tip_slot,
+                local_tip = self.manager.local_tip,
+                behind = self.manager.slots_behind(),
+                "network tip updated"
+            );
+        }
+    }
+
+    /// Called after we process a block. Advances our local tip.
+    pub fn on_block_processed(&mut self, slot: u64) {
+        self.manager.advance_local_tip(slot);
+        if !self.manager.needs_sync() && !self.initial_sync_done {
+            self.initial_sync_done = true;
+            info!(slot, "initial chain sync complete");
+        }
+    }
+
+    /// Try to request the next batch of blocks from a peer.
+    /// Returns true if a request was sent.
+    pub fn request_next_batch(
+        &mut self,
+        swarm: &mut Swarm<PydeBehaviour>,
+    ) -> bool {
+        if !self.manager.needs_sync() {
+            return false;
+        }
+
+        // Don't send multiple concurrent requests
+        if !self.pending.is_empty() {
+            return false;
+        }
+
+        // Pick a connected peer
+        let peer = match swarm.connected_peers().next() {
+            Some(p) => *p,
+            None => {
+                debug!("no peers to sync from");
+                return false;
+            }
+        };
+
+        if let Some(req) = self.manager.next_request() {
+            let (start, count) = match &req {
+                pyde_net::sync::SyncRequest::GetBlocks { start_slot, count } => (*start_slot, *count),
+                _ => return false,
+            };
+
+            let request_id = swarm
+                .behaviour_mut()
+                .sync
+                .send_request(&peer, SyncReq::GetBlocks { start_slot: start, count });
+
+            self.pending.insert(request_id, peer);
+            info!(
+                %peer,
+                start_slot = start,
+                count,
+                "requested blocks for sync"
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Ask a newly connected peer for their chain tip.
+    pub fn request_chain_tip(
+        &mut self,
+        swarm: &mut Swarm<PydeBehaviour>,
+        peer: PeerId,
+    ) {
+        let _id = swarm
+            .behaviour_mut()
+            .sync
+            .send_request(&peer, SyncReq::GetChainTip);
+        debug!(%peer, "requested chain tip");
+    }
+
+    /// Handle a sync response from a peer.
+    /// Returns the number of blocks processed.
+    pub fn on_response(
+        &mut self,
+        request_id: OutboundRequestId,
+        response: SyncResp,
+        chain: &mut ChainState,
+        state: &mut StateManager,
+    ) -> u64 {
+        self.pending.remove(&request_id);
+
+        match response {
+            SyncResp::ChainTip { slot, block_hash } => {
+                self.manager.update_network_tip(slot);
+                info!(slot, hash = hex::encode(block_hash), "received chain tip");
+                0
+            }
+            SyncResp::Blocks(block_data) => {
+                let count = block_data.len();
+                let mut processed = 0u64;
+
+                for data in &block_data {
+                    // Deserialize block header from the data.
+                    // For now, we use a minimal format: slot(8) || parent_hash(32) || state_root(32) || tx_root(32)
+                    // Full serialization will be expanded later.
+                    if let Some(header) = deserialize_block_header(data) {
+                        match BlockProcessor::process_block(chain, state, header, &[]) {
+                            Ok(_) => {
+                                self.manager.advance_local_tip(chain.head_slot);
+                                processed += 1;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "failed to process synced block");
+                                break;
+                            }
+                        }
+                    } else {
+                        warn!(len = data.len(), "failed to deserialize synced block");
+                        break;
+                    }
+                }
+
+                info!(
+                    received = count,
+                    processed,
+                    head = chain.head_slot,
+                    "sync batch processed"
+                );
+                processed
+            }
+            SyncResp::Headers(_) => {
+                debug!("received headers (not used in block sync)");
+                0
+            }
+            SyncResp::NotFound => {
+                warn!("peer doesn't have requested blocks");
+                0
+            }
+        }
+    }
+
+    /// Handle an inbound sync request from a peer.
+    /// Returns the response to send back.
+    pub fn handle_inbound_request(
+        req: &SyncReq,
+        chain: &ChainState,
+    ) -> SyncResp {
+        match req {
+            SyncReq::GetChainTip => {
+                SyncResp::ChainTip {
+                    slot: chain.head_slot,
+                    block_hash: chain.state_root, // simplified: use state_root as block identifier
+                }
+            }
+            SyncReq::GetBlocks { start_slot, count } => {
+                // Serialize block headers from our chain state.
+                // We serve what we have in our header cache.
+                let mut blocks = Vec::new();
+                for slot in *start_slot..(*start_slot + *count as u64) {
+                    if let Some(header) = chain.header(slot) {
+                        blocks.push(serialize_block_header(header));
+                    } else {
+                        break; // stop at first missing slot
+                    }
+                }
+                if blocks.is_empty() {
+                    SyncResp::NotFound
+                } else {
+                    SyncResp::Blocks(blocks)
+                }
+            }
+            SyncReq::GetHeaders { start_slot, count } => {
+                let mut headers = Vec::new();
+                for slot in *start_slot..(*start_slot + *count as u64) {
+                    if let Some(header) = chain.header(slot) {
+                        headers.push(serialize_block_header(header));
+                    } else {
+                        break;
+                    }
+                }
+                if headers.is_empty() {
+                    SyncResp::NotFound
+                } else {
+                    SyncResp::Headers(headers)
+                }
+            }
+        }
+    }
+
+    /// Whether sync is in progress.
+    pub fn is_syncing(&self) -> bool {
+        self.manager.needs_sync()
+    }
+}
+
+/// Minimal block header serialization.
+/// Format: slot(8) || epoch(8) || parent_hash(32) || state_root(32) || tx_root(32) || timestamp(8)
+fn serialize_block_header(header: &pyde_consensus::block::BlockHeader) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(120);
+    buf.extend_from_slice(&header.slot.to_le_bytes());
+    buf.extend_from_slice(&header.epoch.to_le_bytes());
+    buf.extend_from_slice(&header.parent_hash);
+    buf.extend_from_slice(&header.state_root);
+    buf.extend_from_slice(&header.tx_root);
+    buf.extend_from_slice(&header.timestamp.to_le_bytes());
+    buf
+}
+
+/// Minimal block header deserialization.
+fn deserialize_block_header(data: &[u8]) -> Option<pyde_consensus::block::BlockHeader> {
+    if data.len() < 120 {
+        return None;
+    }
+
+    let mut slot_bytes = [0u8; 8];
+    slot_bytes.copy_from_slice(&data[0..8]);
+    let slot = u64::from_le_bytes(slot_bytes);
+
+    let mut epoch_bytes = [0u8; 8];
+    epoch_bytes.copy_from_slice(&data[8..16]);
+    let epoch = u64::from_le_bytes(epoch_bytes);
+
+    let mut parent_hash = [0u8; 32];
+    parent_hash.copy_from_slice(&data[16..48]);
+
+    let mut state_root = [0u8; 32];
+    state_root.copy_from_slice(&data[48..80]);
+
+    let mut tx_root = [0u8; 32];
+    tx_root.copy_from_slice(&data[80..112]);
+
+    let mut ts_bytes = [0u8; 8];
+    ts_bytes.copy_from_slice(&data[112..120]);
+    let timestamp = u64::from_le_bytes(ts_bytes);
+
+    Some(pyde_consensus::block::BlockHeader {
+        slot,
+        epoch,
+        parent_hash,
+        state_root,
+        tx_root,
+        timestamp,
+        proposer: pyde_account::address::ZERO_ADDRESS,
+        vrf_proof: vec![],
+        qc_previous: pyde_consensus::block::QuorumCert::empty(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_account::address::ZERO_ADDRESS;
+    use pyde_consensus::block::{BlockHeader, QuorumCert};
+
+    fn dummy_header(slot: u64) -> BlockHeader {
+        BlockHeader {
+            slot,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: ZERO_ADDRESS,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [slot as u8; 32],
+            state_root: [slot as u8; 32],
+            timestamp: slot * 400,
+        }
+    }
+
+    #[test]
+    fn header_serialization_roundtrip() {
+        let header = dummy_header(42);
+        let bytes = serialize_block_header(&header);
+        let restored = deserialize_block_header(&bytes).unwrap();
+
+        assert_eq!(restored.slot, 42);
+        assert_eq!(restored.epoch, 0);
+        assert_eq!(restored.state_root, [42u8; 32]);
+        assert_eq!(restored.tx_root, [42u8; 32]);
+        assert_eq!(restored.timestamp, 42 * 400);
+    }
+
+    #[test]
+    fn deserialize_too_short_returns_none() {
+        assert!(deserialize_block_header(&[0u8; 50]).is_none());
+    }
+
+    #[test]
+    fn sync_manager_tracks_tips() {
+        let mut sync = ChainSync::new();
+        let peer = PeerId::random();
+
+        sync.on_peer_tip(peer, 100);
+        assert_eq!(sync.manager.network_tip, 100);
+        assert!(sync.manager.needs_sync());
+        assert_eq!(sync.manager.slots_behind(), 100);
+    }
+
+    #[test]
+    fn sync_completes_when_caught_up() {
+        let mut sync = ChainSync::new();
+        let peer = PeerId::random();
+
+        sync.on_peer_tip(peer, 5);
+        assert!(!sync.initial_sync_done);
+
+        for slot in 1..=5 {
+            sync.on_block_processed(slot);
+        }
+
+        assert!(!sync.manager.needs_sync());
+        assert!(sync.initial_sync_done);
+    }
+
+    #[test]
+    fn handle_chain_tip_request() {
+        let mut chain = ChainState::genesis([0u8; 32]);
+        chain.advance(dummy_header(10));
+
+        let resp = ChainSync::handle_inbound_request(&SyncReq::GetChainTip, &chain);
+        match resp {
+            SyncResp::ChainTip { slot, .. } => assert_eq!(slot, 10),
+            _ => panic!("expected ChainTip response"),
+        }
+    }
+
+    #[test]
+    fn handle_get_blocks_request() {
+        let mut chain = ChainState::genesis([0u8; 32]);
+        for slot in 1..=5 {
+            chain.advance(dummy_header(slot));
+        }
+
+        let resp = ChainSync::handle_inbound_request(
+            &SyncReq::GetBlocks { start_slot: 1, count: 3 },
+            &chain,
+        );
+        match resp {
+            SyncResp::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 3);
+                // Verify first block deserializes to slot 1
+                let h = deserialize_block_header(&blocks[0]).unwrap();
+                assert_eq!(h.slot, 1);
+            }
+            _ => panic!("expected Blocks response"),
+        }
+    }
+
+    #[test]
+    fn handle_get_blocks_not_found() {
+        let chain = ChainState::genesis([0u8; 32]);
+
+        let resp = ChainSync::handle_inbound_request(
+            &SyncReq::GetBlocks { start_slot: 100, count: 10 },
+            &chain,
+        );
+        match resp {
+            SyncResp::NotFound => {}
+            _ => panic!("expected NotFound"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Sync protocol: CBOR-encoded request-response over `/pyde/sync/1`
- ChainSync state machine: detect behind peers, request blocks in batches, process responses
- Auto-request chain tip on peer connect
- Serve inbound sync requests (chain tip + block headers)
- Block header serialization for wire transfer
- Added `request-response` behaviour to PydeBehaviour
- 10 new tests (1,602 total workspace)

## Known Limitations (documented in code)
- Header-only sync — block bodies (transactions) not yet transferred
- State trie not synced — requires block wire format + tx execution replay
- State snapshot sync deferred

## Test plan
- [x] `cargo test -p pyde-node` — 32 tests pass
- [x] `cargo test --workspace` — 1,602 tests pass
- [x] `make run-full` starts with sync loop active