### PR TITLE
feat: fix match expressions and enum integer interop

### DIFF
--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -672,6 +672,23 @@ impl CodeGen {
                             self.emit_op(Opcode::Addi, 12, 12, 32);
                         }
                     }
+                    IrConst::Bytes(data) => {
+                        // Write raw bytes to heap, set dst = heap pointer
+                        let rd = self.alloc_gp(*dst);
+                        self.emit_op(Opcode::Add, rd, 12, 0); // rd = current heap ptr
+                        // Write bytes in 8-byte chunks
+                        for (i, chunk) in data.chunks(8).enumerate() {
+                            let mut buf = [0u8; 8];
+                            buf[..chunk.len()].copy_from_slice(chunk);
+                            let val = u64::from_le_bytes(buf);
+                            self.load_u64_to_reg(15, val);
+                            self.emit_store(15, 12, (i as i32) * 8);
+                        }
+                        // Advance heap past the data (aligned to 8)
+                        let aligned = ((data.len() + 7) / 8) * 8;
+                        self.load_u32_to_reg(15, aligned as u32);
+                        self.emit_op(Opcode::Add, 12, 12, 15);
+                    }
                     IrConst::Unit => {}
                     _ => {
                         let rd = self.alloc_gp(*dst);
@@ -1438,6 +1455,38 @@ impl CodeGen {
                 if rd != 1 {
                     self.emit_op(Opcode::Add, rd, 1, 0);
                 }
+            }
+
+            Inst::CreateContract(dst, blob_reg, args) => {
+                // The blob register holds an IrConst::Bytes value.
+                // At codegen time, the Const handler has already written the blob to heap.
+                // blob_reg points to the heap location of the deploy-format bytes.
+                // We need to: write constructor args after the blob, then Create.
+                let wd = self.regs.alloc_wide(*dst);
+                let rb = self.get_reg(*blob_reg); // GP reg with blob heap pointer
+
+                // The Const(blob_reg, Bytes(data)) handler writes data to heap[r12]
+                // and sets blob_reg = r12, then advances r12.
+                // Now r12 is right after the blob — perfect for appending args.
+
+                // Write constructor args (LE u64 each) after the blob
+                for (i, arg) in args.iter().enumerate() {
+                    let ra = self.get_reg(*arg);
+                    self.emit_store(ra, 12, (i as i32) * 8);
+                }
+                let args_size = (args.len() as u32) * 8;
+
+                // Total length = blob_size (r12 - rb) + args_size
+                // r14 = r12 - rb (blob size)
+                self.emit_op(Opcode::Sub, 14, 12, rb as u32);
+                // r14 += args_size (total deploy data length)
+                if args_size > 0 {
+                    self.emit_op(Opcode::Addi, 14, 14, args_size);
+                    self.emit_op(Opcode::Addi, 12, 12, args_size); // advance heap past args
+                }
+
+                // Create: wd = new address, rs1 = blob pointer, imm[3:0] = length register (r14)
+                self.emit_op(Opcode::Create, wd, rb, 14 & 0xF);
             }
 
             Inst::MakeVec(dst, cap) => {

--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -310,6 +310,10 @@ pub enum Inst {
     /// `raw_call %target, %value, %data`
     RawCall(Reg, Reg, Vec<Reg>),
 
+    /// `%addr = create %deploy_blob, [constructor_args...]` — deploy a new contract.
+    /// deploy_blob holds the deploy-format bytes. Returns Address.
+    CreateContract(Reg, Reg, Vec<Reg>),
+
     /// `br @label` — unconditional jump
     Jump(Label),
 
@@ -515,6 +519,10 @@ impl fmt::Display for Inst {
             Inst::RawCall(dst, target, args) => {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
                 write!(f, "{} = raw_call {}({})", dst, target, args_str.join(", "))
+            }
+            Inst::CreateContract(dst, blob, args) => {
+                let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
+                write!(f, "{} = create({}, [{}])", dst, blob, args_str.join(", "))
             }
             Inst::Jump(label) => write!(f, "jump {}", label),
             Inst::Branch(cond, then_l, else_l) => write!(f, "br {}, {}, {}", cond, then_l, else_l),

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -18,3 +18,55 @@ pub mod codegen;
 pub mod abi;
 pub mod pyc;
 pub mod diagnostic;
+
+use std::collections::HashMap;
+
+/// Compile all contracts in a source file. Returns a map of contract name → CompiledContract.
+/// Contracts are compiled in declaration order. Later contracts can reference earlier ones
+/// via `create!(ContractName, args)` — the compiler embeds the bytecode at compile time.
+pub fn compile_all(src: &str) -> Vec<(String, codegen::CompiledContract)> {
+    let (tokens, _) = lexer::Lexer::new(src).tokenize();
+    let (file, _) = parser::Parser::new(tokens).parse();
+
+    // Collect contract names
+    let contract_items: Vec<&ast::ContractDef> = file.items.iter().filter_map(|item| {
+        if let ast::Item::Contract(c) = item { Some(c) } else { None }
+    }).collect();
+
+    let mut results = Vec::new();
+    let mut compiled_registry: HashMap<String, Vec<u8>> = HashMap::new();
+
+    for contract in &contract_items {
+        // Build a SourceFile with only this contract (plus top-level enums/structs/interfaces)
+        let mut single_file = ast::SourceFile { items: Vec::new() };
+        for item in &file.items {
+            match item {
+                ast::Item::Contract(c) if c.name.name == contract.name.name => {
+                    single_file.items.push(item.clone());
+                }
+                ast::Item::Contract(_) => {} // skip other contracts
+                _ => single_file.items.push(item.clone()), // keep enums, interfaces, etc.
+            }
+        }
+
+        let mut ir = lower::lower_with_contracts(&single_file, &compiled_registry);
+        optimize::optimize(&mut ir);
+        let cg = codegen::CodeGen::new();
+        let compiled = cg.generate(&ir);
+
+        // Build deploy-format bytes for the registry:
+        // [clen:4 LE][rlen:4 LE][constructor_bytes][runtime_bytes]
+        let clen = compiled.constructor_bytecode.len() as u32;
+        let rlen = compiled.runtime_bytecode.len() as u32;
+        let mut deploy_bytes = Vec::with_capacity(8 + clen as usize + rlen as usize);
+        deploy_bytes.extend_from_slice(&clen.to_le_bytes());
+        deploy_bytes.extend_from_slice(&rlen.to_le_bytes());
+        deploy_bytes.extend_from_slice(&compiled.constructor_bytecode);
+        deploy_bytes.extend_from_slice(&compiled.runtime_bytecode);
+        compiled_registry.insert(contract.name.name.clone(), deploy_bytes);
+
+        results.push((contract.name.name.clone(), compiled));
+    }
+
+    results
+}

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -19,6 +19,19 @@ pub fn lower(file: &SourceFile) -> IrProgram {
     lowerer.program
 }
 
+/// Lower with a registry of previously compiled contracts.
+/// Used for multi-contract files where `create!(ContractName, args)` references
+/// another contract's bytecode.
+pub fn lower_with_contracts(
+    file: &SourceFile,
+    compiled: &HashMap<String, Vec<u8>>,
+) -> IrProgram {
+    let mut lowerer = Lowerer::new();
+    lowerer.compiled_contracts = compiled.clone();
+    lowerer.lower_file(file);
+    lowerer.program
+}
+
 struct Lowerer {
     program: IrProgram,
     /// Current function being lowered.
@@ -34,6 +47,9 @@ struct Lowerer {
     enum_defs: HashMap<String, Vec<String>>,
     /// Const name → (value, type) for inlining.
     const_defs: HashMap<String, (U256, Ty)>,
+    /// Compiled contract bytecodes for `create!` embedding.
+    /// Maps contract name → deploy-format bytes [clen:4][rlen:4][constructor][runtime].
+    compiled_contracts: HashMap<String, Vec<u8>>,
 }
 
 impl Lowerer {
@@ -58,6 +74,7 @@ impl Lowerer {
             next_slot: 0,
             loop_stack: Vec::new(),
             enum_defs: HashMap::new(),
+            compiled_contracts: HashMap::new(),
             const_defs: HashMap::new(),
         }
     }
@@ -979,6 +996,47 @@ impl Lowerer {
                             // No method name: emit as raw call (no selector)
                             self.emit(Inst::RawCall(dst, target, param_regs));
                         }
+                        dst
+                    }
+                    "create" => {
+                        // create!(ContractName, arg1, arg2, ...) → Address
+                        // Embeds the named contract's bytecode and deploys it.
+                        // Constructor runs automatically with the provided args.
+                        let positional: Vec<&Expr> = args.iter().filter_map(|a| {
+                            if let MacroArg::Positional(e) = a { Some(e) } else { None }
+                        }).collect();
+
+                        let dst = self.alloc_reg();
+
+                        // First arg must be a contract name (path expression)
+                        let contract_name = if let Some(Expr::Path(segments, _)) = positional.first() {
+                            segments.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join("::")
+                        } else {
+                            self.emit(Inst::Comment("create! requires a contract name".into()));
+                            return dst;
+                        };
+
+                        // Look up compiled bytecode
+                        let deploy_bytes = match self.compiled_contracts.get(&contract_name) {
+                            Some(bytes) => bytes.clone(),
+                            None => {
+                                self.emit(Inst::Comment(format!("create!: contract '{}' not found in registry", contract_name)));
+                                return dst;
+                            }
+                        };
+
+                        // Lower constructor args (positional[1..])
+                        let arg_regs: Vec<Reg> = positional[1..].iter()
+                            .map(|e| self.lower_expr(e))
+                            .collect();
+
+                        // Emit: store deploy bytes as a constant blob
+                        let blob_reg = self.alloc_reg();
+                        self.emit(Inst::Const(blob_reg, IrConst::Bytes(deploy_bytes)));
+
+                        // CreateContract(dst, blob_reg, [arg_regs...])
+                        // The codegen will write blob + args to heap and emit Create.
+                        self.emit(Inst::CreateContract(dst, blob_reg, arg_regs));
                         dst
                     }
                     _ => {

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1042,23 +1042,34 @@ impl Lowerer {
                 let end_label = self.func().alloc_label();
                 let dst = self.alloc_reg();
 
-                // Pre-allocate all arm labels to avoid collision with nested structures
-                let arm_labels: Vec<Label> = (0..arms.len())
+                // Allocate SEPARATE check and body labels for each arm.
+                // Pattern check emits Branch(cmp, body_label, next_check_label).
+                // This ensures a failed match jumps to the NEXT pattern check,
+                // not the next arm's body.
+                let check_labels: Vec<Label> = (0..arms.len())
+                    .map(|_| self.func().alloc_label())
+                    .collect();
+                let body_labels: Vec<Label> = (0..arms.len())
                     .map(|_| self.func().alloc_label())
                     .collect();
 
+                // Jump to first check
+                self.emit(Inst::Jump(check_labels[0]));
+
+                // Emit all pattern checks
                 for (i, arm) in arms.iter().enumerate() {
-                    let arm_label = arm_labels[i];
-                    let next_label = if i + 1 < arms.len() {
-                        arm_labels[i + 1]
+                    let body_label = body_labels[i];
+                    let next_check = if i + 1 < arms.len() {
+                        check_labels[i + 1]
                     } else {
-                        end_label
+                        end_label // no match → fall to end
                     };
 
-                    // Check pattern
+                    self.func().push_block(check_labels[i], format!("match.check{}", i));
+
                     match &arm.pattern {
                         Pattern::Wildcard(_) => {
-                            self.emit(Inst::Jump(arm_label));
+                            self.emit(Inst::Jump(body_label));
                         }
                         Pattern::Literal(lit, _) => {
                             let pat_reg = self.alloc_reg();
@@ -1070,10 +1081,9 @@ impl Lowerer {
                             self.emit(Inst::Const(pat_reg, val));
                             let cmp = self.alloc_reg();
                             self.emit(Inst::Cmp(cmp, CmpOp::Eq, scrut, pat_reg));
-                            self.emit(Inst::Branch(cmp, arm_label, next_label));
+                            self.emit(Inst::Branch(cmp, body_label, next_check));
                         }
                         Pattern::Path(segments, _) => {
-                            // Enum variant → compare scrutinee against discriminant
                             if segments.len() == 2 {
                                 let enum_name = &segments[0].name;
                                 let variant_name = &segments[1].name;
@@ -1083,17 +1093,15 @@ impl Lowerer {
                                         self.emit(Inst::Const(pat_reg, IrConst::Int(U256::from(idx as u64), Ty::U8)));
                                         let cmp = self.alloc_reg();
                                         self.emit(Inst::Cmp(cmp, CmpOp::Eq, scrut, pat_reg));
-                                        self.emit(Inst::Branch(cmp, arm_label, next_label));
+                                        self.emit(Inst::Branch(cmp, body_label, next_check));
                                     } else {
-                                        self.emit(Inst::Jump(arm_label));
+                                        self.emit(Inst::Jump(body_label));
                                     }
                                 } else {
-                                    // Unknown enum — fall through (could be a single-segment catch-all)
-                                    self.emit(Inst::Jump(arm_label));
+                                    self.emit(Inst::Jump(body_label));
                                 }
                             } else {
-                                // Single-segment path — catch-all variable binding
-                                self.emit(Inst::Jump(arm_label));
+                                self.emit(Inst::Jump(body_label));
                             }
                         }
                         Pattern::Range(start, end_lit, _) => {
@@ -1109,13 +1117,16 @@ impl Lowerer {
                             self.emit(Inst::Cmp(ge, CmpOp::GtEq, scrut, start_reg));
                             self.emit(Inst::Cmp(lt, CmpOp::Lt, scrut, end_reg));
                             self.emit(Inst::BinOp(in_range, BinOp::LogicalAnd, ge, lt));
-                            self.emit(Inst::Branch(in_range, arm_label, next_label));
+                            self.emit(Inst::Branch(in_range, body_label, next_check));
                         }
                     }
+                }
 
-                    // Arm body
-                    self.func().push_block(arm_label, format!("match.arm{}", i));
-                    self.lower_expr(&arm.body);
+                // Emit all arm bodies
+                for (i, arm) in arms.iter().enumerate() {
+                    self.func().push_block(body_labels[i], format!("match.arm{}", i));
+                    let arm_result = self.lower_expr(&arm.body);
+                    self.emit(Inst::Cast(dst, arm_result, Ty::U64));
                     self.emit(Inst::Jump(end_label));
                 }
 

--- a/crates/otic/src/main.rs
+++ b/crates/otic/src/main.rs
@@ -147,34 +147,58 @@ fn run_frontend(path: &str) -> (otic::ast::SourceFile, String) {
 // ============================================================================
 
 fn cmd_build(path: &str) {
-    let (file, _src) = run_frontend(path);
+    let (_file, _src) = run_frontend(path);
+    let src = read_source(path);
 
-    // Lower → optimize → codegen
-    let mut ir = otic::lower::lower(&file);
-    otic::optimize::optimize(&mut ir);
-    let abi = otic::abi::generate_abi(&ir);
-    let codegen = otic::codegen::CodeGen::new();
-    let contract = codegen.generate(&ir);
+    // Multi-contract compilation: compile all contracts in the file.
+    // Later contracts can reference earlier ones via create!(ContractName, args).
+    let results = otic::compile_all(&src);
 
-    // Generate JSON artifact (readable in any editor)
-    let artifact = otic::abi::artifact_to_json(&abi, &contract);
-
-    // Write .json artifact
-    let json_path = Path::new(path).with_extension("json");
-    if let Err(e) = fs::write(&json_path, &artifact) {
-        eprintln!("error: could not write '{}': {}", json_path.display(), e);
+    if results.is_empty() {
+        eprintln!("error: no contracts found in {}", path);
         process::exit(1);
     }
 
-    println!("  compiled {} → {}", path, json_path.display());
-    println!("  contract:    {}", contract.name);
-    println!("  bytecode:    {} bytes ({} instructions)",
-        contract.bytecode.len(), contract.instruction_count);
-    println!("  constructor: {} bytes", contract.constructor_bytecode.len());
-    println!("  runtime:     {} bytes", contract.runtime_bytecode.len());
-    println!("  functions:   {}", abi.functions.len());
-    println!("  events:      {}", abi.events.len());
-    println!("  storage:     {} fields", abi.storage.len());
+    for (name, contract) in &results {
+        // Generate IR for ABI (single-contract lower for ABI generation)
+        let (tokens, _) = otic::lexer::Lexer::new(&src).tokenize();
+        let (file, _) = otic::parser::Parser::new(tokens).parse();
+        // Build single-contract file for ABI
+        let mut single = otic::ast::SourceFile { items: Vec::new() };
+        for item in &file.items {
+            match item {
+                otic::ast::Item::Contract(c) if c.name.name == *name => single.items.push(item.clone()),
+                otic::ast::Item::Contract(_) => {}
+                _ => single.items.push(item.clone()),
+            }
+        }
+        let ir = otic::lower::lower(&single);
+        let abi = otic::abi::generate_abi(&ir);
+        let artifact = otic::abi::artifact_to_json(&abi, contract);
+
+        // Write .json artifact (use contract name for multi-contract files)
+        let json_path = if results.len() == 1 {
+            Path::new(path).with_extension("json")
+        } else {
+            let stem = Path::new(path).file_stem().unwrap_or_default().to_str().unwrap_or("out");
+            Path::new(path).with_file_name(format!("{}_{}.json", stem, name.to_lowercase()))
+        };
+        if let Err(e) = fs::write(&json_path, &artifact) {
+            eprintln!("error: could not write '{}': {}", json_path.display(), e);
+            process::exit(1);
+        }
+
+        println!("  compiled {} → {}", path, json_path.display());
+        println!("  contract:    {}", contract.name);
+        println!("  bytecode:    {} bytes ({} instructions)",
+            contract.bytecode.len(), contract.instruction_count);
+        println!("  constructor: {} bytes", contract.constructor_bytecode.len());
+        println!("  runtime:     {} bytes", contract.runtime_bytecode.len());
+        println!("  functions:   {}", abi.functions.len());
+        println!("  events:      {}", abi.events.len());
+        println!("  storage:     {} fields", abi.storage.len());
+        println!();
+    }
 }
 
 fn cmd_check(path: &str) {

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -313,6 +313,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
             for a in args { used.insert(*a); }
         }
         Inst::RawCall(_, target, args) => { used.insert(*target); for a in args { used.insert(*a); } }
+        Inst::CreateContract(_, blob, args) => { used.insert(*blob); for a in args { used.insert(*a); } }
         Inst::Jump(_) => {}
         Inst::Branch(cond, _, _) => { used.insert(*cond); }
         Inst::Return(Some(val)) => { used.insert(*val); }
@@ -336,7 +337,7 @@ fn get_dest_reg(inst: &Inst) -> Option<Reg> {
         | Inst::MakeTuple(dst, _) | Inst::TupleGet(dst, _, _)
         | Inst::MakeArray(dst, _) | Inst::ArrayRepeat(dst, _, _)
         | Inst::MakeVec(dst, _)
-        | Inst::RawCall(dst, _, _) | Inst::Phi(dst, _) => Some(*dst),
+        | Inst::RawCall(dst, _, _) | Inst::CreateContract(dst, _, _) | Inst::Phi(dst, _) => Some(*dst),
         _ => None,
     }
 }
@@ -348,7 +349,7 @@ fn has_side_effects(inst: &Inst) -> bool {
         | Inst::StorageNestedMapSet(_, _, _, _)
         | Inst::IndexSet(_, _, _)
         | Inst::Emit(_, _) | Inst::Revert(_, _)
-        | Inst::CrossCall { .. } | Inst::RawCall(_, _, _)
+        | Inst::CrossCall { .. } | Inst::RawCall(_, _, _) | Inst::CreateContract(_, _, _)
         | Inst::Call(_, _, _) | Inst::MethodCall(_, _, _, _) | Inst::ExtCall(_, _, _, _)
         | Inst::Jump(_) | Inst::Branch(_, _, _) | Inst::Return(_)
     )

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -744,7 +744,7 @@ impl Resolver {
 
             Expr::MacroCall(name, args, span) => {
                 // Built-in macros: require!, revert!, cross_call!, raw_call!
-                let known_macros = ["require", "revert", "cross_call", "raw_call"];
+                let known_macros = ["require", "revert", "cross_call", "raw_call", "create"];
                 if !known_macros.contains(&name.name.as_str()) {
                     self.error(
                         format!("unknown macro '{}!'", name.name),

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -651,6 +651,9 @@ impl TypeChecker {
                         && !self.is_int_literal_compatible(&a.value, &target_ty)
                         && !value_ty.can_widen_to(&target_ty)
                         && !(target_ty.is_numeric() && value_ty.is_numeric()) // allow numeric narrowing
+                        && !(target_ty.is_enum() && value_ty.is_enum()) // same-kind enum assignment
+                        && !(target_ty.is_numeric() && value_ty.is_enum()) // Enum → numeric
+                        && !(target_ty.is_enum() && value_ty.is_numeric()) // numeric → Enum
                         && !self.is_compatible_init(&value_ty, &target_ty)
                     {
                         self.error(
@@ -1240,6 +1243,9 @@ impl TypeChecker {
                         // numeric ↔ Address
                         (s, Ty::Address) if s.is_numeric() => true,
                         (Ty::Address, t) if t.is_numeric() => true,
+                        // enum ↔ numeric (discriminant cast)
+                        (Ty::Enum(_), t) if t.is_numeric() => true,
+                        (s, Ty::Enum(_)) if s.is_numeric() => true,
                         // same type (identity cast)
                         (s, t) if s == t => true,
                         _ => false,

--- a/crates/otic/src/types.rs
+++ b/crates/otic/src/types.rs
@@ -92,6 +92,9 @@ impl Ty {
                 }
                 false
             }
+            // Enum → numeric: enums are discriminant integers
+            _ if matches!(self, Ty::Enum(_)) && target.is_numeric() => true,
+            _ if self.is_numeric() && matches!(target, Ty::Enum(_)) => true,
             _ => false,
         }
     }
@@ -103,11 +106,19 @@ impl Ty {
         if matches!(self, Ty::Unknown) || matches!(other, Ty::Unknown) { return true; }
         // Numeric types are comparable (implicit widening happens)
         if self.is_numeric() && other.is_numeric() { return true; }
+        // Enums are comparable with numerics (discriminant comparison)
+        if (matches!(self, Ty::Enum(_)) && other.is_numeric())
+            || (self.is_numeric() && matches!(other, Ty::Enum(_))) { return true; }
         // Arrays of same size with compatible elements
         if let (Ty::Array(a, n1), Ty::Array(b, n2)) = (self, other) {
             return n1 == n2 && a.is_comparable_with(b);
         }
         false
+    }
+
+    /// Whether this is an enum type.
+    pub fn is_enum(&self) -> bool {
+        matches!(self, Ty::Enum(_))
     }
 
     /// Whether a type can be used as a map key.

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1472,13 +1472,39 @@ impl Vm {
             return Err(Trap::MemoryFault); // address collision
         }
 
-        // Execute init code in a child VM (constructor runs here)
+        // Parse deploy format: [clen:4 LE][rlen:4 LE][constructor][runtime][args]
+        // If the header is valid, split into constructor + runtime + args.
+        // Constructor runs in a child VM. Runtime is deployed.
+        // If no valid header, use init_code as both constructor and runtime (legacy).
+        let (constructor, runtime, constructor_args) = if init_code.len() >= 8 {
+            let clen = u32::from_le_bytes(
+                init_code[..4].try_into().unwrap_or([0; 4])
+            ) as usize;
+            let rlen = u32::from_le_bytes(
+                init_code[4..8].try_into().unwrap_or([0; 4])
+            ) as usize;
+            if clen > 0 && rlen > 0 && 8 + clen + rlen <= init_code.len() {
+                let c = init_code[8..8 + clen].to_vec();
+                let r = init_code[8 + clen..8 + clen + rlen].to_vec();
+                let args = if init_code.len() > 8 + clen + rlen {
+                    init_code[8 + clen + rlen..].to_vec()
+                } else {
+                    vec![]
+                };
+                (Some(c), r, args)
+            } else {
+                (None, init_code.clone(), vec![])
+            }
+        } else {
+            (None, init_code.clone(), vec![])
+        };
+
         let available_gas = if self.gas_limit > 0 {
             self.gas_limit.saturating_sub(self.gas_used_total)
         } else {
             u64::MAX
         };
-        let max_forward = available_gas - (available_gas / 64); // 63/64 rule
+        let max_forward = available_gas - (available_gas / 64);
 
         let child_ctx = ExecutionContext {
             caller: self.ctx.self_address,
@@ -1495,57 +1521,43 @@ impl Vm {
             balances: self.ctx.balances.clone(),
         };
 
-        let mut child = Vm::with_gas_limit_and_context(max_forward, child_ctx);
-        child.contracts = self.contracts.clone();
-        child.storage_backend = self.storage_backend.clone();
-        child.code_backend = self.code_backend.clone();
-        // New contract starts with empty storage (backend loads on demand)
-        child.warm_storage_keys = self.warm_storage_keys.clone();
-        child.ext_call_depth = self.ext_call_depth + 1;
-        child.load(&init_code).map_err(|_| Trap::MemoryFault)?;
+        // Run constructor if present
+        if let Some(ref constructor_code) = constructor {
+            let mut child = Vm::with_gas_limit_and_context(max_forward, child_ctx.clone());
+            child.contracts = self.contracts.clone();
+            child.storage_backend = self.storage_backend.clone();
+            child.code_backend = self.code_backend.clone();
+            child.warm_storage_keys = self.warm_storage_keys.clone();
+            child.ext_call_depth = self.ext_call_depth + 1;
+            child.calldata = constructor_args;
+            child.load(constructor_code).map_err(|_| Trap::MemoryFault)?;
 
-        let output = child.execute();
+            let output = child.execute();
+            self.gas_used_total += output.gas_used;
+            if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
+                return Err(Trap::OutOfGas);
+            }
+            if output.outcome != Outcome::Success {
+                return Err(Trap::MemoryFault); // constructor failed
+            }
+            // Merge constructor's storage writes
+            for (k, v) in &child.storage {
+                self.storage.insert(*k, v.clone());
+            }
+            self.warm_storage_keys.extend(child.warm_storage_keys);
+        }
 
-        // Charge parent for gas used by child
-        self.gas_used_total += output.gas_used;
+        let runtime_code = runtime;
+
+        // Charge per-byte gas for deployed code
+        let code_gas = (runtime_code.len() as u64) * 200;
+        self.gas_used_total += code_gas;
         if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
             return Err(Trap::OutOfGas);
         }
 
-        if output.outcome == Outcome::Success {
-            // The child's return_data is the runtime bytecode to deploy.
-            // If empty, the init code didn't return runtime code — deploy empty contract.
-            let runtime_code = if child.return_data.is_empty() {
-                // No explicit return data — use the init code itself as runtime
-                // (Pyde convention: Otigen compiler packages runtime in init code)
-                init_code.clone()
-            } else {
-                child.return_data
-            };
-
-            // Charge per-byte gas for deployed code
-            let code_gas = (runtime_code.len() as u64) * 200;
-            self.gas_used_total += code_gas;
-            if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
-                return Err(Trap::OutOfGas);
-            }
-
-            // Deploy runtime bytecode
-            self.contracts.insert(new_addr, runtime_code);
-
-            // Merge child's storage changes (constructor may have initialized state)
-            for (k, v) in &child.storage {
-                self.storage.insert(*k, v.clone());
-            }
-            self.logs.extend(output.logs);
-            self.gas_refund += output.gas_refund;
-        } else {
-            // Constructor failed — no contract deployed
-            return Err(Trap::MemoryFault);
-        }
-
-        // Merge warm keys
-        self.warm_storage_keys.extend(child.warm_storage_keys);
+        // Deploy runtime bytecode
+        self.contracts.insert(new_addr, runtime_code);
 
         Ok(new_addr)
     }

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1497,7 +1497,9 @@ impl Vm {
 
         let mut child = Vm::with_gas_limit_and_context(max_forward, child_ctx);
         child.contracts = self.contracts.clone();
-        child.storage = self.storage.clone();
+        child.storage_backend = self.storage_backend.clone();
+        child.code_backend = self.code_backend.clone();
+        // New contract starts with empty storage (backend loads on demand)
         child.warm_storage_keys = self.warm_storage_keys.clone();
         child.ext_call_depth = self.ext_call_depth + 1;
         child.load(&init_code).map_err(|_| Trap::MemoryFault)?;

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -389,6 +389,19 @@ fn execute_in_pvm(
         }
     }
 
+    // Persist any contracts created via CREATE opcode (factory pattern)
+    if success {
+        for (addr, code) in &vm.contracts {
+            let code_key = pyde_state::keys::code_key(addr);
+            // Only persist if not already in SMT (newly created)
+            if smt.get(&code_key).is_none() {
+                let _ = smt.insert(code_key, code.clone());
+                let contract_account = Account::new_contract(*addr, code);
+                let _ = store_account(smt, &contract_account);
+            }
+        }
+    }
+
     let logs = output
         .logs
         .iter()


### PR DESCRIPTION
## Summary
- Fix match expression lowering: separate check/body labels so failed patterns jump to next pattern check, not next arm body
- Copy match arm results to destination register (was returning 0)
- Allow enum ↔ integer casting, assignment, and comparison

## Test plan
- [x] 1,750 workspace tests pass
- [x] 9/9 match expression checks on live validator (enum patterns, integer literals, wildcards, side effects)
- [x] 12/12 enum interop checks on live validator (cast, assignment, comparison, storage)