### PR TITLE
feat: add slot clock and block production pipeline

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -8,6 +8,7 @@ mod node;
 mod shutdown;
 mod genesis;
 mod rpc;
+mod slot_clock;
 mod state_manager;
 mod sync;
 mod tx_relay;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3,10 +3,12 @@ use crate::chain::ChainState;
 use crate::config::NodeConfig;
 use crate::rpc::{self, RpcState};
 use crate::shutdown::ShutdownSignal;
+use crate::slot_clock::SlotClock;
 use crate::state_manager::StateManager;
 use crate::sync::ChainSync;
 use crate::tx_relay::TxRelay;
 use crate::validator::{ValidatorEngine, ValidatorIdentity, verify_stake};
+use crate::wire;
 use libp2p::futures::StreamExt;
 use libp2p::gossipsub;
 use libp2p::request_response;
@@ -99,7 +101,8 @@ impl PydeNode {
         let mut chain_sync = ChainSync::new();
         chain_sync.manager.local_tip = chain.read().await.head_slot;
 
-        // 5. Validator engine (only for validator role)
+        // 5. Validator engine + identity (only for validator role)
+        let mut validator_identity: Option<ValidatorIdentity> = None;
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
             // Load validator FALCON signing key (required for validator role)
             let identity = load_validator_identity(datadir)?;
@@ -134,8 +137,9 @@ impl PydeNode {
                 }
             }
 
-            let mut engine = ValidatorEngine::new([0u8; 32]);
+            let engine = ValidatorEngine::new([0u8; 32]);
             info!("validator consensus engine initialized");
+            validator_identity = Some(identity);
             Some(engine)
         } else {
             None
@@ -209,7 +213,12 @@ impl PydeNode {
         // --- Main event loop ---
         let mut shutdown_rx = self.shutdown.subscribe();
 
+        // Slot clock for block timing
+        let slot_clock = SlotClock::new(0); // genesis timestamp 0 = start now
+        let mut last_slot = slot_clock.current_slot();
+
         // Periodic timers
+        let mut slot_interval = tokio::time::interval(std::time::Duration::from_millis(100)); // check slot every 100ms
         let mut maintenance_interval = tokio::time::interval(std::time::Duration::from_secs(10));
         let mut sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
 
@@ -241,6 +250,52 @@ impl PydeNode {
                         }
                         PostEventAction::ContinueSync => {
                             chain_sync.request_next_batch(&mut swarm);
+                        }
+                    }
+                }
+                _ = slot_interval.tick() => {
+                    let current_slot = slot_clock.current_slot();
+                    if current_slot > last_slot {
+                        last_slot = current_slot;
+
+                        // New slot — validator block production
+                        if let Some(engine) = validator_engine.as_mut() {
+                            engine.advance_slot();
+
+                            if let Some(identity) = validator_identity.as_ref() {
+                                // Check if we're the proposer
+                                if let Some(candidate) = engine.check_proposer(identity) {
+                                    info!(
+                                        slot = current_slot,
+                                        score = candidate.score,
+                                        "selected as proposer — building block"
+                                    );
+
+                                    // Build block from mempool
+                                    let chain_r = chain.read().await;
+                                    let block = engine.build_proposal(
+                                        identity,
+                                        chain_r.state_root,
+                                        chain_r.state_root, // state_root = pre-state (unknown post until execution)
+                                        [0u8; 32],          // tx_root computed after tx selection
+                                        candidate.vrf_proof.as_bytes().to_vec(),
+                                        vec![],             // txs from mempool — wired when decryption flow is complete
+                                        pyde_tx::parallel::ExecutionSchedule { groups: vec![], total_txs: 0 },
+                                    );
+                                    drop(chain_r);
+
+                                    // Encode and broadcast via gossipsub
+                                    let block_bytes = wire::encode_block(&block);
+                                    let topic = pyde_net::node::topics::blocks();
+                                    if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, block_bytes) {
+                                        warn!(slot = current_slot, error = %e, "failed to publish block");
+                                    } else {
+                                        info!(slot = current_slot, "block proposal broadcast");
+                                    }
+                                }
+                            }
+
+                            debug!(slot = current_slot, "slot tick");
                         }
                     }
                 }
@@ -318,6 +373,24 @@ fn handle_swarm_event(
                 }
                 Some(Channel::Blocks) => {
                     debug!(bytes = message.data.len(), "received block gossip");
+                    // Decode and process the block
+                    match wire::decode_block(&message.data) {
+                        Ok(block) => {
+                            let slot = block.header.slot;
+                            match BlockProcessor::process_full_block(chain, state, &block) {
+                                Ok((tx_count, gas_used, _receipts)) => {
+                                    chain_sync.on_block_processed(slot);
+                                    info!(slot, tx_count, gas_used, "block received and processed");
+                                }
+                                Err(e) => {
+                                    debug!(slot, error = %e, "block rejected");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = e, "failed to decode block from gossip");
+                        }
+                    }
                 }
                 Some(Channel::Consensus) => {
                     if let Some(_engine) = validator_engine.as_mut() {

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -1,0 +1,117 @@
+//! Slot clock: tracks the current slot based on wall clock time.
+//!
+//! Slot 0 starts at genesis timestamp. Each slot is 400ms.
+//! The slot clock determines when to propose, vote, and advance.
+
+use pyde_consensus::block::BLOCK_TIME_MS;
+use std::time::{Duration, Instant};
+
+/// Slot clock anchored to genesis time.
+pub struct SlotClock {
+    /// When the chain started (genesis timestamp or node start for devnet).
+    genesis_instant: Instant,
+    /// Genesis Unix timestamp in ms (for absolute time reference).
+    genesis_timestamp_ms: u64,
+    /// Slot duration.
+    slot_duration: Duration,
+}
+
+impl SlotClock {
+    /// Create a new slot clock. If genesis_timestamp_ms is 0, use current time.
+    pub fn new(genesis_timestamp_ms: u64) -> Self {
+        let now_ms = current_time_ms();
+        let genesis_instant = if genesis_timestamp_ms == 0 || genesis_timestamp_ms >= now_ms {
+            // Genesis is now or in the future — start from current instant
+            Instant::now()
+        } else {
+            // Genesis was in the past — compute how far back
+            let elapsed_ms = now_ms - genesis_timestamp_ms;
+            Instant::now() - Duration::from_millis(elapsed_ms)
+        };
+
+        Self {
+            genesis_instant,
+            genesis_timestamp_ms: if genesis_timestamp_ms == 0 { now_ms } else { genesis_timestamp_ms },
+            slot_duration: Duration::from_millis(BLOCK_TIME_MS),
+        }
+    }
+
+    /// Current slot number based on elapsed time since genesis.
+    pub fn current_slot(&self) -> u64 {
+        let elapsed = self.genesis_instant.elapsed();
+        (elapsed.as_millis() as u64) / BLOCK_TIME_MS
+    }
+
+    /// Time remaining in the current slot.
+    pub fn time_remaining(&self) -> Duration {
+        let elapsed = self.genesis_instant.elapsed();
+        let elapsed_ms = elapsed.as_millis() as u64;
+        let slot_end_ms = (self.current_slot() + 1) * BLOCK_TIME_MS;
+        let remaining = slot_end_ms.saturating_sub(elapsed_ms);
+        Duration::from_millis(remaining)
+    }
+
+    /// Duration until a specific slot starts.
+    pub fn duration_until_slot(&self, slot: u64) -> Duration {
+        let slot_start_ms = slot * BLOCK_TIME_MS;
+        let elapsed_ms = self.genesis_instant.elapsed().as_millis() as u64;
+        if slot_start_ms > elapsed_ms {
+            Duration::from_millis(slot_start_ms - elapsed_ms)
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    /// Timestamp (Unix ms) for a given slot.
+    pub fn slot_timestamp(&self, slot: u64) -> u64 {
+        self.genesis_timestamp_ms + slot * BLOCK_TIME_MS
+    }
+
+    /// Slot duration.
+    pub fn slot_duration(&self) -> Duration {
+        self.slot_duration
+    }
+}
+
+fn current_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slot_starts_at_zero() {
+        let clock = SlotClock::new(0);
+        // Just created — should be at slot 0 or very early
+        assert!(clock.current_slot() <= 1);
+    }
+
+    #[test]
+    fn slot_advances_with_time() {
+        // Genesis was 2 seconds ago → should be at slot 5 (2000ms / 400ms)
+        let now_ms = current_time_ms();
+        let clock = SlotClock::new(now_ms - 2000);
+        let slot = clock.current_slot();
+        assert!(slot >= 4 && slot <= 6, "expected ~5, got {}", slot);
+    }
+
+    #[test]
+    fn time_remaining_is_bounded() {
+        let clock = SlotClock::new(0);
+        let remaining = clock.time_remaining();
+        assert!(remaining <= Duration::from_millis(BLOCK_TIME_MS));
+    }
+
+    #[test]
+    fn slot_timestamp_consistent() {
+        let genesis_ts = 1_000_000u64;
+        let clock = SlotClock::new(genesis_ts);
+        assert_eq!(clock.slot_timestamp(0), genesis_ts);
+        assert_eq!(clock.slot_timestamp(10), genesis_ts + 10 * BLOCK_TIME_MS);
+    }
+}


### PR DESCRIPTION
## Summary
- SlotClock: wall-clock-based slot tracking (400ms per slot)
- Slot timer in event loop (100ms poll, fires on slot boundary)
- Validator proposer check → build block → wire encode → gossipsub broadcast
- Gossipsub block reception: decode → process via BlockProcessor → advance chain
- Validator identity persisted for proposer VRF checks
- 59 total node tests (4 new slot clock tests)

## Test plan
- [x] `cargo test -p pyde-node` — 59 tests pass
- [x] `make run-validator` starts with slot ticks running
- [x] Block gossip handler decodes and processes incoming blocks