### PR TITLE
feat: test harness with full contract execution, should_panic, and revert variants

### DIFF
--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -143,6 +143,10 @@ pub struct IrFunction {
     pub is_reentrant: bool,
     pub is_payable: bool,
     pub is_test: bool,
+    /// If true, the test is expected to revert.
+    pub should_panic: bool,
+    /// Expected error name for should_panic (e.g., "InsufficientBalance").
+    pub expected_error: Option<String>,
     pub sponsorship: Option<crate::ast::Sponsorship>,
     pub doc: Option<String>,
     pub blocks: Vec<BasicBlock>,
@@ -163,6 +167,8 @@ impl IrFunction {
             is_reentrant: false,
             is_payable: false,
             is_test: false,
+            should_panic: false,
+            expected_error: None,
             sponsorship: None,
             doc: None,
             blocks: vec![BasicBlock::new(Label(0), "entry".into())],

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -13,6 +13,24 @@ use crate::ir::{self, IrProgram, IrFunction, BasicBlock, Label, Reg, Inst, IrCon
 use crate::types::Ty;
 
 /// Lower a source file into an IR program.
+/// Parse `#[should_panic(expected = "ErrorName")]` from attributes.
+/// Returns Some("ErrorName") if present, None otherwise.
+fn parse_expected_error(attrs: &[crate::ast::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if attr.content.starts_with("should_panic") {
+            // #[should_panic(expected = "ErrorName")]
+            if let Some(start) = attr.content.find('"') {
+                if let Some(end) = attr.content[start + 1..].find('"') {
+                    return Some(attr.content[start + 1..start + 1 + end].to_string());
+                }
+            }
+            // #[should_panic] without expected — match any revert
+            return None;
+        }
+    }
+    None
+}
+
 pub fn lower(file: &SourceFile) -> IrProgram {
     let mut lowerer = Lowerer::new();
     lowerer.lower_file(file);
@@ -460,6 +478,8 @@ impl Lowerer {
         ir_func.is_reentrant = func.is_reentrant();
         ir_func.is_payable = func.is_payable();
         ir_func.is_test = func.is_test();
+        ir_func.should_panic = func.has_should_panic();
+        ir_func.expected_error = parse_expected_error(&func.attributes);
         ir_func.sponsorship = func.sponsorship();
         ir_func.doc = func.doc.clone();
 
@@ -1038,9 +1058,16 @@ impl Lowerer {
                     }
                     "revert" => {
                         if let Some(MacroArg::Positional(err_expr)) = args.first() {
-                            let err_regs = self.lower_error_expr(err_expr);
-                            self.emit(Inst::Revert(err_regs.0, err_regs.1));
+                            // revert!("message") — string literal becomes error name
+                            if let Expr::Literal(crate::ast::Literal::String(msg), _) = err_expr {
+                                self.emit(Inst::Revert(msg.clone(), vec![]));
+                            } else {
+                                // revert!(CustomError { fields }) — custom error type
+                                let err_regs = self.lower_error_expr(err_expr);
+                                self.emit(Inst::Revert(err_regs.0, err_regs.1));
+                            }
                         } else {
+                            // revert!() — bare revert with no data
                             self.emit(Inst::Revert("Error".into(), vec![]));
                         }
                         let dst = self.alloc_reg();

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -1,5 +1,6 @@
 use crate::build;
 use crate::project;
+use std::collections::HashMap;
 use std::fs;
 use std::time::Instant;
 
@@ -53,77 +54,151 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
             continue;
         }
 
-        // Lower to IR
-        let ir = otic::lower::lower(&ast_file);
+        // Lower to IR — keep test functions but promote them to pub for dispatch
+        let mut ir = otic::lower::lower(&ast_file);
+        otic::optimize::optimize(&mut ir);
 
-        // Find test functions
-        let test_fns: Vec<&otic::ir::IrFunction> = ir
+        // Collect test function metadata before we modify the IR
+        struct TestMeta {
+            name: String,
+            should_panic: bool,
+            expected_error: Option<String>,
+        }
+        let test_metas: Vec<TestMeta> = ir
             .functions
             .iter()
             .filter(|f| f.is_test)
             .filter(|f| filter.map(|pat| f.name.contains(pat)).unwrap_or(true))
+            .map(|f| TestMeta {
+                name: f.name.clone(),
+                should_panic: f.should_panic,
+                expected_error: f.expected_error.clone(),
+            })
             .collect();
 
-        if test_fns.is_empty() {
+        if test_metas.is_empty() {
             continue;
         }
 
+        // Promote test functions to pub so codegen includes them in the dispatch table
+        for func in &mut ir.functions {
+            if func.is_test {
+                func.is_pub = true;
+                func.is_test = false;
+            }
+        }
+
+        // Build error selector → name map from the contract's error definitions + revert names
+        let error_map = build_error_map(&ir);
+
+        // Compile full contract (constructor + runtime + dispatch including test fns)
+        let codegen = otic::codegen::CodeGen::new();
+        let compiled = codegen.generate(&ir);
+
+        // --- Run constructor to initialize storage ---
+        let constructor_storage = if !compiled.constructor_bytecode.is_empty() {
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit(100_000_000);
+            if let Err(e) = vm.load(&compiled.constructor_bytecode) {
+                eprintln!("  {} — constructor load error: {:?}, skipping", rel.display(), e);
+                total_skip += 1;
+                continue;
+            }
+            let output = vm.execute();
+            if output.outcome != pyde_vm::vm::Outcome::Success {
+                eprintln!(
+                    "  {} — constructor failed: {:?}, skipping",
+                    rel.display(),
+                    output.outcome
+                );
+                total_skip += 1;
+                continue;
+            }
+            vm.storage.clone()
+        } else {
+            HashMap::new()
+        };
+
         println!("  {}", rel.display());
 
-        for func in &test_fns {
-            // Build a minimal program with just this test function
-            let mut test_ir = ir.clone();
-            test_ir.functions = vec![(*func).clone()];
-            test_ir.functions[0].is_pub = true;
-            test_ir.functions[0].is_test = false;
+        // --- Run each test function against the runtime with initialized storage ---
+        for meta in &test_metas {
+            // Snapshot: clone constructor storage for each test (isolation)
+            let snapshot = constructor_storage.clone();
 
-            let mut codegen = otic::codegen::CodeGen::new();
-            codegen.emit_guards = false;
-            let compiled = codegen.generate(&test_ir);
+            // Build calldata: 4-byte selector (BE)
+            let selector = otic::codegen::compute_selector(&meta.name);
+            let calldata = selector.to_be_bytes().to_vec();
 
-            // Run on PVM
-            let mut vm = pyde_vm::vm::Vm::with_gas_limit(10_000_000);
-            if let Err(e) = vm.load(&compiled.bytecode) {
-                eprintln!("    FAIL {} — load error: {:?}", func.name, e);
+            // Create VM with runtime bytecode
+            // Set calldata BEFORE load() so map_calldata() runs during load
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit(100_000_000);
+            vm.calldata = calldata;
+            if let Err(e) = vm.load(&compiled.runtime_bytecode) {
+                eprintln!("    FAIL {} — load error: {:?}", meta.name, e);
                 total_fail += 1;
                 continue;
             }
 
-            let mut steps = 0u64;
-            let mut result = None;
-            loop {
-                match vm.step() {
-                    Ok(Some(r)) => {
-                        result = Some(r);
-                        break;
-                    }
-                    Ok(None) => {
-                        steps += 1;
-                        if steps > 1_000_000 {
-                            break;
+            // Inject constructor storage (after load so it doesn't get cleared)
+            vm.storage = snapshot;
+
+            // Execute
+            let output = vm.execute();
+            let gas = vm.gas_used_total;
+
+            let ok = if meta.should_panic {
+                // Expected to revert
+                match output.outcome {
+                    pyde_vm::vm::Outcome::Revert => {
+                        // If expected_error specified, check revert data matches
+                        if let Some(ref expected) = meta.expected_error {
+                            let expected_selector = otic::codegen::compute_selector(expected);
+                            let actual_selector = if vm.return_data.len() >= 8 {
+                                u64::from_le_bytes(vm.return_data[..8].try_into().unwrap_or([0;8]))
+                            } else {
+                                0
+                            };
+                            if actual_selector == expected_selector as u64 {
+                                true
+                            } else {
+                                println!("    FAIL {} — reverted but wrong error (expected '{}', got selector 0x{:x})",
+                                    meta.name, expected, actual_selector);
+                                false
+                            }
+                        } else {
+                            true // Any revert is fine
                         }
                     }
-                    Err(_) => break,
+                    _ => {
+                        println!("    FAIL {} — expected revert but got {:?}", meta.name, output.outcome);
+                        false
+                    }
                 }
-            }
-
-            let should_panic = func
-                .doc
-                .as_ref()
-                .map_or(false, |d| d.contains("should_panic"));
-
-            let ok = match result {
-                Some(pyde_vm::vm::ExecResult::Halt) => !should_panic,
-                Some(pyde_vm::vm::ExecResult::Revert) => should_panic,
-                _ => false,
+            } else {
+                // Expected to succeed
+                match output.outcome {
+                    pyde_vm::vm::Outcome::Success => true,
+                    pyde_vm::vm::Outcome::Revert => {
+                        // Decode error name from revert data using contract's error map
+                        let err_info = decode_revert_error(&vm.return_data, &error_map);
+                        println!("    FAIL {} — reverted{}", meta.name, err_info);
+                        false
+                    }
+                    other => {
+                        println!("    FAIL {} — {:?}", meta.name, other);
+                        false
+                    }
+                }
             };
 
-            let gas = vm.gas_used_total;
             if ok {
-                println!("    PASS {} ({} gas)", func.name, gas);
+                let panic_tag = if meta.should_panic { " (expected panic)" } else { "" };
+                println!("    PASS {}{} ({} gas)", meta.name, panic_tag, gas);
                 total_pass += 1;
+            } else if !meta.should_panic || meta.expected_error.is_some() {
+                // Error already printed above
+                total_fail += 1;
             } else {
-                println!("    FAIL {}", func.name);
                 total_fail += 1;
             }
         }
@@ -133,15 +208,60 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
     println!();
     println!(
         "  {} passed, {} failed, {} skipped ({:.2}s)",
-        total_pass,
-        total_fail,
-        total_skip,
-        elapsed.as_secs_f64()
+        total_pass, total_fail, total_skip, elapsed.as_secs_f64()
     );
 
     if total_fail > 0 {
         Err(format!("{} test(s) failed", total_fail))
     } else {
         Ok(())
+    }
+}
+
+/// Build a map of error selector → error name from the contract's IR.
+/// Includes: error definitions, built-in names (AssertionFailed, Error),
+/// and any string messages used in revert!("...") calls.
+fn build_error_map(ir: &otic::ir::IrProgram) -> HashMap<u64, String> {
+    let mut map = HashMap::new();
+
+    // Built-in error names
+    for name in &["AssertionFailed", "Error"] {
+        let sel = otic::codegen::compute_selector(name) as u64;
+        map.insert(sel, name.to_string());
+    }
+
+    // Contract-defined errors
+    for err in &ir.error_defs {
+        let sel = otic::codegen::compute_selector(&err.name) as u64;
+        map.insert(sel, err.name.clone());
+    }
+
+    // Scan IR instructions for revert string names
+    for func in &ir.functions {
+        for block in &func.blocks {
+            for inst in &block.instructions {
+                if let otic::ir::Inst::Revert(name, _) = inst {
+                    let sel = otic::codegen::compute_selector(name) as u64;
+                    map.insert(sel, name.clone());
+                }
+            }
+        }
+    }
+
+    map
+}
+
+/// Decode the error name from revert data using the contract's error map.
+/// Revert data format: [selector:8 LE][field0:8][field1:8]...
+fn decode_revert_error(data: &[u8], error_map: &HashMap<u64, String>) -> String {
+    if data.len() < 8 {
+        return String::new();
+    }
+    let selector = u64::from_le_bytes(data[..8].try_into().unwrap_or([0; 8]));
+
+    if let Some(name) = error_map.get(&selector) {
+        format!(" with error: {}", name)
+    } else {
+        format!(" with error selector: 0x{:08x}", selector as u32)
     }
 }


### PR DESCRIPTION
## Summary
- Test runner compiles full contract with dispatch table, runs constructor, snapshots storage
- Each test gets isolated storage snapshot, executes via selector-based calldata
- Cross-function calls work in tests (self.deposit(), self.withdraw(), etc.)
- `#[should_panic]` — match any revert
- `#[should_panic(expected = "ErrorName")]` — match specific custom error or string message
- `revert!("message")` support — string message variant alongside `revert!()` and `revert!(CustomError {})`
- Dynamic error decoding from contract's own error definitions

## Test plan
- [x] Counter tests: test_initial_count, test_increment, test_add_five — all PASS
- [x] Full harness: deposit, withdraw, assert on storage via public API
- [x] `#[should_panic]` matches any revert
- [x] `#[should_panic(expected = "InsufficientBalance")]` matches specific error
- [x] `#[should_panic(expected = "Unauthorized")]` matches custom error from `revert!(Unauthorized {})`
- [x] `revert!("message")` string reverts work
- [x] Failing test correctly reports error name from contract definitions
- [x] `cargo test --workspace` — all 1,779+ tests pass