### PR TITLE
feat: pyde-dev CLI framework with init, build, test, clean, deploy, and assert! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyde-dev"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "glob",
+ "hex",
+ "otic",
+ "pyde-vm",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "pyde-mempool"
 version = "0.1.0"
 dependencies = [
@@ -3824,7 +3841,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ members = [
     "crates/net",
     "crates/otic",
     "crates/node",
+    "crates/pyde-dev",
 ]

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1018,6 +1018,24 @@ impl Lowerer {
                         self.emit(Inst::Const(dst, IrConst::Unit));
                         dst
                     }
+                    "assert" => {
+                        // assert!(cond) → revert if cond is false (no error type needed)
+                        if let Some(MacroArg::Positional(cond_expr)) = args.first() {
+                            let cond = self.lower_expr(cond_expr);
+                            let ok_label = self.func().alloc_label();
+                            let revert_label = self.func().alloc_label();
+
+                            self.emit(Inst::Branch(cond, ok_label, revert_label));
+
+                            self.func().push_block(revert_label, "assert.fail".into());
+                            self.emit(Inst::Revert("AssertionFailed".into(), vec![]));
+
+                            self.func().push_block(ok_label, "assert.ok".into());
+                        }
+                        let dst = self.alloc_reg();
+                        self.emit(Inst::Const(dst, IrConst::Unit));
+                        dst
+                    }
                     "revert" => {
                         if let Some(MacroArg::Positional(err_expr)) = args.first() {
                             let err_regs = self.lower_error_expr(err_expr);

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -744,7 +744,7 @@ impl Resolver {
 
             Expr::MacroCall(name, args, span) => {
                 // Built-in macros: require!, revert!, cross_call!, raw_call!
-                let known_macros = ["require", "revert", "cross_call", "raw_call", "create"];
+                let known_macros = ["require", "revert", "assert", "cross_call", "raw_call", "create"];
                 if !known_macros.contains(&name.name.as_str()) {
                     self.error(
                         format!("unknown macro '{}!'", name.name),

--- a/crates/pyde-dev/Cargo.toml
+++ b/crates/pyde-dev/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "pyde-dev"
+version = "0.1.0"
+edition = "2021"
+description = "Pyde smart contract development framework"
+
+[[bin]]
+name = "pyde-dev"
+path = "src/main.rs"
+
+[dependencies]
+# Compiler
+otic = { path = "../otic" }
+pyde-vm = { path = "../pvm" }
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Config
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+
+# File system
+glob = "0.3"
+sha2 = "0.10"
+hex = "0.4"
+
+# Deploy (RPC)
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -1,0 +1,486 @@
+use crate::project::{self, ProjectConfig};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use sha2::{Sha256, Digest};
+
+/// Build cache stored in out/.build-cache.json for incremental builds.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct BuildCache {
+    /// file path (relative to project root) → content SHA-256 hex
+    hashes: HashMap<String, String>,
+}
+
+/// Result of building the project.
+pub struct BuildResult {
+    pub contracts: Vec<(String, String)>, // (contract_name, artifact_path)
+    pub total_bytecode: usize,
+}
+
+pub fn run() -> Result<(), String> {
+    let (config, root) = project::load_config()?;
+    let result = build_project(&config, &root)?;
+    println!(
+        "\n  {} contract(s) compiled, {} bytes total bytecode",
+        result.contracts.len(),
+        result.total_bytecode
+    );
+    Ok(())
+}
+
+/// Build the full project. Called by both `pyde-dev build` and `pyde-dev test`.
+pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult, String> {
+    let start = Instant::now();
+    let src_dir = root.join(&config.compiler.src);
+    let out_dir = root.join(&config.compiler.out);
+
+    if !src_dir.exists() {
+        return Err(format!("source directory '{}' not found", src_dir.display()));
+    }
+
+    // Find all .oti files
+    let pattern = format!("{}/**/*.oti", src_dir.display());
+    let files: Vec<PathBuf> = glob::glob(&pattern)
+        .map_err(|e| format!("glob error: {}", e))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if files.is_empty() {
+        return Err(format!("no .oti files found in {}", src_dir.display()));
+    }
+
+    // Load build cache for incremental builds
+    let cache_path = out_dir.join(".build-cache.json");
+    let old_cache = load_cache(&cache_path);
+    let mut new_cache = BuildCache::default();
+
+    // Read all source files + compute hashes
+    let mut sources: Vec<(PathBuf, String, String)> = Vec::new(); // (path, source, hash)
+    for file in &files {
+        let source = fs::read_to_string(file)
+            .map_err(|e| format!("cannot read {}: {}", file.display(), e))?;
+        let hash = sha256_hex(&source);
+        sources.push((file.clone(), source, hash));
+    }
+
+    // Build dependency graph from `use` statements
+    let dep_graph = build_dependency_graph(&sources, &src_dir)?;
+
+    // Topological sort (detect cycles)
+    let compile_order = topological_sort(&dep_graph, &sources)?;
+
+    // Check which files need recompilation
+    let mut needs_rebuild: HashSet<usize> = HashSet::new();
+    for (idx, (path, _, hash)) in sources.iter().enumerate() {
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let rel_str = rel.to_string_lossy().to_string();
+        let old_hash = old_cache.hashes.get(&rel_str);
+        if old_hash != Some(hash) {
+            needs_rebuild.insert(idx);
+            // If a file changed, all files that depend on it also need rebuilding
+            mark_dependents(&dep_graph, idx, &mut needs_rebuild, sources.len());
+        }
+        new_cache.hashes.insert(rel_str, hash.clone());
+    }
+
+    // Create output directory
+    fs::create_dir_all(&out_dir)
+        .map_err(|e| format!("cannot create {}: {}", out_dir.display(), e))?;
+
+    // Compile in dependency order
+    let mut compiled_registry: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut result = BuildResult {
+        contracts: Vec::new(),
+        total_bytecode: 0,
+    };
+    let mut had_errors = false;
+
+    for &file_idx in &compile_order {
+        let (ref path, ref source, _) = sources[file_idx];
+        let rel = path.strip_prefix(root).unwrap_or(path);
+
+        // Skip if unchanged and all deps unchanged
+        if !needs_rebuild.contains(&file_idx) {
+            // Still register previously compiled contracts from artifacts
+            load_existing_artifacts(&out_dir, source, &mut compiled_registry, &mut result);
+            continue;
+        }
+
+        // Run frontend: lex → parse → resolve → typecheck → safety
+        if let Err(msg) = run_frontend(path, source) {
+            eprintln!("{}", msg);
+            had_errors = true;
+            continue;
+        }
+
+        // Compile
+        let contracts = otic::compile_all(source);
+        if contracts.is_empty() {
+            println!("  {} — no contracts", rel.display());
+            continue;
+        }
+
+        for (name, contract) in &contracts {
+            // Generate ABI
+            let (tokens, _) = otic::lexer::Lexer::new(source).tokenize();
+            let (file, _) = otic::parser::Parser::new(tokens).parse();
+            let mut single = otic::ast::SourceFile { items: Vec::new() };
+            for item in &file.items {
+                match item {
+                    otic::ast::Item::Contract(c) if c.name.name == *name => {
+                        single.items.push(item.clone());
+                    }
+                    otic::ast::Item::Contract(_) => {}
+                    _ => single.items.push(item.clone()),
+                }
+            }
+            let ir = otic::lower::lower(&single);
+            let abi = otic::abi::generate_abi(&ir);
+            let artifact_json = otic::abi::artifact_to_json(&abi, contract);
+
+            // Write artifact
+            let artifact_path = out_dir.join(format!("{}.json", name));
+            fs::write(&artifact_path, &artifact_json)
+                .map_err(|e| format!("cannot write {}: {}", artifact_path.display(), e))?;
+
+            // Register in compiled_registry for cross-file references
+            let clen = contract.constructor_bytecode.len() as u32;
+            let rlen = contract.runtime_bytecode.len() as u32;
+            let mut deploy_bytes = Vec::with_capacity(8 + clen as usize + rlen as usize);
+            deploy_bytes.extend_from_slice(&clen.to_le_bytes());
+            deploy_bytes.extend_from_slice(&rlen.to_le_bytes());
+            deploy_bytes.extend_from_slice(&contract.constructor_bytecode);
+            deploy_bytes.extend_from_slice(&contract.runtime_bytecode);
+            compiled_registry.insert(name.clone(), deploy_bytes);
+
+            result.total_bytecode += contract.bytecode.len();
+            result
+                .contracts
+                .push((name.clone(), artifact_path.to_string_lossy().to_string()));
+
+            println!(
+                "  {} — {} ({} bytes, {} instructions)",
+                rel.display(),
+                name,
+                contract.bytecode.len(),
+                contract.instruction_count
+            );
+        }
+    }
+
+    if had_errors {
+        return Err("build failed with errors".into());
+    }
+
+    // Save build cache
+    save_cache(&cache_path, &new_cache);
+
+    let elapsed = start.elapsed();
+    println!("  compiled in {:.2}s", elapsed.as_secs_f64());
+
+    Ok(result)
+}
+
+/// Run the otic frontend pipeline. Returns Err with formatted diagnostics on failure.
+fn run_frontend(path: &Path, source: &str) -> Result<(), String> {
+    let path_str = path.to_string_lossy();
+    let mut diagnostics = Vec::new();
+
+    let (tokens, lex_errors) = otic::lexer::Lexer::new(source).tokenize();
+    for err in &lex_errors {
+        diagnostics.push(otic::diagnostic::Diagnostic {
+            level: otic::diagnostic::Level::Error,
+            message: err.message.clone(),
+            file: path_str.to_string(),
+            line: err.line,
+            col: err.col,
+        });
+    }
+    if !diagnostics.is_empty() {
+        return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
+    }
+
+    let (file, parse_errors) = otic::parser::Parser::new(tokens).parse();
+    for err in &parse_errors {
+        diagnostics.push(otic::diagnostic::Diagnostic {
+            level: otic::diagnostic::Level::Error,
+            message: err.message.clone(),
+            file: path_str.to_string(),
+            line: err.span.line,
+            col: err.span.col,
+        });
+    }
+    if !diagnostics.is_empty() {
+        return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
+    }
+
+    let resolve_result = otic::resolve::Resolver::new().resolve(&file);
+    for err in &resolve_result.errors {
+        diagnostics.push(otic::diagnostic::Diagnostic {
+            level: otic::diagnostic::Level::Error,
+            message: err.message.clone(),
+            file: path_str.to_string(),
+            line: err.span.line,
+            col: err.span.col,
+        });
+    }
+    if !diagnostics.is_empty() {
+        return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
+    }
+
+    let tc_result = otic::typecheck::TypeChecker::new().check(&file);
+    for err in &tc_result.errors {
+        diagnostics.push(otic::diagnostic::Diagnostic {
+            level: otic::diagnostic::Level::Error,
+            message: err.message.clone(),
+            file: path_str.to_string(),
+            line: err.span.line,
+            col: err.span.col,
+        });
+    }
+    if !diagnostics.is_empty() {
+        return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
+    }
+
+    let safety_result = otic::safety::SafetyChecker::new().check(&file);
+    for err in &safety_result.errors {
+        diagnostics.push(otic::diagnostic::Diagnostic {
+            level: otic::diagnostic::Level::Error,
+            message: err.message.clone(),
+            file: path_str.to_string(),
+            line: err.span.line,
+            col: err.span.col,
+        });
+    }
+    if !diagnostics.is_empty() {
+        return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
+    }
+
+    Ok(())
+}
+
+/// Build dependency graph: for each source file, find which other project files it imports.
+/// Returns adjacency list: file_index → Vec<dependency_file_index>
+fn build_dependency_graph(
+    sources: &[(PathBuf, String, String)],
+    src_dir: &Path,
+) -> Result<Vec<Vec<usize>>, String> {
+    // Map stem name → file index for resolving `use Token;` → src/Token.oti
+    let mut name_to_idx: HashMap<String, usize> = HashMap::new();
+    for (idx, (path, _, _)) in sources.iter().enumerate() {
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            name_to_idx.insert(stem.to_string(), idx);
+        }
+    }
+
+    let mut graph: Vec<Vec<usize>> = vec![Vec::new(); sources.len()];
+
+    for (idx, (path, source, _)) in sources.iter().enumerate() {
+        // Parse just enough to extract `use` statements
+        let (tokens, _) = otic::lexer::Lexer::new(source).tokenize();
+        let (file, _) = otic::parser::Parser::new(tokens).parse();
+
+        for item in &file.items {
+            if let otic::ast::Item::Use(import) = item {
+                // Skip std:: imports — those are stdlib, not project files
+                if !import.path.is_empty() && import.path[0].name == "std" {
+                    continue;
+                }
+
+                // Resolve: `use Token;` → look for Token.oti in src/
+                // Resolve: `use subdir::Token;` → look for subdir/Token.oti
+                let import_name = import.path.last().map(|p| p.name.as_str()).unwrap_or("");
+                if let Some(&dep_idx) = name_to_idx.get(import_name) {
+                    if dep_idx != idx {
+                        graph[idx].push(dep_idx);
+                    }
+                } else if !import_name.is_empty() {
+                    let rel = path.strip_prefix(src_dir).unwrap_or(path);
+                    return Err(format!(
+                        "error in {}: cannot resolve import '{}' — no {}.oti found in src/",
+                        rel.display(),
+                        import.path.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join("::"),
+                        import_name,
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(graph)
+}
+
+/// Topological sort using Kahn's algorithm. Returns compile order. Errors on cycles.
+fn topological_sort(
+    graph: &[Vec<usize>],
+    sources: &[(PathBuf, String, String)],
+) -> Result<Vec<usize>, String> {
+    let n = graph.len();
+    let mut in_degree = vec![0u32; n];
+    for deps in graph {
+        for &dep in deps {
+            in_degree[dep] += 1;
+        }
+    }
+
+    // Wait — in_degree should count how many files depend on each file.
+    // Actually for topological sort: if A depends on B, edge is A→B.
+    // We want B compiled before A. So reverse: edge B←A means B has in_degree from A.
+    // Let's recompute: in_degree[i] = number of files that i depends on (not reverse).
+    // Actually Kahn's: if A→B means "A depends on B", then we want B first.
+    // Standard: in_degree[node] = number of edges pointing TO node.
+    // Our graph[A] = [B] means "A depends on B", so edge A→B.
+    // For Kahn's on a DAG where we want dependencies first:
+    // Reverse the edges: if A depends on B, then B→A in reverse graph.
+    // in_degree of A in reverse = number of dependencies of A.
+    // Nodes with in_degree 0 in reverse = no dependencies, compile first.
+
+    let mut reverse_in_degree = vec![0u32; n];
+    for (node, deps) in graph.iter().enumerate() {
+        reverse_in_degree[node] = deps.len() as u32;
+    }
+
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    for i in 0..n {
+        if reverse_in_degree[i] == 0 {
+            queue.push_back(i);
+        }
+    }
+
+    // Build reverse adjacency: if A depends on B, then B's dependents include A
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for (node, deps) in graph.iter().enumerate() {
+        for &dep in deps {
+            dependents[dep].push(node);
+        }
+    }
+
+    let mut order = Vec::with_capacity(n);
+    while let Some(node) = queue.pop_front() {
+        order.push(node);
+        for &dependent in &dependents[node] {
+            reverse_in_degree[dependent] -= 1;
+            if reverse_in_degree[dependent] == 0 {
+                queue.push_back(dependent);
+            }
+        }
+    }
+
+    if order.len() != n {
+        // Cycle detected — find the cycle for a nice error message
+        let in_cycle: Vec<&Path> = (0..n)
+            .filter(|i| reverse_in_degree[*i] > 0)
+            .map(|i| sources[i].0.as_path())
+            .collect();
+        let names: Vec<String> = in_cycle.iter().map(|p| {
+            p.file_stem().unwrap_or_default().to_string_lossy().to_string()
+        }).collect();
+        return Err(format!(
+            "circular import detected between: {}",
+            names.join(" <-> ")
+        ));
+    }
+
+    Ok(order)
+}
+
+/// Mark all transitive dependents of a changed file as needing rebuild.
+fn mark_dependents(
+    graph: &[Vec<usize>],
+    changed: usize,
+    needs_rebuild: &mut HashSet<usize>,
+    n: usize,
+) {
+    // Build reverse: who depends on `changed`?
+    let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); n];
+    for (node, deps) in graph.iter().enumerate() {
+        for &dep in deps {
+            dependents[dep].push(node);
+        }
+    }
+
+    let mut queue = VecDeque::new();
+    queue.push_back(changed);
+    while let Some(node) = queue.pop_front() {
+        for &dep in &dependents[node] {
+            if needs_rebuild.insert(dep) {
+                queue.push_back(dep);
+            }
+        }
+    }
+}
+
+/// Load existing artifacts for unchanged files to populate the compiled_registry.
+fn load_existing_artifacts(
+    out_dir: &Path,
+    source: &str,
+    registry: &mut HashMap<String, Vec<u8>>,
+    result: &mut BuildResult,
+) {
+    // Quick parse to find contract names
+    let (tokens, _) = otic::lexer::Lexer::new(source).tokenize();
+    let (file, _) = otic::parser::Parser::new(tokens).parse();
+
+    for item in &file.items {
+        if let otic::ast::Item::Contract(c) = item {
+            let name = &c.name.name;
+            let artifact_path = out_dir.join(format!("{}.json", name));
+            if artifact_path.exists() {
+                if let Ok(json_str) = fs::read_to_string(&artifact_path) {
+                    // Parse constructor + deployed bytecode from artifact
+                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                        let c_hex = val.get("constructorBytecode")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("0x")
+                            .trim_start_matches("0x");
+                        let r_hex = val.get("deployedBytecode")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("0x")
+                            .trim_start_matches("0x");
+
+                        if let (Ok(c_bytes), Ok(r_bytes)) = (hex::decode(c_hex), hex::decode(r_hex)) {
+                            let clen = c_bytes.len() as u32;
+                            let rlen = r_bytes.len() as u32;
+                            let mut deploy = Vec::with_capacity(8 + clen as usize + rlen as usize);
+                            deploy.extend_from_slice(&clen.to_le_bytes());
+                            deploy.extend_from_slice(&rlen.to_le_bytes());
+                            deploy.extend_from_slice(&c_bytes);
+                            deploy.extend_from_slice(&r_bytes);
+                            registry.insert(name.clone(), deploy);
+
+                            result.contracts.push((
+                                name.clone(),
+                                artifact_path.to_string_lossy().to_string(),
+                            ));
+                            result.total_bytecode += c_bytes.len() + r_bytes.len();
+
+                            // Print skip message
+                            println!("  {} — unchanged, skipped", name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn sha256_hex(data: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn load_cache(path: &Path) -> BuildCache {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_cache(path: &Path, cache: &BuildCache) {
+    if let Ok(json) = serde_json::to_string_pretty(cache) {
+        let _ = fs::write(path, json);
+    }
+}

--- a/crates/pyde-dev/src/clean.rs
+++ b/crates/pyde-dev/src/clean.rs
@@ -1,0 +1,17 @@
+use crate::project;
+use std::fs;
+
+pub fn run() -> Result<(), String> {
+    let (config, root) = project::load_config()?;
+    let out_dir = root.join(&config.compiler.out);
+
+    if out_dir.exists() {
+        fs::remove_dir_all(&out_dir)
+            .map_err(|e| format!("cannot remove {}: {}", out_dir.display(), e))?;
+        println!("  removed {}", out_dir.display());
+    } else {
+        println!("  nothing to clean");
+    }
+
+    Ok(())
+}

--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -1,0 +1,45 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "pyde-dev", version, about = "Pyde smart contract development framework")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Initialize a new Pyde project.
+    Init {
+        /// Project name (creates a directory with this name).
+        name: String,
+    },
+
+    /// Compile all contracts in src/.
+    Build,
+
+    /// Run tests in test/.
+    Test {
+        /// Optional filter: only run tests matching this string.
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
+
+    /// Remove build artifacts (out/).
+    Clean,
+
+    /// Deploy a contract to a network.
+    Deploy {
+        /// Network name (must be defined in pyde.toml [networks]).
+        #[arg(short, long, default_value = "devnet")]
+        network: String,
+
+        /// Contract name to deploy (if multiple contracts exist).
+        #[arg(short, long)]
+        contract: Option<String>,
+
+        /// Sender address (hex).
+        #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
+        from: String,
+    },
+}

--- a/crates/pyde-dev/src/deploy.rs
+++ b/crates/pyde-dev/src/deploy.rs
@@ -1,0 +1,188 @@
+use crate::build;
+use crate::project;
+use std::fs;
+
+pub fn run(network: &str, contract: Option<&str>, from: &str) -> Result<(), String> {
+    let (config, root) = project::load_config()?;
+
+    // Get network config
+    let net = config
+        .networks
+        .get(network)
+        .ok_or_else(|| {
+            let available: Vec<&String> = config.networks.keys().collect();
+            format!(
+                "network '{}' not found in pyde.toml (available: {})",
+                network,
+                if available.is_empty() {
+                    "none".to_string()
+                } else {
+                    available.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")
+                }
+            )
+        })?
+        .clone();
+
+    // Build if needed
+    let out_dir = root.join(&config.compiler.out);
+    if !out_dir.exists() {
+        println!("  Building contracts first...");
+        build::build_project(&config, &root)?;
+        println!();
+    }
+
+    // Find the artifact to deploy
+    let artifact_path = if let Some(name) = contract {
+        let p = out_dir.join(format!("{}.json", name));
+        if !p.exists() {
+            return Err(format!("artifact not found: {}", p.display()));
+        }
+        p
+    } else {
+        // Auto-detect: find the first .json artifact in out/
+        let mut artifacts: Vec<_> = glob::glob(&format!("{}/*.json", out_dir.display()))
+            .map_err(|e| format!("glob error: {}", e))?
+            .filter_map(|r| r.ok())
+            .filter(|p| {
+                p.file_name()
+                    .map(|n| n.to_string_lossy() != ".build-cache.json")
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        if artifacts.is_empty() {
+            return Err("no compiled artifacts found in out/ — run `pyde-dev build` first".into());
+        }
+        if artifacts.len() > 1 {
+            let names: Vec<String> = artifacts
+                .iter()
+                .filter_map(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
+                .collect();
+            return Err(format!(
+                "multiple contracts found: {}. Use --contract <name> to specify which to deploy",
+                names.join(", ")
+            ));
+        }
+        artifacts.remove(0)
+    };
+
+    // Read artifact
+    let json_str = fs::read_to_string(&artifact_path)
+        .map_err(|e| format!("cannot read {}: {}", artifact_path.display(), e))?;
+    let artifact: serde_json::Value = serde_json::from_str(&json_str)
+        .map_err(|e| format!("invalid artifact JSON: {}", e))?;
+
+    let contract_name = artifact
+        .get("contractName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let constructor_hex = artifact
+        .get("constructorBytecode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0x")
+        .trim_start_matches("0x");
+    let runtime_hex = artifact
+        .get("deployedBytecode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0x")
+        .trim_start_matches("0x");
+
+    let constructor_len = constructor_hex.len() / 2;
+    let full_bytecode = format!("{}{}", constructor_hex, runtime_hex);
+
+    println!("  Deploying {} to {} ({})", contract_name, network, net.rpc_url);
+    println!("  Constructor: {} bytes", constructor_len);
+    println!("  Runtime:     {} bytes", runtime_hex.len() / 2);
+    println!("  From:        {}", from);
+
+    // Send deploy transaction via JSON-RPC
+    let zero_addr = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "pyde_sendTransaction",
+        "params": [{
+            "from": from,
+            "to": zero_addr,
+            "data": format!("0x{}", full_bytecode),
+            "constructorLen": constructor_len,
+            "gas": 100_000_000,
+            "nonce": get_nonce(&net.rpc_url, from)?,
+            "value": "0"
+        }]
+    });
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(&net.rpc_url)
+        .json(&body)
+        .send()
+        .map_err(|e| format!("RPC request failed: {} — is the node running at {}?", e, net.rpc_url))?;
+
+    let resp_json: serde_json::Value = resp
+        .json()
+        .map_err(|e| format!("invalid RPC response: {}", e))?;
+
+    if let Some(err) = resp_json.get("error") {
+        return Err(format!("deploy failed: {}", err));
+    }
+
+    let result_str = resp_json
+        .get("result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // Parse the result (may be nested JSON string)
+    let (tx_hash, contract_addr) = if let Ok(inner) =
+        serde_json::from_str::<serde_json::Value>(result_str)
+    {
+        let tx = inner
+            .get("txHash")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let addr = inner
+            .get("contractAddress")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        (tx.to_string(), addr.to_string())
+    } else {
+        (result_str.to_string(), "unknown".to_string())
+    };
+
+    println!();
+    println!("  Deployed!");
+    println!("  Contract: {}", contract_addr);
+    println!("  Tx Hash:  {}", tx_hash);
+
+    Ok(())
+}
+
+/// Get the current nonce for an address via RPC.
+fn get_nonce(rpc_url: &str, address: &str) -> Result<u64, String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "pyde_getTransactionCount",
+        "params": [address]
+    });
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .map_err(|e| format!("cannot fetch nonce: {}", e))?;
+
+    let resp_json: serde_json::Value = resp
+        .json()
+        .map_err(|e| format!("invalid nonce response: {}", e))?;
+
+    let nonce_str = resp_json
+        .get("result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0");
+
+    nonce_str
+        .parse::<u64>()
+        .map_err(|_| format!("invalid nonce value: {}", nonce_str))
+}

--- a/crates/pyde-dev/src/init.rs
+++ b/crates/pyde-dev/src/init.rs
@@ -1,0 +1,119 @@
+use crate::project;
+use std::fs;
+use std::path::Path;
+
+pub fn run(name: &str) -> Result<(), String> {
+    let root = Path::new(name);
+    if root.exists() {
+        return Err(format!("directory '{}' already exists", name));
+    }
+
+    // Create project structure
+    fs::create_dir_all(root.join("src"))
+        .map_err(|e| format!("cannot create src/: {}", e))?;
+    fs::create_dir_all(root.join("test"))
+        .map_err(|e| format!("cannot create test/: {}", e))?;
+    fs::create_dir_all(root.join("script"))
+        .map_err(|e| format!("cannot create script/: {}", e))?;
+    fs::create_dir_all(root.join("lib"))
+        .map_err(|e| format!("cannot create lib/: {}", e))?;
+
+    // Write pyde.toml
+    fs::write(root.join("pyde.toml"), project::default_toml(name))
+        .map_err(|e| format!("cannot write pyde.toml: {}", e))?;
+
+    // Write starter contract
+    fs::write(root.join("src/Counter.oti"), STARTER_CONTRACT)
+        .map_err(|e| format!("cannot write Counter.oti: {}", e))?;
+
+    // Write starter test
+    fs::write(root.join("test/Counter.test.oti"), STARTER_TEST)
+        .map_err(|e| format!("cannot write Counter.test.oti: {}", e))?;
+
+    // Write .gitignore
+    fs::write(root.join(".gitignore"), "out/\n")
+        .map_err(|e| format!("cannot write .gitignore: {}", e))?;
+
+    println!("  Initialized project '{}'", name);
+    println!();
+    println!("  {}/", name);
+    println!("  ├── pyde.toml");
+    println!("  ├── src/");
+    println!("  │   └── Counter.oti");
+    println!("  ├── test/");
+    println!("  │   └── Counter.test.oti");
+    println!("  ├── script/");
+    println!("  └── lib/");
+    println!();
+    println!("  Get started:");
+    println!("    cd {}", name);
+    println!("    pyde-dev build");
+    println!("    pyde-dev test");
+
+    Ok(())
+}
+
+const STARTER_CONTRACT: &str = r#"contract Counter {
+    storage {
+        count: u64,
+    }
+
+    #[constructor]
+    pub fn init() {
+        self.count = 0;
+    }
+
+    pub fn get_count() -> u64 {
+        return self.count;
+    }
+
+    pub fn increment() {
+        self.count = self.count + 1;
+    }
+
+    pub fn add(value: u64) {
+        self.count = self.count + value;
+    }
+}
+"#;
+
+const STARTER_TEST: &str = r#"contract Counter {
+    storage {
+        count: u64,
+    }
+
+    #[constructor]
+    pub fn init() {
+        self.count = 0;
+    }
+
+    pub fn get_count() -> u64 {
+        return self.count;
+    }
+
+    pub fn increment() {
+        self.count = self.count + 1;
+    }
+
+    pub fn add(value: u64) {
+        self.count = self.count + value;
+    }
+
+    #[test]
+    fn test_initial_count() {
+        assert!(self.count == 0);
+    }
+
+    #[test]
+    fn test_increment() {
+        self.count = self.count + 1;
+        assert!(self.count == 1);
+    }
+
+    #[test]
+    fn test_add_five() {
+        self.count = self.count + 5;
+        assert!(self.count == 5);
+    }
+}
+"#;

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -1,0 +1,30 @@
+mod cli;
+mod project;
+mod init;
+mod build;
+mod clean;
+mod test_runner;
+mod deploy;
+
+use clap::Parser;
+use cli::{Cli, Command};
+use std::process;
+
+fn main() {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Command::Init { name } => init::run(&name),
+        Command::Build => build::run(),
+        Command::Test { filter } => test_runner::run(filter.as_deref()),
+        Command::Clean => clean::run(),
+        Command::Deploy { network, contract, from } => {
+            deploy::run(&network, contract.as_deref(), &from)
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("error: {}", e);
+        process::exit(1);
+    }
+}

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ProjectConfig {
+    pub project: ProjectSection,
+    #[serde(default)]
+    pub compiler: CompilerSection,
+    #[serde(default)]
+    pub networks: HashMap<String, NetworkConfig>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ProjectSection {
+    pub name: String,
+    pub version: String,
+    #[serde(default)]
+    pub authors: Vec<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct CompilerSection {
+    #[serde(default = "default_true")]
+    pub optimize: bool,
+    #[serde(default = "default_src")]
+    pub src: String,
+    #[serde(default = "default_test")]
+    pub test: String,
+    #[serde(default = "default_out")]
+    pub out: String,
+}
+
+impl Default for CompilerSection {
+    fn default() -> Self {
+        Self {
+            optimize: true,
+            src: "src".into(),
+            test: "test".into(),
+            out: "out".into(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct NetworkConfig {
+    pub rpc_url: String,
+    pub chain_id: u64,
+}
+
+fn default_true() -> bool { true }
+fn default_src() -> String { "src".into() }
+fn default_test() -> String { "test".into() }
+fn default_out() -> String { "out".into() }
+
+/// Find pyde.toml by walking up from the current directory.
+/// Returns (config, project_root_dir).
+pub fn load_config() -> Result<(ProjectConfig, PathBuf), String> {
+    let mut dir = std::env::current_dir()
+        .map_err(|e| format!("cannot read current directory: {}", e))?;
+
+    loop {
+        let config_path = dir.join("pyde.toml");
+        if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path)
+                .map_err(|e| format!("cannot read {}: {}", config_path.display(), e))?;
+            let config: ProjectConfig = toml::from_str(&content)
+                .map_err(|e| format!("invalid pyde.toml: {}", e))?;
+            return Ok((config, dir));
+        }
+        if !dir.pop() {
+            return Err("no pyde.toml found (run `pyde-dev init` to create a project)".into());
+        }
+    }
+}
+
+/// Generate a default pyde.toml string for a new project.
+pub fn default_toml(name: &str) -> String {
+    format!(
+        r#"[project]
+name = "{}"
+version = "0.1.0"
+authors = []
+
+[compiler]
+optimize = true
+src = "src"
+test = "test"
+out = "out"
+
+[networks.devnet]
+rpc_url = "http://127.0.0.1:8545"
+chain_id = 31337
+"#,
+        name
+    )
+}

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -1,0 +1,147 @@
+use crate::build;
+use crate::project;
+use std::fs;
+use std::time::Instant;
+
+pub fn run(filter: Option<&str>) -> Result<(), String> {
+    let (config, root) = project::load_config()?;
+
+    // Build src/ contracts first (tests may depend on them)
+    println!("  Building contracts...");
+    build::build_project(&config, &root)?;
+    println!();
+
+    // Find test files
+    let test_dir = root.join(&config.compiler.test);
+    if !test_dir.exists() {
+        return Err(format!("test directory '{}' not found", test_dir.display()));
+    }
+
+    let pattern = format!("{}/**/*.oti", test_dir.display());
+    let files: Vec<_> = glob::glob(&pattern)
+        .map_err(|e| format!("glob error: {}", e))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if files.is_empty() {
+        println!("  no test files found in {}", test_dir.display());
+        return Ok(());
+    }
+
+    let start = Instant::now();
+    let mut total_pass = 0u32;
+    let mut total_fail = 0u32;
+    let mut total_skip = 0u32;
+
+    for file in &files {
+        let source = fs::read_to_string(file)
+            .map_err(|e| format!("cannot read {}: {}", file.display(), e))?;
+        let rel = file.strip_prefix(&root).unwrap_or(file);
+
+        // Run frontend
+        let (tokens, lex_errors) = otic::lexer::Lexer::new(&source).tokenize();
+        if !lex_errors.is_empty() {
+            eprintln!("  {} — lex errors, skipping", rel.display());
+            total_skip += 1;
+            continue;
+        }
+
+        let (ast_file, parse_errors) = otic::parser::Parser::new(tokens).parse();
+        if !parse_errors.is_empty() {
+            eprintln!("  {} — parse errors, skipping", rel.display());
+            total_skip += 1;
+            continue;
+        }
+
+        // Lower to IR
+        let ir = otic::lower::lower(&ast_file);
+
+        // Find test functions
+        let test_fns: Vec<&otic::ir::IrFunction> = ir
+            .functions
+            .iter()
+            .filter(|f| f.is_test)
+            .filter(|f| filter.map(|pat| f.name.contains(pat)).unwrap_or(true))
+            .collect();
+
+        if test_fns.is_empty() {
+            continue;
+        }
+
+        println!("  {}", rel.display());
+
+        for func in &test_fns {
+            // Build a minimal program with just this test function
+            let mut test_ir = ir.clone();
+            test_ir.functions = vec![(*func).clone()];
+            test_ir.functions[0].is_pub = true;
+            test_ir.functions[0].is_test = false;
+
+            let mut codegen = otic::codegen::CodeGen::new();
+            codegen.emit_guards = false;
+            let compiled = codegen.generate(&test_ir);
+
+            // Run on PVM
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
+            if let Err(e) = vm.load(&compiled.bytecode) {
+                eprintln!("    FAIL {} — load error: {:?}", func.name, e);
+                total_fail += 1;
+                continue;
+            }
+
+            let mut steps = 0u64;
+            let mut result = None;
+            loop {
+                match vm.step() {
+                    Ok(Some(r)) => {
+                        result = Some(r);
+                        break;
+                    }
+                    Ok(None) => {
+                        steps += 1;
+                        if steps > 1_000_000 {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            let should_panic = func
+                .doc
+                .as_ref()
+                .map_or(false, |d| d.contains("should_panic"));
+
+            let ok = match result {
+                Some(pyde_vm::vm::ExecResult::Halt) => !should_panic,
+                Some(pyde_vm::vm::ExecResult::Revert) => should_panic,
+                _ => false,
+            };
+
+            let gas = vm.gas_used_total;
+            if ok {
+                println!("    PASS {} ({} gas)", func.name, gas);
+                total_pass += 1;
+            } else {
+                println!("    FAIL {}", func.name);
+                total_fail += 1;
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    println!();
+    println!(
+        "  {} passed, {} failed, {} skipped ({:.2}s)",
+        total_pass,
+        total_fail,
+        total_skip,
+        elapsed.as_secs_f64()
+    );
+
+    if total_fail > 0 {
+        Err(format!("{} test(s) failed", total_fail))
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- New `crates/pyde-dev/` crate — lightweight developer CLI (no rocksdb/libp2p deps)
- `pyde-dev init <name>` — scaffold project with pyde.toml, starter Counter.oti + test
- `pyde-dev build` — project-wide compilation with import dependency graph, cycle detection, incremental builds (SHA-256 cache)
- `pyde-dev test` — discover `#[test]` functions in test/, run on PVM, report pass/fail with gas
- `pyde-dev clean` — remove configurable out/ directory
- `pyde-dev deploy --network <name>` — deploy via JSON-RPC with auto nonce fetch
- `assert!(cond)` macro added to compiler — reverts transaction on false, works in contracts and tests

## Test plan
- [x] `pyde-dev init myproject` scaffolds correct structure
- [x] `pyde-dev build` compiles Counter.oti, writes artifact to out/
- [x] `pyde-dev build` (second run) skips unchanged files (incremental)
- [x] `pyde-dev test` — 3/3 starter tests pass
- [x] `pyde-dev test` — failing assert! correctly reports FAIL
- [x] `pyde-dev clean` removes out/
- [x] `assert!` works in both tests and real contracts (reverts on false)
- [x] `cargo test --workspace` — all 1,779+ tests pass