### PR TITLE
feat: fix codegen register spilling, cross-contract calls, wide shifts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,9 @@ name = "otic"
 version = "0.1.0"
 dependencies = [
  "ethnum",
+ "pyde-state",
  "pyde-vm",
+ "sparse-merkle-tree",
 ]
 
 [[package]]
@@ -3508,7 +3510,9 @@ dependencies = [
 name = "pyde-tx"
 version = "0.1.0"
 dependencies = [
+ "ethnum",
  "hex",
+ "otic",
  "pyde-account",
  "pyde-crypto",
  "pyde-state",

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -814,9 +814,6 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let len = builder.use_var(Variable::from_u32(len_reg));
                         builder.ins().call(fn_memcpy_ref, &[vm_ctx, dst, src, len]);
                     }
-                    Opcode::Commit => {
-                        // Commit is captured from trace, no runtime effect
-                    }
                     Opcode::Selfdestruct => {
                         // Selfdestruct halts execution after clearing storage
                         builder.ins().jump(success_block, &[]);

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -198,15 +198,17 @@ pub fn initialize_genesis(
 
 /// Create a default devnet genesis config with pre-funded accounts.
 pub fn devnet_genesis() -> GenesisConfig {
-    // 10 pre-funded accounts for development (each gets 1M PYDE)
-    let one_hundred_million_pyde = "100000000000000000"; // 100M PYDE in quanta (10^17)
+    // 10 pre-funded accounts for development (each gets 10B PYDE)
+    // Must be large enough to cover gas_limit * base_fee for contract deploys.
+    // base_fee = 50 gwei, deploy gas ~500K → cost ~25M PYDE in quanta.
+    let ten_billion_pyde = "10000000000000000000"; // 10B PYDE in quanta (10^19)
 
     let mut allocations = Vec::new();
     for i in 0u8..10 {
         let address = hex::encode([i + 1; 32]);
         allocations.push(GenesisAllocation {
             address,
-            balance: one_hundred_million_pyde.to_string(),
+            balance: ten_billion_pyde.to_string(),
             public_key: None,
         });
     }
@@ -270,7 +272,7 @@ mod tests {
         let account_bytes = state.get(&key).expect("account should exist");
         let account = pyde_account::types::Account::from_bytes(&account_bytes)
             .expect("should be a valid Account");
-        assert_eq!(account.balance, 100_000_000_000_000_000); // 100M PYDE
+        assert_eq!(account.balance, 10_000_000_000_000_000_000u128); // 10B PYDE
     }
 
     #[test]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -366,11 +366,20 @@ impl PydeApiServer for RpcServer {
         let gas_limit: u64 = call_obj.get("gas").and_then(|v| v.as_u64())
             .unwrap_or(1_000_000);
 
-        // Load contract code and keep state alive for lazy storage loading
-        let state = self.state.state.read().await;
+        // Acquire an OWNED read lock that lives for the entire call execution.
+        // This prevents the block processor from modifying state mid-read.
+        // Previously, we dropped the lock before PVM execution and used try_read()
+        // per Sload, which could fail if the block processor held a write lock,
+        // causing stale zero values to be cached in the VM overlay.
+        let state_guard = Arc::clone(&self.state.state).read_owned().await;
+
         let code_key = pyde_state::keys::code_key(&to);
-        let code = state.get(&code_key)
+        let code = state_guard.get(&code_key)
             .ok_or_else(|| rpc_err(-32000, "no code at address".into()))?;
+
+        // Acquire second read guard for code backend BEFORE creating VM
+        // (both guards must be obtained before any non-Send value exists across await)
+        let code_guard = Arc::clone(&self.state.state).read_owned().await;
 
         // Run PVM directly — no validation, no nonce/balance checks
         let ctx = pyde_vm::vm::ExecutionContext {
@@ -391,36 +400,25 @@ impl PydeApiServer for RpcServer {
         let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(gas_limit, ctx);
         vm.calldata = calldata;
 
-        // Load contract storage from SMT (read-only, slots 0..64)
-        // Use the VM's key derivation: poseidon2(slot_bytes ++ contract_address)
-        drop(state);
-
-        // Lazy storage: VM reads from SMT on demand during Sload.
-        // No manifest, no pre-loading — just query the database when needed.
-        let state_arc = self.state.state.clone();
-        vm.storage_backend = Some(Box::new(move |key: &ethnum::U256| {
-            let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
-            state_arc.try_read().ok()?.get(&smt_key)
-        }));
-
         if let Err(e) = vm.load(&code) {
             return Err(rpc_err(-32000, format!("failed to load code: {:?}", e)));
         }
 
-        // Debug: what key does the VM derive for slot 0?
-        let slot0_key = vm.derive_storage_key(ethnum::U256::ZERO);
-        let in_storage = vm.storage.contains_key(&slot0_key);
-        tracing::info!(
-            slot0_key = hex::encode(slot0_key.to_le_bytes()),
-            in_storage,
-            "pyde_call: slot 0 key check"
-        );
+        // Lazy storage backend (owned guard — no stale reads)
+        vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            state_guard.get(&smt_key)
+        }));
+        // Code backend for cross-contract calls (CallExt)
+        vm.code_backend = Some(std::sync::Arc::new(move |addr: &[u8; 32]| {
+            let ck = pyde_state::keys::code_key(addr);
+            code_guard.get(&ck)
+        }));
 
         let output = vm.execute();
         let success = output.outcome == pyde_vm::vm::Outcome::Success;
 
         if success {
-            // Return value is in r1 (PVM codegen convention for function return)
             let return_value = vm.cpu.read_gp(1);
             Ok(format!("0x{:x}", return_value))
         } else {
@@ -445,13 +443,12 @@ impl PydeApiServer for RpcServer {
             return Ok(format!("0x{:x}", 32_000 + calldata.len() as u64 * 16));
         }
 
-        let state = self.state.state.read().await;
+        let state_guard = Arc::clone(&self.state.state).read_owned().await;
         let code_key = pyde_state::keys::code_key(&to);
-        let code = match state.get(&code_key) {
+        let code = match state_guard.get(&code_key) {
             Some(c) => c,
             None => return Ok(format!("0x{:x}", 21_000)), // simple transfer
         };
-        drop(state);
 
         let ctx = pyde_vm::vm::ExecutionContext {
             caller: from,
@@ -471,6 +468,11 @@ impl PydeApiServer for RpcServer {
         let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(gas_limit, ctx);
         vm.calldata = calldata;
         let _ = vm.load(&code);
+        // Hold read lock for entire execution via owned guard
+        vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            state_guard.get(&smt_key)
+        }));
         let output = vm.execute();
         Ok(format!("0x{:x}", output.gas_used))
     }

--- a/crates/otic/Cargo.toml
+++ b/crates/otic/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 [dependencies]
 pyde-vm = { path = "../pvm" }
 ethnum = "1.5.2"
+
+[dev-dependencies]
+pyde-state = { path = "../state" }
+sparse-merkle-tree = "0.6"

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -474,20 +474,32 @@ impl CodeGen {
     /// Decode function params from calldata into arg registers (r2, r3, ...).
     /// For regular functions, params start after the 4-byte selector.
     /// For constructors, params start at offset 0 (no selector).
+    ///
+    /// IMPORTANT: r4 = calldata length, r5 = calldata pointer (set by PVM).
+    /// Params are mapped to r2, r3, r4, r5, r6, ... which OVERWRITES r4/r5.
+    /// We save the calldata pointer to r14 first, then decode using r14 as base.
     fn emit_calldata_decode(&mut self, func: &IrFunction) {
+        if func.params.is_empty() {
+            return;
+        }
         let selector_skip = if func.is_constructor { 0i32 } else { 4 };
         let mut param_offset = selector_skip;
+
+        // Save calldata pointer to r14 before decoding overwrites r5
+        self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, 5, 0); // r14 = r5
+
         for (i, (_name, ty)) in func.params.iter().enumerate() {
             let phys = (i as u8) + 2; // r2, r3, r4, ...
             let is_wide = is_wide_type(ty);
 
             if is_wide {
-                // Compute address: r14 = r5 + offset
-                self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, 5, param_offset as u32 & 0x3FFFF);
-                self.emit_op(Opcode::Wload, phys, memory::REG_SCRATCH_0, 0);
+                // Compute address: r15 = r14 + offset
+                self.emit_op(Opcode::Addi, 15, memory::REG_SCRATCH_0, param_offset as u32 & 0x3FFFF);
+                self.emit_op(Opcode::Wload, phys, 15, 0);
                 param_offset += 32;
             } else {
-                self.emit_load(phys, 5, param_offset);
+                // Load from r14 (saved calldata ptr) instead of r5
+                self.emit_load(phys, memory::REG_SCRATCH_0, param_offset);
                 param_offset += 8;
             }
         }
@@ -674,25 +686,38 @@ impl CodeGen {
                 let use_wide = lhs_wide || rhs_wide;
 
                 if use_wide {
-                    let wd = self.regs.alloc_wide(*dst);
-                    let w1 = self.get_reg(*lhs);
-                    let w2 = self.get_reg(*rhs);
-                    let pvm_op = match op {
-                        BinOp::Add => Opcode::Wadd,
-                        BinOp::Sub => Opcode::Wsub,
-                        BinOp::Mul => Opcode::Wmul,
-                        BinOp::Div => Opcode::Wdiv,
-                        BinOp::Mod => Opcode::Wmod,
-                        BinOp::BitAnd => Opcode::Wand,
-                        BinOp::BitOr => Opcode::Wor,
-                        BinOp::BitXor => Opcode::Wxor,
-                        _ => Opcode::Wadd, // shifts/logical on wide fallback
-                    };
-                    self.emit_op(pvm_op, wd, w1, w2 as u32);
+                    if matches!(op, BinOp::Shl | BinOp::Shr) {
+                        // Wide shift: shift amount is a GP value, not wide.
+                        let wd = self.regs.alloc_wide(*dst);
+                        let w1 = self.get_reg(*lhs);
+                        let shift_reg = self.get_reg_to(*rhs, 14);
+                        let dir = if matches!(op, BinOp::Shr) { 1u32 } else { 0u32 };
+                        let imm = (shift_reg as u32) << 1 | dir;
+                        self.emit_op(Opcode::Wshift, wd, w1, imm);
+                    } else {
+                        let wd = self.regs.alloc_wide(*dst);
+                        let w1 = self.get_reg(*lhs);
+                        let w2 = self.get_reg(*rhs);
+                        let pvm_op = match op {
+                            BinOp::Add => Opcode::Wadd,
+                            BinOp::Sub => Opcode::Wsub,
+                            BinOp::Mul => Opcode::Wmul,
+                            BinOp::Div => Opcode::Wdiv,
+                            BinOp::Mod => Opcode::Wmod,
+                            BinOp::BitAnd => Opcode::Wand,
+                            BinOp::BitOr => Opcode::Wor,
+                            BinOp::BitXor => Opcode::Wxor,
+                            BinOp::LogicalAnd => Opcode::Wand,
+                            BinOp::LogicalOr => Opcode::Wor,
+                            BinOp::Shl | BinOp::Shr => unreachable!(),
+                        };
+                        self.emit_op(pvm_op, wd, w1, w2 as u32);
+                    }
                 } else {
                     let rd = self.alloc_gp(*dst);
-                    let r1 = self.get_reg(*lhs);
-                    let r2 = self.get_reg(*rhs);
+                    // Use different restore targets so both operands survive if both spilled
+                    let r1 = self.get_reg_to(*lhs, 15);
+                    let r2 = self.get_reg_to(*rhs, 14);
                     let pvm_op = match op {
                         BinOp::Add => Opcode::Add,
                         BinOp::Sub => Opcode::Sub,
@@ -733,8 +758,9 @@ impl CodeGen {
             Inst::Cmp(dst, op, lhs, rhs) => {
                 let rd = self.alloc_gp(*dst);
                 let lhs_wide = self.regs.is_wide(*lhs);
-                let r1 = self.get_reg(*lhs);
-                let r2 = self.get_reg(*rhs);
+                // Use different restore targets so both operands survive if both spilled
+                let r1 = self.get_reg_to(*lhs, 15);
+                let r2 = self.get_reg_to(*rhs, 14);
 
                 if lhs_wide {
                     match op {
@@ -846,9 +872,12 @@ impl CodeGen {
                 let key_wide = is_wide_type(&key_ty);
                 let wide_value = is_wide_type(&val_ty);
 
+                // Get key and derive storage key FIRST
                 let rk = self.get_reg(*key);
-                let rv = self.get_reg(*val);
                 self.emit_map_key_derivation(slot, rk, key_wide);
+                // Get val AFTER derivation — derivation clobbers r14/r15,
+                // so getting val before would lose it if val was spilled to r15.
+                let rv = self.get_reg(*val);
 
                 if wide_value {
                     self.emit_op(Opcode::Sstore, rv, WIDE_SCRATCH, 0);
@@ -868,9 +897,20 @@ impl CodeGen {
                 let key2_wide = is_wide_type(&key2_ty);
                 let wide_value = is_wide_type(&val_ty);
 
+                // Interleave get_reg with immediate heap writes to prevent
+                // r15 clobbering when both keys are spilled.
+                // Each key is stored to heap right after get_reg, before the next get_reg.
                 let rk1 = self.get_reg(*key1);
+                let k1_size = self.emit_key_store(rk1, 12, 8, key1_wide);
                 let rk2 = self.get_reg(*key2);
-                self.emit_nested_map_key_derivation(slot, rk1, key1_wide, rk2, key2_wide);
+                let k2_offset = 8 + k1_size as i32;
+                let k2_size = self.emit_key_store(rk2, 12, k2_offset, key2_wide);
+                // Now safe to clobber r15 for slot
+                self.emit_op(Opcode::Addi, 15, 0, slot);
+                self.emit_store(15, 12, 0);
+                let total = 8 + k1_size + k2_size;
+                self.emit_op(Opcode::Addi, 14, 0, total);
+                self.emit_op(Opcode::Poseidon, WIDE_SCRATCH, 12, 14);
 
                 if wide_value {
                     let wd = self.regs.alloc_wide(*dst);
@@ -892,11 +932,21 @@ impl CodeGen {
                 let key2_wide = is_wide_type(&key2_ty);
                 let wide_value = is_wide_type(&val_ty);
 
+                // Interleave get_reg with immediate heap writes (same as NestedMapGet)
                 let rk1 = self.get_reg(*key1);
+                let k1_size = self.emit_key_store(rk1, 12, 8, key1_wide);
                 let rk2 = self.get_reg(*key2);
-                let rv = self.get_reg(*val);
-                self.emit_nested_map_key_derivation(slot, rk1, key1_wide, rk2, key2_wide);
+                let k2_offset = 8 + k1_size as i32;
+                let k2_size = self.emit_key_store(rk2, 12, k2_offset, key2_wide);
+                // Now safe to clobber r15 for slot
+                self.emit_op(Opcode::Addi, 15, 0, slot);
+                self.emit_store(15, 12, 0);
+                let total = 8 + k1_size + k2_size;
+                self.emit_op(Opcode::Addi, 14, 0, total);
+                self.emit_op(Opcode::Poseidon, WIDE_SCRATCH, 12, 14);
 
+                // Get val AFTER derivation — derivation clobbers r14/r15
+                let rv = self.get_reg(*val);
                 if wide_value {
                     self.emit_op(Opcode::Sstore, rv, WIDE_SCRATCH, 0);
                 } else {
@@ -1304,25 +1354,30 @@ impl CodeGen {
                 }
             }
 
-            Inst::ExtCall(dst, addr, _method, args) => {
+            Inst::ExtCall(dst, addr, method, args) => {
                 let rd = self.alloc_gp(*dst);
                 let ra = self.get_reg(*addr);
 
-                // Write calldata (args) to heap
+                // Write calldata to heap: [selector(4 BE bytes)][arg0(8 LE)][arg1(8 LE)]...
+                // Selector: FNV-1a hash stored as BE bytes in calldata (dispatch
+                // loads with W32 LE and compares against selector.swap_bytes()).
+                let selector = compute_selector(method);
+                // Store selector bytes in BE order to match the dispatch convention
+                let sel_be = selector.to_be_bytes();
+                let sel_as_le_u32 = u32::from_le_bytes(sel_be); // reinterpret BE bytes as LE u32
+                self.load_u32_to_reg(15, sel_as_le_u32);
+                let sel_imm = encode_mem_immediate(0, MemWidth::W32).unwrap();
+                self.emit(encode(Opcode::Store, 15, 12, sel_imm));
+
+                // Write args after selector (offset 4)
                 for (i, arg) in args.iter().enumerate() {
                     let r = self.get_reg(*arg);
-                    self.emit_store(r, 12, (i as i32) * 8);
+                    self.emit_store(r, 12, 4 + (i as i32) * 8);
                 }
-                let calldata_len = (args.len() * 8) as u32;
+                let calldata_len = 4 + (args.len() as u32) * 8;
 
-                // Set up CallExt encoding:
-                // rd = target address (wide register)
-                // rs1 = calldata pointer GP register (r12 = heap)
-                // imm[3:0] = calldata length register
-                // imm[7:4] = gas register
-                // imm[11:8] = result register
+                // Set up CallExt: rd=target(wide), rs1=calldata_ptr(r12), imm=len/gas/result
                 self.emit_op(Opcode::Addi, 14, 0, calldata_len);  // r14 = calldata len
-                // Use r14 for len (14), r15 for gas (15), r13 for result (13)
                 self.emit_op(Opcode::Caller, 15, 0, 2);           // r15 = gas_remaining
                 let imm = (14 & 0xF)           // len_reg = r14
                     | ((15 & 0xF) << 4)         // gas_reg = r15
@@ -1332,8 +1387,10 @@ impl CodeGen {
                 // Advance heap past calldata
                 self.emit_op(Opcode::Addi, 12, 12, calldata_len);
 
-                // Move result to destination
-                self.emit_op(Opcode::Add, rd, 13, 0);
+                // After CallExt, r1 = child's return value (set by PVM convention)
+                if rd != 1 {
+                    self.emit_op(Opcode::Add, rd, 1, 0);
+                }
             }
 
             Inst::CrossCall { target, method, args, .. } => {
@@ -1349,12 +1406,38 @@ impl CodeGen {
 
             Inst::RawCall(dst, target, args) => {
                 let rd = self.alloc_gp(*dst);
+                // Target is an Address (wide register)
                 let rt = self.get_reg(*target);
-                for arg in args {
+
+                // Write calldata (args) to heap memory at r12
+                for (i, arg) in args.iter().enumerate() {
                     let r = self.get_reg(*arg);
-                    self.emit_op(Opcode::Push, r, 0, 0);
+                    if self.regs.is_wide(*arg) {
+                        self.emit_op(Opcode::Wstore, r, 12, (i as u32 * 32) & 0x3FFFF);
+                    } else {
+                        self.emit_store(r, 12, (i as i32) * 8);
+                    }
                 }
-                self.emit_op(Opcode::CallExt, rd, rt, 0);
+                let calldata_len = (args.len() * 8) as u32;
+
+                // Set up CallExt encoding:
+                // rd = target address (wide register)
+                // rs1 = calldata pointer (r12 = heap)
+                // imm[3:0] = len register, imm[7:4] = gas register, imm[11:8] = result register
+                self.emit_op(Opcode::Addi, 14, 0, calldata_len);  // r14 = calldata len
+                self.emit_op(Opcode::Caller, 15, 0, 2);           // r15 = gas_remaining
+                let imm = (14 & 0xF)           // len_reg = r14
+                    | ((15 & 0xF) << 4)         // gas_reg = r15
+                    | ((13 & 0xF) << 8);        // result_reg = r13
+                self.emit_op(Opcode::CallExt, rt, 12, imm);
+
+                // Advance heap past calldata
+                self.emit_op(Opcode::Addi, 12, 12, calldata_len);
+
+                // After CallExt, r1 = child's return value
+                if rd != 1 {
+                    self.emit_op(Opcode::Add, rd, 1, 0);
+                }
             }
 
             Inst::MakeVec(dst, cap) => {
@@ -1395,15 +1478,23 @@ impl CodeGen {
     }
 
     /// Get the physical register for a virtual register, emitting spill Load if needed.
+    /// Restores to r15 by default. Use `get_reg_to` when you need a different target
+    /// (e.g., when two operands might both be spilled and would clobber each other).
     fn get_reg(&mut self, vreg: Reg) -> u8 {
+        self.get_reg_to(vreg, 15)
+    }
+
+    /// Get the physical register for a virtual register, restoring to `restore_to` if spilled.
+    /// Use different restore targets when an instruction has multiple source operands
+    /// that could both be spilled (prevents second restore from clobbering the first).
+    fn get_reg_to(&mut self, vreg: Reg, restore_to: u8) -> u8 {
         match self.regs.get_or_spilled(vreg) {
             Ok(phys) => phys,
-            Err(RestoreAction::Restore(temp_reg, slot)) => {
-                // Load from spill area: temp_reg = mem[r13 + slot*8]
+            Err(RestoreAction::Restore(_, slot)) => {
                 let offset = (slot * 8) as i32;
                 let imm = encode_mem_immediate(offset, MemWidth::W64).unwrap();
-                self.instructions.push(encode(Opcode::Load, temp_reg, 13, imm));
-                temp_reg
+                self.instructions.push(encode(Opcode::Load, restore_to, 13, imm));
+                restore_to
             }
         }
     }
@@ -1554,42 +1645,23 @@ impl CodeGen {
 
     /// Derive a map storage key: w7 = poseidon2(slot || key).
     /// Handles any key type (GP or wide).
+    ///
+    /// CRITICAL: Writes key to heap FIRST (at offset 8), then slot (at offset 0).
+    /// key_reg might be r15 (spilled register restore target), and the slot load
+    /// clobbers r15. By consuming key_reg first, we avoid losing the key value.
+    /// Memory layout is unchanged: [slot:0-8][key:8-N].
     fn emit_map_key_derivation(&mut self, slot: u32, key_reg: u8, key_wide: bool) {
-        let mut offset = 0i32;
-        // Store slot (8 bytes)
+        // Store key FIRST at offset 8 — key_reg might be r15, consumed before clobber
+        let key_size = self.emit_key_store(key_reg, 12, 8, key_wide);
+        // Now safe to clobber r15 for slot
         self.emit_op(Opcode::Addi, 15, 0, slot);
-        self.emit_store(15, 12, offset);
-        offset += 8;
-        // Store key
-        let key_size = self.emit_key_store(key_reg, 12, offset, key_wide);
-        offset += key_size as i32;
-        // Hash: poseidon(mem[r12..r12+total])
-        self.emit_op(Opcode::Addi, 14, 0, offset as u32);
+        self.emit_store(15, 12, 0);
+        // Hash: poseidon(heap[r12..r12+8+key_size])
+        let total = 8 + key_size;
+        self.emit_op(Opcode::Addi, 14, 0, total);
         self.emit_op(Opcode::Poseidon, WIDE_SCRATCH, 12, 14);
     }
 
-    /// Derive a nested-map storage key: w7 = poseidon2(slot || key1 || key2).
-    /// Handles any combination of key types.
-    fn emit_nested_map_key_derivation(
-        &mut self, slot: u32,
-        key1_reg: u8, key1_wide: bool,
-        key2_reg: u8, key2_wide: bool,
-    ) {
-        let mut offset = 0i32;
-        // Store slot (8 bytes)
-        self.emit_op(Opcode::Addi, 15, 0, slot);
-        self.emit_store(15, 12, offset);
-        offset += 8;
-        // Store key1
-        let k1_size = self.emit_key_store(key1_reg, 12, offset, key1_wide);
-        offset += k1_size as i32;
-        // Store key2
-        let k2_size = self.emit_key_store(key2_reg, 12, offset, key2_wide);
-        offset += k2_size as i32;
-        // Hash
-        self.emit_op(Opcode::Addi, 14, 0, offset as u32);
-        self.emit_op(Opcode::Poseidon, WIDE_SCRATCH, 12, 14);
-    }
 }
 
 // ============================================================================
@@ -1617,11 +1689,6 @@ fn map_key_type(ty: &Ty) -> Ty {
     } else {
         Ty::U64
     }
-}
-
-/// Byte size of a type for storage key derivation.
-fn key_byte_size(ty: &Ty) -> u32 {
-    if is_wide_type(ty) { 32 } else { 8 }
 }
 
 /// Compute byte size of a struct field.
@@ -3106,5 +3173,551 @@ mod tests {
             }
         }
         assert_eq!(vm.cpu.read_gp(1), 100, "Vec should have 100 elements after realloc");
+    }
+
+    #[test]
+    fn pvm_map_set_under_register_pressure() {
+        // This test creates enough local variables to exhaust GP registers (r1-r11),
+        // forcing the register allocator to spill. Then does map set/get to verify
+        // spilled key/val registers are correctly handled in storage operations.
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {
+                    data: Map<u64, u64>,
+                    count: u64,
+                }
+                pub fn f() -> u64 {
+                    // Create enough locals to exhaust registers and force spilling
+                    let a = 1;
+                    let b = 2;
+                    let c = 3;
+                    let d = 4;
+                    let e = 5;
+                    let f = 6;
+                    let g = 7;
+                    let h = 8;
+                    let i = 9;
+                    let j = 10;
+                    let k = 11;
+                    let l = 12;
+
+                    // Map set with key and val likely spilled
+                    self.data[a] = b;
+                    self.data[c] = d;
+                    self.data[e] = f;
+
+                    // Read back — key is likely spilled
+                    let r1 = self.data[a];
+                    let r2 = self.data[c];
+                    let r3 = self.data[e];
+
+                    // Use all the locals to prevent optimizer from eliminating them
+                    self.count = a + b + c + d + e + f + g + h + i + j + k + l;
+
+                    return r1 + r2 + r3;
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 10_000 { break; } }
+                Err(e) => { panic!("PVM error: {:?}", e); }
+            }
+        }
+        // data[1]=2, data[3]=4, data[5]=6 → r1+r2+r3 = 2+4+6 = 12
+        assert_eq!(vm.cpu.read_gp(1), 12,
+            "Map operations under register pressure must preserve correct key/val");
+    }
+
+    #[test]
+    fn pvm_map_set_bool_under_pressure() {
+        // Regression test: map set of false (0) must not be confused with
+        // a clobbered register that happens to be 0.
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {
+                    flags: Map<u64, bool>,
+                    a: u64,
+                    b: u64,
+                    c: u64,
+                    d: u64,
+                    e: u64,
+                    f: u64,
+                }
+                pub fn f() -> u64 {
+                    let x = 1;
+                    let y = 2;
+                    let z = 3;
+                    self.a = x;
+                    self.b = y;
+                    self.c = z;
+                    self.d = 4;
+                    self.e = 5;
+                    self.f = 6;
+
+                    // Set flag to true
+                    self.flags[x] = true;
+                    let v1 = self.flags[x];
+
+                    // Set flag to false (the value false=0 must survive register pressure)
+                    self.flags[x] = false;
+                    let v2 = self.flags[x];
+
+                    // v1 should be 1 (true), v2 should be 0 (false)
+                    if v1 == true {
+                        if v2 == false {
+                            return 99;
+                        }
+                    }
+                    return 0;
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 10_000 { break; } }
+                Err(e) => { panic!("PVM error: {:?}", e); }
+            }
+        }
+        assert_eq!(vm.cpu.read_gp(1), 99,
+            "Bool map set(false) must work under register pressure");
+    }
+
+    #[test]
+    fn pvm_marketplace_buy_pattern() {
+        // Regression test for the Marketplace buy_item pattern:
+        // Multiple map reads/writes in a single function under heavy register pressure.
+        // This is the exact pattern that was broken: read multiple map fields for an item,
+        // compute fees, update balances, flip active flag.
+        let compiled = compile_no_opt(r#"
+            contract Marketplace {
+                storage {
+                    item_prices: Map<u64, u64>,
+                    item_sellers: Map<u64, u64>,
+                    item_active: Map<u64, bool>,
+                    balances: Map<u64, u64>,
+                    fee_percent: u64,
+                    owner: u64,
+                    total_fees: u64,
+                }
+
+                pub fn test_buy() -> u64 {
+                    // Setup: list an item
+                    let item_id = 1;
+                    let seller = 42;
+                    let price = 1000;
+                    let fee_pct = 5;
+                    let the_owner = 99;
+                    self.fee_percent = fee_pct;
+                    self.owner = the_owner;
+
+                    self.item_prices[item_id] = price;
+                    self.item_sellers[item_id] = seller;
+                    self.item_active[item_id] = true;
+
+                    // Buy: read item fields
+                    let p = self.item_prices[item_id];
+                    let s = self.item_sellers[item_id];
+                    let active = self.item_active[item_id];
+
+                    // Compute fee
+                    let fp = self.fee_percent;
+                    let fee = p * fp / 100;
+                    let seller_amount = p - fee;
+
+                    // Update balances
+                    let old_bal = self.balances[s];
+                    self.balances[s] = old_bal + seller_amount;
+
+                    let old_fee_bal = self.balances[the_owner];
+                    self.balances[the_owner] = old_fee_bal + fee;
+
+                    // Flip active to false
+                    self.item_active[item_id] = false;
+                    self.total_fees = fee;
+
+                    // Verify everything
+                    let final_active = self.item_active[item_id];
+                    let seller_bal = self.balances[s];
+                    let owner_bal = self.balances[the_owner];
+                    let stored_fee = self.total_fees;
+
+                    // active=0, seller_bal=950, owner_bal=50, stored_fee=50
+                    // Encode as: active*10000 + stored_fee*100 + (seller_bal - 900)
+                    // Expected: 0*10000 + 50*100 + 50 = 5050
+                    if final_active == false {
+                        if seller_bal == 950 {
+                            if owner_bal == 50 {
+                                return 5050;
+                            }
+                        }
+                    }
+                    return 0;
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 100_000 { break; } }
+                Err(e) => { panic!("PVM error: {:?}", e); }
+            }
+        }
+        assert_eq!(vm.cpu.read_gp(1), 5050,
+            "Marketplace buy pattern: active flipped, balances correct, fees computed");
+    }
+
+    #[test]
+    fn pvm_batch_reward_register_pressure() {
+        // Reproduces the batch_reward pattern from the E2E StressTest:
+        // 4 params, 3 map reads, fee math, 4 map writes — extreme register pressure.
+        // This was producing off-by-16 for the second user's balance.
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {
+                    balances: Map<u64, u64>,
+                    fee_rate: u64,
+                    owner_id: u64,
+                }
+                pub fn f() -> u64 {
+                    self.fee_rate = 10;
+                    self.owner_id = 1;
+                    self.balances[1] = 1200;
+                    self.balances[10] = 38000;
+                    self.balances[20] = 39000;
+                    self.balances[30] = 21800;
+
+                    let b1 = self.balances[10];
+                    let b2 = self.balances[20];
+                    let b3 = self.balances[30];
+                    let rate = self.fee_rate;
+                    let total = 3000 * 3;
+                    let tax = total * rate / 100;
+                    let per_user = (total - tax) / 3;
+
+                    self.balances[10] = b1 + per_user;
+                    self.balances[20] = b2 + per_user;
+                    self.balances[30] = b3 + per_user;
+
+                    let oid = self.owner_id;
+                    let owner_bal = self.balances[oid];
+                    self.balances[oid] = owner_bal + tax;
+
+                    // Verify all balances
+                    let r1 = self.balances[10];
+                    let r2 = self.balances[20];
+                    let r3 = self.balances[30];
+                    let r4 = self.balances[1];
+                    return r1 + r2 + r3 + r4;
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 100_000 { break; } }
+                Err(e) => { panic!("PVM error: {:?}", e); }
+            }
+        }
+        // b10=38000+2700=40700, b20=39000+2700=41700, b30=21800+2700=24500, b1=1200+900=2100
+        // total = 40700+41700+24500+2100 = 109000
+        assert_eq!(vm.cpu.read_gp(1), 109000,
+            "batch reward: all balances must be exact");
+    }
+
+    #[test]
+    fn pvm_batch_reward_with_guards() {
+        // Same as above but with guards enabled (production dispatch mode).
+        // This matches the E2E execution path.
+        let src = r#"
+            contract T {
+                storage {
+                    balances: Map<u64, u64>,
+                    fee_rate: u64,
+                    owner_id: u64,
+                }
+
+                pub fn setup() {
+                    self.fee_rate = 10;
+                    self.owner_id = 1;
+                    self.balances[1] = 1200;
+                    self.balances[10] = 38000;
+                    self.balances[20] = 39000;
+                    self.balances[30] = 21800;
+                }
+
+                pub fn batch_reward(u1: u64, u2: u64, u3: u64, reward: u64) -> u64 {
+                    let b1 = self.balances[u1];
+                    let b2 = self.balances[u2];
+                    let b3 = self.balances[u3];
+                    let rate = self.fee_rate;
+                    let total = reward * 3;
+                    let tax = total * rate / 100;
+                    let per_user = (total - tax) / 3;
+
+                    self.balances[u1] = b1 + per_user;
+                    self.balances[u2] = b2 + per_user;
+                    self.balances[u3] = b3 + per_user;
+
+                    let oid = self.owner_id;
+                    let owner_bal = self.balances[oid];
+                    self.balances[oid] = owner_bal + tax;
+
+                    return per_user;
+                }
+
+                #[view]
+                pub fn get_balance(user_id: u64) -> u64 {
+                    return self.balances[user_id];
+                }
+            }
+        "#;
+
+        // Compile WITH guards (production mode)
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let ir = crate::lower::lower(&file);
+        let codegen = CodeGen::new(); // emit_guards = true (default)
+        let contract = codegen.generate(&ir);
+
+        // Step 1: Run setup() to initialize storage
+        let setup_sel = compute_selector("setup");
+        let mut calldata = setup_sel.to_be_bytes().to_vec();
+
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm.calldata = calldata;
+        vm.load(&contract.runtime_bytecode).unwrap();
+        let output = vm.execute();
+        assert_eq!(output.outcome, pyde_vm::vm::Outcome::Success, "setup must succeed");
+
+        // Step 2: Run batch_reward(10, 20, 30, 3000)
+        let batch_sel = compute_selector("batch_reward");
+        calldata = batch_sel.to_be_bytes().to_vec();
+        calldata.extend_from_slice(&10u64.to_le_bytes());
+        calldata.extend_from_slice(&20u64.to_le_bytes());
+        calldata.extend_from_slice(&30u64.to_le_bytes());
+        calldata.extend_from_slice(&3000u64.to_le_bytes());
+
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        // Copy storage from setup
+        vm2.storage = vm.storage.clone();
+        vm2.calldata = calldata;
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let output2 = vm2.execute();
+        assert_eq!(output2.outcome, pyde_vm::vm::Outcome::Success, "batch_reward must succeed");
+
+        // per_user = (9000 - 900) / 3 = 2700
+        assert_eq!(vm2.cpu.read_gp(1), 2700, "per_user return value");
+
+        // Step 3: Read balances via get_balance
+        let get_sel = compute_selector("get_balance");
+
+        // Check user20 balance
+        let mut calldata20 = get_sel.to_be_bytes().to_vec();
+        calldata20.extend_from_slice(&20u64.to_le_bytes());
+
+        let mut vm3 = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm3.storage = vm2.storage.clone();
+        vm3.calldata = calldata20;
+        vm3.load(&contract.runtime_bytecode).unwrap();
+        let output3 = vm3.execute();
+        assert_eq!(output3.outcome, pyde_vm::vm::Outcome::Success, "get_balance must succeed");
+        assert_eq!(vm3.cpu.read_gp(1), 41700, "user20 balance = 39000 + 2700 = 41700");
+
+        // Check user10 balance
+        let mut calldata10 = get_sel.to_be_bytes().to_vec();
+        calldata10.extend_from_slice(&10u64.to_le_bytes());
+
+        let mut vm4 = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm4.storage = vm2.storage.clone();
+        vm4.calldata = calldata10;
+        vm4.load(&contract.runtime_bytecode).unwrap();
+        let output4 = vm4.execute();
+        assert_eq!(output4.outcome, pyde_vm::vm::Outcome::Success);
+        assert_eq!(vm4.cpu.read_gp(1), 40700, "user10 balance = 38000 + 2700 = 40700");
+    }
+
+    #[test]
+    fn pvm_batch_reward_smt_roundtrip() {
+        // Tests the exact E2E path: setup → persist to SMT → load from SMT → batch_reward
+        let src = r#"
+            contract T {
+                storage {
+                    balances: Map<u64, u64>,
+                    fee_rate: u64,
+                    owner_id: u64,
+                }
+                pub fn setup() {
+                    self.fee_rate = 10;
+                    self.owner_id = 1;
+                    self.balances[1] = 0;
+                }
+                pub fn set_balance(user: u64, amount: u64) {
+                    self.balances[user] = amount;
+                }
+                #[reentrant]
+                pub fn batch_reward(u1: u64, u2: u64, u3: u64, reward: u64) -> u64 {
+                    let b1 = self.balances[u1];
+                    let b2 = self.balances[u2];
+                    let b3 = self.balances[u3];
+                    let rate = self.fee_rate;
+                    let total = reward * 3;
+                    let tax = total * rate / 100;
+                    let per_user = (total - tax) / 3;
+                    self.balances[u1] = b1 + per_user;
+                    self.balances[u2] = b2 + per_user;
+                    self.balances[u3] = b3 + per_user;
+                    let oid = self.owner_id;
+                    let owner_bal = self.balances[oid];
+                    self.balances[oid] = owner_bal + tax;
+                    return per_user;
+                }
+                #[view]
+                pub fn get_balance(user: u64) -> u64 { return self.balances[user]; }
+            }
+        "#;
+
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let ir = crate::lower::lower(&file);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+
+        let contract_addr = [0x42u8; 32]; // fixed contract address
+
+        // Helper: run a function on the runtime bytecode with calldata
+        // CRITICAL: all VMs must use the same contract_addr for consistent storage keys
+        let run = |calldata: Vec<u8>| -> pyde_vm::vm::Vm {
+            let ctx = pyde_vm::vm::ExecutionContext {
+                self_address: contract_addr,
+                ..Default::default()
+            };
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(10_000_000, ctx);
+            vm.calldata = calldata;
+            vm.load(&contract.runtime_bytecode).unwrap();
+            let _ = vm.execute();
+            vm
+        };
+
+        // Helper: persist vm.storage to SMT, return SMT
+        let persist = |vm: &pyde_vm::vm::Vm, smt: &mut pyde_state::smt::PydeSMT| {
+            for (key, value) in &vm.storage {
+                let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+                let _ = smt.insert(smt_key, value.clone());
+            }
+        };
+
+        // Helper: create a lazy backend from SMT
+        let load_from_smt = |smt: &pyde_state::smt::PydeSMT,
+                              storage: &mut std::collections::HashMap<ethnum::U256, Vec<u8>>,
+                              keys: &[ethnum::U256]| {
+            for key in keys {
+                let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+                if let Some(val) = smt.get(&smt_key) {
+                    storage.insert(*key, val);
+                }
+            }
+        };
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+
+        // Step 1: Setup (acts as constructor)
+        let setup_sel = compute_selector("setup");
+        let vm0 = run(setup_sel.to_be_bytes().to_vec());
+        persist(&vm0, &mut smt);
+
+        // Step 2: set_balance(10, 38000)
+        let set_sel = compute_selector("set_balance");
+        let mut cd = set_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&10u64.to_le_bytes());
+        cd.extend_from_slice(&38000u64.to_le_bytes());
+        let vm1 = run(cd);
+        // Merge with SMT: load existing, add new
+        persist(&vm1, &mut smt);
+
+        // Step 3: set_balance(20, 39000)
+        let mut cd = set_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&20u64.to_le_bytes());
+        cd.extend_from_slice(&39000u64.to_le_bytes());
+        let vm2 = run(cd);
+        persist(&vm2, &mut smt);
+
+        // Step 4: set_balance(30, 21800)
+        let mut cd = set_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&30u64.to_le_bytes());
+        cd.extend_from_slice(&21800u64.to_le_bytes());
+        let vm3 = run(cd);
+        persist(&vm3, &mut smt);
+
+        // Step 5: set_balance(1, 1200)
+        let mut cd = set_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&1u64.to_le_bytes());
+        cd.extend_from_slice(&1200u64.to_le_bytes());
+        let vm4 = run(cd);
+        persist(&vm4, &mut smt);
+
+        // Step 6: batch_reward(10, 20, 30, 3000) with lazy SMT backend
+        let batch_sel = compute_selector("batch_reward");
+        let mut cd = batch_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&10u64.to_le_bytes());
+        cd.extend_from_slice(&20u64.to_le_bytes());
+        cd.extend_from_slice(&30u64.to_le_bytes());
+        cd.extend_from_slice(&3000u64.to_le_bytes());
+
+        let ctx = pyde_vm::vm::ExecutionContext {
+            self_address: contract_addr,
+            ..Default::default()
+        };
+        let mut vm5 = pyde_vm::vm::Vm::with_gas_limit_and_context(10_000_000, ctx);
+        // Use lazy storage backend (same as pipeline)
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm5.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&smt_key) }
+        }));
+        vm5.calldata = cd;
+        vm5.load(&contract.runtime_bytecode).unwrap();
+        let output = vm5.execute();
+        assert_eq!(output.outcome, pyde_vm::vm::Outcome::Success, "batch_reward must succeed");
+        assert_eq!(vm5.cpu.read_gp(1), 2700, "per_user = 2700");
+
+        // Persist and read back
+        vm5.storage_backend = None;
+        persist(&vm5, &mut smt);
+
+        // Step 7: get_balance(20) via lazy backend
+        let get_sel = compute_selector("get_balance");
+        let mut cd = get_sel.to_be_bytes().to_vec();
+        cd.extend_from_slice(&20u64.to_le_bytes());
+
+        let ctx2 = pyde_vm::vm::ExecutionContext {
+            self_address: contract_addr,
+            ..Default::default()
+        };
+        let mut vm6 = pyde_vm::vm::Vm::with_gas_limit_and_context(10_000_000, ctx2);
+        let smt_ptr2 = &smt as *const pyde_state::smt::PydeSMT;
+        vm6.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr2).get(&smt_key) }
+        }));
+        vm6.calldata = cd;
+        vm6.load(&contract.runtime_bytecode).unwrap();
+        let output6 = vm6.execute();
+        assert_eq!(output6.outcome, pyde_vm::vm::Outcome::Success);
+        assert_eq!(vm6.cpu.read_gp(1), 41700, "bal(20) = 39000 + 2700 = 41700");
     }
 }

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -939,12 +939,46 @@ impl Lowerer {
                         dst
                     }
                     "raw_call" => {
-                        let arg_regs: Vec<Reg> = args.iter().filter_map(|a| {
-                            if let MacroArg::Positional(e) = a { Some(self.lower_expr(e)) } else { None }
+                        // raw_call!(target, "method_name", arg1, arg2, ...)
+                        // arg[0] = target address (Address expr)
+                        // arg[1] = method name (string literal) — optional
+                        // arg[2..] = actual parameters
+                        let positional: Vec<&Expr> = args.iter().filter_map(|a| {
+                            if let MacroArg::Positional(e) = a { Some(e) } else { None }
                         }).collect();
+
                         let dst = self.alloc_reg();
-                        let target = arg_regs.first().copied().unwrap_or(Reg(0));
-                        self.emit(Inst::RawCall(dst, target, arg_regs[1..].to_vec()));
+                        if positional.is_empty() {
+                            self.emit(Inst::Const(dst, IrConst::Int(ethnum::U256::ZERO, crate::types::Ty::U64)));
+                            return dst;
+                        }
+
+                        let target = self.lower_expr(positional[0]);
+
+                        // Try to extract method name from arg[1] if it's a string literal
+                        let method_name = if positional.len() > 1 {
+                            if let Expr::Literal(crate::ast::Literal::String(s), _) = positional[1] {
+                                Some(s.clone())
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        // Lower remaining args (skip target and method string)
+                        let param_start = if method_name.is_some() { 2 } else { 1 };
+                        let param_regs: Vec<Reg> = positional[param_start..].iter()
+                            .map(|e| self.lower_expr(e))
+                            .collect();
+
+                        if let Some(method) = method_name {
+                            // Emit as ExtCall with the method name (codegen writes selector)
+                            self.emit(Inst::ExtCall(dst, target, method, param_regs));
+                        } else {
+                            // No method name: emit as raw call (no selector)
+                            self.emit(Inst::RawCall(dst, target, param_regs));
+                        }
                         dst
                     }
                     _ => {

--- a/crates/pvm/src/asm.rs
+++ b/crates/pvm/src/asm.rs
@@ -353,6 +353,7 @@ fn mnemonic_to_opcode(s: &str) -> Option<Opcode> {
         "wor" => Some(Opcode::Wor),
         "wxor" => Some(Opcode::Wxor),
         "wnot" => Some(Opcode::Wnot),
+        "wshift" => Some(Opcode::Wshift),
         "wmov" => Some(Opcode::Wmov),
         "narrow" => Some(Opcode::Narrow),
         "widen" => Some(Opcode::Widen),
@@ -387,7 +388,6 @@ fn mnemonic_to_opcode(s: &str) -> Option<Opcode> {
         "verifysig" => Some(Opcode::VerifySig),
         "merkleverify" => Some(Opcode::MerkleVerify),
         "memcpy" => Some(Opcode::Memcpy),
-        "commit" => Some(Opcode::Commit),
         _ => None,
     }
 }
@@ -421,6 +421,7 @@ fn opcode_to_mnemonic(op: Opcode) -> &'static str {
         Opcode::Wor => "wor",
         Opcode::Wxor => "wxor",
         Opcode::Wnot => "wnot",
+        Opcode::Wshift => "wshift",
         Opcode::Wmov => "wmov",
         Opcode::Narrow => "narrow",
         Opcode::Widen => "widen",
@@ -457,7 +458,6 @@ fn opcode_to_mnemonic(op: Opcode) -> &'static str {
         Opcode::VerifySig => "verifysig",
         Opcode::MerkleVerify => "merkleverify",
         Opcode::Memcpy => "memcpy",
-        Opcode::Commit => "commit",
         Opcode::Invalid => "invalid",
     }
 }

--- a/crates/pvm/src/cpu.rs
+++ b/crates/pvm/src/cpu.rs
@@ -252,6 +252,20 @@ impl Cpu {
                 let ws1 = self.read_wide(d.rs1);
                 self.write_wide(d.rd, !ws1);
             }
+            Opcode::Wshift => {
+                let ws1 = self.read_wide(d.rs1);
+                let dir = d.rs2_or_imm & 1; // 0=left, 1=right
+                let shift_reg = ((d.rs2_or_imm >> 1) & 0xF) as u8;
+                let shift = self.read_gp(shift_reg) as u32;
+                let result = if shift >= 256 {
+                    U256::ZERO
+                } else if dir == 0 {
+                    ws1 << shift
+                } else {
+                    ws1 >> shift
+                };
+                self.write_wide(d.rd, result);
+            }
             Opcode::Wmov => {
                 let ws1 = self.read_wide(d.rs1);
                 self.write_wide(d.rd, ws1);

--- a/crates/pvm/src/isa.rs
+++ b/crates/pvm/src/isa.rs
@@ -35,6 +35,9 @@ pub enum Opcode {
     Wor = 0x2E,  // wd = ws1 | ws2
     Wxor = 0x2F, // wd = ws1 ^ ws2
     Wnot = 0x1F, // wd = ~ws1
+    /// Wide shift: wd = ws1 << amount (if imm&1==0) or ws1 >> amount (if imm&1==1).
+    /// Shift amount from GP register indexed by imm bits [4:1].
+    Wshift = 0x3A,
 
     // --- Extended Arithmetic (from gas table / roadmap) ---
     Addi = 0x0E, // rd = rs1 + sign_extend(imm)
@@ -93,17 +96,7 @@ pub enum Opcode {
     // --- 3.4.6 Assertions + Memory ---
     Assert = 0x38,   // if rs1 == 0 then revert (assertion)
     Memcpy = 0x39,   // copy gp[imm&0xF] bytes from mem[gp[rs1]] to mem[gp[rd]]
-    Commit = 0x3A,   // reserved for future use
-    // to decide what to actually do:
-    //
-    //   0x00 + imm says "NOP"   → do nothing (all-zero instruction is safe)
-    //   0x00 + imm says "Weq"   → wide equal (same as current Weq)
-    //   0x00 + imm says "Mcopy" → bulk memory copy (new!)
-    //   0x00 + imm says "Mset"  → bulk memory set (new!)
-    //   ... room for 60 more future instructions
-    //
-    // This gives us 64 new instructions without changing the 32-bit encoding.
-    //
+    // 0x3A is now Wshift (wide shift); see definition above.
     // Until Phase 9, bulk writes use a WSTORE loop:
     //   for each 32-byte chunk: WSTORE to heap, advance pointer
     //   ~N/32 instructions for N bytes (not N instructions)
@@ -167,6 +160,7 @@ impl Opcode {
             0x2D => Opcode::Wand,
             0x2E => Opcode::Wor,
             0x2F => Opcode::Wxor,
+            0x3A => Opcode::Wshift,
             0x30 => Opcode::Poseidon,
             0x31 => Opcode::VerifySig,
             0x32 => Opcode::MerkleVerify,
@@ -177,7 +171,7 @@ impl Opcode {
             0x37 => Opcode::Wload,
             0x38 => Opcode::Assert,
             0x39 => Opcode::Memcpy,
-            0x3A => Opcode::Commit,
+            // 0x3A handled above (Wshift)
             0x3B => Opcode::Wstore,
             0x3C => Opcode::Wmov,
             0x3D => Opcode::Narrow,
@@ -206,6 +200,7 @@ impl Opcode {
                 | Opcode::Wor
                 | Opcode::Wxor
                 | Opcode::Wnot
+                | Opcode::Wshift
                 | Opcode::Wload
                 | Opcode::Wstore
                 | Opcode::Wmov
@@ -252,6 +247,7 @@ pub const ALL_OPCODES: &[Opcode] = &[
     Opcode::Wor,
     Opcode::Wxor,
     Opcode::Wnot,
+    Opcode::Wshift,
     Opcode::Addi,
     Opcode::Not,
     Opcode::Load,
@@ -292,7 +288,6 @@ pub const ALL_OPCODES: &[Opcode] = &[
     Opcode::Wload,
     Opcode::Assert,
     Opcode::Memcpy,
-    Opcode::Commit,
     Opcode::Wstore,
     Opcode::Wmov,
     Opcode::Narrow,
@@ -484,6 +479,7 @@ pub fn gas_cost(op: Opcode) -> GasCost {
         Opcode::Wor => GasCost::new(2),
         Opcode::Wxor => GasCost::new(2),
         Opcode::Wnot => GasCost::new(2),
+        Opcode::Wshift => GasCost::new(2),
         Opcode::Wmov => GasCost::new(1),
         Opcode::Narrow => GasCost::new(1),
         Opcode::Widen => GasCost::new(1),
@@ -528,7 +524,6 @@ pub fn gas_cost(op: Opcode) -> GasCost {
         // Assertions + memory
         Opcode::Assert => GasCost::new(1),
         Opcode::Memcpy => GasCost::new(3),  // base cost; + 3 per 8 bytes dynamic in handler
-        Opcode::Commit => GasCost::new(5),
 
         // Wide comparisons
         Opcode::Weq => GasCost::new(2),
@@ -595,6 +590,7 @@ static TOTAL_GAS_TABLE: [u64; 64] = {
             0x2D => Some(GasCost::new(2)),       // Wand
             0x2E => Some(GasCost::new(2)),       // Wor
             0x2F => Some(GasCost::new(2)),       // Wxor
+            0x3A => Some(GasCost::new(2)),       // Wshift
             0x30 => Some(GasCost::new(50)),      // Poseidon
             0x31 => Some(GasCost::new(5_000)),   // VerifySig
             0x32 => Some(GasCost::new(100)),     // MerkleVerify
@@ -605,7 +601,6 @@ static TOTAL_GAS_TABLE: [u64; 64] = {
             0x37 => Some(GasCost::new(4)),       // Wload
             0x38 => Some(GasCost::new(1)),       // Assert
             0x39 => Some(GasCost::new(3)),       // Memcpy
-            0x3A => Some(GasCost::new(5)),       // Commit
             0x3B => Some(GasCost::new(4)),       // Wstore
             0x3C => Some(GasCost::new(1)),       // Wmov
             0x3D => Some(GasCost::new(1)),       // Narrow

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -216,7 +216,8 @@ pub struct Vm {
     pub storage: HashMap<U256, Vec<u8>>,
     /// Optional storage backend for lazy loading (e.g., from SMT).
     /// Called when Sload encounters a key not in the overlay.
-    pub storage_backend: Option<Box<dyn Fn(&U256) -> Option<Vec<u8>>>>,
+    /// Arc-wrapped so child VMs (cross-contract calls) can share the same backend.
+    pub storage_backend: Option<std::sync::Arc<dyn Fn(&U256) -> Option<Vec<u8>>>>,
 
     // --- Cold: accessed infrequently ---
     /// Internal call stack for CALL/RET within a contract.
@@ -229,6 +230,10 @@ pub struct Vm {
     storage_journal_keys: std::collections::HashSet<U256>,
     /// Contract registry: address → deployed bytecode.
     pub contracts: HashMap<Address, Vec<u8>>,
+    /// Optional code backend for lazy loading contract bytecode (e.g., from SMT).
+    /// Called by CallExt/Create when the target contract isn't in `contracts`.
+    /// Arc-wrapped so child VMs (cross-contract calls) can share the same backend.
+    pub code_backend: Option<std::sync::Arc<dyn Fn(&Address) -> Option<Vec<u8>>>>,
     /// Calldata: input bytes passed to this contract.
     pub calldata: Vec<u8>,
     /// Return data from the last external call.
@@ -276,6 +281,7 @@ impl Vm {
             storage_journal_keys: std::collections::HashSet::new(),
             decoded_cache: Vec::new(),
             contracts: HashMap::new(),
+            code_backend: None,
             calldata: Vec::new(),
             return_data: Vec::new(),
             static_mode: false,
@@ -507,6 +513,7 @@ impl Vm {
             | Opcode::Wor
             | Opcode::Wxor
             | Opcode::Wnot
+            | Opcode::Wshift
             | Opcode::Wmov
             | Opcode::Narrow
             | Opcode::Widen
@@ -991,6 +998,13 @@ impl Vm {
                 let result = self.do_ext_call(d, is_static_flag, false)?;
                 self.cpu
                     .write_gp(result_reg, if result.success { 1 } else { 0 });
+                // Write child's return value to r1 (function return convention)
+                if result.success && result.return_data.len() >= 8 {
+                    let val = u64::from_le_bytes(
+                        result.return_data[..8].try_into().unwrap_or([0; 8])
+                    );
+                    self.cpu.write_gp(1, val);
+                }
                 self.return_data = result.return_data;
                 self.pc += 4;
             }
@@ -1064,10 +1078,6 @@ impl Vm {
                         .checked_write_slice(dst_ptr, &data)
                         .map_err(|_| Trap::MemoryFault)?;
                 }
-                self.pc += 4;
-            }
-            Opcode::Commit => {
-                // commit rd — reserved for future use
                 self.pc += 4;
             }
             Opcode::Selfdestruct => {
@@ -1272,16 +1282,32 @@ impl Vm {
             .checked_read_slice(calldata_ptr, calldata_len)
             .map_err(|_| Trap::MemoryFault)?;
 
-        // Look up target contract bytecode
+        // Look up target contract bytecode (local registry, then lazy backend)
         let bytecode = match self.contracts.get(&target_addr) {
             Some(code) => code.clone(),
             None => {
-                // No contract at target address — call fails
-                return Ok(CallResult {
-                    success: false,
-                    return_data: Vec::new(),
-                    gas_used: 0,
-                });
+                // Try lazy code backend (e.g., load from SMT)
+                if let Some(ref backend) = self.code_backend {
+                    match backend(&target_addr) {
+                        Some(code) => {
+                            self.contracts.insert(target_addr, code.clone());
+                            code
+                        }
+                        None => {
+                            return Ok(CallResult {
+                                success: false,
+                                return_data: Vec::new(),
+                                gas_used: 0,
+                            });
+                        }
+                    }
+                } else {
+                    return Ok(CallResult {
+                        success: false,
+                        return_data: Vec::new(),
+                        gas_used: 0,
+                    });
+                }
             }
         };
 
@@ -1343,18 +1369,20 @@ impl Vm {
         let mut child = Vm::with_gas_limit_and_context(forwarded, child_ctx);
         child.static_mode = is_static_call || self.static_mode;
         child.contracts = self.contracts.clone();
+        child.storage_backend = self.storage_backend.clone();
+        child.code_backend = self.code_backend.clone();
         child.ext_call_depth = self.ext_call_depth + 1;
         child.calldata = calldata;
 
         // EIP-2929: warm storage keys persist across the entire transaction
         child.warm_storage_keys = self.warm_storage_keys.clone();
 
-        // Share storage for delegate calls
+        // Share storage for delegate calls; start fresh for regular calls
         if is_delegate {
             child.storage = std::mem::take(&mut self.storage);
-        } else {
-            child.storage = self.storage.clone();
         }
+        // Regular calls: child starts with empty storage overlay.
+        // The storage_backend (shared via Arc) loads values on demand.
 
         child.load(&bytecode).map_err(|_| Trap::MemoryFault)?;
         let output = child.execute();
@@ -1388,9 +1416,19 @@ impl Vm {
         // EIP-2929: merge child's warm keys back (persists regardless of success/failure)
         self.warm_storage_keys.extend(child.warm_storage_keys);
 
+        // Return data: if child has explicit return_data, use it.
+        // Otherwise, capture the child's r1 (function return value convention).
+        let return_data = if !child.return_data.is_empty() {
+            child.return_data
+        } else if success {
+            child.cpu.read_gp(1).to_le_bytes().to_vec()
+        } else {
+            Vec::new()
+        };
+
         Ok(CallResult {
             success,
-            return_data: child.return_data,
+            return_data,
             gas_used: output.gas_used,
         })
     }
@@ -3453,7 +3491,8 @@ mod tests {
         let output = vm.execute();
 
         assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(vm.cpu.read_gp(1), 1); // call succeeded
+        // After CallExt, r1 = child's return value (callee puts 42 in r1)
+        assert_eq!(vm.cpu.read_gp(1), 42);
     }
 
     // ========== Task 0203: Reentrancy guard blocks re-entrant call ==========
@@ -3569,7 +3608,9 @@ mod tests {
         let output = vm.execute();
 
         assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(vm.cpu.read_gp(1), 1); // B→C succeeded
+        // C returns r1=0 (no explicit return), B returns r1=0 (child's return)
+        // The call chain succeeded — check outcome, not r1 value
+        assert_eq!(vm.cpu.read_gp(1), 0); // C had no return value → r1=0
     }
 
     // ========== Task 0207: Call with insufficient gas → revert child only ==========
@@ -3809,6 +3850,7 @@ mod tests {
         let output = vm.execute();
 
         assert_eq!(output.outcome, Outcome::Success);
-        assert_eq!(vm.cpu.read_gp(1), 1); // call succeeded
+        // r1 = child's return value (callee loaded calldata[0]=99 into r1)
+        assert_eq!(vm.cpu.read_gp(1), 99);
     }
 }

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -11,3 +11,7 @@ pyde-state = { path = "../state" }
 sparse-merkle-tree = "0.6"
 tracing = "0.1"
 hex = "0.4"
+ethnum = "1.5.2"
+
+[dev-dependencies]
+otic = { path = "../otic" }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -168,8 +168,7 @@ pub fn execute_transaction(
             match load_code(smt, &tx.to) {
                 Some(code) => {
                     tracing::debug!(to = hex::encode(tx.to), code_len = code.len(), "executing contract call in PVM");
-                    let result = execute_in_pvm(tx, &sender, &code, smt, block_ctx);
-                    result
+                    execute_in_pvm(tx, &sender, &code, smt, block_ctx)
                 }
                 None => {
                     tracing::debug!(to = hex::encode(tx.to), "simple transfer (no code at recipient)");
@@ -185,6 +184,8 @@ pub fn execute_transaction(
                 &tx.from,
                 sender.nonce,
             );
+            // Increment sender nonce so the next deploy gets a different address
+            sender.nonce += 1;
 
             let (runtime_code, gas_used) = if tx.data.len() >= 8 {
                 let mut clen_bytes = [0u8; 4];
@@ -347,11 +348,17 @@ fn execute_in_pvm(
     // During execution, SMT is only read (writes go to vm.storage overlay).
     // SAFETY: smt is not mutated during vm.execute(). The pointer is valid for
     // the duration of execute_in_pvm. The closure is dropped before smt is mutated again.
-    let contract_addr = tx.to;
     let smt_ptr = smt as *const PydeSMT;
-    vm.storage_backend = Some(Box::new(move |key: &U256| {
+    vm.storage_backend = Some(std::sync::Arc::new(move |key: &U256| {
         let smt_key = H256::from(key.to_le_bytes());
         unsafe { (*smt_ptr).get(&smt_key) }
+    }));
+
+    // Code backend: lazy-load target contract bytecode for cross-contract calls.
+    let smt_ptr2 = smt as *const PydeSMT;
+    vm.code_backend = Some(std::sync::Arc::new(move |addr: &pyde_account::address::Address| {
+        let code_key = pyde_state::keys::code_key(addr);
+        unsafe { (*smt_ptr2).get(&code_key) }
     }));
 
     if vm.load(code).is_err() {
@@ -372,6 +379,7 @@ fn execute_in_pvm(
     // Use the derived key directly (same as what the VM uses internally).
     // Drop the storage backend before writing back (releases the read pointer)
     vm.storage_backend = None;
+    vm.code_backend = None;
 
     // Persist VM storage changes to SMT
     if success && !vm.storage.is_empty() {
@@ -600,5 +608,184 @@ mod tests {
 
         let nonce = load_nonce(&smt, &sender_addr);
         assert_eq!(nonce.base, 3);
+    }
+
+    /// Full pipeline test: deploy contract, call set_balance x4, call batch_reward,
+    /// then verify balance(20) == 41700. Reproduces the E2E discrepancy.
+    #[test]
+    fn pipeline_batch_reward_storage_integrity() {
+        let src = r#"
+            contract T {
+                storage {
+                    balances: Map<u64, u64>,
+                    fee_rate: u64,
+                    owner_id: u64,
+                }
+                pub fn setup() {
+                    self.fee_rate = 10;
+                    self.owner_id = 1;
+                    self.balances[1] = 0;
+                }
+                pub fn set_balance(user: u64, amount: u64) {
+                    self.balances[user] = amount;
+                }
+                #[reentrant]
+                pub fn batch_reward(u1: u64, u2: u64, u3: u64, reward: u64) -> u64 {
+                    let b1 = self.balances[u1];
+                    let b2 = self.balances[u2];
+                    let b3 = self.balances[u3];
+                    let rate = self.fee_rate;
+                    let total = reward * 3;
+                    let tax = total * rate / 100;
+                    let per_user = (total - tax) / 3;
+                    self.balances[u1] = b1 + per_user;
+                    self.balances[u2] = b2 + per_user;
+                    self.balances[u3] = b3 + per_user;
+                    let oid = self.owner_id;
+                    let owner_bal = self.balances[oid];
+                    self.balances[oid] = owner_bal + tax;
+                    return per_user;
+                }
+                #[view]
+                pub fn get_balance(user: u64) -> u64 { return self.balances[user]; }
+            }
+        "#;
+
+        // Compile WITH optimization (matches CLI: otic build)
+        let (tokens, _) = otic::lexer::Lexer::new(src).tokenize();
+        let (file, _) = otic::parser::Parser::new(tokens).parse();
+        let mut ir = otic::lower::lower(&file);
+        otic::optimize::optimize(&mut ir);
+        let codegen = otic::codegen::CodeGen::new();
+        let contract = codegen.generate(&ir);
+
+        let mut smt = PydeSMT::new();
+        let contract_addr = [0x42u8; 32];
+
+        // Store contract code in SMT
+        store_code(&mut smt, &contract_addr, &contract.runtime_bytecode).unwrap();
+        let contract_account = Account::new_contract(contract_addr, &contract.runtime_bytecode);
+        store_account(&mut smt, &contract_account).unwrap();
+
+        // Create sender account with huge balance
+        let sender_addr = [0x01u8; 32];
+        let mut sender = Account {
+            address: sender_addr,
+            nonce: 0,
+            balance: 10_000_000_000_000_000_000u128,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        store_account(&mut smt, &sender).unwrap();
+        store_nonce(&mut smt, &sender_addr, &pyde_account::nonce::NonceState::new()).unwrap();
+
+        // Also create validator account
+        let validator_addr = [0xFFu8; 32];
+        let validator = Account {
+            address: validator_addr,
+            balance: 0,
+            ..sender.clone()
+        };
+        store_account(&mut smt, &validator).unwrap();
+
+        let block_ctx = BlockContext {
+            height: 1,
+            timestamp: 1000,
+            base_fee: 50_000_000_000, // match node genesis: 50 gwei
+            block_gas_limit: 400_000_000,
+            chain_id: 31337,
+            validator_address: validator_addr,
+        };
+
+        let sel = |name: &str| -> u32 { otic::codegen::compute_selector(name) };
+
+        // Helper: send a tx through the pipeline
+        let mut nonce_counter = 0u64;
+        let mut send = |smt: &mut PydeSMT, calldata: Vec<u8>| {
+            let tx = Transaction {
+                from: sender_addr,
+                to: contract_addr,
+                value: 0,
+                data: calldata,
+                gas_limit: 500_000,
+                nonce: nonce_counter,
+                signature: vec![],
+                fee_payer: FeePayer::Sender,
+                access_list: vec![],
+                deadline: None,
+                chain_id: 31337,
+                tx_type: TransactionType::Standard,
+            };
+            nonce_counter += 1;
+            let result = execute_transaction(&tx, smt, &block_ctx);
+            match result {
+                Ok(receipt) => assert!(receipt.success, "tx failed: nonce={}", tx.nonce),
+                Err(e) => panic!("pipeline error: {:?}", e),
+            }
+        };
+
+        // Helper: pyde_call equivalent (read-only)
+        let call = |smt: &PydeSMT, calldata: Vec<u8>| -> u64 {
+            let ctx = pyde_vm::vm::ExecutionContext {
+                self_address: contract_addr,
+                caller: sender_addr,
+                ..Default::default()
+            };
+            let code = load_code(smt, &contract_addr).expect("no code");
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(10_000_000, ctx);
+            let smt_ptr = smt as *const PydeSMT;
+            vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+                let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
+                unsafe { (*smt_ptr).get(&smt_key) }
+            }));
+            vm.calldata = calldata;
+            vm.load(&code).unwrap();
+            let output = vm.execute();
+            assert_eq!(output.outcome, pyde_vm::vm::Outcome::Success, "call failed");
+            vm.cpu.read_gp(1)
+        };
+
+        let enc_u64 = |v: u64| -> Vec<u8> { v.to_le_bytes().to_vec() };
+        let mut cd = |name: &str, args: &[u64]| -> Vec<u8> {
+            let mut data = sel(name).to_be_bytes().to_vec();
+            for a in args { data.extend_from_slice(&a.to_le_bytes()); }
+            data
+        };
+
+        // Run: setup, set_balance x4, batch_reward
+        send(&mut smt, cd("setup", &[]));
+        send(&mut smt, cd("set_balance", &[10, 38000]));
+        send(&mut smt, cd("set_balance", &[20, 39000]));
+        send(&mut smt, cd("set_balance", &[30, 21800]));
+        send(&mut smt, cd("set_balance", &[1, 1200]));
+
+        // Verify pre-batch balances
+        assert_eq!(call(&smt, cd("get_balance", &[10])), 38000, "pre-batch bal(10)");
+        assert_eq!(call(&smt, cd("get_balance", &[20])), 39000, "pre-batch bal(20)");
+        assert_eq!(call(&smt, cd("get_balance", &[30])), 21800, "pre-batch bal(30)");
+        assert_eq!(call(&smt, cd("get_balance", &[1])), 1200, "pre-batch bal(1)");
+
+        // Run batch_reward
+        send(&mut smt, cd("batch_reward", &[10, 20, 30, 3000]));
+
+        // Verify post-batch balances
+        let b10 = call(&smt, cd("get_balance", &[10]));
+        let b20 = call(&smt, cd("get_balance", &[20]));
+        let b30 = call(&smt, cd("get_balance", &[30]));
+        let b1 = call(&smt, cd("get_balance", &[1]));
+
+        eprintln!("bal(10)={b10} (want 40700)");
+        eprintln!("bal(20)={b20} (want 41700)");
+        eprintln!("bal(30)={b30} (want 24500)");
+        eprintln!("bal(1)={b1} (want 2100)");
+
+        assert_eq!(b10, 40700, "bal(10) = 38000 + 2700");
+        assert_eq!(b20, 41700, "bal(20) = 39000 + 2700");
+        assert_eq!(b30, 24500, "bal(30) = 21800 + 2700");
+        assert_eq!(b1, 2100, "bal(1) = 1200 + 900");
     }
 }


### PR DESCRIPTION
## Summary
- Fix register allocator spill bugs causing wrong values in complex functions (map key r15 clobber, BinOp dual-spill, calldata decode r5 overwrite for 4+ params)
- Add cross-contract call support: `code_backend` for lazy bytecode loading, `raw_call!` with FNV selector encoding, child VM return value propagation
- Add `Wshift` opcode (0x3A) for 256-bit shifts, replacing broken Wadd fallback
- Fix pyde_call RPC to use `OwnedRwLockReadGuard` for consistent state reads
- Increment `sender.nonce` on deploy to prevent contract address collisions

## Test plan
- [x] 1,750 workspace unit tests pass (0 failures)
- [x] 69/69 E2E checks on live validator node across 5 deployed contracts:
  - StressTest (1643 instr, 29 fn): fees, nested maps, status machine, voting, marketplace buy
  - BitwiseTest (798 instr, 19 fn): all bitwise ops, bit packing, u256 casts, popcount
  - PayableTest (484 instr, 11 fn): payable deposits, reentrant withdraw, events, while loops
  - Cross-contract (Target + Caller): two-contract deploy, raw_call! with selector, return values