### PR TITLE
feat: wide return values for cross-contract calls

### DIFF
--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -1403,16 +1403,22 @@ impl CodeGen {
                     } else {
                         let rv = self.get_reg(*v);
                         if self.regs.is_wide(*v) {
+                            // Wide return (u256, Address): use blob convention
+                            // Write 32 bytes to heap, set r1 = ptr, r2 = 32
                             if rv != 0 {
                                 self.emit_op(Opcode::Wmov, 0, rv, 0);
                             }
-                            self.emit_op(Opcode::Wstore, 0, 12, 0);
-                            self.emit_load(1, 12, 0);
+                            self.emit_op(Opcode::Wstore, 0, 12, 0);  // mem[heap] = w0
+                            self.emit_op(Opcode::Add, 1, 12, 0);     // r1 = heap ptr
+                            self.emit_op(Opcode::Addi, 2, 0, 32);    // r2 = 32 bytes
                         } else if rv != 1 {
                             self.emit_op(Opcode::Add, 1, rv, 0);
+                            // Clear r2 AFTER rv→r1 copy so blob return check doesn't false-trigger
+                            self.emit_op(Opcode::Addi, 2, 0, 0);
+                        } else {
+                            // rv is already r1, just clear r2
+                            self.emit_op(Opcode::Addi, 2, 0, 0);
                         }
-                        // Clear r2 AFTER rv→r1 copy so blob return check doesn't false-trigger
-                        self.emit_op(Opcode::Addi, 2, 0, 0);
                     }
                 } else {
                     // Void return: clear r2 to prevent false blob detection
@@ -1932,8 +1938,8 @@ impl CodeGen {
                 }
             }
 
-            Inst::ExtCall(dst, addr, method, args) => {
-                let rd = self.alloc_gp(*dst);
+            Inst::ExtCall(dst, addr, method, args, ret_ty) => {
+                let wide_return = is_wide_type(ret_ty);
                 let ra = self.get_reg(*addr);
 
                 // Write calldata to heap: [selector(4 BE bytes)][arg0(8 LE)][arg1(8 LE)]...
@@ -1965,9 +1971,19 @@ impl CodeGen {
                 // Advance heap past calldata
                 self.emit_op(Opcode::Addi, 12, 12, calldata_len);
 
-                // After CallExt, r1 = child's return value (set by PVM convention)
-                if rd != 1 {
-                    self.emit_op(Opcode::Add, rd, 1, 0);
+                if wide_return {
+                    // Wide return (u256, Address): PVM wrote 32 bytes to parent heap
+                    // at r12 and set r1 = r12. Wload from r1 into destination.
+                    let wd = self.regs.alloc_wide(*dst);
+                    self.emit_op(Opcode::Wload, wd, 1, 0);
+                    // Advance heap past the 32-byte return data
+                    self.emit_op(Opcode::Addi, 12, 12, 32);
+                } else {
+                    // GP return (u64, bool, etc.): PVM set r1 = value
+                    let rd = self.alloc_gp(*dst);
+                    if rd != 1 {
+                        self.emit_op(Opcode::Add, rd, 1, 0);
+                    }
                 }
             }
 

--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -269,8 +269,8 @@ pub enum Inst {
     /// `%dst = method_call %obj, "method", [args...]`
     MethodCall(Reg, Reg, String, Vec<Reg>),
 
-    /// `ext_call %interface_addr, "method", [args...]`
-    ExtCall(Reg, Reg, String, Vec<Reg>),
+    /// `ext_call %interface_addr, "method", [args...], return_type`
+    ExtCall(Reg, Reg, String, Vec<Reg>, Ty),
 
     /// `%dst = hash [args...]`
     Hash(Reg, Vec<Reg>),
@@ -484,9 +484,9 @@ impl fmt::Display for Inst {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
                 write!(f, "{} = {}.{}({})", dst, obj, method, args_str.join(", "))
             }
-            Inst::ExtCall(dst, addr, method, args) => {
+            Inst::ExtCall(dst, addr, method, args, ret_ty) => {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
-                write!(f, "{} = ext_call {}, \"{}\"({})", dst, addr, method, args_str.join(", "))
+                write!(f, "{}: {} = ext_call {}, \"{}\"({})", dst, ret_ty, addr, method, args_str.join(", "))
             }
             Inst::Hash(dst, args) => {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -177,6 +177,22 @@ impl Lowerer {
         self.reg_types.get(&reg.0)
     }
 
+    /// Look up the return type of a method on a contract or interface.
+    /// Returns Ty::U64 as default if the method or type isn't found.
+    fn lookup_method_return_type(&self, type_name: &str, method_name: &str) -> Ty {
+        if let Some(fns) = self.contract_functions.get(type_name) {
+            if let Some((_, _, ret)) = fns.iter().find(|(n, _, _)| n == method_name) {
+                return ret.clone();
+            }
+        }
+        if let Some(fns) = self.interface_functions.get(type_name) {
+            if let Some((_, _, ret)) = fns.iter().find(|(n, _, _)| n == method_name) {
+                return ret.clone();
+            }
+        }
+        Ty::U64
+    }
+
     /// Infer the type of an expression (best-effort, for local_types tracking).
     fn infer_expr_type(&self, expr: &ast::Expr) -> Option<Ty> {
         use crate::ast::Expr;
@@ -1035,7 +1051,8 @@ impl Lowerer {
                             match obj_type {
                                 Some(Ty::Contract(ref name)) | Some(Ty::Interface(ref name)) => {
                                     // Typed contract/interface call → ExtCall
-                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), arg_regs));
+                                    let ret_ty = self.lookup_method_return_type(name, &method.name);
+                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), arg_regs, ret_ty));
                                 }
                                 _ => {
                                     self.emit(Inst::MethodCall(dst, obj_reg, method.name.clone(), arg_regs));
@@ -1271,7 +1288,8 @@ impl Lowerer {
 
                         if let Some(method) = method_name {
                             // Emit as ExtCall with the method name (codegen writes selector)
-                            self.emit(Inst::ExtCall(dst, target, method, param_regs));
+                            // No type info available for raw_call — default to GP return
+                            self.emit(Inst::ExtCall(dst, target, method, param_regs, Ty::U64));
                         } else {
                             // No method name: emit as raw call (no selector)
                             self.emit(Inst::RawCall(dst, target, param_regs));

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -299,7 +299,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
         Inst::Builtin(_, _) => {}
         Inst::Call(_, _, args) => { for a in args { used.insert(*a); } }
         Inst::MethodCall(_, obj, _, args) => { used.insert(*obj); for a in args { used.insert(*a); } }
-        Inst::ExtCall(_, addr, _, args) => { used.insert(*addr); for a in args { used.insert(*a); } }
+        Inst::ExtCall(_, addr, _, args, _) => { used.insert(*addr); for a in args { used.insert(*a); } }
         Inst::Hash(_, args) => { for a in args { used.insert(*a); } }
         Inst::StructInit(_, _, fields) => { for (_, r) in fields { used.insert(*r); } }
         Inst::FieldGet(_, obj, _, _) => { used.insert(*obj); }
@@ -335,7 +335,7 @@ fn get_dest_reg(inst: &Inst) -> Option<Reg> {
         | Inst::StorageGet(dst, _) | Inst::StorageMapGet(dst, _, _)
         | Inst::StorageNestedMapGet(dst, _, _, _)
         | Inst::Builtin(dst, _) | Inst::Call(dst, _, _)
-        | Inst::MethodCall(dst, _, _, _) | Inst::ExtCall(dst, _, _, _)
+        | Inst::MethodCall(dst, _, _, _) | Inst::ExtCall(dst, _, _, _, _)
         | Inst::Hash(dst, _) | Inst::StructInit(dst, _, _)
         | Inst::FieldGet(dst, _, _, _) | Inst::IndexGet(dst, _, _)
         | Inst::MakeTuple(dst, _) | Inst::TupleGet(dst, _, _)
@@ -354,7 +354,7 @@ fn has_side_effects(inst: &Inst) -> bool {
         | Inst::IndexSet(_, _, _)
         | Inst::Emit(_, _) | Inst::Revert(_, _)
         | Inst::CrossCall { .. } | Inst::RawCall(_, _, _) | Inst::CreateContract(_, _, _)
-        | Inst::Call(_, _, _) | Inst::MethodCall(_, _, _, _) | Inst::ExtCall(_, _, _, _)
+        | Inst::Call(_, _, _) | Inst::MethodCall(_, _, _, _) | Inst::ExtCall(_, _, _, _, _)
         | Inst::Jump(_) | Inst::Branch(_, _, _) | Inst::Return(_)
     )
 }

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -998,12 +998,29 @@ impl Vm {
                 let result = self.do_ext_call(d, is_static_flag, false)?;
                 self.cpu
                     .write_gp(result_reg, if result.success { 1 } else { 0 });
-                // Write child's return value to r1 (function return convention)
-                if result.success && result.return_data.len() >= 8 {
-                    let val = u64::from_le_bytes(
-                        result.return_data[..8].try_into().unwrap_or([0; 8])
-                    );
-                    self.cpu.write_gp(1, val);
+                if result.success && !result.return_data.is_empty() {
+                    if result.return_data.len() > 8 {
+                        // Wide/blob return: write return_data to parent heap (r12),
+                        // set r1 = heap ptr, r2 = length. Caller reads via Wload/memory.
+                        let heap = self.cpu.read_gp(12) as u32;
+                        if self.memory.checked_write_slice(heap, &result.return_data).is_ok() {
+                            self.cpu.write_gp(1, heap as u64);
+                            self.cpu.write_gp(2, result.return_data.len() as u64);
+                        } else {
+                            // Write failed (OOB) — fall back to GP convention
+                            let val = u64::from_le_bytes(
+                                result.return_data[..8].try_into().unwrap_or([0; 8])
+                            );
+                            self.cpu.write_gp(1, val);
+                            self.cpu.write_gp(2, 0);
+                        }
+                    } else {
+                        // GP return (≤ 8 bytes): r1 = value, r2 = 0
+                        let mut buf = [0u8; 8];
+                        buf[..result.return_data.len()].copy_from_slice(&result.return_data);
+                        self.cpu.write_gp(1, u64::from_le_bytes(buf));
+                        self.cpu.write_gp(2, 0);
+                    }
                 }
                 self.return_data = result.return_data;
                 self.pc += 4;
@@ -1422,12 +1439,30 @@ impl Vm {
         // EIP-2929: merge child's warm keys back (persists regardless of success/failure)
         self.warm_storage_keys.extend(child.warm_storage_keys);
 
-        // Return data: if child has explicit return_data, use it.
-        // Otherwise, capture the child's r1 (function return value convention).
+        // Return data: check multiple sources in priority order.
+        // 1. Explicit return_data (set by Revert or future explicit-return instructions)
+        // 2. Blob/wide return convention: r1 = pointer, r2 = length (> 0)
+        //    Used by u256/Address returns and struct/Vec/String returns.
+        // 3. GP return convention: r1 = 64-bit value (r2 == 0)
         let return_data = if !child.return_data.is_empty() {
             child.return_data
         } else if success {
-            child.cpu.read_gp(1).to_le_bytes().to_vec()
+            let r2 = child.cpu.read_gp(2);
+            if r2 > 0 {
+                // Blob/wide return: read r2 bytes from child memory at address r1
+                let ptr = child.cpu.read_gp(1) as u32;
+                let len = (r2 as usize).min(crate::memory::MEMORY_SIZE);
+                let end = (ptr as usize).saturating_add(len);
+                if end <= crate::memory::MEMORY_SIZE {
+                    child.memory.load_bytes(ptr as usize, len)
+                } else {
+                    // Out of bounds — fall back to GP return
+                    child.cpu.read_gp(1).to_le_bytes().to_vec()
+                }
+            } else {
+                // GP return: r1 as 8 LE bytes
+                child.cpu.read_gp(1).to_le_bytes().to_vec()
+            }
         } else {
             Vec::new()
         };


### PR DESCRIPTION
## Summary
- Fix cross-contract return convention for u256/Address types — previously silently truncated to 64 bits
- Callee uses blob convention (r1=ptr, r2=32) for wide returns instead of lossy r1-only
- PVM reads full blob from child memory via r2, writes to parent heap for Wload access
- ExtCall IR carries return type for codegen to branch on GP vs wide decode
- Bounds checking on all memory operations with OOB fallback

## Test plan
- [x] All 1,779 workspace tests pass
- [x] Audited Step 1 (deploy! type propagation through wide registers) — correct
- [x] Audited Step 2 (pre-pass resolve_ty dependencies) — correct
- [x] Audited Step 3 bounds: child memory read, parent heap write, short return_data