### PR TITLE
feat: lazy storage backend + contract address fix

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -297,9 +297,19 @@ impl PydeApiServer for RpcServer {
         let tx_bytes = crate::wire::encode_transaction(&tx);
         let tx_hash = pyde_crypto::poseidon2::poseidon2_hash(&tx_bytes).to_bytes();
 
-        // For deploy txs, compute the contract address
+        // For deploy txs, compute the contract address.
+        // Use Account.nonce (always 0 in devnet since pipeline doesn't increment Account.nonce).
+        // This matches what the pipeline uses: derive_create_address(&from, sender.nonce).
         let contract_address = if tx_type == pyde_tx::types::TransactionType::Deploy {
-            let addr = pyde_account::address::derive_create_address(&from, nonce);
+            // Read the account nonce from state (matches pipeline's sender.nonce)
+            let state = self.state.state.read().await;
+            let balance_key = pyde_state::keys::balance_key(&from);
+            let account_nonce = state.get(&balance_key)
+                .and_then(|b| pyde_account::types::Account::from_bytes(&b))
+                .map(|a| a.nonce)
+                .unwrap_or(0);
+            drop(state);
+            let addr = pyde_account::address::derive_create_address(&from, account_nonce);
             Some(format!("0x{}", hex::encode(addr)))
         } else {
             None
@@ -356,12 +366,11 @@ impl PydeApiServer for RpcServer {
         let gas_limit: u64 = call_obj.get("gas").and_then(|v| v.as_u64())
             .unwrap_or(1_000_000);
 
-        // Load contract code
+        // Load contract code and keep state alive for lazy storage loading
         let state = self.state.state.read().await;
         let code_key = pyde_state::keys::code_key(&to);
         let code = state.get(&code_key)
             .ok_or_else(|| rpc_err(-32000, "no code at address".into()))?;
-        drop(state);
 
         // Run PVM directly — no validation, no nonce/balance checks
         let ctx = pyde_vm::vm::ExecutionContext {
@@ -384,8 +393,7 @@ impl PydeApiServer for RpcServer {
 
         // Load contract storage from SMT (read-only, slots 0..64)
         // Use the VM's key derivation: poseidon2(slot_bytes ++ contract_address)
-        // Load contract storage keys from manifest, then load values.
-        let state = self.state.state.read().await;
+        // Pre-load storage from manifest (known keys from previous writes)
         let mut manifest_input = Vec::with_capacity(44);
         manifest_input.extend_from_slice(b"storage_keys");
         manifest_input.extend_from_slice(&to);

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -214,6 +214,9 @@ pub struct Vm {
     pub ctx: ExecutionContext,
     /// Key-value storage overlay (derived_key → variable-length bytes).
     pub storage: HashMap<U256, Vec<u8>>,
+    /// Optional storage backend for lazy loading (e.g., from SMT).
+    /// Called when Sload encounters a key not in the overlay.
+    pub storage_backend: Option<Box<dyn Fn(&U256) -> Option<Vec<u8>>>>,
 
     // --- Cold: accessed infrequently ---
     /// Internal call stack for CALL/RET within a contract.
@@ -267,6 +270,7 @@ impl Vm {
             gas_refund: 0,
             ctx: ExecutionContext::default(),
             storage: HashMap::new(),
+            storage_backend: None,
             logs: Vec::new(),
             storage_journal: Vec::new(),
             storage_journal_keys: std::collections::HashSet::new(),
@@ -688,12 +692,32 @@ impl Vm {
                         return Err(Trap::OutOfGas);
                     }
                 }
+                // Lazy storage load: check overlay first, then backend
+                let storage_value = self.storage.get(&key).cloned().or_else(|| {
+                    if let Some(ref backend) = self.storage_backend {
+                        let val = backend(&key);
+                        // Cache in overlay for future reads
+                        if let Some(ref v) = val {
+                            // Can't borrow self.storage mutably here, cache after match
+                        }
+                        val
+                    } else {
+                        None
+                    }
+                });
+                // Cache backend result in overlay
+                if !self.storage.contains_key(&key) {
+                    if let Some(ref val) = storage_value {
+                        self.storage.insert(key, val.clone());
+                    }
+                }
+
                 let mode = d.rs2_or_imm & 0x3;
                 match mode {
                     0 => {
                         // Wide register mode: sload wd, ws1
                         let mut buf = [0u8; 32];
-                        if let Some(data) = self.storage.get(&key) {
+                        if let Some(data) = storage_value.as_ref() {
                             let len = data.len().min(32);
                             buf[..len].copy_from_slice(&data[..len]);
                         }
@@ -703,8 +727,7 @@ impl Vm {
                         // Memory mode: sloadb rd_len, ws1, rs_ptr
                         let ptr_reg = ((d.rs2_or_imm >> 2) & 0xF) as u8;
                         let ptr = self.cpu.read_gp(ptr_reg) as u32;
-                        if let Some(data) = self.storage.get(&key) {
-                            // Dynamic gas: 3 per 8 bytes of data read from storage
+                        if let Some(data) = storage_value.as_ref() {
                             let dynamic_gas = ((data.len() as u64 + 7) / 8) * 3;
                             self.gas_used_total += dynamic_gas;
                             if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
@@ -721,7 +744,7 @@ impl Vm {
                     2 => {
                         // GP register mode: sloadg rd, ws1
                         let mut buf = [0u8; 8];
-                        if let Some(data) = self.storage.get(&key) {
+                        if let Some(data) = storage_value.as_ref() {
                             let len = data.len().min(8);
                             buf[..len].copy_from_slice(&data[..len]);
                         }


### PR DESCRIPTION
## Summary
- PVM: optional storage_backend for lazy Sload from external state
- Sload: overlay → backend → cache pattern
- RPC: contract address uses Account.nonce (matches pipeline)
- Counter: deploy → increment → get_count = 1,2,3 ✅
- Token: constructor executes (gas=7878) ✅

## Known Issue
- Token total_supply/balance_of return 0 after constructor
- Root cause: manifest key mismatch between constructor write and pyde_call read
- Counter works because it uses simple slot storage, not maps

## Test plan
- [x] All tests pass (node 72, tx 92, vm 318)