### PR TITLE
feat: wire cheatcodes into test runner

### DIFF
--- a/crates/pyde-dev/src/cheatcodes.rs
+++ b/crates/pyde-dev/src/cheatcodes.rs
@@ -74,7 +74,7 @@ pub fn execute_with_cheatcodes(vm: &mut Vm, cheat_state: &mut CheatcodeState) ->
     vm.clear_journal();
     let logs_start = vm.logs.len();
 
-    loop {
+    let result = loop {
         // Peek at current instruction before stepping
         let idx = (vm.pc / 4) as usize;
         let maybe_instr = vm.decoded_cache().get(idx).copied();
@@ -136,7 +136,11 @@ pub fn execute_with_cheatcodes(vm: &mut Vm, cheat_state: &mut CheatcodeState) ->
                 }
             }
         }
-    }
+    };
+
+    // Post-execution cleanup (matches vm.execute() behavior)
+    vm.clear_journal();
+    result
 }
 
 /// Handle a single cheatcode call. Returns true on success.

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -1,4 +1,5 @@
 use crate::build;
+use crate::cheatcodes::{self, CheatcodeState};
 use crate::project;
 use std::collections::HashMap;
 use std::fs;
@@ -142,13 +143,14 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
             // Inject constructor storage (after load so it doesn't get cleared)
             vm.storage = snapshot;
 
-            // Execute
-            let output = vm.execute();
+            // Execute with cheatcode interception (fresh state per test)
+            let mut cheat_state = CheatcodeState::new();
+            let outcome = cheatcodes::execute_with_cheatcodes(&mut vm, &mut cheat_state);
             let gas = vm.gas_used_total;
 
             let ok = if meta.should_panic {
                 // Expected to revert
-                match output.outcome {
+                match outcome {
                     pyde_vm::vm::Outcome::Revert => {
                         // If expected_error specified, check revert data matches
                         if let Some(ref expected) = meta.expected_error {
@@ -170,13 +172,13 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
                         }
                     }
                     _ => {
-                        println!("    FAIL {} — expected revert but got {:?}", meta.name, output.outcome);
+                        println!("    FAIL {} — expected revert but got {:?}", meta.name, outcome);
                         false
                     }
                 }
             } else {
                 // Expected to succeed
-                match output.outcome {
+                match outcome {
                     pyde_vm::vm::Outcome::Success => true,
                     pyde_vm::vm::Outcome::Revert => {
                         // Decode error name from revert data using contract's error map


### PR DESCRIPTION
## Summary
- Replace `vm.execute()` with `execute_with_cheatcodes()` for test function execution
- Cheatcodes (warp, roll, prank, deal, makeAddr) now active during tests
- Fresh `CheatcodeState` per test — no state leaking between tests
- Constructor unchanged (uses `vm.execute()`, no cheatcodes during init)
- Post-loop journal cleanup added to match `vm.execute()` behavior

## Test plan
- [x] All 1,779 workspace tests pass
- [x] No warnings in changed files
- [x] Behavioral parity audit: journal clear, log snapshot, rollback, cleanup all match vm.execute()