### PR TITLE
feat: deploy! macro returns typed contract handle

### DIFF
--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1254,10 +1254,12 @@ impl Lowerer {
                         }
                         dst
                     }
-                    "create" => {
-                        // create!(ContractName, arg1, arg2, ...) → Address
+                    "deploy" | "create" => {
+                        // deploy!(ContractName, arg1, arg2, ...) → Ty::Contract("ContractName")
+                        // create! is an alias for deploy!.
                         // Embeds the named contract's bytecode and deploys it.
                         // Constructor runs automatically with the provided args.
+                        // Returns a typed contract handle (enables c.method() dispatch).
                         let positional: Vec<&Expr> = args.iter().filter_map(|a| {
                             if let MacroArg::Positional(e) = a { Some(e) } else { None }
                         }).collect();
@@ -1268,7 +1270,7 @@ impl Lowerer {
                         let contract_name = if let Some(Expr::Path(segments, _)) = positional.first() {
                             segments.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join("::")
                         } else {
-                            self.emit(Inst::Comment("create! requires a contract name".into()));
+                            self.emit(Inst::Comment("deploy! requires a contract name".into()));
                             return dst;
                         };
 
@@ -1276,7 +1278,7 @@ impl Lowerer {
                         let deploy_bytes = match self.compiled_contracts.get(&contract_name) {
                             Some(bytes) => bytes.clone(),
                             None => {
-                                self.emit(Inst::Comment(format!("create!: contract '{}' not found in registry", contract_name)));
+                                self.emit(Inst::Comment(format!("deploy!: contract '{}' not found in registry", contract_name)));
                                 return dst;
                             }
                         };
@@ -1293,6 +1295,11 @@ impl Lowerer {
                         // CreateContract(dst, blob_reg, [arg_regs...])
                         // The codegen will write blob + args to heap and emit Create.
                         self.emit(Inst::CreateContract(dst, blob_reg, arg_regs));
+
+                        // Tag the result register as Ty::Contract so method calls
+                        // on the handle (e.g. c.increment()) resolve to ExtCall.
+                        self.set_local_type_for_reg(dst, Ty::Contract(contract_name.clone()));
+
                         dst
                     }
                     _ => {

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -139,7 +139,9 @@ impl TypeChecker {
             self.check_item(item);
         }
 
-        TypeCheckResult { errors: self.errors }
+        TypeCheckResult {
+            errors: self.errors,
+        }
     }
 
     fn error(&mut self, message: String, span: Span) {
@@ -158,10 +160,13 @@ impl TypeChecker {
             // Array with int literal elements adapts to any numeric element type
             // e.g., [0; 32] (inferred as [u256; 32]) is compatible with [u8; 32]
             (Ty::Array(a_elem, a_size), Ty::Array(b_elem, b_size)) => {
-                a_size == b_size && (a_elem == b_elem
-                    || **a_elem == Ty::Unknown || **b_elem == Ty::Unknown
-                    || a_elem.can_widen_to(b_elem) || b_elem.can_widen_to(a_elem)
-                    || (a_elem.is_numeric() && b_elem.is_numeric()))
+                a_size == b_size
+                    && (a_elem == b_elem
+                        || **a_elem == Ty::Unknown
+                        || **b_elem == Ty::Unknown
+                        || a_elem.can_widen_to(b_elem)
+                        || b_elem.can_widen_to(a_elem)
+                        || (a_elem.is_numeric() && b_elem.is_numeric()))
             }
             // Unknown/Error declared type accepts anything
             (_, Ty::Unknown) | (_, Ty::Error) => true,
@@ -289,24 +294,60 @@ impl TypeChecker {
         match (module, func) {
             // std::math
             ("math", "sqrt") => Some((vec![("x".into(), Ty::U256)], Ty::U256)),
-            ("math", "pow") => Some((vec![("base".into(), Ty::U256), ("exp".into(), Ty::U256)], Ty::U256)),
-            ("math", "min") => Some((vec![("a".into(), Ty::U256), ("b".into(), Ty::U256)], Ty::U256)),
-            ("math", "max") => Some((vec![("a".into(), Ty::U256), ("b".into(), Ty::U256)], Ty::U256)),
-            ("math", "clamp") => Some((vec![("x".into(), Ty::U256), ("lo".into(), Ty::U256), ("hi".into(), Ty::U256)], Ty::U256)),
-            ("math", "mul_div") => Some((vec![("a".into(), Ty::U256), ("b".into(), Ty::U256), ("c".into(), Ty::U256)], Ty::U256)),
+            ("math", "pow") => Some((
+                vec![("base".into(), Ty::U256), ("exp".into(), Ty::U256)],
+                Ty::U256,
+            )),
+            ("math", "min") => Some((
+                vec![("a".into(), Ty::U256), ("b".into(), Ty::U256)],
+                Ty::U256,
+            )),
+            ("math", "max") => Some((
+                vec![("a".into(), Ty::U256), ("b".into(), Ty::U256)],
+                Ty::U256,
+            )),
+            ("math", "clamp") => Some((
+                vec![
+                    ("x".into(), Ty::U256),
+                    ("lo".into(), Ty::U256),
+                    ("hi".into(), Ty::U256),
+                ],
+                Ty::U256,
+            )),
+            ("math", "mul_div") => Some((
+                vec![
+                    ("a".into(), Ty::U256),
+                    ("b".into(), Ty::U256),
+                    ("c".into(), Ty::U256),
+                ],
+                Ty::U256,
+            )),
             // std::signature
             ("signature", "verify") => Some((
-                vec![("message".into(), Ty::Array(Box::new(Ty::U8), 32)), ("sig".into(), Ty::Bytes), ("pubkey".into(), Ty::Bytes)],
+                vec![
+                    ("message".into(), Ty::Array(Box::new(Ty::U8), 32)),
+                    ("sig".into(), Ty::Bytes),
+                    ("pubkey".into(), Ty::Bytes),
+                ],
                 Ty::Bool,
             )),
             ("signature", "recover") => Some((
-                vec![("message".into(), Ty::Array(Box::new(Ty::U8), 32)), ("sig".into(), Ty::Bytes)],
+                vec![
+                    ("message".into(), Ty::Array(Box::new(Ty::U8), 32)),
+                    ("sig".into(), Ty::Bytes),
+                ],
                 Ty::Address,
             )),
             // std::hash
-            ("hash", "poseidon2") => Some((vec![("data".into(), Ty::Bytes)], Ty::Array(Box::new(Ty::U8), 32))),
+            ("hash", "poseidon2") => Some((
+                vec![("data".into(), Ty::Bytes)],
+                Ty::Array(Box::new(Ty::U8), 32),
+            )),
             ("hash", "poseidon2_pair") => Some((
-                vec![("a".into(), Ty::Array(Box::new(Ty::U8), 32)), ("b".into(), Ty::Array(Box::new(Ty::U8), 32))],
+                vec![
+                    ("a".into(), Ty::Array(Box::new(Ty::U8), 32)),
+                    ("b".into(), Ty::Array(Box::new(Ty::U8), 32)),
+                ],
                 Ty::Array(Box::new(Ty::U8), 32),
             )),
             _ => None,
@@ -334,7 +375,9 @@ impl TypeChecker {
     }
 
     fn collect_struct(&mut self, s: &StructDef) {
-        let fields: Vec<(String, Ty)> = s.fields.iter()
+        let fields: Vec<(String, Ty)> = s
+            .fields
+            .iter()
             .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty)))
             .collect();
         self.env.struct_defs.insert(s.name.name.clone(), fields);
@@ -360,42 +403,60 @@ impl TypeChecker {
     }
 
     fn collect_event(&mut self, e: &EventDef) {
-        let fields: Vec<(String, Ty, bool)> = e.fields.iter()
+        let fields: Vec<(String, Ty, bool)> = e
+            .fields
+            .iter()
             .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty), f.indexed))
             .collect();
         self.env.event_defs.insert(e.name.name.clone(), fields);
     }
 
     fn collect_error(&mut self, e: &ErrorDef) {
-        let fields: Vec<(String, Ty)> = e.fields.iter()
+        let fields: Vec<(String, Ty)> = e
+            .fields
+            .iter()
             .map(|f| (f.name.name.clone(), self.resolve_type(&f.ty)))
             .collect();
         self.env.error_defs.insert(e.name.name.clone(), fields);
     }
 
     fn collect_func_sig(&mut self, f: &FunctionDef) {
-        let params: Vec<(String, Ty)> = f.params.iter()
+        let params: Vec<(String, Ty)> = f
+            .params
+            .iter()
             .map(|p| (p.name.name.clone(), self.resolve_type(&p.ty)))
             .collect();
-        let ret = f.return_type.as_ref()
+        let ret = f
+            .return_type
+            .as_ref()
             .map(|t| self.resolve_type(t))
             .unwrap_or(Ty::Unit);
-        self.env.func_sigs.insert(f.name.name.clone(), (params, ret));
+        self.env
+            .func_sigs
+            .insert(f.name.name.clone(), (params, ret));
     }
 
     fn collect_interface(&mut self, iface: &InterfaceDef) {
-        let funcs: Vec<(String, Vec<(String, Ty)>, Ty)> = iface.functions.iter()
+        let funcs: Vec<(String, Vec<(String, Ty)>, Ty)> = iface
+            .functions
+            .iter()
             .map(|f| {
-                let params: Vec<(String, Ty)> = f.params.iter()
+                let params: Vec<(String, Ty)> = f
+                    .params
+                    .iter()
                     .map(|p| (p.name.name.clone(), self.resolve_type(&p.ty)))
                     .collect();
-                let ret = f.return_type.as_ref()
+                let ret = f
+                    .return_type
+                    .as_ref()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(Ty::Unit);
                 (f.name.name.clone(), params, ret)
             })
             .collect();
-        self.env.interface_defs.insert(iface.name.name.clone(), funcs);
+        self.env
+            .interface_defs
+            .insert(iface.name.name.clone(), funcs);
     }
 
     // ========================================================================
@@ -406,7 +467,9 @@ impl TypeChecker {
         match item {
             Item::Contract(c) => self.check_contract(c),
             Item::Function(f) => self.check_function(f),
-            Item::Const(c) => { self.infer_expr(&c.value); }
+            Item::Const(c) => {
+                self.infer_expr(&c.value);
+            }
             _ => {}
         }
     }
@@ -416,7 +479,9 @@ impl TypeChecker {
         for item in &contract.items {
             match item {
                 ContractItem::Function(f) => self.check_function(f),
-                ContractItem::Const(c) => { self.infer_expr(&c.value); }
+                ContractItem::Const(c) => {
+                    self.infer_expr(&c.value);
+                }
                 _ => {}
             }
         }
@@ -433,7 +498,9 @@ impl TypeChecker {
         }
 
         // Check body with expected return type
-        let ret_ty = func.return_type.as_ref()
+        let ret_ty = func
+            .return_type
+            .as_ref()
             .map(|t| self.resolve_type(t))
             .unwrap_or(Ty::Unit);
 
@@ -522,12 +589,14 @@ impl TypeChecker {
                         // Void function returning a value
                         if *expected == Ty::Unit {
                             self.error(
-                                "function does not return a value, but 'return' has an expression".into(),
+                                "function does not return a value, but 'return' has an expression"
+                                    .into(),
                                 r.span,
                             );
                         }
                         // Type mismatch
-                        else if ret_ty != Ty::Unknown && ret_ty != Ty::Error
+                        else if ret_ty != Ty::Unknown
+                            && ret_ty != Ty::Error
                             && *expected != Ty::Unknown
                             && ret_ty != *expected
                             && !self.is_int_literal_compatible(val, expected)
@@ -536,7 +605,10 @@ impl TypeChecker {
                             && !self.is_compatible_init(&ret_ty, expected)
                         {
                             self.error(
-                                format!("return type mismatch: expected {}, found {}", expected, ret_ty),
+                                format!(
+                                    "return type mismatch: expected {}, found {}",
+                                    expected, ret_ty
+                                ),
                                 r.span,
                             );
                         }
@@ -565,7 +637,9 @@ impl TypeChecker {
                 self.check_block(&w.body);
                 self.env.pop_scope();
             }
-            Stmt::Expr(e) => { self.infer_expr(&e.expr); }
+            Stmt::Expr(e) => {
+                self.infer_expr(&e.expr);
+            }
             Stmt::Break(_) | Stmt::Continue(_) => {}
         }
     }
@@ -577,13 +651,18 @@ impl TypeChecker {
             let t = self.resolve_type(ty);
             // Check compatibility — integer literals are polymorphic,
             // and Vec<?>/Unknown types are compatible with concrete types
-            if init_ty != Ty::Unknown && init_ty != Ty::Error && t != init_ty
+            if init_ty != Ty::Unknown
+                && init_ty != Ty::Error
+                && t != init_ty
                 && !self.is_int_literal_compatible(&l.initializer, &t)
                 && !self.is_compatible_init(&init_ty, &t)
                 && !init_ty.can_widen_to(&t)
             {
                 self.error(
-                    format!("type mismatch: declared {}, but initializer is {}", t, init_ty),
+                    format!(
+                        "type mismatch: declared {}, but initializer is {}",
+                        t, init_ty
+                    ),
                     l.span,
                 );
             }
@@ -594,7 +673,8 @@ impl TypeChecker {
 
         match &l.binding {
             LetBinding::Name(name) => {
-                self.env.declare_local(&name.name, declared_ty, l.is_mutable);
+                self.env
+                    .declare_local(&name.name, declared_ty, l.is_mutable);
             }
             LetBinding::Tuple(names, span) => {
                 if let Ty::Tuple(types) = &declared_ty {
@@ -602,7 +682,8 @@ impl TypeChecker {
                         self.error(
                             format!(
                                 "tuple destructuring: expected {} elements, found {}",
-                                types.len(), names.len()
+                                types.len(),
+                                names.len()
                             ),
                             *span,
                         );
@@ -621,7 +702,8 @@ impl TypeChecker {
                     }
                 } else {
                     for name in names {
-                        self.env.declare_local(&name.name, Ty::Unknown, l.is_mutable);
+                        self.env
+                            .declare_local(&name.name, Ty::Unknown, l.is_mutable);
                     }
                 }
             }
@@ -642,8 +724,10 @@ impl TypeChecker {
         let target_ty = self.infer_expr(&a.target);
         let value_ty = self.infer_expr(&a.value);
 
-        if target_ty != Ty::Unknown && value_ty != Ty::Unknown
-            && target_ty != Ty::Error && value_ty != Ty::Error
+        if target_ty != Ty::Unknown
+            && value_ty != Ty::Unknown
+            && target_ty != Ty::Error
+            && value_ty != Ty::Error
         {
             match a.op {
                 AssignOp::Assign => {
@@ -669,13 +753,20 @@ impl TypeChecker {
                         && !value_ty.can_widen_to(&target_ty)
                     {
                         self.error(
-                            format!("type mismatch in compound assignment: {} and {}", target_ty, value_ty),
+                            format!(
+                                "type mismatch in compound assignment: {} and {}",
+                                target_ty, value_ty
+                            ),
                             a.span,
                         );
                     }
-                    if !target_ty.is_numeric() && target_ty != Ty::Unknown && target_ty != Ty::Error {
+                    if !target_ty.is_numeric() && target_ty != Ty::Unknown && target_ty != Ty::Error
+                    {
                         self.error(
-                            format!("compound assignment requires numeric type, found {}", target_ty),
+                            format!(
+                                "compound assignment requires numeric type, found {}",
+                                target_ty
+                            ),
                             a.span,
                         );
                     }
@@ -691,7 +782,9 @@ impl TypeChecker {
                 self.error(
                     format!(
                         "event '{}' expects {} fields, found {}",
-                        e.event_name.name, event_fields.len(), e.fields.len()
+                        e.event_name.name,
+                        event_fields.len(),
+                        e.fields.len()
                     ),
                     e.span,
                 );
@@ -710,7 +803,9 @@ impl TypeChecker {
                             field.span,
                         );
                     }
-                    if value_ty != Ty::Unknown && value_ty != Ty::Error && value_ty != *expected_ty
+                    if value_ty != Ty::Unknown
+                        && value_ty != Ty::Error
+                        && value_ty != *expected_ty
                         && !value_ty.can_widen_to(expected_ty)
                         && !self.is_int_literal_compatible(&field.value, expected_ty)
                         && !(value_ty.is_numeric() && expected_ty.is_numeric())
@@ -787,14 +882,28 @@ impl TypeChecker {
                     }
                     UnaryOp::LogicalNot => {
                         // Allow ! on bool (logical NOT) and integers (bitwise NOT, like C)
-                        if ty != Ty::Bool && !ty.is_integer() && ty != Ty::Unknown && ty != Ty::Error {
-                            self.error(format!("logical NOT requires bool or integer, found {}", ty), *span);
+                        if ty != Ty::Bool
+                            && !ty.is_integer()
+                            && ty != Ty::Unknown
+                            && ty != Ty::Error
+                        {
+                            self.error(
+                                format!("logical NOT requires bool or integer, found {}", ty),
+                                *span,
+                            );
                         }
-                        if ty.is_integer() { ty } else { Ty::Bool }
+                        if ty.is_integer() {
+                            ty
+                        } else {
+                            Ty::Bool
+                        }
                     }
                     UnaryOp::BitNot => {
                         if !ty.is_integer() && ty != Ty::Unknown && ty != Ty::Error {
-                            self.error(format!("bitwise NOT requires integer, found {}", ty), *span);
+                            self.error(
+                                format!("bitwise NOT requires integer, found {}", ty),
+                                *span,
+                            );
                         }
                         ty
                     }
@@ -813,7 +922,10 @@ impl TypeChecker {
                         && !self.env.storage_fields.is_empty()
                     {
                         self.error(
-                            format!("'{}' is not a storage field or function in this contract", field.name),
+                            format!(
+                                "'{}' is not a storage field or function in this contract",
+                                field.name
+                            ),
                             *span,
                         );
                         return Ty::Error;
@@ -852,9 +964,7 @@ impl TypeChecker {
 
             Expr::Call(callee, args, span) => {
                 // Infer all argument types
-                let arg_types: Vec<Ty> = args.iter()
-                    .map(|arg| self.infer_expr(arg))
-                    .collect();
+                let arg_types: Vec<Ty> = args.iter().map(|arg| self.infer_expr(arg)).collect();
 
                 // Try to resolve the function return type and check args
                 match callee.as_ref() {
@@ -866,15 +976,14 @@ impl TypeChecker {
                         if ident.name == "address" {
                             // address() only accepts self or Address-typed arguments
                             if args.len() != 1 {
-                                self.error(
-                                    "address() takes exactly one argument".into(),
-                                    *span,
-                                );
+                                self.error("address() takes exactly one argument".into(), *span);
                             } else if let Some(arg) = args.first() {
                                 let is_self = matches!(arg, Expr::SelfExpr(_));
                                 let arg_ty = &arg_types[0];
-                                if !is_self && *arg_ty != Ty::Address
-                                    && *arg_ty != Ty::Unknown && *arg_ty != Ty::Error
+                                if !is_self
+                                    && *arg_ty != Ty::Address
+                                    && *arg_ty != Ty::Unknown
+                                    && *arg_ty != Ty::Error
                                 {
                                     self.error(
                                         format!(
@@ -926,24 +1035,45 @@ impl TypeChecker {
                         let obj_ty = self.infer_expr(obj);
                         // self.method() → function return type + arg check
                         if matches!(**obj, Expr::SelfExpr(_)) {
-                            if let Some((params, ret)) = self.env.func_sigs.get(&method.name).cloned() {
-                                self.check_call_args(&method.name, &params, &arg_types, args, *span);
+                            if let Some((params, ret)) =
+                                self.env.func_sigs.get(&method.name).cloned()
+                            {
+                                self.check_call_args(
+                                    &method.name,
+                                    &params,
+                                    &arg_types,
+                                    args,
+                                    *span,
+                                );
                                 return ret;
                             }
                         }
                         // Common method return types
-                        let is_math_method = matches!(method.name.as_str(),
-                            "sqrt" | "pow" | "min" | "max" | "clamp"
-                            | "mul_div" | "checked_add" | "checked_sub"
-                            | "saturating_add" | "saturating_sub"
-                            | "wrapping_add" | "wrapping_sub"
+                        let is_math_method = matches!(
+                            method.name.as_str(),
+                            "sqrt"
+                                | "pow"
+                                | "min"
+                                | "max"
+                                | "clamp"
+                                | "mul_div"
+                                | "checked_add"
+                                | "checked_sub"
+                                | "saturating_add"
+                                | "saturating_sub"
+                                | "wrapping_add"
+                                | "wrapping_sub"
                         );
 
                         // Math methods only work on numeric types
                         if is_math_method {
-                            if !obj_ty.is_numeric() && obj_ty != Ty::Unknown && obj_ty != Ty::Error {
+                            if !obj_ty.is_numeric() && obj_ty != Ty::Unknown && obj_ty != Ty::Error
+                            {
                                 self.error(
-                                    format!("'{}' can only be called on numeric types, found {}", method.name, obj_ty),
+                                    format!(
+                                        "'{}' can only be called on numeric types, found {}",
+                                        method.name, obj_ty
+                                    ),
                                     *span,
                                 );
                                 return Ty::Error;
@@ -954,9 +1084,15 @@ impl TypeChecker {
                         match method.name.as_str() {
                             // len() → u64 — only on Vec, Map, Array, String, bytes
                             "len" => {
-                                let valid = matches!(obj_ty,
-                                    Ty::Vec(_) | Ty::Map(_, _) | Ty::Array(_, _)
-                                    | Ty::StringTy | Ty::Bytes | Ty::Unknown | Ty::Error
+                                let valid = matches!(
+                                    obj_ty,
+                                    Ty::Vec(_)
+                                        | Ty::Map(_, _)
+                                        | Ty::Array(_, _)
+                                        | Ty::StringTy
+                                        | Ty::Bytes
+                                        | Ty::Unknown
+                                        | Ty::Error
                                 );
                                 if !valid {
                                     self.error(
@@ -970,7 +1106,10 @@ impl TypeChecker {
                             "push" | "pop" => {
                                 if !matches!(obj_ty, Ty::Vec(_) | Ty::Unknown | Ty::Error) {
                                     self.error(
-                                        format!("'{}' can only be called on Vec, found {}", method.name, obj_ty),
+                                        format!(
+                                            "'{}' can only be called on Vec, found {}",
+                                            method.name, obj_ty
+                                        ),
                                         *span,
                                     );
                                 }
@@ -978,9 +1117,14 @@ impl TypeChecker {
                             }
                             // is_empty() → bool — on Vec, Map, String, bytes
                             "is_empty" => {
-                                let valid = matches!(obj_ty,
-                                    Ty::Vec(_) | Ty::Map(_, _) | Ty::StringTy
-                                    | Ty::Bytes | Ty::Unknown | Ty::Error
+                                let valid = matches!(
+                                    obj_ty,
+                                    Ty::Vec(_)
+                                        | Ty::Map(_, _)
+                                        | Ty::StringTy
+                                        | Ty::Bytes
+                                        | Ty::Unknown
+                                        | Ty::Error
                                 );
                                 if !valid {
                                     self.error(
@@ -992,8 +1136,10 @@ impl TypeChecker {
                             }
                             // concat() → same type — only on String or bytes
                             "concat" => {
-                                if obj_ty != Ty::StringTy && obj_ty != Ty::Bytes
-                                    && obj_ty != Ty::Unknown && obj_ty != Ty::Error
+                                if obj_ty != Ty::StringTy
+                                    && obj_ty != Ty::Bytes
+                                    && obj_ty != Ty::Unknown
+                                    && obj_ty != Ty::Error
                                 {
                                     self.error(
                                         format!("'concat' can only be called on String or bytes, found {}", obj_ty),
@@ -1004,8 +1150,13 @@ impl TypeChecker {
                             }
                             // as_bytes/to_bytes → bytes — on String, Address, numeric types
                             "as_bytes" | "to_bytes" => {
-                                let valid = matches!(obj_ty,
-                                    Ty::StringTy | Ty::Address | Ty::Bytes | Ty::Unknown | Ty::Error
+                                let valid = matches!(
+                                    obj_ty,
+                                    Ty::StringTy
+                                        | Ty::Address
+                                        | Ty::Bytes
+                                        | Ty::Unknown
+                                        | Ty::Error
                                 ) || obj_ty.is_numeric();
                                 if !valid {
                                     self.error(
@@ -1017,9 +1168,15 @@ impl TypeChecker {
                             }
                             // append() → Unit — only on bytes or Vec
                             "append" => {
-                                if !matches!(obj_ty, Ty::Bytes | Ty::Vec(_) | Ty::Unknown | Ty::Error) {
+                                if !matches!(
+                                    obj_ty,
+                                    Ty::Bytes | Ty::Vec(_) | Ty::Unknown | Ty::Error
+                                ) {
                                     self.error(
-                                        format!("'append' can only be called on bytes or Vec, found {}", obj_ty),
+                                        format!(
+                                            "'append' can only be called on bytes or Vec, found {}",
+                                            obj_ty
+                                        ),
                                         *span,
                                     );
                                 }
@@ -1027,8 +1184,8 @@ impl TypeChecker {
                             }
                             // Unknown method — error only for primitives where we know all methods
                             _ => {
-                                let is_primitive = obj_ty.is_numeric()
-                                    || matches!(obj_ty, Ty::Bool | Ty::Address);
+                                let is_primitive =
+                                    obj_ty.is_numeric() || matches!(obj_ty, Ty::Bool | Ty::Address);
                                 if is_primitive {
                                     self.error(
                                         format!("type {} has no method '{}'", obj_ty, method.name),
@@ -1057,7 +1214,8 @@ impl TypeChecker {
                                 (_, "at_payable") => {
                                     if arg_types.len() != 2 {
                                         self.error(
-                                            "at_payable() takes 2 arguments (address, value)".into(),
+                                            "at_payable() takes 2 arguments (address, value)"
+                                                .into(),
                                             *span,
                                         );
                                     }
@@ -1100,8 +1258,12 @@ impl TypeChecker {
                 let mut arg_types = Vec::new();
                 for arg in args {
                     match arg {
-                        MacroArg::Positional(expr) => { arg_types.push(self.infer_expr(expr)); }
-                        MacroArg::Named(_, expr) => { arg_types.push(self.infer_expr(expr)); }
+                        MacroArg::Positional(expr) => {
+                            arg_types.push(self.infer_expr(expr));
+                        }
+                        MacroArg::Named(_, expr) => {
+                            arg_types.push(self.infer_expr(expr));
+                        }
                     }
                 }
 
@@ -1110,7 +1272,10 @@ impl TypeChecker {
                     "require" => {
                         // require!(condition, error) — first arg must be bool
                         if let Some(cond_ty) = arg_types.first() {
-                            if *cond_ty != Ty::Bool && *cond_ty != Ty::Unknown && *cond_ty != Ty::Error {
+                            if *cond_ty != Ty::Bool
+                                && *cond_ty != Ty::Unknown
+                                && *cond_ty != Ty::Error
+                            {
                                 self.error(
                                     format!("require! condition must be bool, found {}", cond_ty),
                                     *span,
@@ -1121,29 +1286,54 @@ impl TypeChecker {
                     }
                     "revert" | "cross_call" => Ty::Unit,
                     "raw_call" => Ty::Unknown,
+                    "deploy" | "create" => {
+                        // deploy!(ContractName, args...) → Ty::Contract("ContractName")
+                        // First arg is the contract name (path expression).
+                        if let Some(MacroArg::Positional(first)) = args.first() {
+                            if let Expr::Path(segments, _) = first {
+                                let name = segments
+                                    .iter()
+                                    .map(|s| s.name.as_str())
+                                    .collect::<Vec<_>>()
+                                    .join("::");
+                                Ty::Contract(name)
+                            } else {
+                                self.error(
+                                    "deploy! first argument must be a contract name".into(),
+                                    *span,
+                                );
+                                Ty::Address
+                            }
+                        } else {
+                            self.error("deploy! requires a contract name argument".into(), *span);
+                            Ty::Address
+                        }
+                    }
                     _ => Ty::Unknown,
                 }
             }
 
             Expr::StructInit(name_segments, fields, span) => {
-                let struct_name = name_segments.first()
-                    .map(|s| s.name.as_str())
-                    .unwrap_or("");
+                let struct_name = name_segments.first().map(|s| s.name.as_str()).unwrap_or("");
 
                 // Check if it's a struct init or error init
                 if let Some(struct_fields) = self.env.struct_defs.get(struct_name).cloned() {
                     for field in fields {
                         let value_ty = self.infer_expr(&field.value);
-                        if let Some((_, expected_ty)) = struct_fields.iter()
+                        if let Some((_, expected_ty)) = struct_fields
+                            .iter()
                             .find(|(name, _)| name == &field.name.name)
                         {
-                            if value_ty != Ty::Unknown && value_ty != Ty::Error
-                                && *expected_ty != Ty::Unknown && *expected_ty != Ty::Error
+                            if value_ty != Ty::Unknown
+                                && value_ty != Ty::Error
+                                && *expected_ty != Ty::Unknown
+                                && *expected_ty != Ty::Error
                                 && value_ty != *expected_ty
                                 && !self.is_int_literal_compatible(&field.value, expected_ty)
                                 && !value_ty.can_widen_to(expected_ty)
                                 && !self.is_compatible_init(&value_ty, expected_ty)
-                                && !(value_ty.is_numeric() && expected_ty.is_numeric()) // allow numeric narrowing (runtime checked)
+                                && !(value_ty.is_numeric() && expected_ty.is_numeric())
+                            // allow numeric narrowing (runtime checked)
                             {
                                 self.error(
                                     format!(
@@ -1231,8 +1421,10 @@ impl TypeChecker {
                 let target = self.resolve_type(target_ty);
 
                 // Validate cast compatibility
-                if source_ty != Ty::Unknown && source_ty != Ty::Error
-                    && target != Ty::Unknown && target != Ty::Error
+                if source_ty != Ty::Unknown
+                    && source_ty != Ty::Error
+                    && target != Ty::Unknown
+                    && target != Ty::Error
                 {
                     let valid = match (&source_ty, &target) {
                         // numeric → numeric (any direction)
@@ -1251,19 +1443,14 @@ impl TypeChecker {
                         _ => false,
                     };
                     if !valid {
-                        self.error(
-                            format!("cannot cast {} to {}", source_ty, target),
-                            *span,
-                        );
+                        self.error(format!("cannot cast {} to {}", source_ty, target), *span);
                     }
                 }
                 target
             }
 
             Expr::Tuple(elements, _) => {
-                let types: Vec<Ty> = elements.iter()
-                    .map(|e| self.infer_expr(e))
-                    .collect();
+                let types: Vec<Ty> = elements.iter().map(|e| self.infer_expr(e)).collect();
                 Ty::Tuple(types)
             }
 
@@ -1299,15 +1486,34 @@ impl TypeChecker {
         }
     }
 
-    fn check_binary_op_full(&mut self, lhs_expr: &Expr, lhs: &Ty, op: &BinaryOp, rhs_expr: &Expr, rhs: &Ty, span: Span) -> Ty {
+    fn check_binary_op_full(
+        &mut self,
+        lhs_expr: &Expr,
+        lhs: &Ty,
+        op: &BinaryOp,
+        rhs_expr: &Expr,
+        rhs: &Ty,
+        span: Span,
+    ) -> Ty {
         // Error/Unknown propagation
         if matches!(lhs, Ty::Error | Ty::Unknown) || matches!(rhs, Ty::Error | Ty::Unknown) {
             return match op {
-                BinaryOp::Eq | BinaryOp::NotEq | BinaryOp::Lt | BinaryOp::Gt
-                | BinaryOp::LtEq | BinaryOp::GtEq | BinaryOp::LogicalAnd
+                BinaryOp::Eq
+                | BinaryOp::NotEq
+                | BinaryOp::Lt
+                | BinaryOp::Gt
+                | BinaryOp::LtEq
+                | BinaryOp::GtEq
+                | BinaryOp::LogicalAnd
                 | BinaryOp::LogicalOr => Ty::Bool,
                 BinaryOp::Range => Ty::Unknown,
-                _ => if *lhs != Ty::Unknown && *lhs != Ty::Error { lhs.clone() } else { rhs.clone() },
+                _ => {
+                    if *lhs != Ty::Unknown && *lhs != Ty::Error {
+                        lhs.clone()
+                    } else {
+                        rhs.clone()
+                    }
+                }
             };
         }
 
@@ -1317,8 +1523,7 @@ impl TypeChecker {
 
         match op {
             // Arithmetic: both same numeric type → same type
-            BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul
-            | BinaryOp::Div | BinaryOp::Mod => {
+            BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => {
                 if lhs == Ty::StringTy || rhs == Ty::StringTy {
                     self.error(
                         "cannot use '+' on strings — use .concat() instead".into(),
@@ -1334,7 +1539,10 @@ impl TypeChecker {
                     return Ty::Error;
                 }
                 if !lhs.is_numeric() {
-                    self.error(format!("arithmetic requires numeric type, found {}", lhs), span);
+                    self.error(
+                        format!("arithmetic requires numeric type, found {}", lhs),
+                        span,
+                    );
                     return Ty::Error;
                 }
                 if lhs != rhs {
@@ -1347,10 +1555,16 @@ impl TypeChecker {
             }
 
             // Bitwise: both same integer type → same type
-            BinaryOp::BitAnd | BinaryOp::BitOr | BinaryOp::BitXor
-            | BinaryOp::Shl | BinaryOp::Shr => {
+            BinaryOp::BitAnd
+            | BinaryOp::BitOr
+            | BinaryOp::BitXor
+            | BinaryOp::Shl
+            | BinaryOp::Shr => {
                 if !lhs.is_integer() {
-                    self.error(format!("bitwise op requires integer type, found {}", lhs), span);
+                    self.error(
+                        format!("bitwise op requires integer type, found {}", lhs),
+                        span,
+                    );
                     return Ty::Error;
                 }
                 if lhs != rhs {
@@ -1363,13 +1577,14 @@ impl TypeChecker {
             }
 
             // Comparison: compatible types → bool
-            BinaryOp::Eq | BinaryOp::NotEq | BinaryOp::Lt | BinaryOp::Gt
-            | BinaryOp::LtEq | BinaryOp::GtEq => {
+            BinaryOp::Eq
+            | BinaryOp::NotEq
+            | BinaryOp::Lt
+            | BinaryOp::Gt
+            | BinaryOp::LtEq
+            | BinaryOp::GtEq => {
                 if !lhs.is_comparable_with(&rhs) {
-                    self.error(
-                        format!("cannot compare {} with {}", lhs, rhs),
-                        span,
-                    );
+                    self.error(format!("cannot compare {} with {}", lhs, rhs), span);
                 }
                 Ty::Bool
             }
@@ -1386,9 +1601,7 @@ impl TypeChecker {
             }
 
             // Range: numeric → range (used in for loops)
-            BinaryOp::Range => {
-                Ty::Unknown
-            }
+            BinaryOp::Range => Ty::Unknown,
         }
     }
 
@@ -1397,8 +1610,16 @@ impl TypeChecker {
     /// 1. Integer literals adapt to the other operand's concrete type
     /// 2. Implicit widening: smaller → larger (u64 + u256 → u256)
     /// 3. Same signedness required (no implicit signed/unsigned mixing)
-    fn coerce_numeric_pair(&self, lhs_expr: &Expr, lhs: &Ty, rhs_expr: &Expr, rhs: &Ty) -> (Ty, Ty) {
-        if lhs == rhs { return (lhs.clone(), rhs.clone()); }
+    fn coerce_numeric_pair(
+        &self,
+        lhs_expr: &Expr,
+        lhs: &Ty,
+        rhs_expr: &Expr,
+        rhs: &Ty,
+    ) -> (Ty, Ty) {
+        if lhs == rhs {
+            return (lhs.clone(), rhs.clone());
+        }
 
         // If LHS is a literal and RHS is concrete numeric, adapt LHS
         if self.is_int_literal_compatible(lhs_expr, rhs) && rhs.is_numeric() {
@@ -1435,15 +1656,19 @@ impl TypeChecker {
             self.error(
                 format!(
                     "'{}' expects {} arguments, found {}",
-                    func_name, params.len(), arg_types.len()
+                    func_name,
+                    params.len(),
+                    arg_types.len()
                 ),
                 span,
             );
             return;
         }
 
-        for (i, ((param_name, param_ty), arg_ty)) in params.iter().zip(arg_types.iter()).enumerate() {
-            if *arg_ty != Ty::Unknown && *arg_ty != Ty::Error
+        for (i, ((param_name, param_ty), arg_ty)) in params.iter().zip(arg_types.iter()).enumerate()
+        {
+            if *arg_ty != Ty::Unknown
+                && *arg_ty != Ty::Error
                 && *param_ty != Ty::Unknown
                 && *arg_ty != *param_ty
                 && !arg_ty.can_widen_to(param_ty)
@@ -1451,7 +1676,8 @@ impl TypeChecker {
                 && !self.is_compatible_init(arg_ty, param_ty)
             {
                 // Also check if the arg is a literal that can adapt
-                let is_literal = arg_exprs.get(i)
+                let is_literal = arg_exprs
+                    .get(i)
                     .map(|e| self.is_int_literal_compatible(e, param_ty))
                     .unwrap_or(false);
                 if !is_literal {
@@ -1470,14 +1696,17 @@ impl TypeChecker {
     /// Check that a match on an enum covers all variants (or has a wildcard).
     fn check_match_exhaustiveness(&mut self, enum_name: &str, arms: &[MatchArm], span: Span) {
         // If there's a wildcard pattern, it's exhaustive
-        let has_wildcard = arms.iter().any(|a| matches!(a.pattern, Pattern::Wildcard(_)));
+        let has_wildcard = arms
+            .iter()
+            .any(|a| matches!(a.pattern, Pattern::Wildcard(_)));
         if has_wildcard {
             return;
         }
 
         // Get enum variants
         if let Some(variants) = self.env.enum_defs.get(enum_name) {
-            let covered: std::collections::HashSet<String> = arms.iter()
+            let covered: std::collections::HashSet<String> = arms
+                .iter()
                 .filter_map(|a| {
                     if let Pattern::Path(segments, _) = &a.pattern {
                         segments.last().map(|s| s.name.clone())
@@ -1487,12 +1716,11 @@ impl TypeChecker {
                 })
                 .collect();
 
-            let missing: Vec<&String> = variants.iter()
-                .filter(|v| !covered.contains(*v))
-                .collect();
+            let missing: Vec<&String> = variants.iter().filter(|v| !covered.contains(*v)).collect();
 
             if !missing.is_empty() {
-                let missing_str = missing.iter()
+                let missing_str = missing
+                    .iter()
                     .map(|v| format!("{}::{}", enum_name, v))
                     .collect::<Vec<_>>()
                     .join(", ");
@@ -1564,7 +1792,8 @@ mod tests {
 
     #[test]
     fn check_simple_contract() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract Token {
                 storage { supply: u256, }
                 #[constructor]
@@ -1576,12 +1805,14 @@ mod tests {
                     return self.supply;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_arithmetic_same_type() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let a: u256 = 10;
@@ -1589,12 +1820,14 @@ mod tests {
                     let c = a + b;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_boolean_logic() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let a = true;
@@ -1603,12 +1836,14 @@ mod tests {
                     let d = a || !b;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_comparison_returns_bool() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let a: u256 = 10;
@@ -1619,24 +1854,28 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_struct_init() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 struct Point { x: u64, y: u64 }
                 pub fn f() {
                     let p = Point { x: 1, y: 2 };
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_enum_pattern() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 enum Status { Active, Paused }
                 pub fn f() {
@@ -1648,24 +1887,28 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_event_emit() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 event Transfer { from: Address, to: Address, amount: u256, }
                 pub fn f() {
                     emit Transfer { from: msg.sender, to: msg.sender, amount: 100 };
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_tuple_destructuring() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn get_pair() -> (u64, u64) {
                     return (1, 2);
@@ -1674,46 +1917,54 @@ mod tests {
                     let (a, b) = self.get_pair();
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_cast_expression() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let a: u64 = 42;
                     let b = a as u256;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_array_literal() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let arr = [1, 2, 3];
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_hash_builtin() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let h = hash(42);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_for_loop() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     for i in 0..10 {
@@ -1721,14 +1972,16 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     // ========== Type errors ==========
 
     #[test]
     fn error_if_condition_not_bool() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     if 42 {
@@ -1736,13 +1989,15 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("if condition must be bool"));
     }
 
     #[test]
     fn error_while_condition_not_bool() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     while 42 {
@@ -1750,44 +2005,53 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("while condition must be bool"));
     }
 
     #[test]
     fn logical_not_on_int_is_allowed() {
         // ! on integers is bitwise NOT (like C), returns same type
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let x = !42;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_logical_not_on_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = !"hello";
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("logical NOT requires bool or integer"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("logical NOT requires bool or integer"));
     }
 
     #[test]
     fn error_wrong_event_field_count() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 event Transfer { from: Address, to: Address, amount: u256, }
                 pub fn f() {
                     emit Transfer { from: msg.sender };
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("expects 3 fields, found 1"));
     }
 
@@ -1795,72 +2059,85 @@ mod tests {
 
     #[test]
     fn check_return_type_correct() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     return 42;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_return_type_mismatch() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     return "hello";
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("return type mismatch"));
     }
 
     #[test]
     fn check_return_type_widening() {
         // u64 returned for u256 function — widening is ok
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 storage { count: u64, }
                 pub fn f() -> u256 {
                     return self.count;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     // ========== Function call argument validation ==========
 
     #[test]
     fn error_wrong_argument_count() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 fn helper(x: u256, y: u256) {}
                 pub fn f() {
                     self.helper(1);
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("expects 2 arguments, found 1"));
     }
 
     #[test]
     fn error_wrong_argument_type() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 fn helper(x: u256) {}
                 pub fn f() {
                     self.helper("hello");
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("argument 'x' expects u256, found String"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("argument 'x' expects u256, found String"));
     }
 
     #[test]
     fn check_argument_widening() {
         // u64 arg for u256 param — ok
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 storage { count: u64, }
                 fn helper(x: u256) {}
@@ -1868,137 +2145,166 @@ mod tests {
                     self.helper(self.count);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_argument_literal() {
         // Literal adapts to param type
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 fn helper(x: u64) {}
                 pub fn f() {
                     self.helper(42);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     // ========== Mutability checking ==========
 
     #[test]
     fn check_mutable_assignment() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let mut x = 1;
                     x = 2;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_immutable_assignment() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = 1;
                     x = 2;
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("cannot assign to immutable variable 'x'"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("cannot assign to immutable variable 'x'"));
     }
 
     #[test]
     fn check_compound_mutable_assignment() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let mut count = 0;
                     count += 1;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_immutable_compound_assignment() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let count = 0;
                     count += 1;
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("cannot assign to immutable variable 'count'"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("cannot assign to immutable variable 'count'"));
     }
 
     // ========== require! condition checking ==========
 
     #[test]
     fn check_require_bool_condition() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 error Fail {}
                 pub fn f() {
                     require!(true, Fail {});
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_require_non_bool_condition() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 error Fail {}
                 pub fn f() {
                     require!(42, Fail {});
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("require! condition must be bool"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("require! condition must be bool"));
     }
 
     // ========== Void function returning value ==========
 
     #[test]
     fn check_void_function_no_return() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let x = 1;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_void_function_returning_value() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     return 42;
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("function does not return a value"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("function does not return a value"));
     }
 
     // ========== String concat error ==========
 
     #[test]
     fn error_string_plus_operator() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = "hello" + "world";
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("use .concat() instead"));
     }
 
@@ -2006,198 +2312,245 @@ mod tests {
 
     #[test]
     fn error_sqrt_on_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = "hello".sqrt();
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("can only be called on numeric types"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("can only be called on numeric types"));
     }
 
     #[test]
     fn error_pow_on_bool() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = true.pow(3);
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("can only be called on numeric types"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("can only be called on numeric types"));
     }
 
     #[test]
     fn check_sqrt_on_u256() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let x: u256 = 100;
                     let root = x.sqrt();
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_concat_on_number() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x: u256 = 100;
                     let y = x.concat(200);
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("can only be called on String or bytes"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("can only be called on String or bytes"));
     }
 
     #[test]
     fn error_push_on_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let s = "hello";
                     s.push("x");
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("'push' can only be called on Vec"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("'push' can only be called on Vec"));
     }
 
     #[test]
     fn error_len_on_number() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x: u256 = 100;
                     let n = x.len();
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("'len' can only be called on collections"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("'len' can only be called on collections"));
     }
 
     #[test]
     fn error_is_empty_on_number() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x: u256 = 100;
                     let b = x.is_empty();
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("'is_empty' can only be called on collections"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("'is_empty' can only be called on collections"));
     }
 
     #[test]
     fn error_append_on_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let s = "hello";
                     s.append("x");
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("'append' can only be called on bytes or Vec"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("'append' can only be called on bytes or Vec"));
     }
 
     // ========== address() enforcement ==========
 
     #[test]
     fn check_address_self() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let addr = address(self);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_address_integer() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let addr = address(0);
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("expects 'self' or an Address"));
     }
 
     #[test]
     fn error_address_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let addr = address("hello");
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("expects 'self' or an Address"));
     }
 
     #[test]
     fn check_address_of_address_var() {
         // Passing an Address variable is fine (identity)
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let sender = msg.sender;
                     let addr = address(sender);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     // ========== Std import function validation ==========
 
     #[test]
     fn check_imported_sqrt_correct_args() {
-        check_ok(r#"
+        check_ok(
+            r#"
             use std::math::sqrt;
             contract T {
                 pub fn f() {
                     let x = sqrt(100);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_imported_sqrt_wrong_type() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             use std::math::sqrt;
             contract T {
                 pub fn f() {
                     let x = sqrt("hello");
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("argument 'x' expects u256, found String"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("argument 'x' expects u256, found String"));
     }
 
     #[test]
     fn error_imported_sqrt_wrong_count() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             use std::math::sqrt;
             contract T {
                 pub fn f() {
                     let x = sqrt(1, 2);
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("expects 1 arguments, found 2"));
     }
 
     #[test]
     fn check_imported_verify_correct() {
-        check_ok(r#"
+        check_ok(
+            r#"
             use std::signature::verify;
             contract T {
                 pub fn f() {
@@ -2207,12 +2560,14 @@ mod tests {
                     let valid = verify(msg_hash, sig, pk);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_grouped_import_validation() {
-        check_ok(r#"
+        check_ok(
+            r#"
             use std::math::{sqrt, pow};
             contract T {
                 pub fn f() {
@@ -2220,14 +2575,16 @@ mod tests {
                     let b = pow(2, 10);
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     // ========== Cast validation ==========
 
     #[test]
     fn check_valid_casts() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let a: u64 = 42;
@@ -2237,30 +2594,35 @@ mod tests {
                     let e = true as u256;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_cast_string_to_int() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = "hello" as u256;
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("cannot cast String to u256"));
     }
 
     #[test]
     fn error_cast_bool_to_string() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() {
                     let x = true as String;
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("cannot cast bool to String"));
     }
 
@@ -2268,7 +2630,8 @@ mod tests {
 
     #[test]
     fn check_exhaustive_match_with_wildcard() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 enum Status { Active, Paused, Closed }
                 pub fn f() {
@@ -2279,12 +2642,14 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_exhaustive_match_all_variants() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 enum Status { Active, Paused }
                 pub fn f() {
@@ -2295,12 +2660,14 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_non_exhaustive_match() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 enum Status { Active, Paused, Closed }
                 pub fn f() {
@@ -2310,7 +2677,8 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("non-exhaustive match"));
         assert!(errors[0].message.contains("Paused"));
         assert!(errors[0].message.contains("Closed"));
@@ -2320,31 +2688,36 @@ mod tests {
 
     #[test]
     fn check_function_with_return() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     return 42;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_missing_return() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     let x = 42;
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("must return"));
     }
 
     #[test]
     fn check_return_after_loop() {
         // Return after loop is fine — loop might not execute
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn find(items: Vec<u256>, target: u256) -> u256 {
                     for i in 0..10 {
@@ -2355,13 +2728,15 @@ mod tests {
                     return 0;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_revert_after_loop() {
         // Revert after loop is a valid exit path
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 error NotFound {}
                 pub fn find(items: Vec<u256>, target: u256) -> u256 {
@@ -2373,13 +2748,15 @@ mod tests {
                     revert!(NotFound {});
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn error_return_only_inside_loop() {
         // Return only inside loop — loop might not execute
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     for i in 0..10 {
@@ -2387,75 +2764,91 @@ mod tests {
                     }
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("must return"));
     }
 
     #[test]
     fn error_bare_return_in_non_void() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 pub fn f() -> u256 {
                     return;
                 }
             }
-        "#);
+        "#,
+        );
         assert!(errors[0].message.contains("'return' has no value"));
     }
 
     #[test]
     fn error_undefined_storage_field() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 storage { balance: u256, }
                 pub fn f() {
                     let x = self.nonexistent;
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("not a storage field or function"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("not a storage field or function"));
     }
 
     #[test]
     fn error_assign_undefined_storage_field() {
-        let errors = check_err(r#"
+        let errors = check_err(
+            r#"
             contract T {
                 storage { balance: u256, }
                 pub fn f() {
                     self.fake = 100;
                 }
             }
-        "#);
-        assert!(errors[0].message.contains("not a storage field or function"));
+        "#,
+        );
+        assert!(errors[0]
+            .message
+            .contains("not a storage field or function"));
     }
 
     #[test]
     fn check_bare_return_in_void_ok() {
         // return; in void function is fine (early exit)
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     if true { return; }
                     let x = 42;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_void_function_no_return_needed() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 pub fn f() {
                     let x = 42;
                 }
             }
-        "#);
+        "#,
+        );
     }
 
     #[test]
     fn check_valid_method_types() {
-        check_ok(r#"
+        check_ok(
+            r#"
             contract T {
                 storage { items: Vec<u256>, data: bytes, }
                 pub fn f() {
@@ -2469,6 +2862,7 @@ mod tests {
                     let nb = name.as_bytes();
                 }
             }
-        "#);
+        "#,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `deploy!` as the primary contract deployment macro, `create!` becomes alias
- Both return `Ty::Contract(name)` instead of raw `Address`, enabling typed method dispatch (`c.increment()`) on the returned handle
- Typechecker infers `Ty::Contract(name)` from first path argument with error reporting for malformed calls

## Test plan
- [x] All 1,779 workspace tests pass
- [x] Type propagates through `let c = deploy!(Counter);` via reg_types → local_types pipeline
- [x] Existing `create!` behavior unchanged at runtime (CreateContract instruction)