### PR TITLE
feat: add JSON-RPC server with chain query endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
+dependencies = [
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+dependencies = [
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "keccak"
 version = "0.2.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,6 +3238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.8+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,6 +3352,7 @@ dependencies = [
  "clap",
  "directories",
  "hex",
+ "jsonrpsee",
  "libp2p",
  "metrics",
  "metrics-exporter-prometheus",
@@ -3635,6 +3734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
 name = "rtnetlink"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,6 +3967,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4085,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -4249,6 +4381,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,6 +4400,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4269,8 +4414,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4283,6 +4428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4291,9 +4445,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4301,6 +4476,27 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -4314,6 +4510,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4954,6 +5151,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -39,6 +39,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
+# RPC
+jsonrpsee = { version = "0.24", features = ["server", "macros"] }
+
 # Misc
 directories = "5"
 hex = "0.4"

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -6,6 +6,7 @@ mod logging;
 mod metrics;
 mod node;
 mod shutdown;
+mod rpc;
 mod state_manager;
 mod sync;
 mod tx_relay;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1,6 +1,7 @@
 use crate::block_processor::BlockProcessor;
 use crate::chain::ChainState;
 use crate::config::NodeConfig;
+use crate::rpc::{self, RpcState};
 use crate::shutdown::ShutdownSignal;
 use crate::state_manager::StateManager;
 use crate::sync::ChainSync;
@@ -18,6 +19,8 @@ use pyde_net::node::{
     PydeBehaviour, PydeBehaviourEvent,
 };
 use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 /// The main Pyde node. Owns all subsystems.
@@ -54,7 +57,7 @@ impl PydeNode {
         // --- Initialize subsystems ---
 
         // 1. State storage (RocksDB + SMT)
-        let mut state = StateManager::open(datadir, self.config.storage.cache_size)?;
+        let state = StateManager::open(datadir, self.config.storage.cache_size)?;
         info!(
             state_root = hex::encode(state.root()),
             empty = state.is_empty(),
@@ -62,15 +65,19 @@ impl PydeNode {
         );
 
         // 2. Chain state tracker
-        let mut chain = ChainState::genesis(state.root());
+        let chain = ChainState::genesis(state.root());
         info!(head_slot = chain.head_slot, "chain initialized");
+
+        // Wrap in Arc<RwLock> for RPC sharing
+        let chain = Arc::new(RwLock::new(chain));
+        let state = Arc::new(RwLock::new(state));
 
         // 3. Transaction relay / mempool
         let mut tx_relay = TxRelay::new();
 
         // 4. Chain sync
         let mut chain_sync = ChainSync::new();
-        chain_sync.manager.local_tip = chain.head_slot;
+        chain_sync.manager.local_tip = chain.read().await.head_slot;
 
         // 5. Validator engine (only for validator role)
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
@@ -82,26 +89,29 @@ impl PydeNode {
             );
 
             // Check stake if state is available (non-genesis)
-            if !state.is_empty() {
-                let balance_key = pyde_state::keys::balance_key(&identity.address);
-                let balance = state.get(&balance_key)
-                    .map(|b| {
-                        if b.len() >= 16 {
-                            let mut buf = [0u8; 16];
-                            buf.copy_from_slice(&b[..16]);
-                            u128::from_le_bytes(buf)
-                        } else {
-                            0u128
-                        }
-                    })
-                    .unwrap_or(0);
+            {
+                let state_guard = state.read().await;
+                if !state_guard.is_empty() {
+                    let balance_key = pyde_state::keys::balance_key(&identity.address);
+                    let balance = state_guard.get(&balance_key)
+                        .map(|b| {
+                            if b.len() >= 16 {
+                                let mut buf = [0u8; 16];
+                                buf.copy_from_slice(&b[..16]);
+                                u128::from_le_bytes(buf)
+                            } else {
+                                0u128
+                            }
+                        })
+                        .unwrap_or(0);
 
-                verify_stake(balance).map_err(|e| {
-                    format!("cannot start as validator: {}", e)
-                })?;
-                info!(balance, "validator stake verified");
-            } else {
-                warn!("state is empty (genesis) — stake verification deferred until chain syncs");
+                    verify_stake(balance).map_err(|e| {
+                        format!("cannot start as validator: {}", e)
+                    })?;
+                    info!(balance, "validator stake verified");
+                } else {
+                    warn!("state is empty (genesis) — stake verification deferred until chain syncs");
+                }
             }
 
             let mut engine = ValidatorEngine::new([0u8; 32]);
@@ -153,6 +163,23 @@ impl PydeNode {
             }
         }
 
+        // 10. Start RPC server if enabled
+        if self.config.rpc.enabled {
+            let rpc_state = Arc::new(RpcState {
+                chain: chain.clone(),
+                state: state.clone(),
+            });
+            match rpc::start_rpc_server(
+                &self.config.rpc.listen,
+                self.config.rpc.port,
+                rpc_state,
+                self.config.node.chain_id,
+            ).await {
+                Ok(addr) => info!(%addr, "JSON-RPC server started"),
+                Err(e) => warn!("RPC server disabled: {}", e),
+            }
+        }
+
         info!(
             role = role_str,
             port = self.config.network.port,
@@ -170,14 +197,18 @@ impl PydeNode {
             tokio::select! {
                 event = swarm.select_next_some() => {
                     // Process event, collecting any actions that need the swarm
-                    let action = handle_swarm_event(
-                        event,
-                        &mut chain,
-                        &mut state,
-                        &mut tx_relay,
-                        &mut chain_sync,
-                        &mut validator_engine,
-                    );
+                    let action = {
+                        let mut chain_w = chain.write().await;
+                        let mut state_w = state.write().await;
+                        handle_swarm_event(
+                            event,
+                            &mut chain_w,
+                            &mut state_w,
+                            &mut tx_relay,
+                            &mut chain_sync,
+                            &mut validator_engine,
+                        )
+                    };
 
                     // Execute post-event actions that need swarm access
                     match action {
@@ -205,10 +236,11 @@ impl PydeNode {
                     crate::metrics::record_mempool(tx_relay.mempool_size());
                     let peer_count = swarm.connected_peers().count();
                     crate::metrics::record_peers(peer_count);
+                    let head = chain.read().await.head_slot;
                     debug!(
                         peers = peer_count,
                         mempool = tx_relay.mempool_size(),
-                        head = chain.head_slot,
+                        head,
                         syncing = chain_sync.is_syncing(),
                         behind = chain_sync.manager.slots_behind(),
                         "maintenance tick"
@@ -221,11 +253,14 @@ impl PydeNode {
             }
         }
 
-        info!(
-            head_slot = chain.head_slot,
-            state_root = hex::encode(chain.state_root),
-            "node stopped cleanly"
-        );
+        {
+            let chain_r = chain.read().await;
+            info!(
+                head_slot = chain_r.head_slot,
+                state_root = hex::encode(chain_r.state_root),
+                "node stopped cleanly"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1,0 +1,280 @@
+//! JSON-RPC server for Pyde node.
+//!
+//! Exposes chain state queries over HTTP.
+//! Methods follow a similar pattern to Ethereum's JSON-RPC but with Pyde-specific naming.
+
+use crate::chain::ChainState;
+use crate::state_manager::StateManager;
+use jsonrpsee::core::async_trait;
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::server::Server;
+use jsonrpsee::types::ErrorObjectOwned;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::info;
+
+/// Shared node state accessible by RPC handlers.
+pub struct RpcState {
+    pub chain: Arc<RwLock<ChainState>>,
+    pub state: Arc<RwLock<StateManager>>,
+}
+
+/// Define the Pyde JSON-RPC API.
+#[rpc(server)]
+pub trait PydeApi {
+    /// Get the balance of an address (hex-encoded, returns decimal string).
+    #[method(name = "pyde_getBalance")]
+    async fn get_balance(&self, address: String) -> Result<String, ErrorObjectOwned>;
+
+    /// Get the transaction count (nonce) of an address.
+    #[method(name = "pyde_getTransactionCount")]
+    async fn get_transaction_count(&self, address: String) -> Result<String, ErrorObjectOwned>;
+
+    /// Get the deployed code at an address (hex-encoded).
+    #[method(name = "pyde_getCode")]
+    async fn get_code(&self, address: String) -> Result<String, ErrorObjectOwned>;
+
+    /// Get a storage value at an address and slot index.
+    #[method(name = "pyde_getStorageAt")]
+    async fn get_storage_at(&self, address: String, slot: u64) -> Result<String, ErrorObjectOwned>;
+
+    /// Get the current base fee (gas price).
+    #[method(name = "pyde_gasPrice")]
+    async fn gas_price(&self) -> Result<String, ErrorObjectOwned>;
+
+    /// Get the chain ID.
+    #[method(name = "pyde_chainId")]
+    async fn chain_id(&self) -> Result<String, ErrorObjectOwned>;
+
+    /// Get the latest block number (slot).
+    #[method(name = "pyde_blockNumber")]
+    async fn block_number(&self) -> Result<String, ErrorObjectOwned>;
+
+    /// Get block info by slot number.
+    #[method(name = "pyde_getBlockByNumber")]
+    async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned>;
+
+    /// Get the state root at the chain tip.
+    #[method(name = "pyde_stateRoot")]
+    async fn state_root(&self) -> Result<String, ErrorObjectOwned>;
+
+    /// Get sync status.
+    #[method(name = "pyde_syncing")]
+    async fn syncing(&self) -> Result<serde_json::Value, ErrorObjectOwned>;
+}
+
+/// RPC server implementation.
+pub struct RpcServer {
+    pub state: Arc<RpcState>,
+    pub chain_id: u64,
+}
+
+#[async_trait]
+impl PydeApiServer for RpcServer {
+    async fn get_balance(&self, address: String) -> Result<String, ErrorObjectOwned> {
+        let addr = parse_address(&address)?;
+        let key = pyde_state::keys::balance_key(&addr);
+        let state = self.state.state.read().await;
+        let balance = state.get(&key)
+            .map(|b| decode_u128(&b))
+            .unwrap_or(0);
+        Ok(balance.to_string())
+    }
+
+    async fn get_transaction_count(&self, address: String) -> Result<String, ErrorObjectOwned> {
+        let addr = parse_address(&address)?;
+        let key = pyde_state::keys::nonce_key(&addr);
+        let state = self.state.state.read().await;
+        let nonce = state.get(&key)
+            .map(|b| decode_u64(&b))
+            .unwrap_or(0);
+        Ok(nonce.to_string())
+    }
+
+    async fn get_code(&self, address: String) -> Result<String, ErrorObjectOwned> {
+        let addr = parse_address(&address)?;
+        let key = pyde_state::keys::code_key(&addr);
+        let state = self.state.state.read().await;
+        let code = state.get(&key).unwrap_or_default();
+        Ok(format!("0x{}", hex::encode(&code)))
+    }
+
+    async fn get_storage_at(&self, address: String, slot: u64) -> Result<String, ErrorObjectOwned> {
+        let addr = parse_address(&address)?;
+        let key = pyde_state::keys::storage_slot_key(&addr, slot);
+        let state = self.state.state.read().await;
+        let value = state.get(&key).unwrap_or_default();
+        Ok(format!("0x{}", hex::encode(&value)))
+    }
+
+    async fn gas_price(&self) -> Result<String, ErrorObjectOwned> {
+        let chain = self.state.chain.read().await;
+        Ok(chain.base_fee.to_string())
+    }
+
+    async fn chain_id(&self) -> Result<String, ErrorObjectOwned> {
+        Ok(format!("0x{:x}", self.chain_id))
+    }
+
+    async fn block_number(&self) -> Result<String, ErrorObjectOwned> {
+        let chain = self.state.chain.read().await;
+        Ok(format!("0x{:x}", chain.head_slot))
+    }
+
+    async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned> {
+        let chain = self.state.chain.read().await;
+        match chain.header(slot) {
+            Some(header) => Ok(serde_json::json!({
+                "slot": header.slot,
+                "epoch": header.epoch,
+                "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
+                "stateRoot": format!("0x{}", hex::encode(header.state_root)),
+                "txRoot": format!("0x{}", hex::encode(header.tx_root)),
+                "timestamp": format!("0x{:x}", header.timestamp),
+                "proposer": format!("0x{}", hex::encode(header.proposer)),
+            })),
+            None => Err(ErrorObjectOwned::owned(
+                -32602,
+                format!("block not found at slot {}", slot),
+                None::<()>,
+            )),
+        }
+    }
+
+    async fn state_root(&self) -> Result<String, ErrorObjectOwned> {
+        let chain = self.state.chain.read().await;
+        Ok(format!("0x{}", hex::encode(chain.state_root)))
+    }
+
+    async fn syncing(&self) -> Result<serde_json::Value, ErrorObjectOwned> {
+        let chain = self.state.chain.read().await;
+        Ok(serde_json::json!({
+            "headSlot": chain.head_slot,
+            "epoch": chain.epoch,
+            "stateRoot": format!("0x{}", hex::encode(chain.state_root)),
+        }))
+    }
+}
+
+/// Start the JSON-RPC HTTP server.
+pub async fn start_rpc_server(
+    listen: &str,
+    port: u16,
+    rpc_state: Arc<RpcState>,
+    chain_id: u64,
+) -> Result<SocketAddr, String> {
+    let addr: SocketAddr = format!("{}:{}", listen, port)
+        .parse()
+        .map_err(|e| format!("invalid RPC address: {}", e))?;
+
+    let server = Server::builder()
+        .build(addr)
+        .await
+        .map_err(|e| format!("failed to start RPC server: {}", e))?;
+
+    let bound_addr = server.local_addr()
+        .map_err(|e| format!("failed to get RPC server address: {}", e))?;
+
+    let rpc = RpcServer {
+        state: rpc_state,
+        chain_id,
+    };
+
+    let handle = server.start(rpc.into_rpc());
+    // Keep the server running in the background
+    tokio::spawn(handle.stopped());
+
+    info!(%bound_addr, "JSON-RPC server started");
+    Ok(bound_addr)
+}
+
+/// Parse a hex address string to 32-byte address.
+fn parse_address(input: &str) -> Result<[u8; 32], ErrorObjectOwned> {
+    let hex_str = input.strip_prefix("0x").unwrap_or(input);
+    let bytes = hex::decode(hex_str).map_err(|e| {
+        ErrorObjectOwned::owned(-32602, format!("invalid address: {}", e), None::<()>)
+    })?;
+    if bytes.len() != 32 {
+        return Err(ErrorObjectOwned::owned(
+            -32602,
+            format!("address must be 32 bytes, got {}", bytes.len()),
+            None::<()>,
+        ));
+    }
+    let mut addr = [0u8; 32];
+    addr.copy_from_slice(&bytes);
+    Ok(addr)
+}
+
+/// Decode a u128 from LE bytes (balance).
+fn decode_u128(data: &[u8]) -> u128 {
+    if data.len() >= 16 {
+        let mut buf = [0u8; 16];
+        buf.copy_from_slice(&data[..16]);
+        u128::from_le_bytes(buf)
+    } else {
+        0
+    }
+}
+
+/// Decode a u64 from LE bytes (nonce).
+fn decode_u64(data: &[u8]) -> u64 {
+    if data.len() >= 8 {
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&data[..8]);
+        u64::from_le_bytes(buf)
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_address() {
+        let hex_addr = format!("0x{}", hex::encode([0xAA; 32]));
+        let addr = parse_address(&hex_addr).unwrap();
+        assert_eq!(addr, [0xAA; 32]);
+    }
+
+    #[test]
+    fn parse_address_no_prefix() {
+        let hex_addr = hex::encode([0xBB; 32]);
+        let addr = parse_address(&hex_addr).unwrap();
+        assert_eq!(addr, [0xBB; 32]);
+    }
+
+    #[test]
+    fn parse_invalid_address_length() {
+        let result = parse_address("0xdeadbeef");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_invalid_hex() {
+        let result = parse_address("0xnothex");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_u128_from_bytes() {
+        let val: u128 = 10_000_000_000_000;
+        let bytes = val.to_le_bytes();
+        assert_eq!(decode_u128(&bytes), val);
+    }
+
+    #[test]
+    fn decode_u128_short_returns_zero() {
+        assert_eq!(decode_u128(&[1, 2, 3]), 0);
+    }
+
+    #[test]
+    fn decode_u64_from_bytes() {
+        let val: u64 = 42;
+        let bytes = val.to_le_bytes();
+        assert_eq!(decode_u64(&bytes), val);
+    }
+}


### PR DESCRIPTION
## Summary
- JSON-RPC HTTP server via jsonrpsee on port 8545
- 10 endpoints: getBalance, getTransactionCount, getCode, getStorageAt, gasPrice, chainId, blockNumber, getBlockByNumber, stateRoot, syncing
- Chain/state shared via Arc<RwLock> for concurrent RPC + event loop access
- 7 new RPC tests, 39 total node tests, 1,609 workspace total

## Test plan
- [x] `cargo test -p pyde-node` — 39 tests pass
- [x] `cargo test --workspace` — 1,609 tests pass
- [x] `make run-full` starts with RPC server on 127.0.0.1:8545
- [x] `curl -X POST http://127.0.0.1:8545 -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"pyde_blockNumber","params":[],"id":1}'` returns result