### PR TITLE
feat: as casts for Contract/Interface types

### DIFF
--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -1543,8 +1543,15 @@ impl CodeGen {
                     let rd = self.alloc_gp(*dst);
                     let ws = self.get_reg(*src);
                     self.emit_op(Opcode::Narrow, rd, ws, 0);
+                } else if src_wide && dst_wide {
+                    // Wide → Wide: copy (e.g., Address ↔ Contract/Interface)
+                    let wd = self.regs.alloc_wide(*dst);
+                    let ws = self.get_reg(*src);
+                    if wd != ws {
+                        self.emit_op(Opcode::Wmov, wd, ws, 0);
+                    }
                 } else {
-                    // Same register file: copy
+                    // GP → GP: copy
                     let rd = self.alloc_gp(*dst);
                     let rs = self.get_reg(*src);
                     if rd != rs {
@@ -3079,7 +3086,7 @@ impl CodeGen {
 
 /// Check if a type uses wide (256-bit) register.
 fn is_wide_type(ty: &Ty) -> bool {
-    matches!(ty, Ty::U256 | Ty::I256 | Ty::Address)
+    matches!(ty, Ty::U256 | Ty::I256 | Ty::Address | Ty::Contract(_) | Ty::Interface(_))
 }
 
 /// Return the PVM MemWidth for a GP type (used by emit_load_typed / emit_store_typed).

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1543,7 +1543,14 @@ impl Lowerer {
                 let src = self.lower_expr(inner);
                 let dst = self.alloc_reg();
                 let target_ty = self.resolve_ty(ty);
-                self.emit(Inst::Cast(dst, src, target_ty));
+                self.emit(Inst::Cast(dst, src, target_ty.clone()));
+                // Propagate Contract/Interface type info for typed dispatch
+                match &target_ty {
+                    Ty::Contract(_) | Ty::Interface(_) => {
+                        self.set_local_type_for_reg(dst, target_ty);
+                    }
+                    _ => {}
+                }
                 dst
             }
 

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -4,7 +4,7 @@
 //! Infers types for expressions, checks assignments, function calls,
 //! struct inits, emit statements, and casts.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ast::*;
 use crate::token::Span;
@@ -55,6 +55,8 @@ pub struct TypeEnv {
     interface_defs: HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
     /// Contract name → constructor param types (for deploy!/create! validation)
     contract_constructors: HashMap<String, Vec<(String, Ty)>>,
+    /// Known contract names (for cast validation and type resolution)
+    contract_names: HashSet<String>,
 }
 
 impl TypeEnv {
@@ -71,6 +73,7 @@ impl TypeEnv {
             error_defs: HashMap::new(),
             interface_defs: HashMap::new(),
             contract_constructors: HashMap::new(),
+            contract_names: HashSet::new(),
         }
     }
 
@@ -217,6 +220,12 @@ impl TypeChecker {
                 if self.env.enum_defs.contains_key(&ident.name) {
                     return Ty::Enum(ident.name.clone());
                 }
+                if self.env.interface_defs.contains_key(&ident.name) {
+                    return Ty::Interface(ident.name.clone());
+                }
+                if self.env.contract_names.contains(&ident.name) {
+                    return Ty::Contract(ident.name.clone());
+                }
                 Ty::Unknown
             }
             Type::Tuple(types, _) => {
@@ -358,6 +367,7 @@ impl TypeChecker {
     }
 
     fn collect_contract_defs(&mut self, contract: &ContractDef) {
+        self.env.contract_names.insert(contract.name.name.clone());
         for item in &contract.items {
             match item {
                 ContractItem::Storage(s) => {
@@ -1497,6 +1507,17 @@ impl TypeChecker {
                         // enum ↔ numeric (discriminant cast)
                         (Ty::Enum(_), t) if t.is_numeric() => true,
                         (s, Ty::Enum(_)) if s.is_numeric() => true,
+                        // Contract/Interface → Address (strip type info)
+                        (Ty::Contract(_), Ty::Address) => true,
+                        (Ty::Interface(_), Ty::Address) => true,
+                        // Address → Contract/Interface (wrap with type info)
+                        (Ty::Address, Ty::Contract(_)) => true,
+                        (Ty::Address, Ty::Interface(_)) => true,
+                        // Contract/Interface ↔ Contract/Interface (re-cast)
+                        (Ty::Contract(_), Ty::Contract(_)) => true,
+                        (Ty::Interface(_), Ty::Interface(_)) => true,
+                        (Ty::Contract(_), Ty::Interface(_)) => true,
+                        (Ty::Interface(_), Ty::Contract(_)) => true,
                         // same type (identity cast)
                         (s, t) if s == t => true,
                         _ => false,


### PR DESCRIPTION
## Summary
- `handle as Address` — strip typed handle back to raw Address
- `addr as Counter` / `addr as IERC20` — wrap Address with type info for method dispatch
- Fix pre-existing bug: wide→wide cast used `alloc_gp` instead of `Wmov`
- `is_wide_type` includes Contract/Interface (32-byte addresses)
- Typechecker resolves named types to Contract/Interface, validates all cast directions

## Test plan
- [x] All 1,779 workspace tests pass
- [x] Audited is_wide_type ripple effects across all 30+ call sites — correct
- [x] No name collision risk (resolver prevents duplicate struct/contract names)
- [x] contract_names populated for all contracts before type checking pass
- [x] No warnings in changed files