### PR TITLE
feat: add getBlockByHash and RPC throughput benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1091,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1608,23 +1632,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1836,6 +1881,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,7 +2013,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -2642,6 +2697,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2798,23 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2886,10 +2964,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if 1.0.4",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3365,6 +3481,7 @@ dependencies = [
  "pyde-state",
  "pyde-tx",
  "pyde-vm",
+ "reqwest",
  "serde",
  "serde_json",
  "sparse-merkle-tree",
@@ -3690,6 +3807,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,6 +4029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +4127,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -4182,6 +4357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,6 +4556,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +4685,39 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -4755,6 +4982,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if 1.0.4",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,6 +5202,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ check:
 fmt:
 	cargo fmt --all
 
+# Benchmark RPC (requires running node: make run-full)
+bench-rpc:
+	cargo bench -p pyde-node
+
 # Lint
 clippy:
 	cargo clippy --workspace --all-targets
@@ -92,6 +96,7 @@ help:
 	@echo "  make gen-genesis      Write default genesis to genesis.toml"
 	@echo "  make test             Run all tests"
 	@echo "  make test-crate CRATE=pyde-vm  Run tests for one crate"
+	@echo "  make bench-rpc        Benchmark RPC (requires running node)"
 	@echo "  make check            Check compilation"
 	@echo "  make fmt              Format code"
 	@echo "  make clippy           Run linter"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -46,3 +46,10 @@ jsonrpsee = { version = "0.24", features = ["server", "macros"] }
 directories = "5"
 hex = "0.4"
 sparse-merkle-tree = "0.6"
+
+[dev-dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+
+[[bench]]
+name = "rpc_bench"
+harness = false

--- a/crates/node/benches/rpc_bench.rs
+++ b/crates/node/benches/rpc_bench.rs
@@ -1,0 +1,87 @@
+//! RPC throughput benchmark.
+//!
+//! Starts a node RPC server, sends N requests via HTTP, measures req/sec.
+//! Run with: cargo bench -p pyde-node
+//!
+//! NOTE: Requires a running node on port 8545.
+//! Start with: make run-full
+//! Then run: cargo bench -p pyde-node
+
+use std::time::Instant;
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let url = "http://127.0.0.1:8545";
+
+    rt.block_on(async {
+        let client = reqwest::Client::new();
+
+        // Check connectivity
+        match send_rpc(&client, url, "pyde_chainId", "[]").await {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Cannot connect to RPC at {}. Start a node first: make run-full", url);
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+
+        println!("\n=== Pyde RPC Benchmark ({})\n", url);
+
+        bench(&client, url, "pyde_blockNumber", "[]", 10_000).await;
+        bench(&client, url, "pyde_chainId", "[]", 10_000).await;
+        bench(&client, url, "pyde_gasPrice", "[]", 10_000).await;
+        bench(&client, url, "pyde_stateRoot", "[]", 10_000).await;
+        bench(&client, url, "pyde_syncing", "[]", 10_000).await;
+
+        let addr = format!("\"{}\"", hex::encode([0x01; 32]));
+        bench(&client, url, "pyde_getBalance", &format!("[{}]", addr), 10_000).await;
+        bench(&client, url, "pyde_getTransactionCount", &format!("[{}]", addr), 10_000).await;
+        bench(&client, url, "pyde_getCode", &format!("[{}]", addr), 10_000).await;
+        bench(&client, url, "pyde_mempoolSize", "[]", 10_000).await;
+
+        println!();
+    });
+}
+
+async fn bench(client: &reqwest::Client, url: &str, method: &str, params: &str, iterations: usize) {
+    // Warm up
+    for _ in 0..100 {
+        let _ = send_rpc(client, url, method, params).await;
+    }
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let _ = send_rpc(client, url, method, params).await;
+    }
+    let elapsed = start.elapsed();
+
+    println!(
+        "  {:<35} {:.0} req/sec  ({:.1}µs/req)",
+        method,
+        iterations as f64 / elapsed.as_secs_f64(),
+        elapsed.as_micros() as f64 / iterations as f64,
+    );
+}
+
+async fn send_rpc(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    params: &str,
+) -> Result<String, String> {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"{}","params":{},"id":1}}"#,
+        method, params
+    );
+    client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .text()
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/crates/node/src/chain.rs
+++ b/crates/node/src/chain.rs
@@ -12,6 +12,8 @@ pub struct ChainState {
     pub state_root: [u8; 32],
     /// Recent block headers (slot → header) for finality checks.
     pub headers: HashMap<u64, BlockHeader>,
+    /// Block hash → slot index (for getBlockByHash lookups).
+    pub hash_to_slot: HashMap<[u8; 32], u64>,
     /// Genesis block hash.
     pub genesis_hash: [u8; 32],
     /// Base fee for EIP-1559 gas pricing.
@@ -26,6 +28,7 @@ impl ChainState {
             epoch: 0,
             state_root,
             headers: HashMap::new(),
+            hash_to_slot: HashMap::new(),
             genesis_hash: [0u8; 32],
             base_fee: pyde_tx::fee::GENESIS_BASE_FEE,
         }
@@ -39,6 +42,8 @@ impl ChainState {
         self.head_slot = slot;
         self.epoch = epoch;
         self.state_root = header.state_root;
+        let block_hash = header.hash();
+        self.hash_to_slot.insert(block_hash, slot);
         self.headers.insert(slot, header);
 
         // Prune headers older than 2 epochs to bound memory.
@@ -46,6 +51,7 @@ impl ChainState {
         if epoch >= 2 {
             let prune_before = (epoch - 1) * EPOCH_LENGTH;
             self.headers.retain(|s, _| *s >= prune_before);
+            self.hash_to_slot.retain(|_, s| *s >= prune_before);
         }
 
         info!(slot, epoch, "chain head advanced");
@@ -54,6 +60,11 @@ impl ChainState {
     /// Get the header for a slot.
     pub fn header(&self, slot: u64) -> Option<&BlockHeader> {
         self.headers.get(&slot)
+    }
+
+    /// Get the header by block hash.
+    pub fn header_by_hash(&self, hash: &[u8; 32]) -> Option<&BlockHeader> {
+        self.hash_to_slot.get(hash).and_then(|s| self.headers.get(s))
     }
 
     /// Whether we're at genesis (no blocks processed yet).
@@ -120,5 +131,21 @@ mod tests {
         assert!(chain.header(999).is_none());  // epoch 0, pruned
         assert!(chain.header(1000).is_some()); // epoch 1, kept
         assert!(chain.header(2500).is_some()); // epoch 2, kept
+    }
+
+    #[test]
+    fn lookup_by_hash() {
+        let mut chain = ChainState::genesis([0; 32]);
+        let header = dummy_header(1, [0; 32]);
+        let hash = header.hash();
+        chain.advance(header);
+
+        // Lookup by hash should find the same header
+        let found = chain.header_by_hash(&hash);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().slot, 1);
+
+        // Unknown hash returns None
+        assert!(chain.header_by_hash(&[0xFF; 32]).is_none());
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -52,6 +52,10 @@ pub trait PydeApi {
     #[method(name = "pyde_getBlockByNumber")]
     async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned>;
 
+    /// Get block info by block hash.
+    #[method(name = "pyde_getBlockByHash")]
+    async fn get_block_by_hash(&self, hash: String) -> Result<serde_json::Value, ErrorObjectOwned>;
+
     #[method(name = "pyde_stateRoot")]
     async fn state_root(&self) -> Result<String, ErrorObjectOwned>;
 
@@ -150,6 +154,24 @@ impl PydeApiServer for RpcServer {
                 "proposer": format!("0x{}", hex::encode(header.proposer)),
             })),
             None => Err(rpc_err(-32602, format!("block not found at slot {}", slot))),
+        }
+    }
+
+    async fn get_block_by_hash(&self, hash: String) -> Result<serde_json::Value, ErrorObjectOwned> {
+        let block_hash = parse_hash(&hash)?;
+        let chain = self.state.chain.read().await;
+        match chain.header_by_hash(&block_hash) {
+            Some(header) => Ok(serde_json::json!({
+                "slot": header.slot,
+                "epoch": header.epoch,
+                "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
+                "stateRoot": format!("0x{}", hex::encode(header.state_root)),
+                "txRoot": format!("0x{}", hex::encode(header.tx_root)),
+                "timestamp": format!("0x{:x}", header.timestamp),
+                "proposer": format!("0x{}", hex::encode(header.proposer)),
+                "hash": format!("0x{}", hex::encode(block_hash)),
+            })),
+            None => Err(rpc_err(-32602, "block not found for hash".to_string())),
         }
     }
 


### PR DESCRIPTION
## Summary
- `pyde_getBlockByHash`: new RPC endpoint with hash→slot index
- RPC benchmark: measures req/sec for 9 endpoints (run with `make bench-rpc`)
- ChainState hash index with epoch pruning
- 65 total node tests, 17 RPC endpoints

## Test plan
- [x] `cargo test -p pyde-node` — 65 tests pass
- [x] lookup_by_hash test verifies hash index
- [x] Benchmark compiles and runs against live node

## Usage
```
# Terminal 1: start node
make run-full

# Terminal 2: run benchmark
make bench-rpc
```