### PR TITLE
fix: contract storage persistence — full compile→deploy→call pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,11 +3508,13 @@ dependencies = [
 name = "pyde-tx"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "pyde-account",
  "pyde-crypto",
  "pyde-state",
  "pyde-vm",
  "sparse-merkle-tree",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -353,12 +353,25 @@ impl PydeApiServer for RpcServer {
 
         // Load contract storage from SMT (read-only, slots 0..64)
         // Use the VM's key derivation: poseidon2(slot_bytes ++ contract_address)
+        // Load contract storage keys from manifest, then load values.
         let state = self.state.state.read().await;
-        for slot in 0u64..64 {
-            let vm_key = vm.derive_storage_key(ethnum::U256::from(slot));
-            let smt_key = sparse_merkle_tree::H256::from(vm_key.to_le_bytes());
-            if let Some(value_bytes) = state.get(&smt_key) {
-                vm.storage.insert(vm_key, value_bytes);
+        let mut manifest_input = Vec::with_capacity(44);
+        manifest_input.extend_from_slice(b"storage_keys");
+        manifest_input.extend_from_slice(&to);
+        let manifest_key = sparse_merkle_tree::H256::from(
+            pyde_crypto::poseidon2::poseidon2_hash(&manifest_input).to_bytes()
+        );
+        if let Some(key_list) = state.get(&manifest_key) {
+            for chunk in key_list.chunks(32) {
+                if chunk.len() == 32 {
+                    let mut key_bytes = [0u8; 32];
+                    key_bytes.copy_from_slice(chunk);
+                    let vm_key = ethnum::U256::from_le_bytes(key_bytes);
+                    let smt_key = sparse_merkle_tree::H256::from(key_bytes);
+                    if let Some(value_bytes) = state.get(&smt_key) {
+                        vm.storage.insert(vm_key, value_bytes);
+                    }
+                }
             }
         }
         drop(state);
@@ -371,8 +384,8 @@ impl PydeApiServer for RpcServer {
         let success = output.outcome == pyde_vm::vm::Outcome::Success;
 
         if success {
-            // Return value is in r0 (PVM convention for function return)
-            let return_value = vm.cpu.read_gp(0);
+            // Return value is in r1 (PVM codegen convention for function return)
+            let return_value = vm.cpu.read_gp(1);
             Ok(format!("0x{:x}", return_value))
         } else {
             Err(rpc_err(-32000, format!("execution failed: {:?}", output.outcome)))

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -2648,6 +2648,42 @@ mod tests {
         assert_eq!(vm.cpu.read_gp(1), 42, "add(10, 32) via dispatch should be 42");
     }
 
+    #[test]
+    fn pvm_storage_increment_persists() {
+        // Verify that increment() actually writes to vm.storage
+        let (tokens, _) = Lexer::new(r#"
+            contract Counter {
+                storage { count: u64 }
+                pub fn increment() { self.count = self.count + 1; }
+                pub fn get_count() -> u64 { return self.count; }
+            }
+        "#).tokenize();
+        let (file, _) = Parser::new(tokens).parse();
+        let ir = lower::lower(&file);
+        let mut codegen = CodeGen::new();
+        codegen.emit_guards = true;
+        let compiled = codegen.generate(&ir);
+
+        // Run increment()
+        let selector = compute_selector("increment");
+        let calldata = selector.to_be_bytes().to_vec();
+
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(500_000);
+        vm.calldata = calldata;
+        vm.load(&compiled.runtime_bytecode).unwrap();
+        let output = vm.execute();
+
+        println!("outcome: {:?}", output.outcome);
+        println!("gas: {}", output.gas_used);
+        println!("storage entries: {}", vm.storage.len());
+        for (k, v) in &vm.storage {
+            println!("  key={} value_bytes={:?}", k, &v[..v.len().min(16)]);
+        }
+
+        assert_eq!(output.outcome, pyde_vm::vm::Outcome::Success, "increment should succeed");
+        assert!(vm.storage.len() > 0, "vm.storage should have entries after Sstore");
+    }
+
     // ========================================================================
     // Wide storage u256 (PVM-verified)
     // ========================================================================

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -9,3 +9,5 @@ pyde-account = { path = "../account" }
 pyde-vm = { path = "../pvm" }
 pyde-state = { path = "../state" }
 sparse-merkle-tree = "0.6"
+tracing = "0.1"
+hex = "0.4"

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -167,11 +167,12 @@ pub fn execute_transaction(
             // Contract call
             match load_code(smt, &tx.to) {
                 Some(code) => {
+                    tracing::debug!(to = hex::encode(tx.to), code_len = code.len(), "executing contract call in PVM");
                     let result = execute_in_pvm(tx, &sender, &code, smt, block_ctx);
                     result
                 }
                 None => {
-                    // Simple transfer (no code at recipient)
+                    tracing::debug!(to = hex::encode(tx.to), "simple transfer (no code at recipient)");
                     (true, 21_000u64, 0u64, vec![])
                 }
             }
@@ -273,15 +274,23 @@ fn execute_in_pvm(
     let mut vm = Vm::with_gas_limit_and_context(tx.gas_limit, ctx);
     vm.calldata = tx.data.clone();
 
-    // Load contract storage from SMT into VM.
-    // The VM derives storage keys as: poseidon2(slot_bytes ++ contract_address)
-    // We scan slots 0..64 using the same derivation.
+    // Load contract storage from SMT into VM using the storage manifest.
     let contract_addr = tx.to;
-    for slot in 0u64..64 {
-        let vm_key = vm.derive_storage_key(U256::from(slot));
-        let smt_key = H256::from(vm_key.to_le_bytes());
-        if let Some(value_bytes) = smt.get(&smt_key) {
-            vm.storage.insert(vm_key, value_bytes);
+    let mut manifest_input = Vec::with_capacity(44);
+    manifest_input.extend_from_slice(b"storage_keys");
+    manifest_input.extend_from_slice(&contract_addr);
+    let manifest_key = H256::from(pyde_crypto::poseidon2::poseidon2_hash(&manifest_input).to_bytes());
+    if let Some(key_list) = smt.get(&manifest_key) {
+        for chunk in key_list.chunks(32) {
+            if chunk.len() == 32 {
+                let mut key_bytes = [0u8; 32];
+                key_bytes.copy_from_slice(chunk);
+                let vm_key = U256::from_le_bytes(key_bytes);
+                let smt_key = H256::from(key_bytes);
+                if let Some(value_bytes) = smt.get(&smt_key) {
+                    vm.storage.insert(vm_key, value_bytes);
+                }
+            }
         }
     }
 
@@ -292,12 +301,32 @@ fn execute_in_pvm(
     let output = vm.execute();
     let success = output.outcome == Outcome::Success;
 
+    tracing::debug!(
+        success,
+        gas = output.gas_used,
+        storage_entries = vm.storage.len(),
+        "execute_in_pvm completed"
+    );
+
     // Persist VM storage changes back to SMT.
     // Use the derived key directly (same as what the VM uses internally).
     if success && !vm.storage.is_empty() {
+        let mut key_list: Vec<u8> = Vec::new();
         for (vm_key, value_bytes) in &vm.storage {
-            let smt_key = H256::from(vm_key.to_le_bytes());
-            let _ = smt.insert(smt_key, value_bytes.clone());
+            let key_bytes = vm_key.to_le_bytes();
+            let smt_key = H256::from(key_bytes);
+            if let Err(e) = smt.insert(smt_key, value_bytes.clone()) {
+                tracing::warn!(error = e, "failed to persist storage entry");
+            }
+            key_list.extend_from_slice(&key_bytes);
+        }
+        // Storage manifest: list of all VM storage keys for this contract
+        let mut manifest_input = Vec::with_capacity(44);
+        manifest_input.extend_from_slice(b"storage_keys");
+        manifest_input.extend_from_slice(&contract_addr);
+        let manifest_key = H256::from(pyde_crypto::poseidon2::poseidon2_hash(&manifest_input).to_bytes());
+        if let Err(e) = smt.insert(manifest_key, key_list) {
+            tracing::warn!(error = e, "failed to persist storage manifest");
         }
     }
 


### PR DESCRIPTION
## Summary
- Storage manifest: pipeline writes per-contract key list to SMT after execution
- Storage pre-load: pipeline and pyde_call read manifest to load VM storage
- Return register: pyde_call reads r1 (codegen convention), not r0
- New test: pvm_storage_increment_persists

## End-to-End Verified
```
deploy Counter → increment() x3 → get_count() returns 0x3
```

## Root Causes Found
1. Return value was read from r0 instead of r1 (codegen uses r1 for returns)
2. Storage keys are poseidon2-derived hashes — scanning slots 0..63 doesn't find them
3. Fix: storage manifest tracks exact VM keys per contract for deterministic load

## Test plan
- [x] cargo test (otic 342, node 72, tx 92 — all pass)
- [x] Counter contract: deploy → increment x3 → get_count = 3