### PR TITLE
feat: compile-time constructor arg validation for deploy!/create!

### DIFF
--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -78,6 +78,8 @@ struct Lowerer {
     interface_functions: HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
     /// Contract name → public function signatures (for typed method dispatch).
     contract_functions: HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
+    /// Contract name → constructor param list (for deploy!/create! arg validation).
+    contract_constructors: HashMap<String, Vec<(String, Ty)>>,
     /// Register → type tracking for Contract/Interface typed handles.
     reg_types: HashMap<u32, Ty>,
 }
@@ -111,6 +113,7 @@ impl Lowerer {
             const_defs: HashMap::new(),
             interface_functions: HashMap::new(),
             contract_functions: HashMap::new(),
+            contract_constructors: HashMap::new(),
             reg_types: HashMap::new(),
         }
     }
@@ -440,6 +443,18 @@ impl Lowerer {
                 }
                 if !pub_fns.is_empty() {
                     self.contract_functions.insert(c.name.name.clone(), pub_fns);
+                }
+                // Collect constructor signature
+                for ci in &c.items {
+                    if let ContractItem::Function(f) = ci {
+                        if f.is_constructor() {
+                            let params: Vec<(String, Ty)> = f.params.iter()
+                                .map(|p| (p.name.name.clone(), self.resolve_ty(&p.ty)))
+                                .collect();
+                            self.contract_constructors.insert(c.name.name.clone(), params);
+                            break; // only one constructor per contract
+                        }
+                    }
                 }
             }
         }
@@ -1325,8 +1340,26 @@ impl Lowerer {
                             }
                         };
 
+                        // Validate constructor args against signature (if known)
+                        let user_args = &positional[1..];
+                        if let Some(ctor_params) = self.contract_constructors.get(&contract_name) {
+                            if user_args.len() != ctor_params.len() {
+                                self.emit(Inst::Comment(format!(
+                                    "deploy!: {}() expects {} args, got {}",
+                                    contract_name, ctor_params.len(), user_args.len()
+                                )));
+                            }
+                        }
+                        // No constructor defined but args provided
+                        if !self.contract_constructors.contains_key(&contract_name) && !user_args.is_empty() {
+                            self.emit(Inst::Comment(format!(
+                                "deploy!: {} has no constructor, but {} args provided",
+                                contract_name, user_args.len()
+                            )));
+                        }
+
                         // Lower constructor args (positional[1..])
-                        let arg_regs: Vec<Reg> = positional[1..].iter()
+                        let arg_regs: Vec<Reg> = user_args.iter()
                             .map(|e| self.lower_expr(e))
                             .collect();
 

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -53,6 +53,8 @@ pub struct TypeEnv {
     error_defs: HashMap<String, Vec<(String, Ty)>>,
     /// Interface name → function sigs
     interface_defs: HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
+    /// Contract name → constructor param types (for deploy!/create! validation)
+    contract_constructors: HashMap<String, Vec<(String, Ty)>>,
 }
 
 impl TypeEnv {
@@ -68,6 +70,7 @@ impl TypeEnv {
             event_defs: HashMap::new(),
             error_defs: HashMap::new(),
             interface_defs: HashMap::new(),
+            contract_constructors: HashMap::new(),
         }
     }
 
@@ -369,7 +372,17 @@ impl TypeChecker {
                 ContractItem::TypeAlias(t) => self.collect_type_alias(t),
                 ContractItem::Event(e) => self.collect_event(e),
                 ContractItem::Error(e) => self.collect_error(e),
-                ContractItem::Function(f) => self.collect_func_sig(f),
+                ContractItem::Function(f) => {
+                    self.collect_func_sig(f);
+                    if f.is_constructor() {
+                        let params: Vec<(String, Ty)> = f.params.iter()
+                            .map(|p| (p.name.name.clone(), self.resolve_type(&p.ty)))
+                            .collect();
+                        self.env.contract_constructors.insert(
+                            contract.name.name.clone(), params,
+                        );
+                    }
+                }
             }
         }
     }
@@ -1291,12 +1304,58 @@ impl TypeChecker {
                         // First arg is the contract name (path expression).
                         if let Some(MacroArg::Positional(first)) = args.first() {
                             if let Expr::Path(segments, _) = first {
-                                let name = segments
+                                let contract_name = segments
                                     .iter()
                                     .map(|s| s.name.as_str())
                                     .collect::<Vec<_>>()
                                     .join("::");
-                                Ty::Contract(name)
+
+                                // Validate constructor args (count + types)
+                                let user_arg_types = &arg_types[1..]; // skip contract name
+                                let ctor_params = self.env.contract_constructors.get(&contract_name).cloned();
+                                if let Some(ref params) = ctor_params {
+                                    if user_arg_types.len() != params.len() {
+                                        self.error(
+                                            format!(
+                                                "deploy!: {}() constructor expects {} args, got {}",
+                                                contract_name, params.len(), user_arg_types.len()
+                                            ),
+                                            *span,
+                                        );
+                                    } else {
+                                        // Check each arg type
+                                        for ((_param_name, param_ty), arg_ty) in
+                                            params.iter().zip(user_arg_types.iter())
+                                        {
+                                            if *arg_ty != Ty::Unknown
+                                                && *arg_ty != Ty::Error
+                                                && *param_ty != Ty::Unknown
+                                                && *arg_ty != *param_ty
+                                                && !arg_ty.can_widen_to(param_ty)
+                                                && !(arg_ty.is_numeric() && param_ty.is_numeric())
+                                            {
+                                                self.error(
+                                                    format!(
+                                                        "deploy!: {}() arg '{}' expects {}, got {}",
+                                                        contract_name, _param_name, param_ty, arg_ty
+                                                    ),
+                                                    *span,
+                                                );
+                                            }
+                                        }
+                                    }
+                                } else if !user_arg_types.is_empty() {
+                                    // No constructor but args provided
+                                    self.error(
+                                        format!(
+                                            "deploy!: {} has no constructor, but {} args provided",
+                                            contract_name, user_arg_types.len()
+                                        ),
+                                        *span,
+                                    );
+                                }
+
+                                Ty::Contract(contract_name)
                             } else {
                                 self.error(
                                     "deploy! first argument must be a contract name".into(),

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1033,6 +1033,28 @@ impl Vm {
                 let result = self.do_ext_call(d, false, true)?;
                 self.cpu
                     .write_gp(result_reg, if result.success { 1 } else { 0 });
+                // Same return convention as CallExt: wide/blob → heap, GP → r1
+                if result.success && !result.return_data.is_empty() {
+                    if result.return_data.len() > 8 {
+                        let heap = self.cpu.read_gp(12) as u32;
+                        if self.memory.checked_write_slice(heap, &result.return_data).is_ok() {
+                            self.cpu.write_gp(1, heap as u64);
+                            self.cpu.write_gp(2, result.return_data.len() as u64);
+                        } else {
+                            let mut buf = [0u8; 8];
+                            buf[..result.return_data.len().min(8)].copy_from_slice(
+                                &result.return_data[..result.return_data.len().min(8)],
+                            );
+                            self.cpu.write_gp(1, u64::from_le_bytes(buf));
+                            self.cpu.write_gp(2, 0);
+                        }
+                    } else {
+                        let mut buf = [0u8; 8];
+                        buf[..result.return_data.len()].copy_from_slice(&result.return_data);
+                        self.cpu.write_gp(1, u64::from_le_bytes(buf));
+                        self.cpu.write_gp(2, 0);
+                    }
+                }
                 self.return_data = result.return_data;
                 self.pc += 4;
             }


### PR DESCRIPTION
## Summary
- Validate `deploy!(Counter, x, y)` args against constructor signature at compile time
- Lowerer: `contract_constructors` populated in pre-pass 2, arg count validated
- Typechecker: validates both arg count and types (with widening compatibility)
- PVM: Delegate handler now uses same wide return convention as CallExt

## Test plan
- [x] All 1,779 workspace tests pass
- [x] No warnings in changed files
- [x] Verified typechecker collect_defs runs for ALL contracts before check pass
- [x] Verified Delegate handler parity with CallExt return convention