### PR TITLE
feat: packed struct layout, inline nested structs, Push/Pop register spilling

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -419,8 +419,27 @@ impl PydeApiServer for RpcServer {
         let success = output.outcome == pyde_vm::vm::Outcome::Success;
 
         if success {
-            let return_value = vm.cpu.read_gp(1);
-            Ok(format!("0x{:x}", return_value))
+            // Check r2 for blob return (Struct/Vec/String): r1=pointer, r2=byte_length
+            let r2 = vm.cpu.read_gp(2);
+            if r2 > 0 {
+                let r1 = vm.cpu.read_gp(1) as usize;
+                let len = r2 as usize;
+                // Read serialized blob from VM memory
+                let blob = vm.memory.load_bytes(r1, len);
+                Ok(format!("0x{}", hex::encode(blob)))
+            } else {
+                // Check wide register w0 for Address/u256 returns
+                let w0 = vm.cpu.read_wide(0);
+                if w0 != ethnum::U256::ZERO {
+                    // Wide return: format as full 32-byte hex
+                    let bytes = w0.to_le_bytes();
+                    Ok(format!("0x{}", hex::encode(bytes)))
+                } else {
+                    // GP return: r1
+                    let return_value = vm.cpu.read_gp(1);
+                    Ok(format!("0x{:x}", return_value))
+                }
+            }
         } else {
             Err(rpc_err(-32000, format!("execution failed: {:?}", output.outcome)))
         }

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -38,6 +38,17 @@ const WIDE_SCRATCH: u8 = 7;
 /// Second wide scratch register index.
 const WIDE_SCRATCH2: u8 = 6;
 
+/// Total bytes reserved for spill area + serialize loop state per function.
+const SPILL_AREA_TOTAL: u32 = 512;
+/// Base offset (from r13) for serialize/deserialize loop state.
+/// Placed above the register spill slots (which use r13+0..r13+447) to avoid collision.
+const LOOP_STATE_BASE: i32 = 448;
+// Loop state slots at r13+LOOP_STATE_BASE:
+//   +0  = loop counter (i) or remaining
+//   +8  = count
+//   +16 = src_ptr
+//   +24 = dst_data_ptr
+
 // ============================================================================
 // Output
 // ============================================================================
@@ -113,11 +124,17 @@ impl RegAlloc {
 
     /// Allocate a GP (64-bit) physical register.
     /// Returns (physical_reg, optional spill action if eviction needed).
+    ///
+    /// NO-EVICTION policy: once a register is assigned (r1-r11), it stays
+    /// assigned for the entire function. When all 11 registers are in use,
+    /// new vregs become "spill-only" — they use r14 as a temporary write
+    /// target and immediately write through to their spill slot. This
+    /// prevents loop-carried register corruption where a register assigned
+    /// to one vreg gets repurposed for another within a loop body.
     fn alloc(&mut self, vreg: Reg) -> (u8, Option<SpillAction>) {
         if let Some(&phys) = self.mapping.get(&vreg) {
             return (phys, None);
         }
-        // If this vreg was previously spilled, it will be restored on get()
         if self.next_gp <= 11 {
             let phys = self.next_gp;
             self.next_gp += 1;
@@ -125,22 +142,18 @@ impl RegAlloc {
             self.reverse.insert(phys, vreg);
             (phys, None)
         } else {
-            // Evict: reuse registers cyclically (r1-r11)
-            let phys = ((self.next_gp - 1) % 11) + 1;
-            self.next_gp += 1;
-            // Evict the old occupant to spill slot
-            let spill = if let Some(&old_vreg) = self.reverse.get(&phys) {
+            // No free registers — borrow r1 via Push/Pop.
+            // r1 is saved to the PVM stack at alloc_gp time and restored
+            // at the end of gen_instruction. The borrowed register is used
+            // for the new vreg's computation. The vreg gets a spill slot
+            // for subsequent reads.
+            if !self.spilled.contains_key(&vreg) {
                 let slot = self.next_spill_slot;
                 self.next_spill_slot += 1;
-                self.spilled.insert(old_vreg, slot);
-                self.mapping.remove(&old_vreg);
-                Some(SpillAction::Save(phys, slot))
-            } else {
-                None
-            };
-            self.mapping.insert(vreg, phys);
-            self.reverse.insert(phys, vreg);
-            (phys, spill)
+                self.spilled.insert(vreg, slot);
+            }
+            // Return r1 as the borrowed register (Push/Pop handled by alloc_gp)
+            (1, None)
         }
     }
 
@@ -218,6 +231,11 @@ pub struct CodeGen {
     fixups: Vec<(usize, Label)>,
     /// Register allocator.
     regs: RegAlloc,
+    /// Pending write-through stores: (physical_reg, vreg).
+    /// Collected by alloc_gp, emitted at the end of gen_instruction.
+    pending_writebacks: Vec<(u8, Reg)>,
+    /// Registers borrowed for spill-only vregs (need Pop to restore at end of instruction).
+    pending_restores: Vec<u8>,
     /// Whether current function has reentrancy guard (needs cleanup on return).
     needs_guard_cleanup: bool,
     /// Whether to emit runtime guards (disabled for testing).
@@ -230,12 +248,14 @@ pub struct CodeGen {
     storage_types: HashMap<String, Ty>,
     /// Struct name → ordered fields (for field offset computation).
     struct_defs: HashMap<String, Vec<(String, Ty)>>,
-    /// Global field name → byte offset (built from struct_defs).
-    field_offsets: HashMap<String, u32>,
+    /// Struct-scoped field offsets: struct_name → field_name → (byte_offset, field_type).
+    field_offsets: HashMap<String, HashMap<String, (u32, Ty)>>,
     /// Label counter for generating unique labels.
     label_counter: u32,
     /// Current function's IR label → codegen label remapping.
     current_label_remap: Option<HashMap<Label, Label>>,
+    /// Current function's return type (for blob return serialization).
+    current_return_ty: Ty,
 }
 
 impl CodeGen {
@@ -245,6 +265,8 @@ impl CodeGen {
             label_offsets: HashMap::new(),
             fixups: Vec::new(),
             regs: RegAlloc::new(),
+            pending_writebacks: Vec::new(),
+            pending_restores: Vec::new(),
             needs_guard_cleanup: false,
             emit_guards: true,
             func_labels: HashMap::new(),
@@ -254,6 +276,7 @@ impl CodeGen {
             field_offsets: HashMap::new(),
             label_counter: 0,
             current_label_remap: None,
+            current_return_ty: Ty::Unit,
         }
     }
 
@@ -287,16 +310,23 @@ impl CodeGen {
             self.storage_types.insert(field.name.clone(), field.ty.clone());
         }
 
-        // Build struct field offset map
+        // Build struct definitions first (needed for recursive field_byte_size)
+        for sdef in &program.struct_defs {
+            let fields: Vec<(String, Ty)> = sdef.fields.iter()
+                .map(|(fname, fty)| (fname.clone(), fty.clone()))
+                .collect();
+            self.struct_defs.insert(sdef.name.clone(), fields);
+        }
+
+        // Build struct-scoped field offset map using recursive field sizes
         for sdef in &program.struct_defs {
             let mut offset = 0u32;
-            let mut fields = Vec::new();
+            let mut field_map = HashMap::new();
             for (fname, fty) in &sdef.fields {
-                self.field_offsets.insert(fname.clone(), offset);
-                fields.push((fname.clone(), fty.clone()));
-                offset += field_byte_size(fty);
+                field_map.insert(fname.clone(), (offset, fty.clone()));
+                offset += self.field_byte_size(fty);
             }
-            self.struct_defs.insert(sdef.name.clone(), fields);
+            self.field_offsets.insert(sdef.name.clone(), field_map);
         }
 
         // Pre-pass: reserve labels for each function body + dispatch entry
@@ -325,6 +355,10 @@ impl CodeGen {
             if func.is_constructor {
                 // Init heap pointer: r12 = r5 + r4 + 8 (past calldata)
                 self.emit_heap_init();
+                // Set up r13 (spill base) for calldata decode
+                self.emit_op(Opcode::Add, 13, 12, 0);
+                self.load_u32_to_reg(15, SPILL_AREA_TOTAL);
+                self.emit_op(Opcode::Add, 12, 12, 15);
                 // Decode calldata params into arg registers
                 self.emit_calldata_decode(func);
                 // Emit constructor body directly (no Call/Ret, just Halt at end)
@@ -350,6 +384,11 @@ impl CodeGen {
                     .expect("dispatch entry references non-existent function");
 
                 self.emit_heap_init();
+                // Set up r13 (spill base) for calldata decode — emit_unflatten
+                // may use LOOP_STATE_BASE which is r13-relative.
+                self.emit_op(Opcode::Add, 13, 12, 0);
+                self.load_u32_to_reg(15, SPILL_AREA_TOTAL);
+                self.emit_op(Opcode::Add, 12, 12, 15);
                 self.emit_calldata_decode(func);
                 self.emit_function_guards(func);
                 self.emit_jump_placeholder(Opcode::Call, 0, 0, *func_label);
@@ -459,6 +498,53 @@ impl CodeGen {
     // Calldata decode + heap init
     // ========================================================================
 
+    // ========================================================================
+    // Struct layout helpers (inline nested structs)
+    // ========================================================================
+
+    /// Compute the byte size of a struct field in the packed inline layout.
+    /// Uses actual type sizes: u8→1, u16→2, u32→4, u64→8, u256→32, etc.
+    fn field_byte_size(&self, ty: &Ty) -> u32 {
+        match ty {
+            Ty::U8 | Ty::I8 | Ty::Bool | Ty::Enum(_) => 1,
+            Ty::U16 | Ty::I16 => 2,
+            Ty::U32 | Ty::I32 => 4,
+            Ty::U64 | Ty::I64 => 8,
+            Ty::U128 | Ty::I128 => 16,
+            Ty::U256 | Ty::I256 | Ty::Address => 32,
+            Ty::Struct(name) => self.compute_struct_size(name),
+            // Vec/String/Bytes/Map stored as pointers (8 bytes) — they can grow
+            _ => 8,
+        }
+    }
+
+    /// Compute total byte size of a struct with inline nested structs.
+    fn compute_struct_size(&self, name: &str) -> u32 {
+        if let Some(fields) = self.struct_defs.get(name) {
+            fields.iter().map(|(_, fty)| self.field_byte_size(fty)).sum()
+        } else {
+            memory::WORD_SIZE // fallback
+        }
+    }
+
+    /// Fallback: search all structs for a field name (backward compat for untyped access).
+    fn find_field_offset_any(&self, field_name: &str) -> u32 {
+        for (_sname, fmap) in &self.field_offsets {
+            if let Some((off, _)) = fmap.get(field_name) {
+                return *off;
+            }
+        }
+        0
+    }
+
+    /// Look up a field's (offset, type) from the struct-scoped field_offsets.
+    fn lookup_field(&self, struct_name: &str, field_name: &str) -> (u32, Ty) {
+        self.field_offsets.get(struct_name)
+            .and_then(|m| m.get(field_name))
+            .cloned()
+            .unwrap_or((0, Ty::U64))
+    }
+
     /// Initialize heap pointer past calldata.
     /// When calldata exists: r5=HEAP_START, r4=len, so r12 = r5 + r4 + 8.
     /// When calldata is empty: PVM doesn't set r5/r4, so fallback to HEAP_START.
@@ -483,24 +569,102 @@ impl CodeGen {
             return;
         }
         let selector_skip = if func.is_constructor { 0i32 } else { 4 };
-        let mut param_offset = selector_skip;
 
-        // Save calldata pointer to r14 before decoding overwrites r5
-        self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, 5, 0); // r14 = r5
+        // Check if any param is variable-length (needs runtime cursor)
+        let has_blob = func.params.iter().any(|(_, ty)| is_blob_type(ty));
 
-        for (i, (_name, ty)) in func.params.iter().enumerate() {
-            let phys = (i as u8) + 2; // r2, r3, r4, ...
-            let is_wide = is_wide_type(ty);
+        if has_blob {
+            // Dynamic calldata decode: use a runtime cursor register.
+            // r14 = current calldata cursor (advances at runtime for each param).
+            self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, 5, selector_skip as u32 & 0x3FFFF);
 
-            if is_wide {
-                // Compute address: r15 = r14 + offset
-                self.emit_op(Opcode::Addi, 15, memory::REG_SCRATCH_0, param_offset as u32 & 0x3FFFF);
-                self.emit_op(Opcode::Wload, phys, 15, 0);
-                param_offset += 32;
-            } else {
-                // Load from r14 (saved calldata ptr) instead of r5
-                self.emit_load(phys, memory::REG_SCRATCH_0, param_offset);
-                param_offset += 8;
+            for (i, (_name, ty)) in func.params.iter().enumerate() {
+                let phys = (i as u8) + 2;
+
+                if matches!(ty, Ty::Vec(_)) || matches!(ty, Ty::Struct(_)) {
+                    // Vec/Struct arg: calldata has [byte_len:8 LE][flat data].
+                    // Copy blob to heap buffer, then unflatten to pointer-based layout.
+                    // Same approach as the Struct calldata path (proven working).
+                    self.emit_op(Opcode::Push, memory::REG_SCRATCH_0, 0, 0); // save cursor
+
+                    self.emit_load(15, memory::REG_SCRATCH_0, 0);  // r15 = byte_len
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 8);
+                    self.emit_op(Opcode::Push, 12, 0, 0);          // save buffer_start
+                    self.emit_op(Opcode::Memcpy, 12, memory::REG_SCRATCH_0, 15);
+                    // Advance heap past buffer (aligned)
+                    self.emit_op(Opcode::Addi, 14, 15, 7);
+                    self.emit_op(Opcode::Addi, 15, 0, 3);
+                    self.emit_op(Opcode::Shr, 14, 14, 15);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                    // Stack: [old_cursor, buffer_start]
+
+                    // Unflatten: use r11 as read cursor
+                    self.emit_op(Opcode::Push, 11, 0, 0);          // save r11
+                    // Stack: [old_cursor, buffer_start, r11_saved]
+                    self.emit_op(Opcode::Pop, 15, 0, 0);           // r15 = r11_saved
+                    self.emit_op(Opcode::Pop, 11, 0, 0);           // r11 = buffer_start
+                    self.emit_op(Opcode::Push, 15, 0, 0);          // push r11_saved back
+                    // Stack: [old_cursor, r11_saved]
+
+                    let ty_clone = ty.clone();
+                    self.emit_unflatten(&ty_clone, 11, phys);
+
+                    self.emit_op(Opcode::Pop, 11, 0, 0);           // restore r11
+                    // Stack: [old_cursor]
+
+                    // Advance calldata cursor: old_cursor + 8 + align8(byte_len)
+                    self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0);
+                    self.emit_load(15, memory::REG_SCRATCH_0, 0);  // re-read byte_len
+                    self.emit_op(Opcode::Addi, 14, 15, 7);
+                    self.emit_op(Opcode::Addi, 15, 0, 3);
+                    self.emit_op(Opcode::Shr, 14, 14, 15);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 8);
+                    self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 14);
+                } else if matches!(ty, Ty::StringTy | Ty::Bytes) {
+                    // String/bytes: calldata has [byte_len:8 LE][data bytes]
+                    // Build Vec on heap directly (format unchanged)
+                    self.emit_op(Opcode::Add, phys, 12, 0);  // phys = Vec base = r12
+                    self.emit_load(15, memory::REG_SCRATCH_0, 0); // r15 = byte_len
+                    self.emit_store(15, 12, 0);               // header.length
+                    self.emit_store(15, 12, 8);               // header.capacity
+                    self.emit_op(Opcode::Addi, 12, 12, memory::VEC_DATA_OFFSET);
+                    self.emit_op(Opcode::Push, memory::REG_SCRATCH_0, 0, 0);
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 8);
+                    self.emit_op(Opcode::Memcpy, 12, memory::REG_SCRATCH_0, 15);
+                    self.emit_op(Opcode::Addi, 14, 15, 7);
+                    self.emit_op(Opcode::Addi, 15, 0, 3);
+                    self.emit_op(Opcode::Shr, 14, 14, 15);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                    self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0);
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 8);
+                    self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 14);
+                } else if is_wide_type(ty) {
+                    self.emit_op(Opcode::Wload, phys, memory::REG_SCRATCH_0, 0);
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 32);
+                } else {
+                    self.emit_load(phys, memory::REG_SCRATCH_0, 0);
+                    self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 8);
+                }
+            }
+        } else {
+            // Static calldata decode: all params fixed-size, use compile-time offsets.
+            let mut param_offset = selector_skip;
+            self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, 5, 0); // r14 = r5
+
+            for (i, (_name, ty)) in func.params.iter().enumerate() {
+                let phys = (i as u8) + 2;
+
+                if is_wide_type(ty) {
+                    self.emit_op(Opcode::Addi, 15, memory::REG_SCRATCH_0, param_offset as u32 & 0x3FFFF);
+                    self.emit_op(Opcode::Wload, phys, 15, 0);
+                    param_offset += 32;
+                } else {
+                    self.emit_load(phys, memory::REG_SCRATCH_0, param_offset);
+                    param_offset += 8;
+                }
             }
         }
     }
@@ -558,6 +722,7 @@ impl CodeGen {
     fn gen_function(&mut self, func: &IrFunction, is_entry: bool) {
         self.regs.reset();
         self.needs_guard_cleanup = false;
+        self.current_return_ty = func.return_ty.clone();
 
         // Remap IR labels to unique codegen labels to prevent cross-function collisions.
         // IR labels (L0, L1, L2, ...) restart per function, but codegen label_offsets is global.
@@ -576,11 +741,12 @@ impl CodeGen {
         }
 
         // Initialize spill base pointer: r13 = r12 (current heap top).
-        // Spill slots live at r13 + 0, r13 + 8, r13 + 16, ...
-        // Advance r12 past the spill area (reserve 256 bytes = 32 slots max).
+        // Spill slots live at r13 + 0, r13 + 8, ... (up to ~56 slots).
+        // Serialize/deserialize loop state lives at r13 + LOOP_STATE_BASE.
+        // Advance r12 past the entire reserved area.
         self.emit_op(Opcode::Add, 13, 12, 0);  // r13 = r12
-        self.load_u32_to_reg(15, 256);
-        self.emit_op(Opcode::Add, 12, 12, 15); // r12 += 256
+        self.load_u32_to_reg(15, SPILL_AREA_TOTAL);
+        self.emit_op(Opcode::Add, 12, 12, 15); // r12 += SPILL_AREA_TOTAL
 
         // Pre-map params to convention registers (r2, r3, ...)
         // In test mode without dispatch, params aren't loaded from calldata,
@@ -611,6 +777,9 @@ impl CodeGen {
     // ========================================================================
 
     fn gen_instruction(&mut self, inst: &Inst, is_entry: bool) {
+        // Clear pending writebacks from previous instruction
+        self.pending_writebacks.clear();
+        self.pending_restores.clear();
         match inst {
             Inst::Const(dst, val) => {
                 match val {
@@ -689,6 +858,28 @@ impl CodeGen {
                         self.load_u32_to_reg(15, aligned as u32);
                         self.emit_op(Opcode::Add, 12, 12, 15);
                     }
+                    IrConst::String(s) => {
+                        // Build Vec layout on heap: [byte_len:8][cap:8][char data...]
+                        let rd = self.alloc_gp(*dst);
+                        self.emit_op(Opcode::Add, rd, 12, 0); // rd = Vec base
+                        let byte_len = s.len() as u32;
+                        // Write header
+                        self.load_u32_to_reg(15, byte_len);
+                        self.emit_store(15, 12, 0);  // length = byte_len
+                        self.emit_store(15, 12, 8);  // capacity = byte_len
+                        // Write string bytes after header
+                        for (i, chunk) in s.as_bytes().chunks(8).enumerate() {
+                            let mut buf = [0u8; 8];
+                            buf[..chunk.len()].copy_from_slice(chunk);
+                            let val = u64::from_le_bytes(buf);
+                            self.load_u64_to_reg(15, val);
+                            self.emit_store(15, 12, (memory::VEC_DATA_OFFSET as i32) + (i as i32) * 8);
+                        }
+                        // Advance heap past header + data (aligned)
+                        let total = memory::VEC_DATA_OFFSET as u32 + ((byte_len + 7) / 8) * 8;
+                        self.load_u32_to_reg(15, total);
+                        self.emit_op(Opcode::Add, 12, 12, 15);
+                    }
                     IrConst::Unit => {}
                     _ => {
                         let rd = self.alloc_gp(*dst);
@@ -755,7 +946,8 @@ impl CodeGen {
 
             Inst::UnOp(dst, op, src) => {
                 let rd = self.alloc_gp(*dst);
-                let r1 = self.get_reg(*src);
+                // Restore to r14 (not r15) so LogicalNot's Addi r15 can't clobber src
+                let r1 = self.get_reg_to(*src, 14);
                 match op {
                     UnOp::Neg => {
                         // Two's complement: -a = ~a + 1 (avoids PVM checked_sub underflow trap)
@@ -763,7 +955,7 @@ impl CodeGen {
                         self.emit_op(Opcode::Addi, rd, rd, 1);     // rd = ~a + 1 = -a
                     }
                     UnOp::LogicalNot => {
-                        self.emit_op(Opcode::Addi, 15, 0, 1);
+                        self.emit_op(Opcode::Addi, 15, 0, 1);      // r15 = 1 (safe: r1 ∈ {r1-r11, r14})
                         self.emit_op(Opcode::Xor, rd, r1, 15);
                     }
                     UnOp::BitNot => {
@@ -848,8 +1040,8 @@ impl CodeGen {
                     self.emit_op(Opcode::Shr, 15, 15, 14);
                     self.emit_op(Opcode::Shl, 15, 15, 14);
                     self.emit_op(Opcode::Add, 12, 12, 15);
-                    // Deserialize from r11 into rd
-                    self.emit_deserialize(&ty, 11, rd);
+                    // Unflatten from r11 into rd
+                    self.emit_unflatten(&ty, 11, rd);
                     self.emit_op(Opcode::Pop, 11, 0, 0);      // restore r11
                 } else if is_wide_type(&ty) {
                     let wd = self.regs.alloc_wide(*dst);
@@ -870,9 +1062,9 @@ impl CodeGen {
 
                 let rv = self.get_reg(*val);
                 if is_blob_type(&ty) {
-                    // Save buffer_start on stack (emit_serialize clobbers r14/r15)
+                    // Save buffer_start on stack (emit_flatten clobbers r14/r15)
                     self.emit_op(Opcode::Push, 12, 0, 0);
-                    self.emit_serialize(&ty, rv);
+                    self.emit_flatten(&ty, rv);
                     self.emit_op(Opcode::Pop, 14, 0, 0);      // r14 = buffer_start
                     self.emit_op(Opcode::Sub, 15, 12, 14);    // r15 = byte_count
                     let imm = 1 | ((14 & 0xF) << 2) | ((15 & 0xF) << 6);
@@ -910,8 +1102,8 @@ impl CodeGen {
                     self.emit_op(Opcode::Shr, 15, 15, 14);
                     self.emit_op(Opcode::Shl, 15, 15, 14);
                     self.emit_op(Opcode::Add, 12, 12, 15);
-                    // Deserialize from r11 into rd
-                    self.emit_deserialize(&val_ty, 11, rd);
+                    // Unflatten from r11 into rd
+                    self.emit_unflatten(&val_ty, 11, rd);
                     self.emit_op(Opcode::Pop, 11, 0, 0);      // restore r11
                 } else if is_wide_type(&val_ty) {
                     let wd = self.regs.alloc_wide(*dst);
@@ -945,9 +1137,9 @@ impl CodeGen {
                 };
 
                 if is_blob_type(&val_ty) {
-                    // Borsh-serialize: save buffer_start on stack (emit_serialize clobbers r14/r15)
+                    // Flatten: save buffer_start on stack
                     self.emit_op(Opcode::Push, 12, 0, 0);     // push buffer_start = current r12
-                    self.emit_serialize(&val_ty, rv);
+                    self.emit_flatten(&val_ty, rv);
                     self.emit_op(Opcode::Pop, 14, 0, 0);      // r14 = buffer_start
                     self.emit_op(Opcode::Sub, 15, 12, 14);    // r15 = byte_count
                     let imm = 1 | ((14 & 0xF) << 2) | ((15 & 0xF) << 6);
@@ -1099,15 +1291,34 @@ impl CodeGen {
 
             Inst::Return(val) => {
                 if let Some(v) = val {
-                    let rv = self.get_reg(*v);
-                    if rv != 1 {
+                    let ret_ty = self.current_return_ty.clone();
+                    if is_blob_type(&ret_ty) {
+                        // Blob return (Struct/Vec/String): Borsh-serialize to heap,
+                        // set r1 = buffer_start, r2 = byte_length.
+                        // The RPC handler reads vm.memory[r1..r1+r2] for the full result.
+                        let rv = self.get_reg(*v);
+                        self.emit_op(Opcode::Push, 12, 0, 0);     // save buffer_start = current r12
+                        self.emit_flatten(&ret_ty, rv);
+                        self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = buffer_start
+                        self.emit_op(Opcode::Sub, 2, 12, 15);     // r2 = byte_length = r12 - buffer_start
+                        self.emit_op(Opcode::Add, 1, 15, 0);      // r1 = buffer_start
+                    } else {
+                        let rv = self.get_reg(*v);
                         if self.regs.is_wide(*v) {
-                            // Wide return: Narrow to GP r1 (traps if > u64::MAX)
-                            self.emit_op(Opcode::Narrow, 1, rv, 0);
-                        } else {
+                            if rv != 0 {
+                                self.emit_op(Opcode::Wmov, 0, rv, 0);
+                            }
+                            self.emit_op(Opcode::Wstore, 0, 12, 0);
+                            self.emit_load(1, 12, 0);
+                        } else if rv != 1 {
                             self.emit_op(Opcode::Add, 1, rv, 0);
                         }
+                        // Clear r2 AFTER rv→r1 copy so blob return check doesn't false-trigger
+                        self.emit_op(Opcode::Addi, 2, 0, 0);
                     }
+                } else {
+                    // Void return: clear r2 to prevent false blob detection
+                    self.emit_op(Opcode::Addi, 2, 0, 0);
                 }
                 if is_entry {
                     self.emit_op(Opcode::Halt, 0, 0, 0);
@@ -1238,74 +1449,92 @@ impl CodeGen {
                 }
             }
 
-            Inst::StructInit(dst, _name, fields) => {
+            Inst::StructInit(dst, name, fields) => {
                 let rd = self.alloc_gp(*dst);
-                let struct_size = (fields.len() as u32) * memory::WORD_SIZE;
+                let struct_size = self.compute_struct_size(name);
                 // Allocate on heap: rd = heap_ptr; heap_ptr += struct_size
                 self.emit_op(Opcode::Add, rd, 12, 0);
-                self.emit_op(Opcode::Addi, 12, 12, struct_size);
-                for (i, (fname, freg)) in fields.iter().enumerate() {
+                if struct_size <= 0x1FFFF {
+                    self.emit_op(Opcode::Addi, 12, 12, struct_size);
+                } else {
+                    self.load_u32_to_reg(15, struct_size);
+                    self.emit_op(Opcode::Add, 12, 12, 15);
+                }
+                for (fname, freg) in fields.iter() {
+                    let (offset, field_ty) = self.lookup_field(name, fname);
                     let fr = self.get_reg(*freg);
-                    let offset = (i as u32) * memory::WORD_SIZE;
-                    self.emit_store(fr, rd, offset as i32);
+                    if let Ty::Struct(inner) = &field_ty {
+                        // Inline nested struct: Memcpy from fr (pointer to temp alloc)
+                        // into rd+offset (inline slot in parent).
+                        let copy_size = self.compute_struct_size(inner);
+                        self.emit_op(Opcode::Push, rd, 0, 0);
+                        self.emit_op(Opcode::Addi, 15, rd, offset);  // dst = rd + offset
+                        self.load_u32_to_reg(14, copy_size);
+                        self.emit_op(Opcode::Memcpy, 15, fr, 14);
+                        self.emit_op(Opcode::Pop, rd, 0, 0);
+                    } else {
+                        // GP/wide field: typed store at computed offset
+                        self.emit_store_typed(fr, rd, offset as i32, &field_ty);
+                    }
                 }
             }
 
-            Inst::FieldGet(dst, obj, field) => {
-                let rd = self.alloc_gp(*dst);
+            Inst::FieldGet(dst, obj, struct_name, field) => {
                 let ro = self.get_reg(*obj);
-                // Numeric field name (e.g., "0", "1") = tuple index access
-                let offset = if let Ok(idx) = field.parse::<u32>() {
-                    idx * memory::WORD_SIZE as u32
+
+                if let Ok(idx) = field.parse::<u32>() {
+                    // Tuple index access: fixed 8-byte offsets
+                    let rd = self.alloc_gp(*dst);
+                    let offset = idx * memory::WORD_SIZE;
+                    self.emit_load(rd, ro, offset as i32);
+                } else if !struct_name.is_empty() {
+                    // Struct-aware field access
+                    let (offset, field_ty) = self.lookup_field(struct_name, field);
+                    if matches!(field_ty, Ty::Struct(_)) {
+                        // Inline nested struct: return interior pointer (Addi, no Load)
+                        let rd = self.alloc_gp(*dst);
+                        self.emit_op(Opcode::Addi, rd, ro, offset);
+                    } else if is_wide_type(&field_ty) {
+                        // Wide field: Wload
+                        let wd = self.regs.alloc_wide(*dst);
+                        self.emit_load_typed(wd, ro, offset as i32, &field_ty);
+                    } else {
+                        // GP field: typed load (W8/W16/W32/W64 based on field type)
+                        let rd = self.alloc_gp(*dst);
+                        self.emit_load_typed(rd, ro, offset as i32, &field_ty);
+                    }
                 } else {
-                    // Named field: look up in struct_defs
-                    self.field_offsets.get(field.as_str())
-                        .copied()
-                        .unwrap_or(0)
-                };
-                self.emit_load(rd, ro, offset as i32);
+                    // Non-struct access (balance, etc.): fallback global search
+                    let rd = self.alloc_gp(*dst);
+                    let offset = self.find_field_offset_any(field);
+                    self.emit_load(rd, ro, offset as i32);
+                }
             }
 
             Inst::IndexGet(dst, obj, idx) => {
                 let rd = self.alloc_gp(*dst);
-                // Use different restore targets for obj and idx
-                let ro = self.get_reg_to(*obj, 15);
-                let ri = self.get_reg_to(*idx, 14);
-                // addr = base + VEC_DATA_OFFSET + idx * 8
-                self.emit_op(Opcode::Addi, 14, 0, 3);
-                self.emit_op(Opcode::Shl, 14, ri, 14);      // r14 = idx * 8
-                self.emit_op(Opcode::Add, 15, ro, 14);       // r15 = base + idx*8
+                // With write-through, get_reg_to always re-loads from spill,
+                // so each call gets the correct value regardless of prior clobbers.
+                let ri = self.get_reg_to(*idx, 14);          // r14 = idx
+                self.emit_op(Opcode::Addi, 15, 0, 3);       // r15 = 3
+                self.emit_op(Opcode::Shl, 14, ri, 15);      // r14 = idx * 8
+                let ro = self.get_reg_to(*obj, 15);          // r15 = base (re-loaded from spill)
+                self.emit_op(Opcode::Add, 15, ro, 14);      // r15 = base + idx*8
                 self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
                 self.emit_load(rd, 15, 0);
             }
 
             Inst::IndexSet(obj, idx, val) => {
-                // Get all three with different targets, save val on stack
-                let ro = self.get_reg_to(*obj, 15);
-                let ri = self.get_reg_to(*idx, 14);
-                self.emit_op(Opcode::Push, ro, 0, 0);    // save base
-                let rv = self.get_reg(*val);              // might clobber ro
-                self.emit_op(Opcode::Push, rv, 0, 0);    // save val
-                self.emit_op(Opcode::Pop, 14, 0, 0);     // r14 = val
-                // Compute address
-                self.emit_op(Opcode::Pop, 15, 0, 0);     // r15 = base
-                // ri might have been clobbered — but we only need idx*8.
-                // Recompute: we lost ri. Need to re-get idx.
-                // Actually: ri = r14 from get_reg_to. But r14 was overwritten by Pop.
-                // This is getting circular. Let me just push idx too.
-                // Restart with clean Push/Pop approach:
-                self.emit_op(Opcode::Push, 14, 0, 0);    // push val back
-                self.emit_op(Opcode::Push, 15, 0, 0);    // push base back
-                // Now stack: [val, base]
-                // Re-get idx
-                let ri2 = self.get_reg_to(*idx, 14);
-                self.emit_op(Opcode::Addi, 14, 0, 3);
-                self.emit_op(Opcode::Shl, 14, ri2, 14);  // r14 = idx * 8
-                self.emit_op(Opcode::Pop, 15, 0, 0);     // r15 = base
-                self.emit_op(Opcode::Add, 15, 15, 14);   // r15 = base + idx*8
+                // With write-through, get_reg_to re-loads from spill each call,
+                // so sequential calls are safe without Push/Pop.
+                let ri = self.get_reg_to(*idx, 14);          // r14 = idx
+                self.emit_op(Opcode::Addi, 15, 0, 3);       // r15 = 3
+                self.emit_op(Opcode::Shl, 14, ri, 15);      // r14 = idx * 8
+                let ro = self.get_reg_to(*obj, 15);          // r15 = base (re-loaded)
+                self.emit_op(Opcode::Add, 15, ro, 14);      // r15 = base + idx*8
                 self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
-                self.emit_op(Opcode::Pop, 14, 0, 0);     // r14 = val
-                self.emit_store(14, 15, 0);
+                let rv = self.get_reg_to(*val, 14);          // r14 = val (re-loaded)
+                self.emit_store(rv, 15, 0);                  // data[idx] = val
             }
 
             Inst::MakeTuple(dst, regs) => {
@@ -1349,6 +1578,8 @@ impl CodeGen {
             Inst::ArrayRepeat(dst, val, count) => {
                 let rd = self.alloc_gp(*dst);
                 let rv = self.get_reg(*val);
+                // Save val to stack — load_u32_to_reg(15, count) clobbers r15 (and r14 as scratch)
+                self.emit_op(Opcode::Push, rv, 0, 0);
                 let data_size = (*count as u32) * memory::WORD_SIZE;
                 let total = memory::VEC_DATA_OFFSET as u32 + data_size;
                 self.emit_op(Opcode::Add, rd, 12, 0);
@@ -1356,9 +1587,11 @@ impl CodeGen {
                 self.load_u32_to_reg(15, *count as u32);
                 self.emit_store(15, rd, 0);  // length
                 self.emit_store(15, rd, 8);  // capacity
+                // Restore val from stack
+                self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = val (restored)
                 for i in 0..*count {
                     let offset = memory::VEC_DATA_OFFSET as u32 + (i as u32) * memory::WORD_SIZE;
-                    self.emit_store(rv, rd, offset as i32);
+                    self.emit_store(15, rd, offset as i32);
                 }
             }
 
@@ -1368,66 +1601,116 @@ impl CodeGen {
 
                 match method.as_str() {
                     "push" if !args.is_empty() => {
-                        // Use get_reg_to to put val in r14 (not r15), keeping ro safe
-                        let val_reg = self.get_reg_to(args[0], 14);
-                        // Save val on stack (r14 gets clobbered by capacity load below)
-                        self.emit_op(Opcode::Push, val_reg, 0, 0);
-                        // Load length and capacity (uses r15 and r14 as scratch)
-                        self.emit_load(memory::REG_SCRATCH_1, ro, memory::VEC_LENGTH_OFFSET as i32);  // r15 = length
-                        self.emit_load(memory::REG_SCRATCH_0, ro, memory::VEC_CAPACITY_OFFSET as i32); // r14 = capacity
+                        // Unified push handler: works for both permanent (r1-r11) and
+                        // spill-only (r14/r15) Vec registers. Saves the Vec base to a
+                        // fixed spill slot and reloads as needed. Includes full realloc.
+                        const PUSH_OBJ_SPILL: i32 = LOOP_STATE_BASE + 32;
 
-                        // Branch: length < capacity → fast path, else → realloc
+                        let val_reg = self.get_reg_to(args[0], 14);
+                        self.emit_op(Opcode::Push, val_reg, 0, 0);  // save val on stack
+                        self.emit_store(ro, 13, PUSH_OBJ_SPILL);    // save Vec base
+
+                        // Load length (r15) and capacity (r14) from base
+                        // Load base once, read both fields before base register is clobbered.
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);  // r15 = base
+                        self.emit_load(memory::REG_SCRATCH_0, 15, memory::VEC_CAPACITY_OFFSET as i32); // r14 = cap
+                        self.emit_load(memory::REG_SCRATCH_1, 15, memory::VEC_LENGTH_OFFSET as i32);   // r15 = len (clobbers base, OK)
+
                         let fast_label = self.alloc_label();
                         let realloc_label = self.alloc_label();
                         let write_label = self.alloc_label();
 
+                        // Branch: len < cap → fast path, else → realloc
                         self.emit_op(Opcode::Lt, 15, memory::REG_SCRATCH_1, memory::REG_SCRATCH_0 as u32);
                         self.emit_jump_placeholder(Opcode::Bne, 15, 0, fast_label);
                         self.emit_jump_placeholder(Opcode::Jmp, 0, 0, realloc_label);
 
                         // === Realloc ===
                         self.mark_label(realloc_label);
-                        self.emit_load(memory::REG_SCRATCH_0, ro, memory::VEC_CAPACITY_OFFSET as i32);
+                        // New capacity = old_cap * 2
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                        self.emit_load(memory::REG_SCRATCH_0, 15, memory::VEC_CAPACITY_OFFSET as i32);
                         self.emit_op(Opcode::Addi, 15, 0, 1);
-                        self.emit_op(Opcode::Shl, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 15);
-                        self.emit_load(memory::REG_SCRATCH_1, ro, memory::VEC_LENGTH_OFFSET as i32);
+                        self.emit_op(Opcode::Shl, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, 15); // r14 = cap*2
+                        // Read old length
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                        self.emit_load(memory::REG_SCRATCH_1, 15, memory::VEC_LENGTH_OFFSET as i32); // r15 = len
+                        // Write new header at r12 (new allocation)
                         self.emit_store(memory::REG_SCRATCH_1, 12, memory::VEC_LENGTH_OFFSET as i32);
                         self.emit_store(memory::REG_SCRATCH_0, 12, memory::VEC_CAPACITY_OFFSET as i32);
-                        // Memcpy old data (avoid r13)
+                        // Memcpy old data: count = len*8, src = old_base+16, dst = r12+16
                         self.emit_op(Opcode::Addi, 14, 0, 3);
-                        self.emit_op(Opcode::Shl, 14, memory::REG_SCRATCH_1, 14);
-                        self.emit_op(Opcode::Addi, 15, 12, memory::VEC_DATA_OFFSET);
-                        self.emit_op(Opcode::Push, ro, 0, 0);
-                        self.emit_op(Opcode::Addi, ro, ro, memory::VEC_DATA_OFFSET);
-                        self.emit_op(Opcode::Memcpy, 15, ro, 14);
-                        self.emit_op(Opcode::Pop, ro, 0, 0);
-                        // Update ro and advance heap
+                        self.emit_op(Opcode::Shl, 14, memory::REG_SCRATCH_1, 14); // r14 = len*8
+                        self.emit_op(Opcode::Addi, 15, 12, memory::VEC_DATA_OFFSET); // r15 = new data ptr
+                        self.emit_op(Opcode::Push, 15, 0, 0);   // save new data ptr
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                        self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET); // r15 = old data ptr
+                        self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0); // r14_tmp = new data ptr (actually into r14... let me use stack properly)
+                        // Stack juggle: need Memcpy(new_data, old_data, len*8)
+                        // r15 = old data ptr, r14 = len*8, need new_data_ptr
+                        self.emit_op(Opcode::Push, 14, 0, 0);   // save len*8
+                        self.emit_op(Opcode::Push, 15, 0, 0);   // save old_data
+                        self.emit_op(Opcode::Addi, 15, 12, memory::VEC_DATA_OFFSET); // r15 = new data
+                        self.emit_op(Opcode::Pop, 14, 0, 0);    // r14 = old_data (src)
+                        self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0); // ... need 3 regs for Memcpy
+                        // Use r11 for len
+                        self.emit_op(Opcode::Push, 11, 0, 0);
+                        self.emit_op(Opcode::Addi, 11, 0, 3);
+                        self.emit_load(memory::REG_SCRATCH_0, 13, PUSH_OBJ_SPILL);
+                        self.emit_load(memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, memory::VEC_LENGTH_OFFSET as i32);
+                        self.emit_op(Opcode::Shl, 11, memory::REG_SCRATCH_0, 11); // r11 = len*8
+                        self.emit_load(14, 13, PUSH_OBJ_SPILL);
+                        self.emit_op(Opcode::Addi, 14, 14, memory::VEC_DATA_OFFSET); // r14 = old data
+                        self.emit_op(Opcode::Addi, 15, 12, memory::VEC_DATA_OFFSET); // r15 = new data
+                        self.emit_op(Opcode::Memcpy, 15, 14, 11); // copy old→new
+                        self.emit_op(Opcode::Pop, 11, 0, 0);    // restore r11
+                        // Update base to new allocation, advance heap
+                        self.emit_store(12, 13, PUSH_OBJ_SPILL); // base = r12 (new alloc)
                         self.emit_load(memory::REG_SCRATCH_0, 12, memory::VEC_CAPACITY_OFFSET as i32);
-                        self.emit_op(Opcode::Add, ro, 12, 0);
                         self.emit_op(Opcode::Addi, 15, 0, 3);
-                        self.emit_op(Opcode::Shl, 15, memory::REG_SCRATCH_0, 15);
+                        self.emit_op(Opcode::Shl, 15, memory::REG_SCRATCH_0, 15); // r15 = cap*8
                         self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
-                        self.emit_op(Opcode::Add, 12, 12, 15);
-                        self.emit_load(memory::REG_SCRATCH_1, ro, memory::VEC_LENGTH_OFFSET as i32);
+                        self.emit_op(Opcode::Add, 12, 12, 15);  // r12 past new allocation
+                        // Load len for write path
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                        self.emit_load(memory::REG_SCRATCH_1, 15, memory::VEC_LENGTH_OFFSET as i32);
                         self.emit_jump_placeholder(Opcode::Jmp, 0, 0, write_label);
 
                         // === Fast path ===
                         self.mark_label(fast_label);
-                        self.emit_load(memory::REG_SCRATCH_1, ro, memory::VEC_LENGTH_OFFSET as i32);
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                        self.emit_load(memory::REG_SCRATCH_1, 15, memory::VEC_LENGTH_OFFSET as i32);
 
                         // === Write value ===
                         self.mark_label(write_label);
-                        // r15 = length. Compute address, increment length, then pop val and store.
-                        self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, 0, 3);
-                        self.emit_op(Opcode::Shl, memory::REG_SCRATCH_0, memory::REG_SCRATCH_1, memory::REG_SCRATCH_0 as u32);
-                        self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, ro, memory::REG_SCRATCH_0 as u32);
+                        // r15 (REG_SCRATCH_1) = len from fast/realloc path.
+                        // First: increment length and store it (before r15 gets clobbered)
+                        self.emit_op(Opcode::Addi, memory::REG_SCRATCH_1, memory::REG_SCRATCH_1, 1); // r15 = len+1
+                        self.emit_op(Opcode::Push, memory::REG_SCRATCH_1, 0, 0); // save new_len
+                        self.emit_load(memory::REG_SCRATCH_0, 13, PUSH_OBJ_SPILL); // r14 = base
+                        self.emit_op(Opcode::Pop, memory::REG_SCRATCH_1, 0, 0);    // r15 = new_len
+                        self.emit_store(memory::REG_SCRATCH_1, memory::REG_SCRATCH_0, memory::VEC_LENGTH_OFFSET as i32);
+                        // Compute write addr = base + VEC_DATA_OFFSET + old_len*8
+                        // old_len = new_len - 1
+                        self.emit_op(Opcode::Addi, memory::REG_SCRATCH_1, memory::REG_SCRATCH_1, 0x3FFFF); // r15 = old_len (-1)
+                        self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, 0, 3);   // r14 = 3
+                        self.emit_op(Opcode::Shl, memory::REG_SCRATCH_0, memory::REG_SCRATCH_1, memory::REG_SCRATCH_0 as u32); // r14 = old_len*8
+                        self.emit_load(15, 13, PUSH_OBJ_SPILL);                    // r15 = base
+                        self.emit_op(Opcode::Add, memory::REG_SCRATCH_0, 15, memory::REG_SCRATCH_0 as u32); // r14 = base+old_len*8
                         self.emit_op(Opcode::Addi, memory::REG_SCRATCH_0, memory::REG_SCRATCH_0, memory::VEC_DATA_OFFSET);
-                        // Increment length first (r15 still has it)
-                        self.emit_op(Opcode::Addi, memory::REG_SCRATCH_1, memory::REG_SCRATCH_1, 1);
-                        self.emit_store(memory::REG_SCRATCH_1, ro, memory::VEC_LENGTH_OFFSET as i32);
-                        // Pop saved val and write
+                        // Pop val and write
                         self.emit_op(Opcode::Pop, memory::REG_SCRATCH_1, 0, 0);
                         self.emit_store(memory::REG_SCRATCH_1, memory::REG_SCRATCH_0, 0);
+
+                        // If obj was spill-only, update its vreg's canonical spill slot
+                        // so subsequent reads get the (potentially reallocated) base.
+                        if self.regs.is_spilled(*obj) {
+                            self.emit_load(15, 13, PUSH_OBJ_SPILL);
+                            self.emit_writeback(*obj, 15);
+                        } else if ro <= 11 {
+                            // Permanent register: update it with the (potentially new) base
+                            self.emit_load(ro, 13, PUSH_OBJ_SPILL);
+                        }
                     }
                     "pop" => {
                         // Load length, assert > 0
@@ -1500,8 +1783,9 @@ impl CodeGen {
             }
 
             Inst::CrossCall { target, method, args, .. } => {
-                let rt = self.get_reg(*target);
-                let rm = self.get_reg(*method);
+                // Use different restore targets so both survive if both spilled
+                let rt = self.get_reg_to(*target, 15);
+                let rm = self.get_reg_to(*method, 14);
                 for arg in args {
                     let r = self.get_reg(*arg);
                     self.emit_op(Opcode::Push, r, 0, 0);
@@ -1553,6 +1837,8 @@ impl CodeGen {
                 // We need to: write constructor args after the blob, then Create.
                 let wd = self.regs.alloc_wide(*dst);
                 let rb = self.get_reg(*blob_reg); // GP reg with blob heap pointer
+                // Save blob pointer to stack — args loop's get_reg calls may clobber r15
+                self.emit_op(Opcode::Push, rb, 0, 0);
 
                 // The Const(blob_reg, Bytes(data)) handler writes data to heap[r12]
                 // and sets blob_reg = r12, then advances r12.
@@ -1565,17 +1851,20 @@ impl CodeGen {
                 }
                 let args_size = (args.len() as u32) * 8;
 
+                // Restore blob pointer from stack
+                self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = blob pointer (restored)
+
                 // Total length = blob_size (r12 - rb) + args_size
-                // r14 = r12 - rb (blob size)
-                self.emit_op(Opcode::Sub, 14, 12, rb as u32);
+                // r14 = r12 - r15 (blob size)
+                self.emit_op(Opcode::Sub, 14, 12, 15);
                 // r14 += args_size (total deploy data length)
                 if args_size > 0 {
                     self.emit_op(Opcode::Addi, 14, 14, args_size);
                     self.emit_op(Opcode::Addi, 12, 12, args_size); // advance heap past args
                 }
 
-                // Create: wd = new address, rs1 = blob pointer, imm[3:0] = length register (r14)
-                self.emit_op(Opcode::Create, wd, rb, 14 & 0xF);
+                // Create: wd = new address, rs1 = blob pointer (r15), imm[3:0] = length register (r14)
+                self.emit_op(Opcode::Create, wd, 15, 14 & 0xF);
             }
 
             Inst::MakeVec(dst, cap) => {
@@ -1597,6 +1886,16 @@ impl CodeGen {
             Inst::Comment(_) => {}
             Inst::Phi(_, _) => {}
         }
+
+        // Flush pending write-through stores: after each instruction that writes
+        // a GP register, store the result to the canonical spill slot.
+        for (phys, vreg) in std::mem::take(&mut self.pending_writebacks) {
+            self.emit_writeback(vreg, phys);
+        }
+        // Restore borrowed registers (LIFO order — Pop in reverse)
+        for reg in std::mem::take(&mut self.pending_restores).into_iter().rev() {
+            self.emit_op(Opcode::Pop, reg, 0, 0);
+        }
     }
 
     // ========================================================================
@@ -1604,6 +1903,7 @@ impl CodeGen {
     // ========================================================================
 
     /// Allocate a GP register for a virtual register, emitting spill Store if eviction needed.
+    /// Also ensures the vreg has a canonical spill slot (for write-through loop safety).
     fn alloc_gp(&mut self, vreg: Reg) -> u8 {
         let (phys, spill) = self.regs.alloc(vreg);
         if let Some(SpillAction::Save(reg, slot)) = spill {
@@ -1612,7 +1912,36 @@ impl CodeGen {
             let imm = encode_mem_immediate(offset, MemWidth::W64).unwrap();
             self.instructions.push(encode(Opcode::Store, reg, 13, imm));
         }
+        // If this vreg is spill-only (no permanent register), borrow r1:
+        // 1. Ensure the vreg currently in r1 has a spill slot (so get_reg_to
+        //    can load it from spill while r1 is borrowed)
+        // 2. Store r1 to that spill slot (write-through for the displaced vreg)
+        // 3. Push r1 to PVM stack (for restoration at end of instruction)
+        // 4. Use r1 for the new vreg
+        if self.regs.is_spilled(vreg) {
+            // Ensure the vreg occupying r1 has a spill slot
+            if let Some(&displaced_vreg) = self.regs.reverse.get(&phys) {
+                if !self.regs.spilled.contains_key(&displaced_vreg) {
+                    let slot = self.regs.next_spill_slot;
+                    self.regs.next_spill_slot += 1;
+                    self.regs.spilled.insert(displaced_vreg, slot);
+                }
+                // Write r1's current value to the displaced vreg's spill slot
+                self.emit_writeback(displaced_vreg, phys);
+            }
+            self.emit_op(Opcode::Push, phys, 0, 0); // save r1 to stack
+            self.pending_writebacks.push((phys, vreg));
+            self.pending_restores.push(phys);
+        }
         phys
+    }
+
+    /// Write-through: store a GP register's value to its canonical spill slot.
+    /// Must be called AFTER every instruction that writes a GP destination register.
+    fn emit_writeback(&mut self, vreg: Reg, phys: u8) {
+        if let Some(&slot) = self.regs.spilled.get(&vreg) {
+            self.emit_store(phys, 13, (slot * 8) as i32);
+        }
     }
 
     /// Get the physical register for a virtual register, emitting spill Load if needed.
@@ -1623,15 +1952,23 @@ impl CodeGen {
     }
 
     /// Get the physical register for a virtual register, restoring to `restore_to` if spilled.
-    /// Use different restore targets when an instruction has multiple source operands
-    /// that could both be spilled (prevents second restore from clobbering the first).
+    /// If the vreg's register is currently borrowed (in pending_restores), loads from
+    /// the vreg's spill slot instead of returning the register directly.
     fn get_reg_to(&mut self, vreg: Reg, restore_to: u8) -> u8 {
         match self.regs.get_or_spilled(vreg) {
-            Ok(phys) => phys,
+            Ok(phys) => {
+                // Check if this register is currently borrowed by a spill-only alloc.
+                // If so, the register doesn't hold this vreg's value — load from spill.
+                if self.pending_restores.contains(&phys) {
+                    if let Some(&slot) = self.regs.spilled.get(&vreg) {
+                        self.emit_load(restore_to, 13, (slot * 8) as i32);
+                        return restore_to;
+                    }
+                }
+                phys
+            }
             Err(RestoreAction::Restore(_, slot)) => {
-                let offset = (slot * 8) as i32;
-                let imm = encode_mem_immediate(offset, MemWidth::W64).unwrap();
-                self.instructions.push(encode(Opcode::Load, restore_to, 13, imm));
+                self.emit_load(restore_to, 13, (slot * 8) as i32);
                 restore_to
             }
         }
@@ -1653,6 +1990,40 @@ impl CodeGen {
     fn emit_store(&mut self, val: u8, base: u8, offset: i32) {
         let imm = encode_mem_immediate(offset, MemWidth::W64).unwrap();
         self.emit(encode(Opcode::Store, val, base, imm));
+    }
+
+    /// Load a struct field using the correct memory width for the type.
+    /// Wide types use Wload (32 bytes), GP types use Load with W8/W16/W32/W64.
+    fn emit_load_typed(&mut self, rd: u8, base: u8, offset: i32, ty: &Ty) {
+        if is_wide_type(ty) {
+            if offset != 0 {
+                self.emit_op(Opcode::Addi, 15, base, offset as u32 & 0x3FFFF);
+                self.emit_op(Opcode::Wload, rd, 15, 0);
+            } else {
+                self.emit_op(Opcode::Wload, rd, base, 0);
+            }
+        } else {
+            let width = mem_width_for_type(ty);
+            let imm = encode_mem_immediate(offset, width).unwrap();
+            self.emit(encode(Opcode::Load, rd, base, imm));
+        }
+    }
+
+    /// Store a struct field using the correct memory width for the type.
+    /// Wide types use Wstore (32 bytes), GP types use Store with W8/W16/W32/W64.
+    fn emit_store_typed(&mut self, val: u8, base: u8, offset: i32, ty: &Ty) {
+        if is_wide_type(ty) {
+            if offset != 0 {
+                self.emit_op(Opcode::Addi, 15, base, offset as u32 & 0x3FFFF);
+                self.emit_op(Opcode::Wstore, val, 15, 0);
+            } else {
+                self.emit_op(Opcode::Wstore, val, base, 0);
+            }
+        } else {
+            let width = mem_width_for_type(ty);
+            let imm = encode_mem_immediate(offset, width).unwrap();
+            self.emit(encode(Opcode::Store, val, base, imm));
+        }
     }
 
     fn current_offset(&self) -> usize {
@@ -1800,12 +2171,8 @@ impl CodeGen {
         self.emit_op(Opcode::Poseidon, WIDE_SCRATCH, 12, 14);
     }
 
-    // ========================================================================
-    // Borsh-style serialization (Phase A: GP + String + Vec<fixed>)
-    // ========================================================================
-
-    /// Serialize a value in `val_reg` to heap at r12, advancing r12.
-    /// Produces a packed byte stream: GP→8B, wide→32B, String→[len:8][data], Vec→[count:8][data].
+    /// DEPRECATED: old Borsh-style serializer. Replaced by emit_flatten.
+    #[allow(dead_code)]
     fn emit_serialize(&mut self, ty: &Ty, val_reg: u8) {
         if is_wide_type(ty) {
             // Wide types (u256, i256, Address): 32 bytes via Wstore
@@ -1813,11 +2180,13 @@ impl CodeGen {
             self.emit_op(Opcode::Addi, 12, 12, 32);
         } else if matches!(ty, Ty::StringTy | Ty::Bytes) {
             // String/Bytes: val_reg points to Vec layout [len:8][cap:8][data...]
-            // Serialize as [byte_len:8][data bytes padded to 8-alignment]
-            self.emit_load(14, val_reg, 0);              // r14 = element count (byte_len for String)
+            // Save val_reg (might be r14 which gets clobbered by byte_len load)
+            self.emit_op(Opcode::Push, val_reg, 0, 0);
+            self.emit_load(14, val_reg, 0);              // r14 = byte_len
             self.emit_store(14, 12, 0);                   // write byte_len prefix
             self.emit_op(Opcode::Addi, 12, 12, 8);       // advance past prefix
-            self.emit_op(Opcode::Addi, 15, val_reg, memory::VEC_DATA_OFFSET); // r15 = data ptr
+            self.emit_op(Opcode::Pop, 15, 0, 0);         // r15 = val_reg (string base)
+            self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET); // r15 = data ptr
             self.emit_op(Opcode::Memcpy, 12, 15, 14);    // Memcpy dst=r12, src=r15, len=r14
             // Advance r12 by align8(byte_len): r12 += (byte_len + 7) & ~7
             self.emit_op(Opcode::Addi, 14, 14, 7);
@@ -1849,33 +2218,33 @@ impl CodeGen {
                 Some(32) => {
                     // Vec of wide elements: loop with Wload/Wstore
                     self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = vec base (saved)
-                    self.emit_store(14, 13, 208);              // spill count
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 8);              // spill count
                     self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
-                    self.emit_store(15, 13, 216);              // spill src_ptr
+                    self.emit_store(15, 13, LOOP_STATE_BASE + 16);              // spill src_ptr
                     self.emit_op(Opcode::Addi, 14, 0, 0);     // i = 0
-                    self.emit_store(14, 13, 200);              // spill i
+                    self.emit_store(14, 13, LOOP_STATE_BASE);              // spill i
 
                     let loop_label = self.alloc_label();
                     let done_label = self.alloc_label();
                     self.mark_label(loop_label);
 
                     // Check i < count
-                    self.emit_load(14, 13, 200);               // r14 = i
-                    self.emit_load(15, 13, 208);               // r15 = count
+                    self.emit_load(14, 13, LOOP_STATE_BASE);               // r14 = i
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 8);               // r15 = count
                     self.emit_jump_placeholder(Opcode::Beq, 14, 15, done_label); // if i == count → done
 
                     // Load src_ptr, Wload element, Wstore to r12
-                    self.emit_load(15, 13, 216);               // r15 = src_ptr
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 16);               // r15 = src_ptr
                     self.emit_op(Opcode::Wload, WIDE_SCRATCH2, 15, 0); // w6 = *src_ptr
                     self.emit_op(Opcode::Wstore, WIDE_SCRATCH2, 12, 0); // *r12 = w6
                     self.emit_op(Opcode::Addi, 12, 12, 32);   // r12 += 32
                     self.emit_op(Opcode::Addi, 15, 15, 32);   // src_ptr += 32
-                    self.emit_store(15, 13, 216);              // update src_ptr
+                    self.emit_store(15, 13, LOOP_STATE_BASE + 16);              // update src_ptr
 
                     // i++
-                    self.emit_load(14, 13, 200);
+                    self.emit_load(14, 13, LOOP_STATE_BASE);
                     self.emit_op(Opcode::Addi, 14, 14, 1);
-                    self.emit_store(14, 13, 200);
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
                     self.emit_jump_placeholder(Opcode::Jmp, 0, 0, loop_label);
 
                     self.mark_label(done_label);
@@ -1928,15 +2297,38 @@ impl CodeGen {
                 }
             }
         } else if let Ty::Struct(name) = ty {
-            // Struct: serialize field-by-field (all GP fields → flat Memcpy)
+            // Struct: serialize field-by-field, recursing into nested structs.
             if let Some(fields) = self.struct_defs.get(name).cloned() {
-                let byte_size = (fields.len() as u32) * memory::WORD_SIZE;
-                // Save val_reg to stack (Memcpy setup clobbers r14/r15)
-                self.emit_op(Opcode::Push, val_reg, 0, 0);
-                self.emit_op(Opcode::Pop, 15, 0, 0);            // r15 = struct base
-                self.load_u32_to_reg(14, byte_size);             // r14 = byte count
-                self.emit_op(Opcode::Memcpy, 12, 15, 14);       // copy struct → buffer
-                self.emit_op(Opcode::Add, 12, 12, 14);          // advance r12
+                let has_nested = fields.iter().any(|(_, fty)| matches!(fty, Ty::Struct(_)) || is_blob_type(fty));
+                if has_nested {
+                    // Recursive: serialize each field individually.
+                    // Push val_reg (struct base) before each field, Pop AFTER serialize
+                    // so that emit_serialize can freely use r14/r15 as scratch without
+                    // clobbering val_reg (critical when val_reg is r14/r15 for spill-only).
+                    for (i, (_, fty)) in fields.iter().enumerate() {
+                        let offset = (i as u32) * memory::WORD_SIZE;
+                        self.emit_op(Opcode::Push, val_reg, 0, 0);
+                        // Load field value from struct
+                        if is_wide_type(&fty) {
+                            self.emit_op(Opcode::Addi, 15, val_reg, offset);
+                            self.emit_op(Opcode::Wload, WIDE_SCRATCH2, 15, 0);
+                            self.emit_serialize(&fty, WIDE_SCRATCH2);
+                        } else {
+                            self.emit_load(14, val_reg, offset as i32);
+                            self.emit_serialize(&fty, 14);
+                        }
+                        // Restore struct base for next field iteration
+                        self.emit_op(Opcode::Pop, val_reg, 0, 0);
+                    }
+                } else {
+                    // Flat: all GP fields, Memcpy the whole struct
+                    let byte_size = (fields.len() as u32) * memory::WORD_SIZE;
+                    self.emit_op(Opcode::Push, val_reg, 0, 0);
+                    self.emit_op(Opcode::Pop, 15, 0, 0);
+                    self.load_u32_to_reg(14, byte_size);
+                    self.emit_op(Opcode::Memcpy, 12, 15, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                }
             }
         } else {
             // GP types (u8-u64, bool, Enum, etc.): 8 bytes via Store
@@ -1945,8 +2337,304 @@ impl CodeGen {
         }
     }
 
-    /// Deserialize from mem[src_reg] into dst_reg, advancing src_reg.
-    /// Allocates new heap structures at r12 for variable-length types.
+    // ========================================================================
+    // Flat inline format: flatten (pointer-based → flat wire bytes at r12)
+    // ========================================================================
+
+    /// Flatten a value in `val_reg` to heap at r12, advancing r12.
+    /// Produces flat inline bytes: GP→8B, wide→32B, String→[byte_len:8][data],
+    /// Vec→[len:8][cap:8][elem0][elem1]..., Struct→fields inlined recursively.
+    fn emit_flatten(&mut self, ty: &Ty, val_reg: u8) {
+        if is_wide_type(ty) {
+            self.emit_op(Opcode::Wstore, val_reg, 12, 0);
+            self.emit_op(Opcode::Addi, 12, 12, 32);
+        } else if matches!(ty, Ty::StringTy | Ty::Bytes) {
+            // String/Bytes: val_reg → Vec layout [len:8][cap:8][data...]
+            // Write [byte_len:8][data padded to 8]
+            self.emit_op(Opcode::Push, val_reg, 0, 0);
+            self.emit_load(14, val_reg, 0);              // r14 = byte_len
+            self.emit_store(14, 12, 0);                   // write byte_len prefix
+            self.emit_op(Opcode::Addi, 12, 12, 8);
+            self.emit_op(Opcode::Pop, 15, 0, 0);         // r15 = string base
+            self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
+            self.emit_op(Opcode::Memcpy, 12, 15, 14);
+            // Advance r12 by align8(byte_len)
+            self.emit_op(Opcode::Addi, 14, 14, 7);
+            self.emit_op(Opcode::Addi, 15, 0, 3);
+            self.emit_op(Opcode::Shr, 14, 14, 15);
+            self.emit_op(Opcode::Shl, 14, 14, 15);
+            self.emit_op(Opcode::Add, 12, 12, 14);
+        } else if let Ty::Vec(elem_ty) = ty {
+            let defs = self.struct_defs.clone();
+            let elem_size = flat_elem_size(elem_ty, &defs);
+            // Save val_reg (may be r14/r15), then Pop to r15 for safe field access
+            self.emit_op(Opcode::Push, val_reg, 0, 0);
+            self.emit_op(Opcode::Pop, 15, 0, 0);          // r15 = vec base (safe)
+            self.emit_op(Opcode::Push, 15, 0, 0);         // push back for later use
+            // Write [len:8][cap:8] header
+            self.emit_load(14, 15, memory::VEC_LENGTH_OFFSET as i32);  // r14 = len
+            self.emit_store(14, 12, 0);                    // write len
+            self.emit_op(Opcode::Push, 14, 0, 0);         // save len
+            self.emit_load(14, 15, memory::VEC_CAPACITY_OFFSET as i32); // r14 = cap
+            self.emit_store(14, 12, 8);                    // write cap
+            self.emit_op(Opcode::Pop, 14, 0, 0);          // restore r14 = len (count)
+            self.emit_op(Opcode::Addi, 12, 12, 16);       // advance past 16-byte header
+            // r14 = count for the element loop below
+
+            match elem_size {
+                Some(sz) if sz == 8 || sz == 16 || sz == 32 => {
+                    // Fixed-size elements: bulk Memcpy count * sz bytes
+                    self.emit_op(Opcode::Pop, 15, 0, 0);     // r15 = vec base
+                    self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
+                    self.emit_op(Opcode::Push, 15, 0, 0);    // save data ptr
+                    let shift = if sz == 8 { 3 } else if sz == 16 { 4 } else { 5 };
+                    self.emit_op(Opcode::Addi, 15, 0, shift);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);   // r14 = count * sz
+                    self.emit_op(Opcode::Pop, 15, 0, 0);     // r15 = data ptr
+                    self.emit_op(Opcode::Memcpy, 12, 15, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                }
+                Some(sz) => {
+                    // Fixed-size struct elements: bulk Memcpy count * sz bytes
+                    // sz is not a power of 2, so compute count * sz via multiply
+                    self.emit_op(Opcode::Pop, 15, 0, 0);     // r15 = vec base
+                    self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
+                    self.emit_op(Opcode::Push, 15, 0, 0);
+                    self.load_u32_to_reg(15, sz);
+                    self.emit_op(Opcode::Mul, 14, 14, 15);   // r14 = count * sz
+                    self.emit_op(Opcode::Pop, 15, 0, 0);
+                    self.emit_op(Opcode::Memcpy, 12, 15, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                }
+                None => {
+                    // Variable-size elements: stack-based countdown loop
+                    self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = vec base
+                    self.emit_load(14, 15, 0);                 // r14 = count
+                    self.emit_op(Opcode::Addi, 15, 15, memory::VEC_DATA_OFFSET);
+                    self.emit_op(Opcode::Push, 14, 0, 0);     // push remaining
+                    self.emit_op(Opcode::Push, 15, 0, 0);     // push src_ptr
+
+                    let loop_label = self.alloc_label();
+                    let done_label = self.alloc_label();
+                    self.mark_label(loop_label);
+
+                    self.emit_op(Opcode::Pop, 15, 0, 0);      // r15 = src_ptr
+                    self.emit_op(Opcode::Pop, 14, 0, 0);      // r14 = remaining
+                    self.emit_jump_placeholder(Opcode::Beq, 14, 0, done_label);
+
+                    self.emit_op(Opcode::Addi, 14, 14, 0x3FFFF); // remaining--
+                    self.emit_op(Opcode::Push, 14, 0, 0);
+                    self.emit_op(Opcode::Addi, 14, 15, 8);    // new src_ptr
+                    self.emit_op(Opcode::Push, 14, 0, 0);
+                    self.emit_load(14, 15, 0);                 // r14 = *src_ptr (element ptr)
+
+                    let elem_ty_clone = (**elem_ty).clone();
+                    self.emit_flatten(&elem_ty_clone, 14);
+
+                    self.emit_jump_placeholder(Opcode::Jmp, 0, 0, loop_label);
+                    self.mark_label(done_label);
+                }
+            }
+        } else if let Ty::Struct(name) = ty {
+            // Struct: ALWAYS recursive field-by-field with actual byte offsets.
+            // For inline nested structs, use Addi (interior pointer) instead of Load.
+            if let Some(fields) = self.struct_defs.get(name).cloned() {
+                let offsets: Vec<(u32, Ty)> = fields.iter()
+                    .map(|(fname, _)| self.lookup_field(name, fname))
+                    .collect();
+                for (offset, fty) in &offsets {
+                    self.emit_op(Opcode::Push, val_reg, 0, 0);
+                    if matches!(fty, Ty::Struct(_)) {
+                        // Inline nested struct: Addi to get interior pointer
+                        self.emit_op(Opcode::Addi, 14, val_reg, *offset);
+                        self.emit_flatten(fty, 14);
+                    } else if is_wide_type(fty) {
+                        self.emit_load_typed(WIDE_SCRATCH2, val_reg, *offset as i32, fty);
+                        self.emit_flatten(fty, WIDE_SCRATCH2);
+                    } else {
+                        // GP: typed load (W8/W16/W32/W64) into r14
+                        self.emit_load_typed(14, val_reg, *offset as i32, fty);
+                        self.emit_flatten(fty, 14);
+                    }
+                    self.emit_op(Opcode::Pop, val_reg, 0, 0);
+                }
+            }
+        } else {
+            // GP types: 8 bytes
+            self.emit_store(val_reg, 12, 0);
+            self.emit_op(Opcode::Addi, 12, 12, 8);
+        }
+    }
+
+    // ========================================================================
+    // Flat inline format: unflatten (flat wire bytes → pointer-based in-memory)
+    // ========================================================================
+
+    /// Unflatten from flat wire bytes at mem[src_reg] into pointer-based in-memory
+    /// layout, advancing src_reg. Result goes into dst_reg.
+    /// Flat format: GP→8B, wide→32B, String→[byte_len:8][data],
+    /// Vec→[len:8][cap:8][elem0]..., Struct→fields inlined recursively.
+    fn emit_unflatten(&mut self, ty: &Ty, src_reg: u8, dst_reg: u8) {
+        if is_wide_type(ty) {
+            self.emit_op(Opcode::Wload, dst_reg, src_reg, 0);
+            self.emit_op(Opcode::Addi, src_reg, src_reg, 32);
+        } else if matches!(ty, Ty::StringTy | Ty::Bytes) {
+            // String: read [byte_len:8][data...], build Vec layout on heap
+            self.emit_op(Opcode::Add, dst_reg, 12, 0);       // dst = Vec base
+            let dst_saved = dst_reg == 14 || dst_reg == 15;
+            if dst_saved { self.emit_op(Opcode::Push, dst_reg, 0, 0); }
+            self.emit_load(14, src_reg, 0);                    // r14 = byte_len
+            self.emit_op(Opcode::Addi, src_reg, src_reg, 8);
+            self.emit_store(14, 12, 0);                        // header.length
+            self.emit_store(14, 12, 8);                        // header.capacity
+            self.emit_op(Opcode::Addi, 12, 12, memory::VEC_DATA_OFFSET);
+            self.emit_op(Opcode::Memcpy, 12, src_reg, 14);
+            // Advance src and r12 by align8(byte_len)
+            self.emit_op(Opcode::Addi, 15, 14, 7);
+            self.emit_op(Opcode::Addi, 14, 0, 3);
+            self.emit_op(Opcode::Shr, 15, 15, 14);
+            self.emit_op(Opcode::Shl, 15, 15, 14);
+            self.emit_op(Opcode::Add, src_reg, src_reg, 15);
+            self.emit_op(Opcode::Add, 12, 12, 15);
+            if dst_saved { self.emit_op(Opcode::Pop, dst_reg, 0, 0); }
+        } else if let Ty::Vec(elem_ty) = ty {
+            let defs = self.struct_defs.clone();
+            let elem_size = flat_elem_size(elem_ty, &defs);
+            // dst = Vec base on heap
+            self.emit_op(Opcode::Add, dst_reg, 12, 0);
+            let dst_saved = dst_reg == 14 || dst_reg == 15;
+            if dst_saved { self.emit_op(Opcode::Push, dst_reg, 0, 0); }
+            // Read [len:8][cap:8] from flat wire
+            self.emit_load(14, src_reg, 0);                    // r14 = len
+            self.emit_op(Opcode::Addi, src_reg, src_reg, 8);
+            self.emit_load(15, src_reg, 0);                    // r15 = cap
+            self.emit_op(Opcode::Addi, src_reg, src_reg, 8);
+            // Write Vec header on heap
+            self.emit_store(14, 12, 0);                        // header.length = len
+            self.emit_store(15, 12, 8);                        // header.capacity = cap
+            self.emit_op(Opcode::Addi, 12, 12, memory::VEC_DATA_OFFSET);
+
+            match elem_size {
+                Some(sz) if sz == 8 || sz == 16 || sz == 32 => {
+                    // Fixed-size elements: bulk Memcpy
+                    let shift = if sz == 8 { 3 } else if sz == 16 { 4 } else { 5 };
+                    self.emit_op(Opcode::Addi, 15, 0, shift);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);     // r14 = count * sz
+                    self.emit_op(Opcode::Memcpy, 12, src_reg, 14);
+                    self.emit_op(Opcode::Add, src_reg, src_reg, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                }
+                Some(sz) => {
+                    // Fixed-size struct elements: bulk Memcpy count * sz
+                    self.emit_op(Opcode::Push, 14, 0, 0);      // save count
+                    self.load_u32_to_reg(15, sz);
+                    self.emit_op(Opcode::Pop, 14, 0, 0);
+                    self.emit_op(Opcode::Mul, 14, 14, 15);     // r14 = count * sz
+                    self.emit_op(Opcode::Memcpy, 12, src_reg, 14);
+                    self.emit_op(Opcode::Add, src_reg, src_reg, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                }
+                None => {
+                    // Variable-size elements: loop unflatten each into Vec data slots
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 8);  // spill count
+                    self.emit_store(src_reg, 13, LOOP_STATE_BASE + 16); // spill src_reg
+                    self.emit_op(Opcode::Add, 14, 12, 0);      // r14 = data start
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 24); // spill dst_data_ptr
+                    // Reserve pointer array: count * 8
+                    self.emit_load(14, 13, LOOP_STATE_BASE + 8);
+                    self.emit_op(Opcode::Addi, 15, 0, 3);
+                    self.emit_op(Opcode::Shl, 14, 14, 15);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+
+                    self.emit_op(Opcode::Addi, 14, 0, 0);      // i = 0
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
+
+                    let loop_label = self.alloc_label();
+                    let done_label = self.alloc_label();
+                    self.mark_label(loop_label);
+
+                    self.emit_load(14, 13, LOOP_STATE_BASE);
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 8);
+                    self.emit_jump_placeholder(Opcode::Beq, 14, 15, done_label);
+
+                    self.emit_op(Opcode::Push, 12, 0, 0);      // save elem_ptr
+                    self.emit_load(src_reg, 13, LOOP_STATE_BASE + 16);
+                    let elem_ty_clone = (**elem_ty).clone();
+                    self.emit_unflatten(&elem_ty_clone, src_reg, 14);
+                    self.emit_store(src_reg, 13, LOOP_STATE_BASE + 16);
+
+                    self.emit_op(Opcode::Pop, 15, 0, 0);       // r15 = elem_ptr
+                    self.emit_load(14, 13, LOOP_STATE_BASE + 24);
+                    self.emit_store(15, 14, 0);
+                    self.emit_op(Opcode::Addi, 14, 14, 8);
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 24);
+
+                    self.emit_load(14, 13, LOOP_STATE_BASE);
+                    self.emit_op(Opcode::Addi, 14, 14, 1);
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
+                    self.emit_jump_placeholder(Opcode::Jmp, 0, 0, loop_label);
+
+                    self.mark_label(done_label);
+                    self.emit_load(src_reg, 13, LOOP_STATE_BASE + 16);
+                }
+            }
+            if dst_saved { self.emit_op(Opcode::Pop, dst_reg, 0, 0); }
+        } else if let Ty::Struct(name) = ty {
+            // Struct: ALWAYS recursive — allocate struct on heap with actual inline size,
+            // unflatten each field at its actual byte offset.
+            if let Some(fields) = self.struct_defs.get(name).cloned() {
+                let struct_size = self.compute_struct_size(name);
+                self.emit_op(Opcode::Push, 12, 0, 0);         // push struct base = r12
+                if struct_size <= 0x1FFFF {
+                    self.emit_op(Opcode::Addi, 12, 12, struct_size);
+                } else {
+                    self.load_u32_to_reg(15, struct_size);
+                    self.emit_op(Opcode::Add, 12, 12, 15);
+                }
+
+                let offsets: Vec<(u32, Ty)> = fields.iter()
+                    .map(|(fname, _)| self.lookup_field(name, fname))
+                    .collect();
+                for (offset, fty) in &offsets {
+                    if matches!(fty, Ty::Struct(..)) {
+                        // Inline nested struct: unflatten creates a temp heap alloc,
+                        // then Memcpy into parent's inline slot at struct_base + offset.
+                        let inner_size = self.field_byte_size(fty);
+                        self.emit_unflatten(fty, src_reg, 14); // r14 = temp alloc ptr (src)
+                        self.emit_op(Opcode::Pop, 15, 0, 0);  // r15 = struct_base (peek)
+                        self.emit_op(Opcode::Push, 15, 0, 0);
+                        self.emit_op(Opcode::Addi, 15, 15, *offset); // r15 = dst
+                        // Borrow r11 for len
+                        self.emit_op(Opcode::Push, 11, 0, 0);
+                        self.load_u32_to_reg(11, inner_size);
+                        self.emit_op(Opcode::Memcpy, 15, 14, 11); // dst=r15, src=r14, len=r11
+                        self.emit_op(Opcode::Pop, 11, 0, 0);
+                    } else if is_wide_type(fty) {
+                        // Wide field: unflatten into wide register, Wstore at offset
+                        let wd = WIDE_SCRATCH2; // w6
+                        self.emit_unflatten(fty, src_reg, wd);
+                        self.emit_op(Opcode::Pop, 15, 0, 0);  // peek struct base
+                        self.emit_op(Opcode::Push, 15, 0, 0);
+                        self.emit_store_typed(wd, 15, *offset as i32, fty);
+                    } else {
+                        // GP field or pointer: unflatten returns value in r14, typed store
+                        self.emit_unflatten(fty, src_reg, 14);
+                        self.emit_op(Opcode::Pop, 15, 0, 0);  // peek struct base
+                        self.emit_op(Opcode::Push, 15, 0, 0);
+                        self.emit_store_typed(14, 15, *offset as i32, fty);
+                    }
+                }
+                self.emit_op(Opcode::Pop, dst_reg, 0, 0);     // dst = struct base
+            }
+        } else {
+            // GP types: 8 bytes
+            self.emit_load(dst_reg, src_reg, 0);
+            self.emit_op(Opcode::Addi, src_reg, src_reg, 8);
+        }
+    }
+
+    /// DEPRECATED: old Borsh-style deserializer. Replaced by emit_unflatten.
+    #[allow(dead_code)]
     fn emit_deserialize(&mut self, ty: &Ty, src_reg: u8, dst_reg: u8) {
         if is_wide_type(ty) {
             // Wide types: 32 bytes via Wload
@@ -1957,6 +2645,11 @@ impl CodeGen {
             // Build Vec layout at r12: [len:8][cap:8][data...]
             // dst_reg = base of new Vec = r12
             self.emit_op(Opcode::Add, dst_reg, 12, 0);       // dst = r12 (Vec base)
+            // Save dst_reg if it conflicts with scratch
+            let dst_saved = dst_reg == 14 || dst_reg == 15;
+            if dst_saved {
+                self.emit_op(Opcode::Push, dst_reg, 0, 0);
+            }
             self.emit_load(14, src_reg, 0);                    // r14 = byte_len
             self.emit_op(Opcode::Addi, src_reg, src_reg, 8);  // advance past length prefix
             // Write Vec header
@@ -1973,10 +2666,19 @@ impl CodeGen {
             self.emit_op(Opcode::Add, src_reg, src_reg, 15);  // src_reg += aligned
             // Advance r12 past data
             self.emit_op(Opcode::Add, 12, 12, 15);            // r12 += aligned
+            if dst_saved {
+                self.emit_op(Opcode::Pop, dst_reg, 0, 0);
+            }
         } else if let Ty::Vec(elem_ty) = ty {
             let elem_size = serialized_elem_size(elem_ty);
             // dst_reg = base of new Vec = r12
             self.emit_op(Opcode::Add, dst_reg, 12, 0);        // dst = Vec base
+            // Save dst_reg if it's a scratch register (r14/r15) — scratch gets
+            // clobbered during header setup and element processing below.
+            let dst_saved = dst_reg == 14 || dst_reg == 15;
+            if dst_saved {
+                self.emit_op(Opcode::Push, dst_reg, 0, 0);
+            }
             self.emit_load(14, src_reg, 0);                     // r14 = count
             self.emit_op(Opcode::Addi, src_reg, src_reg, 8);   // advance past count prefix
             // Write Vec header
@@ -1995,85 +2697,85 @@ impl CodeGen {
                 }
                 Some(32) => {
                     // Vec<wide>: loop Wload/Wstore
-                    // Spill state: r13+200=i, r13+208=count, r13+216=src_reg value
-                    self.emit_store(14, 13, 208);               // spill count
-                    self.emit_store(src_reg, 13, 216);          // spill src_reg
+                    // Spill state at r13+LOOP_STATE_BASE: +0=i, +8=count, +16=src_reg
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 8);               // spill count
+                    self.emit_store(src_reg, 13, LOOP_STATE_BASE + 16);          // spill src_reg
                     self.emit_op(Opcode::Addi, 14, 0, 0);      // i = 0
-                    self.emit_store(14, 13, 200);               // spill i
+                    self.emit_store(14, 13, LOOP_STATE_BASE);               // spill i
 
                     let loop_label = self.alloc_label();
                     let done_label = self.alloc_label();
                     self.mark_label(loop_label);
 
-                    self.emit_load(14, 13, 200);                // r14 = i
-                    self.emit_load(15, 13, 208);                // r15 = count
+                    self.emit_load(14, 13, LOOP_STATE_BASE);                // r14 = i
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 8);                // r15 = count
                     self.emit_jump_placeholder(Opcode::Beq, 14, 15, done_label);
 
-                    self.emit_load(15, 13, 216);                // r15 = src ptr
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 16);                // r15 = src ptr
                     self.emit_op(Opcode::Wload, WIDE_SCRATCH2, 15, 0);
                     self.emit_op(Opcode::Wstore, WIDE_SCRATCH2, 12, 0);
                     self.emit_op(Opcode::Addi, 12, 12, 32);
                     self.emit_op(Opcode::Addi, 15, 15, 32);
-                    self.emit_store(15, 13, 216);               // update src ptr
+                    self.emit_store(15, 13, LOOP_STATE_BASE + 16);               // update src ptr
 
-                    self.emit_load(14, 13, 200);
+                    self.emit_load(14, 13, LOOP_STATE_BASE);
                     self.emit_op(Opcode::Addi, 14, 14, 1);
-                    self.emit_store(14, 13, 200);
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
                     self.emit_jump_placeholder(Opcode::Jmp, 0, 0, loop_label);
 
                     self.mark_label(done_label);
                     // Restore src_reg to final position
-                    self.emit_load(src_reg, 13, 216);
+                    self.emit_load(src_reg, 13, LOOP_STATE_BASE + 16);
                 }
                 None => {
                     // Vec of variable-size elements: loop deserialize each into Vec data slots.
                     // Each data slot holds a pointer (8 bytes) to the deserialized object.
-                    self.emit_store(14, 13, 208);               // spill count
-                    self.emit_store(src_reg, 13, 216);          // spill src_reg
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 8);               // spill count
+                    self.emit_store(src_reg, 13, LOOP_STATE_BASE + 16);          // spill src_reg
                     // r13+224 = dst_data_ptr (where to write element pointers in Vec data)
                     self.emit_op(Opcode::Add, 14, 12, 0);      // r14 = data start = r12
-                    self.emit_store(14, 13, 224);
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 24);
                     // Reserve space for pointer array: count * 8 bytes
-                    self.emit_load(14, 13, 208);                // r14 = count
+                    self.emit_load(14, 13, LOOP_STATE_BASE + 8);                // r14 = count
                     self.emit_op(Opcode::Addi, 15, 0, 3);
                     self.emit_op(Opcode::Shl, 14, 14, 15);     // r14 = count * 8
                     self.emit_op(Opcode::Add, 12, 12, 14);     // r12 past pointer array
 
                     self.emit_op(Opcode::Addi, 14, 0, 0);      // i = 0
-                    self.emit_store(14, 13, 200);
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
 
                     let loop_label = self.alloc_label();
                     let done_label = self.alloc_label();
                     self.mark_label(loop_label);
 
-                    self.emit_load(14, 13, 200);                // r14 = i
-                    self.emit_load(15, 13, 208);                // r15 = count
+                    self.emit_load(14, 13, LOOP_STATE_BASE);                // r14 = i
+                    self.emit_load(15, 13, LOOP_STATE_BASE + 8);                // r15 = count
                     self.emit_jump_placeholder(Opcode::Beq, 14, 15, done_label);
 
                     // Deserialize element from src into heap at r12
                     // The deserialized object's base pointer will be r12 (before deserialize advances it)
                     self.emit_op(Opcode::Push, 12, 0, 0);       // save elem_ptr = r12
-                    self.emit_load(src_reg, 13, 216);            // restore src_reg
+                    self.emit_load(src_reg, 13, LOOP_STATE_BASE + 16);            // restore src_reg
                     let elem_ty_clone = (**elem_ty).clone();
                     // Use r14 as temp dst for deserialize (we just need r12 to be the base)
                     self.emit_deserialize(&elem_ty_clone, src_reg, 14);
-                    self.emit_store(src_reg, 13, 216);           // save updated src_reg
+                    self.emit_store(src_reg, 13, LOOP_STATE_BASE + 16);           // save updated src_reg
 
                     // Store element pointer into Vec data array
                     self.emit_op(Opcode::Pop, 15, 0, 0);        // r15 = elem_ptr
-                    self.emit_load(14, 13, 224);                 // r14 = dst_data_ptr
+                    self.emit_load(14, 13, LOOP_STATE_BASE + 24);                 // r14 = dst_data_ptr
                     self.emit_store(15, 14, 0);                  // *dst_data_ptr = elem_ptr
                     self.emit_op(Opcode::Addi, 14, 14, 8);
-                    self.emit_store(14, 13, 224);                // advance dst_data_ptr
+                    self.emit_store(14, 13, LOOP_STATE_BASE + 24);                // advance dst_data_ptr
 
                     // i++
-                    self.emit_load(14, 13, 200);
+                    self.emit_load(14, 13, LOOP_STATE_BASE);
                     self.emit_op(Opcode::Addi, 14, 14, 1);
-                    self.emit_store(14, 13, 200);
+                    self.emit_store(14, 13, LOOP_STATE_BASE);
                     self.emit_jump_placeholder(Opcode::Jmp, 0, 0, loop_label);
 
                     self.mark_label(done_label);
-                    self.emit_load(src_reg, 13, 216);            // restore final src_reg
+                    self.emit_load(src_reg, 13, LOOP_STATE_BASE + 16);            // restore final src_reg
                 }
                 Some(_) => {
                     // 16-byte elements: bulk Memcpy count*16
@@ -2084,17 +2786,50 @@ impl CodeGen {
                     self.emit_op(Opcode::Add, 12, 12, 14);
                 }
             }
+            // Restore dst_reg from stack if it was saved (scratch register conflict)
+            if dst_saved {
+                self.emit_op(Opcode::Pop, dst_reg, 0, 0);
+            }
         } else if let Ty::Struct(name) = ty {
-            // Struct: deserialize by copying flat bytes to heap
             if let Some(fields) = self.struct_defs.get(name).cloned() {
-                let byte_size = (fields.len() as u32) * memory::WORD_SIZE;
-                // Save struct base pointer (r12) to stack, then use r14 for byte_size
-                self.emit_op(Opcode::Push, 12, 0, 0);           // push struct base = r12
-                self.load_u32_to_reg(14, byte_size);
-                self.emit_op(Opcode::Memcpy, 12, src_reg, 14);  // copy buffer → heap
-                self.emit_op(Opcode::Add, src_reg, src_reg, 14); // advance src
-                self.emit_op(Opcode::Add, 12, 12, 14);           // advance heap
-                self.emit_op(Opcode::Pop, dst_reg, 0, 0);       // dst_reg = struct base
+                let has_nested = fields.iter().any(|(_, fty)| matches!(fty, Ty::Struct(_)) || is_blob_type(fty));
+                if has_nested {
+                    // Recursive: allocate struct on heap, deserialize each field
+                    self.emit_op(Opcode::Push, 12, 0, 0);       // push struct base = r12
+                    let field_count = fields.len() as u32;
+                    let struct_size = field_count * memory::WORD_SIZE;
+                    self.emit_op(Opcode::Addi, 12, 12, struct_size); // reserve struct space
+
+                    for (i, (_, fty)) in fields.iter().enumerate() {
+                        let offset = (i as u32) * memory::WORD_SIZE;
+                        // Deserialize field from src into temp register, then store to struct
+                        if is_wide_type(&fty) {
+                            self.emit_deserialize(&fty, src_reg, 14); // wide → but we use 14 as GP temp
+                            // For wide fields in struct, store the wide value at struct+offset
+                            // Actually wide fields need 32 bytes but struct layout uses 8 per field (pointer)
+                            // This is a limitation — skip for now
+                            self.emit_op(Opcode::Pop, 15, 0, 0);     // peek struct base
+                            self.emit_op(Opcode::Push, 15, 0, 0);
+                            self.emit_store(14, 15, offset as i32);
+                        } else {
+                            self.emit_deserialize(&fty, src_reg, 14);
+                            // Store field value/pointer at struct[offset]
+                            self.emit_op(Opcode::Pop, 15, 0, 0);     // peek struct base
+                            self.emit_op(Opcode::Push, 15, 0, 0);
+                            self.emit_store(14, 15, offset as i32);
+                        }
+                    }
+                    self.emit_op(Opcode::Pop, dst_reg, 0, 0);   // dst = struct base
+                } else {
+                    // Flat: all GP fields, bulk Memcpy
+                    let byte_size = (fields.len() as u32) * memory::WORD_SIZE;
+                    self.emit_op(Opcode::Push, 12, 0, 0);
+                    self.load_u32_to_reg(14, byte_size);
+                    self.emit_op(Opcode::Memcpy, 12, src_reg, 14);
+                    self.emit_op(Opcode::Add, src_reg, src_reg, 14);
+                    self.emit_op(Opcode::Add, 12, 12, 14);
+                    self.emit_op(Opcode::Pop, dst_reg, 0, 0);
+                }
             }
         } else {
             // GP types: 8 bytes via Load
@@ -2112,6 +2847,16 @@ impl CodeGen {
 /// Check if a type uses wide (256-bit) register.
 fn is_wide_type(ty: &Ty) -> bool {
     matches!(ty, Ty::U256 | Ty::I256 | Ty::Address)
+}
+
+/// Return the PVM MemWidth for a GP type (used by emit_load_typed / emit_store_typed).
+fn mem_width_for_type(ty: &Ty) -> MemWidth {
+    match ty {
+        Ty::U8 | Ty::I8 | Ty::Bool | Ty::Enum(_) => MemWidth::W8,
+        Ty::U16 | Ty::I16 => MemWidth::W16,
+        Ty::U32 | Ty::I32 => MemWidth::W32,
+        _ => MemWidth::W64, // u64, u128 (low half), pointers, etc.
+    }
 }
 
 /// Whether a type is variable-length (stored via Sload/Sstore mode 1: memory blob).
@@ -2157,6 +2902,30 @@ fn serialized_elem_size(ty: &Ty) -> Option<u32> {
         Ty::U256 | Ty::I256 | Ty::Address => Some(32),
         // Variable-size types: need recursive serialization
         Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_) => None,
+        _ => Some(8),
+    }
+}
+
+// ============================================================================
+// Flat inline format helpers
+// ============================================================================
+
+/// Return the fixed flat-inline size for a type, or None for variable-length types.
+/// Used by emit_flatten/emit_unflatten to decide between bulk Memcpy (fixed) and
+/// per-element loop (variable). Unlike `serialized_elem_size`, this correctly
+/// returns `Some(N*8)` for all-fixed-field structs (enabling bulk copy for Vec<Struct>).
+fn flat_elem_size(ty: &Ty, struct_defs: &HashMap<String, Vec<(String, Ty)>>) -> Option<u32> {
+    match ty {
+        Ty::U8 | Ty::U16 | Ty::U32 | Ty::U64
+        | Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64
+        | Ty::Bool | Ty::Enum(_) => Some(8),
+        Ty::U128 | Ty::I128 => Some(16),
+        Ty::U256 | Ty::I256 | Ty::Address => Some(32),
+        Ty::StringTy | Ty::Bytes | Ty::Vec(_) => None, // variable due to inline data
+        // Struct is always None for Vec element sizing: Vec<Struct> must use per-element
+        // unflatten loop (allocates each struct on heap, stores pointer in Vec data slot).
+        // Bulk Memcpy would copy raw flat bytes into pointer slots — wrong.
+        Ty::Struct(_) => None,
         _ => Some(8),
     }
 }
@@ -4563,5 +5332,1046 @@ mod tests {
             }
         }
         assert_eq!(vm2.cpu.read_gp(1), 150, "sum = 10+20+30+40+50 = 150 (many-function contract)");
+    }
+
+    #[test]
+    fn pvm_vec_string_storage() {
+        // Vec<String> storage: store vec of strings, read back lengths
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {
+                    tags: Map<u64, Vec<String>>,
+                }
+                pub fn store_tags(id: u64) -> u64 {
+                    let mut v = Vec::new();
+                    v.push("hello");
+                    v.push("world");
+                    self.tags[id] = v;
+                    return 2;
+                }
+                pub fn read_tag_count(id: u64) -> u64 {
+                    let v = self.tags[id];
+                    return v.len();
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 200_000 { panic!("too many steps"); } }
+                Err(e) => { panic!("PVM error at step {}: {:?}", steps, e); }
+            }
+        }
+        assert_eq!(vm.cpu.read_gp(1), 2, "stored 2 strings");
+    }
+
+    #[test]
+    fn pvm_string_storage() {
+        // Test String storage: store a string, read it back, check length
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {
+                    names: Map<u64, String>,
+                }
+                pub fn store_name(id: u64) -> u64 {
+                    let s = "hello world";
+                    self.names[id] = s;
+                    return s.len();
+                }
+                pub fn read_name_len(id: u64) -> u64 {
+                    let s = self.names[id];
+                    return s.len();
+                }
+            }
+        "#);
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+        vm.load(&compiled.bytecode).unwrap();
+        let mut steps = 0;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 100_000 { panic!("too many steps"); } }
+                Err(e) => { panic!("PVM error at step {}: {:?}", steps, e); }
+            }
+        }
+        // "hello world" = 11 chars
+        assert_eq!(vm.cpu.read_gp(1), 11, "string length should be 11");
+    }
+
+    #[test]
+    fn pvm_struct_vec_rank() {
+        // Reproduces compute_rank: read struct + vec from storage, loop with comparison
+        let src = r#"
+            contract T {
+                struct Player { id: u64, score: u64, }
+                storage { players: Map<u64, Player>, boards: Map<u64, Vec<u64>>, }
+                pub fn setup() {
+                    let p = Player { id: 1, score: 400 };
+                    self.players[1] = p;
+                    let mut b = Vec::new();
+                    b.push(100); b.push(200); b.push(300);
+                    self.boards[1] = b;
+                }
+                pub fn rank() -> u64 {
+                    let p = self.players[1];
+                    let board = self.boards[1];
+                    let score = p.score;
+                    let mut r = 0;
+                    let mut i = 0;
+                    let len = board.len();
+                    while i < len {
+                        if board[i] > score { r = r + 1; }
+                        i = i + 1;
+                    }
+                    return r + 1;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0x42u8; 32];
+
+        // Setup
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("setup").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "setup failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Rank
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = compute_selector("rank").to_be_bytes().to_vec();
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm2.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => {
+                    steps += 1;
+                    if steps > 1_000_000 {
+                        panic!("infinite loop at step {}", steps);
+                    }
+                }
+                Err(e) => {
+                    let pc = vm2.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1={:#x} r2={:#x} r3={:#x} r4={:#x} r5={:#x} r6={:#x} r7={:#x} r8={:#x} r9={:#x} r10={:#x} r11={:#x}\n  r12={:#x} r13={:#x} r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm2.cpu.read_gp(1), vm2.cpu.read_gp(2), vm2.cpu.read_gp(3),
+                        vm2.cpu.read_gp(4), vm2.cpu.read_gp(5), vm2.cpu.read_gp(6),
+                        vm2.cpu.read_gp(7), vm2.cpu.read_gp(8), vm2.cpu.read_gp(9),
+                        vm2.cpu.read_gp(10), vm2.cpu.read_gp(11),
+                        vm2.cpu.read_gp(12), vm2.cpu.read_gp(13),
+                        vm2.cpu.read_gp(14), vm2.cpu.read_gp(15));
+                }
+            }
+        }
+        // score=400, board=[100,200,300]. 0 entries > 400. rank = 0+1 = 1.
+        assert_eq!(vm2.cpu.read_gp(1), 1, "rank should be 1");
+    }
+
+    #[test]
+    fn pvm_nested_struct_with_vec_storage() {
+        // Nested struct (Hero { Stats, Vec<u64> }) in Map storage:
+        // serialize, store, load, deserialize, access nested fields + loop over Vec.
+        let src = r#"
+            contract T {
+                struct Stats { hp: u64, mp: u64, level: u64, }
+                struct Hero { id: u64, stats: Stats, scores: Vec<u64>, }
+                storage { heroes: Map<u64, Hero>, }
+                pub fn create_hero() {
+                    let s = Stats { hp: 100, mp: 50, level: 5 };
+                    let mut sc = Vec::new();
+                    sc.push(10); sc.push(20); sc.push(30);
+                    let h = Hero { id: 1, stats: s, scores: sc };
+                    self.heroes[1] = h;
+                }
+                pub fn hero_power() -> u64 {
+                    let h = self.heroes[1];
+                    let base = h.stats.hp + h.stats.mp * h.stats.level;
+                    let mut bonus = 0;
+                    let mut i = 0;
+                    let len = h.scores.len();
+                    while i < len {
+                        bonus = bonus + h.scores[i];
+                        i = i + 1;
+                    }
+                    return base + bonus;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0x55u8; 32];
+
+        // Run create_hero
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("create_hero").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm1.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => {
+                    steps += 1;
+                    if steps > 1_000_000 { panic!("infinite loop"); }
+                }
+                Err(e) => {
+                    let pc = vm1.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("create_hero trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1={:#x} r2={:#x} r3={:#x} r4={:#x} r5={:#x} r6={:#x} r7={:#x} r8={:#x} r9={:#x} r10={:#x} r11={:#x}\n  r12={:#x} r13={:#x} r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm1.cpu.read_gp(1), vm1.cpu.read_gp(2), vm1.cpu.read_gp(3),
+                        vm1.cpu.read_gp(4), vm1.cpu.read_gp(5), vm1.cpu.read_gp(6),
+                        vm1.cpu.read_gp(7), vm1.cpu.read_gp(8), vm1.cpu.read_gp(9),
+                        vm1.cpu.read_gp(10), vm1.cpu.read_gp(11),
+                        vm1.cpu.read_gp(12), vm1.cpu.read_gp(13),
+                        vm1.cpu.read_gp(14), vm1.cpu.read_gp(15));
+                }
+            }
+        }
+
+        // Persist storage to SMT
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Run hero_power
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = compute_selector("hero_power").to_be_bytes().to_vec();
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm2.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => {
+                    steps += 1;
+                    if steps > 1_000_000 { panic!("infinite loop at step {}", steps); }
+                }
+                Err(e) => {
+                    let pc = vm2.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1={:#x} r2={:#x} r3={:#x} r4={:#x} r5={:#x} r6={:#x} r7={:#x} r8={:#x}\n  r12={:#x} r13={:#x} r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm2.cpu.read_gp(1), vm2.cpu.read_gp(2), vm2.cpu.read_gp(3),
+                        vm2.cpu.read_gp(4), vm2.cpu.read_gp(5), vm2.cpu.read_gp(6),
+                        vm2.cpu.read_gp(7), vm2.cpu.read_gp(8),
+                        vm2.cpu.read_gp(12), vm2.cpu.read_gp(13),
+                        vm2.cpu.read_gp(14), vm2.cpu.read_gp(15));
+                }
+            }
+        }
+        // base = hp + mp * level = 100 + 50 * 5 = 350
+        // bonus = 10 + 20 + 30 = 60
+        // total = 350 + 60 = 410
+        assert_eq!(vm2.cpu.read_gp(1), 410, "hero_power should be 410");
+    }
+
+    #[test]
+    fn pvm_complex_struct_arg_and_return() {
+        // Tests:
+        // 1. Struct with Vec<u64> field as function ARGUMENT (calldata deserialization)
+        // 2. Struct as function RETURN VALUE (blob return serialization, r1=ptr r2=len)
+        // 3. Struct with Vec field in storage (round-trip serialize/deserialize)
+        let src = r#"
+            contract T {
+                struct Profile {
+                    id: u64,
+                    score: u64,
+                    tags: Vec<u64>,
+                }
+                storage { profiles: Map<u64, Profile>, }
+
+                pub fn store_profile(p: Profile) {
+                    self.profiles[p.id] = p;
+                }
+
+                pub fn get_score(pid: u64) -> u64 {
+                    let p = self.profiles[pid];
+                    return p.score;
+                }
+
+                pub fn tag_sum(pid: u64) -> u64 {
+                    let p = self.profiles[pid];
+                    let mut total = 0;
+                    let mut i = 0;
+                    let len = p.tags.len();
+                    while i < len {
+                        total = total + p.tags[i];
+                        i = i + 1;
+                    }
+                    return total;
+                }
+
+                pub fn load_profile(pid: u64) -> Profile {
+                    let p = self.profiles[pid];
+                    return p;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0x77u8; 32];
+
+        // === Step 1: Call store_profile(Profile { id: 42, score: 99, tags: [10, 20, 30] }) ===
+        // Build calldata: selector + Borsh-serialized Profile blob
+        // Profile Borsh: [id:8][score:8][tags_count:8][tag0:8][tag1:8][tag2:8] = 48 bytes
+        let store_sel = compute_selector("store_profile");
+        let mut calldata = store_sel.to_be_bytes().to_vec();
+        // Blob prefix: byte_len = 48
+        calldata.extend_from_slice(&56u64.to_le_bytes()); // flat: id(8)+score(8)+len(8)+cap(8)+3*tag(24)=56
+        // id = 42
+        calldata.extend_from_slice(&42u64.to_le_bytes());
+        // score = 99
+        calldata.extend_from_slice(&99u64.to_le_bytes());
+        // tags: len=3, cap=3 (flat format), elements=[10,20,30]
+        calldata.extend_from_slice(&3u64.to_le_bytes()); // len
+        calldata.extend_from_slice(&3u64.to_le_bytes()); // cap
+        calldata.extend_from_slice(&10u64.to_le_bytes());
+        calldata.extend_from_slice(&20u64.to_le_bytes());
+        calldata.extend_from_slice(&30u64.to_le_bytes());
+
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = calldata;
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success,
+            "store_profile failed: {:?}", out1.outcome);
+
+        // Persist storage
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // === Step 2: Call get_score(42) — scalar return from stored struct ===
+        let score_sel = compute_selector("get_score");
+        let mut cd2 = score_sel.to_be_bytes().to_vec();
+        cd2.extend_from_slice(&42u64.to_le_bytes());
+
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = cd2;
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let out2 = vm2.execute();
+        assert_eq!(out2.outcome, pyde_vm::vm::Outcome::Success, "get_score failed");
+        assert_eq!(vm2.cpu.read_gp(1), 99, "score should be 99");
+
+        // === Step 3: Call tag_sum(42) — loop over Vec field from stored struct ===
+        let tag_sel = compute_selector("tag_sum");
+        let mut cd3 = tag_sel.to_be_bytes().to_vec();
+        cd3.extend_from_slice(&42u64.to_le_bytes());
+
+        let ctx3 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm3 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx3);
+        vm3.calldata = cd3;
+        let smt_ptr3 = &smt as *const pyde_state::smt::PydeSMT;
+        vm3.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr3).get(&sk) }
+        }));
+        vm3.load(&contract.runtime_bytecode).unwrap();
+        let out3 = vm3.execute();
+        assert_eq!(out3.outcome, pyde_vm::vm::Outcome::Success, "tag_sum failed");
+        assert_eq!(vm3.cpu.read_gp(1), 60, "tag_sum should be 10+20+30=60");
+
+        // === Step 4: Call load_profile(42) — struct RETURN (blob serialization) ===
+        let load_sel = compute_selector("load_profile");
+        let mut cd4 = load_sel.to_be_bytes().to_vec();
+        cd4.extend_from_slice(&42u64.to_le_bytes());
+
+        let ctx4 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm4 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx4);
+        vm4.calldata = cd4;
+        let smt_ptr4 = &smt as *const pyde_state::smt::PydeSMT;
+        vm4.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr4).get(&sk) }
+        }));
+        vm4.load(&contract.runtime_bytecode).unwrap();
+        let out4 = vm4.execute();
+        assert_eq!(out4.outcome, pyde_vm::vm::Outcome::Success, "load_profile failed");
+
+        // r1 = buffer pointer, r2 = byte length of Borsh-serialized Profile
+        let r1 = vm4.cpu.read_gp(1) as usize;
+        let r2 = vm4.cpu.read_gp(2) as usize;
+        assert!(r2 > 0, "r2 should be > 0 for blob return");
+        // Flat format: [id:8][score:8][len:8][cap:8][tag0:8][tag1:8][tag2:8] = 56 bytes
+        assert_eq!(r2, 56, "flat Profile should be 56 bytes (id+score+len+cap+3*tag)");
+        let blob = vm4.memory.load_bytes(r1, r2);
+        let id = u64::from_le_bytes(blob[0..8].try_into().unwrap());
+        let score = u64::from_le_bytes(blob[8..16].try_into().unwrap());
+        let count = u64::from_le_bytes(blob[16..24].try_into().unwrap());
+        let cap = u64::from_le_bytes(blob[24..32].try_into().unwrap());
+        let tag0 = u64::from_le_bytes(blob[32..40].try_into().unwrap());
+        let tag1 = u64::from_le_bytes(blob[40..48].try_into().unwrap());
+        let tag2 = u64::from_le_bytes(blob[48..56].try_into().unwrap());
+        assert_eq!(id, 42, "returned profile.id");
+        assert_eq!(score, 99, "returned profile.score");
+        assert_eq!(count, 3, "returned profile.tags.len");
+        assert_eq!(cap, 3, "returned profile.tags.cap");
+        assert_eq!((tag0, tag1, tag2), (10, 20, 30), "returned profile.tags");
+    }
+
+    #[test]
+    fn pvm_all_global_vars() {
+        // Test every global variable: msg.sender, msg.value, block.height,
+        // block.timestamp, block.proposer, tx.nonce, tx.gas_limit, tx.gas_price,
+        // tx.hash, address(self), gas_remaining
+        let src = r#"
+            contract T {
+                storage {}
+                pub fn get_block_height() -> u64 { return block.height; }
+                pub fn get_block_timestamp() -> u64 { return block.timestamp; }
+                pub fn get_tx_nonce() -> u64 { return tx.nonce; }
+                pub fn get_tx_gas_limit() -> u64 { return tx.gas_limit; }
+                pub fn get_gas_remaining() -> u64 { return gas_remaining(); }
+                pub fn get_msg_sender() -> Address { return msg.sender; }
+                pub fn get_msg_value() -> u256 { return msg.value; }
+                pub fn get_self_address() -> Address { return address(self); }
+                pub fn get_tx_gas_price() -> u256 { return tx.gas_price; }
+                pub fn get_block_proposer() -> Address { return block.proposer; }
+                pub fn get_tx_hash() -> u256 { return tx.hash; }
+            }
+        "#;
+        // Use production compilation (with dispatch + guards) for selector-based calling
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let ir = crate::lower::lower(&file);
+        let compiled = CodeGen::new().generate(&ir);
+
+        let caller = [0xAAu8; 32];
+        let self_addr = [0xBBu8; 32];
+        let proposer = [0xCCu8; 32];
+        // call_value must be 0 for non-payable functions (production guard checks)
+        let ctx = pyde_vm::vm::ExecutionContext {
+            caller,
+            self_address: self_addr,
+            call_value: ethnum::U256::ZERO,
+            block_number: 42,
+            timestamp: 1_700_000_000,
+            gas_price: ethnum::U256::from(50_000_000_000u64),
+            tx_nonce: 7,
+            tx_gas_limit: 100_000_000,
+            tx_hash: ethnum::U256::from(0xDEADBEEFu64),
+            block_proposer: proposer,
+            block_hashes: vec![],
+            balances: std::collections::HashMap::new(),
+        };
+
+        // Helper: run a function and return (r1, w0)
+        let run = |sel_name: &str, ctx: &pyde_vm::vm::ExecutionContext| -> (u64, ethnum::U256) {
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(10_000_000, ctx.clone());
+            vm.calldata = compute_selector(sel_name).to_be_bytes().to_vec();
+            vm.load(&compiled.runtime_bytecode).unwrap();
+            let out = vm.execute();
+            assert_eq!(out.outcome, pyde_vm::vm::Outcome::Success, "{} failed", sel_name);
+            (vm.cpu.read_gp(1), vm.cpu.read_wide(0))
+        };
+
+        // GP globals (returned in r1)
+        let (r1, _) = run("get_block_height", &ctx);
+        assert_eq!(r1, 42, "block.height");
+
+        let (r1, _) = run("get_block_timestamp", &ctx);
+        assert_eq!(r1, 1_700_000_000, "block.timestamp");
+
+        let (r1, _) = run("get_tx_nonce", &ctx);
+        assert_eq!(r1, 7, "tx.nonce");
+
+        let (r1, _) = run("get_tx_gas_limit", &ctx);
+        assert_eq!(r1, 100_000_000, "tx.gas_limit");
+
+        let (r1, _) = run("get_gas_remaining", &ctx);
+        assert!(r1 > 0 && r1 <= 10_000_000, "gas_remaining should be >0, got {}", r1);
+
+        // Wide globals (returned in w0, with low 64 bits in r1)
+        let (_, w0) = run("get_msg_sender", &ctx);
+        assert_eq!(w0.to_le_bytes(), caller, "msg.sender");
+
+        let (_, w0) = run("get_msg_value", &ctx);
+        assert_eq!(w0, ethnum::U256::ZERO, "msg.value (0 for non-payable)");
+
+        let (_, w0) = run("get_self_address", &ctx);
+        assert_eq!(w0.to_le_bytes(), self_addr, "address(self)");
+
+        let (_, w0) = run("get_tx_gas_price", &ctx);
+        assert_eq!(w0, ethnum::U256::from(50_000_000_000u64), "tx.gas_price");
+
+        let (_, w0) = run("get_block_proposer", &ctx);
+        assert_eq!(w0.to_le_bytes(), proposer, "block.proposer");
+
+        let (_, w0) = run("get_tx_hash", &ctx);
+        assert_eq!(w0, ethnum::U256::from(0xDEADBEEFu64), "tx.hash");
+    }
+
+    #[test]
+    fn pvm_packed_struct_mixed_field_sizes() {
+        // Test packed layout: u8 (1B) + u8 (1B) + u64 (8B) + u64 (8B) = 18 bytes total
+        // Offsets: age@+0, level@+1, hp@+2, score@+10
+        let compiled = compile_no_opt(r#"
+            contract T {
+                storage {}
+                struct Char { age: u8, level: u8, hp: u64, score: u64, }
+                pub fn test_packed() -> u64 {
+                    let c = Char { age: 25, level: 10, hp: 1000, score: 9999 };
+                    let a = c.age;
+                    let l = c.level;
+                    let h = c.hp;
+                    let s = c.score;
+                    return a + l + h + s;
+                }
+            }
+        "#);
+        let vm = run_pvm(&compiled.bytecode);
+        // 25 + 10 + 1000 + 9999 = 11034
+        assert_eq!(vm.cpu.read_gp(1), 11034, "packed struct field access: 25+10+1000+9999");
+    }
+
+    #[test]
+    fn pvm_packed_struct_storage_roundtrip() {
+        // Packed struct (u8, u8, u32) through FULL storage roundtrip:
+        // StructInit → emit_flatten → Sstore → Sload → emit_unflatten → FieldGet
+        let src = r#"
+            contract T {
+                struct Stats { hp: u8, mp: u8, level: u32, }
+                storage { data: Map<u64, Stats>, }
+                pub fn store_stats() {
+                    let s = Stats { hp: 100, mp: 50, level: 5 };
+                    self.data[1] = s;
+                }
+                pub fn read_stats() -> u64 {
+                    let s = self.data[1];
+                    return s.hp + s.mp * s.level;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0x88u8; 32];
+
+        // Store
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("store_stats").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "store_stats failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Read
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = compute_selector("read_stats").to_be_bytes().to_vec();
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm2.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 1_000_000 { panic!("infinite loop"); } }
+                Err(e) => {
+                    let pc = vm2.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1={:#x} r2={:#x} r3={:#x} r4={:#x} r5={:#x} r6={:#x}\n  r12={:#x} r13={:#x} r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm2.cpu.read_gp(1), vm2.cpu.read_gp(2), vm2.cpu.read_gp(3),
+                        vm2.cpu.read_gp(4), vm2.cpu.read_gp(5), vm2.cpu.read_gp(6),
+                        vm2.cpu.read_gp(12), vm2.cpu.read_gp(13),
+                        vm2.cpu.read_gp(14), vm2.cpu.read_gp(15));
+                }
+            }
+        }
+        // hp + mp * level = 100 + 50 * 5 = 350
+        assert_eq!(vm2.cpu.read_gp(1), 350, "packed struct storage roundtrip: 100 + 50*5");
+    }
+
+    #[test]
+    fn pvm_packed_hero_with_vec_storage() {
+        // Full test: packed Stats (u8+u8+u32) inside Hero with Vec<u64>, through storage.
+        let src = r#"
+            contract T {
+                struct Stats { hp: u8, mp: u8, level: u32, }
+                struct Hero { id: u64, stats: Stats, scores: Vec<u64>, }
+                storage { heroes: Map<u64, Hero>, }
+                pub fn create() {
+                    let s = Stats { hp: 100, mp: 50, level: 5 };
+                    let mut sc = Vec::new();
+                    sc.push(10); sc.push(20); sc.push(30); sc.push(40); sc.push(50);
+                    let h = Hero { id: 1, stats: s, scores: sc };
+                    self.heroes[1] = h;
+                }
+                pub fn power() -> u64 {
+                    let h = self.heroes[1];
+                    let base = h.stats.hp + h.stats.mp * h.stats.level;
+                    let mut bonus = 0;
+                    let mut i = 0;
+                    let len = h.scores.len();
+                    while i < len {
+                        bonus = bonus + h.scores[i];
+                        i = i + 1;
+                    }
+                    return base + bonus;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0x99u8; 32];
+
+        // Create hero
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("create").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "create failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Read power
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = compute_selector("power").to_be_bytes().to_vec();
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm2.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 1_000_000 { panic!("infinite loop"); } }
+                Err(e) => {
+                    let pc = vm2.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1-r6: {:#x} {:#x} {:#x} {:#x} {:#x} {:#x}\n  r7-r11: {:#x} {:#x} {:#x} {:#x} {:#x}\n  r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm2.cpu.read_gp(1), vm2.cpu.read_gp(2), vm2.cpu.read_gp(3),
+                        vm2.cpu.read_gp(4), vm2.cpu.read_gp(5), vm2.cpu.read_gp(6),
+                        vm2.cpu.read_gp(7), vm2.cpu.read_gp(8), vm2.cpu.read_gp(9),
+                        vm2.cpu.read_gp(10), vm2.cpu.read_gp(11),
+                        vm2.cpu.read_gp(14), vm2.cpu.read_gp(15));
+                }
+            }
+        }
+        // base = 100 + 50*5 = 350, bonus = 10+20+30+40+50 = 150, total = 500
+        assert_eq!(vm2.cpu.read_gp(1), 500, "packed hero power: 100+50*5+10+20+30+40+50");
+    }
+
+    #[test]
+    fn pvm_vec_of_struct_storage_roundtrip() {
+        // Vec<Struct> through full storage roundtrip: flatten, store, load, unflatten, access.
+        let src = r#"
+            contract T {
+                struct Point { x: u64, y: u64, }
+                storage { points: Map<u64, Vec<Point>>, }
+                pub fn store_points() {
+                    let mut v = Vec::new();
+                    v.push(Point { x: 10, y: 20 });
+                    v.push(Point { x: 30, y: 40 });
+                    v.push(Point { x: 50, y: 60 });
+                    self.points[1] = v;
+                }
+                pub fn sum_points() -> u64 {
+                    let pts = self.points[1];
+                    let mut total = 0;
+                    let mut i = 0;
+                    let len = pts.len();
+                    while i < len {
+                        let p = pts[i];
+                        total = total + p.x + p.y;
+                        i = i + 1;
+                    }
+                    return total;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let codegen = CodeGen::new();
+        let contract = codegen.generate(&ir);
+        let addr = [0xAAu8; 32];
+
+        // Store
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("store_points").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "store_points failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Read
+        let ctx2 = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm2 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx2);
+        vm2.calldata = compute_selector("sum_points").to_be_bytes().to_vec();
+        let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+        vm2.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+            let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&sk) }
+        }));
+        vm2.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm2.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 1_000_000 { panic!("infinite loop"); } }
+                Err(e) => {
+                    let pc = vm2.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm);
+                }
+            }
+        }
+        // (10+20) + (30+40) + (50+60) = 210
+        assert_eq!(vm2.cpu.read_gp(1), 210, "Vec<Point> storage roundtrip: sum of x+y");
+    }
+
+    #[test]
+    fn pvm_vec_struct_as_arg() {
+        // Vec<Point> as function argument via calldata
+        let src = r#"
+            contract T {
+                struct Point { x: u64, y: u64, }
+                storage {}
+                pub fn sum_arg(pts: Vec<Point>) -> u64 {
+                    let mut total = 0;
+                    let mut i = 0;
+                    let len = pts.len();
+                    while i < len {
+                        let p = pts[i];
+                        total = total + p.x + p.y;
+                        i = i + 1;
+                    }
+                    return total;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let ir = crate::lower::lower(&file);
+        let contract = CodeGen::new().generate(&ir);
+
+        // Build calldata: selector + [byte_len:8][len:8][cap:8][p0.x:8][p0.y:8][p1.x:8][p1.y:8]
+        let sel = compute_selector("sum_arg");
+        let mut calldata = sel.to_be_bytes().to_vec();
+        calldata.extend_from_slice(&48u64.to_le_bytes()); // byte_len = 48
+        calldata.extend_from_slice(&2u64.to_le_bytes());  // len = 2
+        calldata.extend_from_slice(&2u64.to_le_bytes());  // cap = 2
+        calldata.extend_from_slice(&5u64.to_le_bytes());  // p0.x = 5
+        calldata.extend_from_slice(&10u64.to_le_bytes()); // p0.y = 10
+        calldata.extend_from_slice(&20u64.to_le_bytes()); // p1.x = 20
+        calldata.extend_from_slice(&40u64.to_le_bytes()); // p1.y = 40
+
+        let ctx = pyde_vm::vm::ExecutionContext::default();
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm.calldata = calldata;
+        vm.load(&contract.runtime_bytecode).unwrap();
+        let mut steps = 0u64;
+        loop {
+            match vm.step() {
+                Ok(Some(_)) => break,
+                Ok(None) => { steps += 1; if steps > 1_000_000 { panic!("infinite loop"); } }
+                Err(e) => {
+                    let pc = vm.pc as usize;
+                    let w = u32::from_le_bytes(contract.runtime_bytecode[pc..pc+4].try_into().unwrap_or([0;4]));
+                    let d = pyde_vm::isa::decode(pyde_vm::isa::Instruction(w));
+                    panic!("trap at step {} PC={}: {:?}\n  {:?} rd={} rs1={} imm={:#x}\n  r1={:#x} r2={:#x} r3={:#x} r4={:#x} r5={:#x}\n  r11={:#x} r12={:#x} r13={:#x} r14={:#x} r15={:#x}",
+                        steps, pc, e, d.opcode, d.rd, d.rs1, d.rs2_or_imm,
+                        vm.cpu.read_gp(1), vm.cpu.read_gp(2), vm.cpu.read_gp(3),
+                        vm.cpu.read_gp(4), vm.cpu.read_gp(5),
+                        vm.cpu.read_gp(11), vm.cpu.read_gp(12), vm.cpu.read_gp(13),
+                        vm.cpu.read_gp(14), vm.cpu.read_gp(15));
+                }
+            }
+        }
+        // 5 + 10 + 20 + 40 = 75
+        assert_eq!(vm.cpu.read_gp(1), 75, "Vec<Point> arg: sum of x+y");
+    }
+
+    #[test]
+    fn pvm_string_struct_vec_full() {
+        // Full test: struct with String field + Vec<Point> + String in storage/return.
+        // Tests: String in struct, Vec<String> in storage, struct+string round-trip.
+        let src = r#"
+            contract T {
+                struct NamedPoint { x: u64, y: u64, label: String, }
+                storage {
+                    points: Map<u64, Vec<NamedPoint>>,
+                    tags: Map<u64, Vec<String>>,
+                    name: Map<u64, String>,
+                }
+                pub fn store_data() {
+                    self.name[1] = "hello";
+                    let mut t = Vec::new();
+                    t.push("alpha");
+                    t.push("beta");
+                    self.tags[1] = t;
+                    let mut pts = Vec::new();
+                    pts.push(NamedPoint { x: 10, y: 20, label: "first" });
+                    pts.push(NamedPoint { x: 30, y: 40, label: "second" });
+                    self.points[1] = pts;
+                }
+                pub fn sum_xy() -> u64 {
+                    let pts = self.points[1];
+                    let mut total = 0;
+                    let mut i = 0;
+                    let len = pts.len();
+                    while i < len {
+                        let p = pts[i];
+                        total = total + p.x + p.y;
+                        i = i + 1;
+                    }
+                    return total;
+                }
+                pub fn get_name_len() -> u64 {
+                    let n = self.name[1];
+                    return n.len();
+                }
+                pub fn get_tags_count() -> u64 {
+                    let t = self.tags[1];
+                    return t.len();
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let contract = CodeGen::new().generate(&ir);
+        let addr = [0xBBu8; 32];
+
+        // Store
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("store_data").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "store_data failed: {:?}", out1.outcome);
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage {
+            let sk = sparse_merkle_tree::H256::from(k.to_le_bytes());
+            let _ = smt.insert(sk, v.clone());
+        }
+
+        // Helper to run a function
+        let run = |sel: &str| -> u64 {
+            let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+            vm.calldata = compute_selector(sel).to_be_bytes().to_vec();
+            let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+            vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
+                let sk = sparse_merkle_tree::H256::from(key.to_le_bytes());
+                unsafe { (*smt_ptr).get(&sk) }
+            }));
+            vm.load(&contract.runtime_bytecode).unwrap();
+            let out = vm.execute();
+            assert_eq!(out.outcome, pyde_vm::vm::Outcome::Success, "{} failed", sel);
+            vm.cpu.read_gp(1)
+        };
+
+        assert_eq!(run("sum_xy"), 100, "sum_xy: (10+20)+(30+40) = 100");
+        assert_eq!(run("get_name_len"), 5, "name 'hello' has 5 bytes");
+        assert_eq!(run("get_tags_count"), 2, "tags has 2 elements");
+    }
+
+    #[test]
+    fn pvm_profile_string_first_field() {
+        // Reproducer: struct with String as FIRST field, through storage round-trip.
+        let src = r#"
+            contract T {
+                struct Profile { name: String, age: u64, }
+                storage { profiles: Map<u64, Profile>, }
+                pub fn store_prof() {
+                    let p = Profile { name: "alice", age: 30 };
+                    self.profiles[1] = p;
+                }
+                pub fn get_age() -> u64 {
+                    let p = self.profiles[1];
+                    return p.age;
+                }
+                pub fn get_name_len() -> u64 {
+                    let p = self.profiles[1];
+                    return p.name.len();
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let contract = CodeGen::new().generate(&ir);
+        let addr = [0xCCu8; 32];
+
+        // Store
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("store_prof").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "store_prof failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage { let sk = sparse_merkle_tree::H256::from(k.to_le_bytes()); let _ = smt.insert(sk, v.clone()); }
+
+        let run = |sel: &str| -> u64 {
+            let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+            vm.calldata = compute_selector(sel).to_be_bytes().to_vec();
+            let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+            vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| { let sk = sparse_merkle_tree::H256::from(key.to_le_bytes()); unsafe { (*smt_ptr).get(&sk) } }));
+            vm.load(&contract.runtime_bytecode).unwrap();
+            let out = vm.execute();
+            assert_eq!(out.outcome, pyde_vm::vm::Outcome::Success, "{} failed", sel);
+            vm.cpu.read_gp(1)
+        };
+
+        assert_eq!(run("get_age"), 30, "age should be 30");
+        assert_eq!(run("get_name_len"), 5, "name 'alice' should be 5 bytes");
+    }
+
+    #[test]
+    fn pvm_profile_full_fields() {
+        // Profile { name: String, age: u64, tags: Vec<String>, scores: Vec<u64> }
+        let src = r#"
+            contract T {
+                struct Profile { age: u64, name: String, tags: Vec<u64>, scores: Vec<u64>, }
+                storage { profiles: Map<u64, Profile>, }
+                pub fn store_prof() {
+                    let mut tags = Vec::new(); tags.push(100); tags.push(200); tags.push(300);
+                    let mut scores = Vec::new(); scores.push(10); scores.push(20); scores.push(30);
+                    let p = Profile { age: 30, name: "alice", tags: tags, scores: scores };
+                    self.profiles[1] = p;
+                }
+                pub fn get_age() -> u64 { let p = self.profiles[1]; return p.age; }
+                pub fn get_name_len() -> u64 { let p = self.profiles[1]; return p.name.len(); }
+                pub fn get_tags_count() -> u64 { let p = self.profiles[1]; return p.tags.len(); }
+                pub fn get_score_sum() -> u64 {
+                    let p = self.profiles[1];
+                    let mut t=0; let mut i=0; let l=p.scores.len();
+                    while i<l { t=t+p.scores[i]; i=i+1; }
+                    return t;
+                }
+            }
+        "#;
+        let (tokens, _) = crate::lexer::Lexer::new(src).tokenize();
+        let (file, _) = crate::parser::Parser::new(tokens).parse();
+        let mut ir = crate::lower::lower(&file);
+        crate::optimize::optimize(&mut ir);
+        let contract = CodeGen::new().generate(&ir);
+        let addr = [0xDDu8; 32];
+
+        let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+        let mut vm1 = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm1.calldata = compute_selector("store_prof").to_be_bytes().to_vec();
+        vm1.load(&contract.runtime_bytecode).unwrap();
+        let out1 = vm1.execute();
+        assert_eq!(out1.outcome, pyde_vm::vm::Outcome::Success, "store_prof failed");
+
+        let mut smt = pyde_state::smt::PydeSMT::new();
+        for (k, v) in &vm1.storage { let sk = sparse_merkle_tree::H256::from(k.to_le_bytes()); let _ = smt.insert(sk, v.clone()); }
+
+        let run = |sel: &str| -> u64 {
+            let ctx = pyde_vm::vm::ExecutionContext { self_address: addr, ..Default::default() };
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+            vm.calldata = compute_selector(sel).to_be_bytes().to_vec();
+            let smt_ptr = &smt as *const pyde_state::smt::PydeSMT;
+            vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| { let sk = sparse_merkle_tree::H256::from(key.to_le_bytes()); unsafe { (*smt_ptr).get(&sk) } }));
+            vm.load(&contract.runtime_bytecode).unwrap();
+            let out = vm.execute();
+            assert_eq!(out.outcome, pyde_vm::vm::Outcome::Success, "{} failed", sel);
+            vm.cpu.read_gp(1)
+        };
+
+        for (k, v) in &vm1.storage {
+            eprintln!("STORAGE key={}: {} bytes: {:02x?}", k, v.len(), &v[..v.len().min(80)]);
+        }
+        assert_eq!(run("get_age"), 30, "age");
+        assert_eq!(run("get_name_len"), 5, "name 'alice' = 5 bytes");
+        assert_eq!(run("get_tags_count"), 3, "tags count");
+        assert_eq!(run("get_score_sum"), 60, "scores 10+20+30");
     }
 }

--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -272,8 +272,8 @@ pub enum Inst {
     /// `%dst = struct_init "name", [(field, reg)...]`
     StructInit(Reg, String, Vec<(String, Reg)>),
 
-    /// `%dst = field_get %obj, "field_name"`
-    FieldGet(Reg, Reg, String),
+    /// `%dst = field_get %obj, "struct_name", "field_name"`
+    FieldGet(Reg, Reg, String, String),
 
     /// `%dst = index_get %obj, %idx`
     IndexGet(Reg, Reg, Reg),
@@ -490,7 +490,10 @@ impl fmt::Display for Inst {
                 let fields_str: Vec<String> = fields.iter().map(|(n, r)| format!("{}: {}", n, r)).collect();
                 write!(f, "{} = {} {{ {} }}", dst, name, fields_str.join(", "))
             }
-            Inst::FieldGet(dst, obj, field) => write!(f, "{} = {}.{}", dst, obj, field),
+            Inst::FieldGet(dst, obj, sname, field) => {
+                if sname.is_empty() { write!(f, "{} = {}.{}", dst, obj, field) }
+                else { write!(f, "{} = {}:{}.{}", dst, obj, sname, field) }
+            }
             Inst::IndexGet(dst, obj, idx) => write!(f, "{} = {}[{}]", dst, obj, idx),
             Inst::IndexSet(obj, idx, val) => write!(f, "{}[{}] = {}", obj, idx, val),
             Inst::MakeTuple(dst, regs) => {

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -38,8 +38,12 @@ struct Lowerer {
     current_fn: Option<IrFunction>,
     /// Variable name → register mapping (scoped).
     locals: Vec<HashMap<String, Reg>>,
+    /// Variable name → type (scoped, parallel to locals). For struct-aware FieldGet.
+    local_types: Vec<HashMap<String, Ty>>,
     /// Storage field name → slot index.
     storage_slots: HashMap<String, u32>,
+    /// Storage field name → type (for inferring struct types from Map<K, V> access).
+    storage_types: HashMap<String, Ty>,
     next_slot: u32,
     /// Loop label stack: (header_label, exit_label) for break/continue.
     loop_stack: Vec<(Label, Label)>,
@@ -47,6 +51,8 @@ struct Lowerer {
     enum_defs: HashMap<String, Vec<String>>,
     /// Const name → (value, type) for inlining.
     const_defs: HashMap<String, (U256, Ty)>,
+    /// Struct name → field definitions (for type lookups in FieldGet).
+    struct_field_defs: HashMap<String, Vec<(String, Ty)>>,
     /// Compiled contract bytecodes for `create!` embedding.
     /// Maps contract name → deploy-format bytes [clen:4][rlen:4][constructor][runtime].
     compiled_contracts: HashMap<String, Vec<u8>>,
@@ -70,10 +76,13 @@ impl Lowerer {
             },
             current_fn: None,
             locals: vec![HashMap::new()],
+            local_types: vec![HashMap::new()],
             storage_slots: HashMap::new(),
+            storage_types: HashMap::new(),
             next_slot: 0,
             loop_stack: Vec::new(),
             enum_defs: HashMap::new(),
+            struct_field_defs: HashMap::new(),
             compiled_contracts: HashMap::new(),
             const_defs: HashMap::new(),
         }
@@ -93,15 +102,23 @@ impl Lowerer {
 
     fn push_scope(&mut self) {
         self.locals.push(HashMap::new());
+        self.local_types.push(HashMap::new());
     }
 
     fn pop_scope(&mut self) {
         self.locals.pop();
+        self.local_types.pop();
     }
 
     fn declare_local(&mut self, name: &str, reg: Reg) {
         if let Some(scope) = self.locals.last_mut() {
             scope.insert(name.to_string(), reg);
+        }
+    }
+
+    fn declare_local_type(&mut self, name: &str, ty: Ty) {
+        if let Some(scope) = self.local_types.last_mut() {
+            scope.insert(name.to_string(), ty);
         }
     }
 
@@ -112,6 +129,90 @@ impl Lowerer {
             }
         }
         None
+    }
+
+    fn lookup_local_type(&self, name: &str) -> Option<Ty> {
+        for scope in self.local_types.iter().rev() {
+            if let Some(ty) = scope.get(name) {
+                return Some(ty.clone());
+            }
+        }
+        None
+    }
+
+    /// Infer the type of an expression (best-effort, for local_types tracking).
+    fn infer_expr_type(&self, expr: &ast::Expr) -> Option<Ty> {
+        use crate::ast::Expr;
+        match expr {
+            Expr::StructInit(path, _, _) => {
+                let name = path.last().map(|i| i.name.clone()).unwrap_or_default();
+                Some(Ty::Struct(name))
+            }
+            Expr::Ident(ident) => self.lookup_local_type(&ident.name),
+            Expr::FieldAccess(obj, field, _) => {
+                let parent = self.resolve_expr_struct_type(obj);
+                if !parent.is_empty() {
+                    if let Some(fields) = self.struct_field_defs.get(&parent) {
+                        for (fname, fty) in fields {
+                            if fname == &field.name {
+                                return Some(fty.clone());
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            // self.field[key] → infer value type from Map<K, V>
+            Expr::Index(obj, _, _) => {
+                if let Expr::FieldAccess(inner, field, _) = obj.as_ref() {
+                    if matches!(inner.as_ref(), Expr::SelfExpr(_)) {
+                        if let Some(map_ty) = self.storage_types.get(&field.name) {
+                            if let Ty::Map(_, val_ty) = map_ty {
+                                return Some(*val_ty.clone());
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolve the struct type name for an expression (for FieldGet context).
+    /// Returns the struct name if the expression is known to be a struct type,
+    /// or empty string if unknown/non-struct.
+    fn resolve_expr_struct_type(&self, expr: &ast::Expr) -> String {
+        use crate::ast::Expr;
+        match expr {
+            Expr::Ident(ident) => {
+                // Look up variable type
+                if let Some(Ty::Struct(name)) = self.lookup_local_type(&ident.name) {
+                    name
+                } else {
+                    String::new()
+                }
+            }
+            Expr::FieldAccess(obj, field, _) => {
+                // Chained access: obj.field — determine the type of field
+                let parent_struct = self.resolve_expr_struct_type(obj);
+                if !parent_struct.is_empty() {
+                    // Look up the field's type in the parent struct
+                    if let Some(fields) = self.struct_field_defs.get(&parent_struct) {
+                        for (fname, fty) in fields {
+                            if fname == &field.name {
+                                if let Ty::Struct(inner) = fty {
+                                    return inner.clone();
+                                }
+                                return String::new();
+                            }
+                        }
+                    }
+                }
+                String::new()
+            }
+            _ => String::new(),
+        }
     }
 
     /// Convert an AST type to an IR type.
@@ -147,6 +248,7 @@ impl Lowerer {
         let slot = self.next_slot;
         self.next_slot += 1;
         self.storage_slots.insert(name.to_string(), slot);
+        self.storage_types.insert(name.to_string(), ty.clone());
         self.program.storage_fields.push(StorageFieldDef {
             name: name.to_string(),
             ty,
@@ -186,6 +288,7 @@ impl Lowerer {
                     let fields: Vec<(String, Ty)> = s.fields.iter()
                         .map(|f| (f.name.name.clone(), self.resolve_ty(&f.ty)))
                         .collect();
+                    self.struct_field_defs.insert(s.name.name.clone(), fields.clone());
                     self.program.struct_defs.push(ir::StructDef {
                         name: s.name.name.clone(),
                         fields,
@@ -265,6 +368,7 @@ impl Lowerer {
                     let fields: Vec<(String, Ty)> = s.fields.iter()
                         .map(|f| (f.name.name.clone(), self.resolve_ty(&f.ty)))
                         .collect();
+                    self.struct_field_defs.insert(s.name.name.clone(), fields.clone());
                     self.program.struct_defs.push(ir::StructDef {
                         name: s.name.name.clone(),
                         fields,
@@ -346,10 +450,11 @@ impl Lowerer {
         self.current_fn = Some(ir_func);
         self.push_scope();
 
-        // Declare parameters as local registers
-        for (name, _ty) in &params {
+        // Declare parameters as local registers (with type tracking)
+        for (name, ty) in &params {
             let reg = self.alloc_reg();
             self.declare_local(name, reg);
+            self.declare_local_type(name, ty.clone());
         }
 
         // Lower body
@@ -401,11 +506,18 @@ impl Lowerer {
     }
 
     fn lower_let(&mut self, l: &LetStmt) {
+        // Infer struct type from initializer for FieldGet context tracking
+        let inferred_ty = self.infer_expr_type(&l.initializer);
         let val = self.lower_expr(&l.initializer);
 
         match &l.binding {
             LetBinding::Name(name) => {
                 self.declare_local(&name.name, val);
+                if let Some(ty) = &l.ty {
+                    self.declare_local_type(&name.name, self.resolve_ty(ty));
+                } else if let Some(ty) = inferred_ty {
+                    self.declare_local_type(&name.name, ty);
+                }
             }
             LetBinding::Tuple(names, _) => {
                 // Destructure tuple into individual registers
@@ -721,14 +833,15 @@ impl Lowerer {
                 if field.name == "balance" {
                     let obj_reg = self.lower_expr(obj);
                     let dst = self.alloc_reg();
-                    self.emit(Inst::FieldGet(dst, obj_reg, "balance".into()));
+                    self.emit(Inst::FieldGet(dst, obj_reg, String::new(), "balance".into()));
                     return dst;
                 }
 
-                // obj.field → field_get
+                // obj.field → field_get with struct type context
+                let struct_name = self.resolve_expr_struct_type(obj);
                 let obj_reg = self.lower_expr(obj);
                 let dst = self.alloc_reg();
-                self.emit(Inst::FieldGet(dst, obj_reg, field.name.clone()));
+                self.emit(Inst::FieldGet(dst, obj_reg, struct_name, field.name.clone()));
                 dst
             }
 

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -302,7 +302,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
         Inst::ExtCall(_, addr, _, args) => { used.insert(*addr); for a in args { used.insert(*a); } }
         Inst::Hash(_, args) => { for a in args { used.insert(*a); } }
         Inst::StructInit(_, _, fields) => { for (_, r) in fields { used.insert(*r); } }
-        Inst::FieldGet(_, obj, _) => { used.insert(*obj); }
+        Inst::FieldGet(_, obj, _, _) => { used.insert(*obj); }
         Inst::IndexGet(_, obj, idx) => { used.insert(*obj); used.insert(*idx); }
         Inst::IndexSet(obj, idx, val) => { used.insert(*obj); used.insert(*idx); used.insert(*val); }
         Inst::MakeTuple(_, regs) => { for r in regs { used.insert(*r); } }
@@ -337,7 +337,7 @@ fn get_dest_reg(inst: &Inst) -> Option<Reg> {
         | Inst::Builtin(dst, _) | Inst::Call(dst, _, _)
         | Inst::MethodCall(dst, _, _, _) | Inst::ExtCall(dst, _, _, _)
         | Inst::Hash(dst, _) | Inst::StructInit(dst, _, _)
-        | Inst::FieldGet(dst, _, _) | Inst::IndexGet(dst, _, _)
+        | Inst::FieldGet(dst, _, _, _) | Inst::IndexGet(dst, _, _)
         | Inst::MakeTuple(dst, _) | Inst::TupleGet(dst, _, _)
         | Inst::MakeArray(dst, _) | Inst::ArrayRepeat(dst, _, _)
         | Inst::MakeVec(dst, _)

--- a/crates/pvm/src/memory.rs
+++ b/crates/pvm/src/memory.rs
@@ -208,6 +208,11 @@ impl Memory {
         Ok(new_sp)
     }
 
+    /// Read a contiguous byte range from memory.
+    pub fn load_bytes(&self, addr: usize, len: usize) -> Vec<u8> {
+        (0..len).map(|i| self.read_byte((addr + i) as u32)).collect()
+    }
+
     // --- Byte-level load/store ---
 
     pub fn load8(&mut self, addr: u32) -> Result<u8, MemoryError> {

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -801,4 +801,117 @@ mod tests {
         assert_eq!(b30, 24500, "bal(30) = 21800 + 2700");
         assert_eq!(b1, 2100, "bal(1) = 1200 + 900");
     }
+
+    // ========== E2E: Otigen compile → deploy → call (struct + Vec + while loop) ==========
+
+    #[test]
+    fn e2e_rank_contract() {
+        // Compile the RankTest contract from source
+        let src = r#"
+            contract RankTest {
+                struct Player { id: u64, score: u64, }
+                storage {
+                    players: Map<u64, Player>,
+                    boards: Map<u64, Vec<u64>>,
+                }
+                #[constructor] pub fn init() {}
+                pub fn setup() {
+                    let p = Player { id: 1, score: 400 };
+                    self.players[1] = p;
+                    let mut b = Vec::new();
+                    b.push(100); b.push(200); b.push(300);
+                    self.boards[1] = b;
+                }
+                pub fn rank(pid: u64, bid: u64) -> u64 {
+                    let p = self.players[pid];
+                    let board = self.boards[bid];
+                    let score = p.score;
+                    let mut rank = 0;
+                    let mut i = 0;
+                    let len = board.len();
+                    while i < len {
+                        if board[i] > score { rank = rank + 1; }
+                        i = i + 1;
+                    }
+                    return rank + 1;
+                }
+            }
+        "#;
+
+        let (tokens, _) = otic::lexer::Lexer::new(src).tokenize();
+        let (file, _) = otic::parser::Parser::new(tokens).parse();
+        let mut ir = otic::lower::lower(&file);
+        otic::optimize::optimize(&mut ir);
+        let codegen = otic::codegen::CodeGen::new();
+        let contract = codegen.generate(&ir);
+
+        // Build deploy-format bytecode: [clen:4 LE][rlen:4 LE][constructor][runtime]
+        let clen = contract.constructor_bytecode.len() as u32;
+        let rlen = contract.runtime_bytecode.len() as u32;
+        let mut deploy_data = Vec::new();
+        deploy_data.extend_from_slice(&clen.to_le_bytes());
+        deploy_data.extend_from_slice(&rlen.to_le_bytes());
+        deploy_data.extend_from_slice(&contract.constructor_bytecode);
+        deploy_data.extend_from_slice(&contract.runtime_bytecode);
+
+        // Setup accounts and deploy
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let mut smt = PydeSMT::new();
+        let block_ctx = make_block_ctx();
+        let sender_addr = setup_funded_account(&mut smt, &pk_bytes, 1_000_000_000_000);
+        let contract_addr = pyde_account::address::derive_create_address(&sender_addr, 0);
+
+        // Deploy transaction
+        let mut deploy_tx = make_signed_tx(sender_addr, ZERO_ADDRESS, 0, 100_000_000, 0, &sk);
+        deploy_tx.tx_type = TransactionType::Deploy;
+        deploy_tx.data = deploy_data;
+        let hash = deploy_tx.hash();
+        deploy_tx.signature = falcon_sign(&sk, &hash).unwrap().as_bytes().to_vec();
+
+        let receipt = execute_transaction(&deploy_tx, &mut smt, &block_ctx).unwrap();
+        assert!(receipt.success, "deploy failed: {:?}", receipt);
+
+        // Verify contract code was stored
+        let code = load_code(&smt, &contract_addr);
+        assert!(code.is_some(), "contract code not found");
+        assert_eq!(code.unwrap(), contract.runtime_bytecode);
+
+        // Call setup() — populates storage with Player and board
+        let setup_sel = otic::codegen::compute_selector("setup");
+        let mut setup_tx = make_signed_tx(sender_addr, contract_addr, 0, 100_000_000, 1, &sk);
+        setup_tx.data = setup_sel.to_be_bytes().to_vec();
+        let hash = setup_tx.hash();
+        setup_tx.signature = falcon_sign(&sk, &hash).unwrap().as_bytes().to_vec();
+
+        let receipt = execute_transaction(&setup_tx, &mut smt, &block_ctx).unwrap();
+        assert!(receipt.success, "setup() failed: {:?}", receipt);
+
+        // Call rank(1, 1) via direct PVM execution (to read return value from r1)
+        // score=400, board=[100,200,300] — no entries > 400, so rank = 0+1 = 1
+        let rank_sel = otic::codegen::compute_selector("rank");
+        let mut calldata = rank_sel.to_be_bytes().to_vec();
+        calldata.extend_from_slice(&1u64.to_le_bytes()); // pid = 1
+        calldata.extend_from_slice(&1u64.to_le_bytes()); // bid = 1
+
+        let ctx = pyde_vm::vm::ExecutionContext {
+            self_address: contract_addr.into(),
+            ..Default::default()
+        };
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);
+        vm.calldata = calldata;
+
+        // Wire up storage backend to read from SMT
+        let smt_ptr = &smt as *const PydeSMT;
+        vm.storage_backend = Some(std::sync::Arc::new(move |key: &U256| {
+            let smt_key = H256::from(key.to_le_bytes());
+            unsafe { (*smt_ptr).get(&smt_key) }
+        }));
+
+        let runtime_code = load_code(&smt, &contract_addr).expect("runtime code");
+        vm.load(&runtime_code).unwrap();
+        let output = vm.execute();
+        assert_eq!(output.outcome, pyde_vm::vm::Outcome::Success, "rank() failed");
+        assert_eq!(vm.cpu.read_gp(1), 1, "rank should be 1 (no board entries > 400)");
+    }
 }


### PR DESCRIPTION
## Summary

- **Packed struct layout**: fields use actual byte sizes (u8→1B, u16→2B, u32→4B, u64→8B, u256→32B) instead of padding everything to 8 bytes
- **Inline nested structs**: fixed-size structs flattened directly in parent memory — `hero.stats.hp` is 1 Load instead of 2
- **Push/Pop register borrowing**: when >11 vregs, borrows r1 via Push/Pop instead of the broken r14 shared-temp approach. Fixes all register clobbering bugs.
- **Unified flat serialization**: one format for calldata args, storage blobs, and return values
- **Struct/Vec<Struct>/Vec<String> as args, returns, and storage** — all verified on live validator node
- **Typed Load/Store** (W8/W16/W32/W64/Wload) for packed field access
- **Blob return** via r1=ptr r2=len for complex type returns
- **Struct-aware FieldGet** with IR 4-tuple for correct offset computation

## Test plan

- [x] `cargo test -p otic` — 367 tests pass
- [x] `cargo test --workspace` — 1,770 tests, 0 failures
- [x] Live validator node E2E: deploy + store + read for Profile{String, u64, Vec<String>, Vec<u64>}
- [x] Struct return decoded: `Profile { name: "alice", age: 30, tags: ["dev","rust","web3"], scores: [10,20,30] }`
- [x] Vec<Point> as arg/storage/return
- [x] Vec<String> as arg/return
- [x] Packed struct with u8/u32 fields through storage round-trip