### PR TITLE
feat: wire build registry into test file compilation

### DIFF
--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -50,6 +50,27 @@ pub fn lower_with_contracts(
     lowerer.program
 }
 
+/// Lower with full external context: bytecode registry, function signatures,
+/// and constructor signatures. Used by the test runner for cross-file imports.
+pub fn lower_with_context(
+    file: &SourceFile,
+    compiled: &HashMap<String, Vec<u8>>,
+    ext_contract_functions: &HashMap<String, Vec<(String, Vec<(String, Ty)>, Ty)>>,
+    ext_contract_constructors: &HashMap<String, Vec<(String, Ty)>>,
+) -> IrProgram {
+    let mut lowerer = Lowerer::new();
+    lowerer.compiled_contracts = compiled.clone();
+    // Inject external contract signatures so typed dispatch works for imported contracts
+    for (name, fns) in ext_contract_functions {
+        lowerer.contract_functions.insert(name.clone(), fns.clone());
+    }
+    for (name, params) in ext_contract_constructors {
+        lowerer.contract_constructors.insert(name.clone(), params.clone());
+    }
+    lowerer.lower_file(file);
+    lowerer.program
+}
+
 struct Lowerer {
     program: IrProgram,
     /// Current function being lowered.

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -10,7 +10,7 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
 
     // Build src/ contracts first (tests may depend on them)
     println!("  Building contracts...");
-    build::build_project(&config, &root)?;
+    let build_result = build::build_project(&config, &root)?;
     println!();
 
     // Find test files
@@ -55,8 +55,13 @@ pub fn run(filter: Option<&str>) -> Result<(), String> {
             continue;
         }
 
-        // Lower to IR — keep test functions but promote them to pub for dispatch
-        let mut ir = otic::lower::lower(&ast_file);
+        // Lower to IR with src/ contract context (bytecode + signatures for deploy!/dispatch)
+        let mut ir = otic::lower::lower_with_context(
+            &ast_file,
+            &build_result.compiled_registry,
+            &build_result.contract_functions,
+            &build_result.contract_constructors,
+        );
         otic::optimize::optimize(&mut ir);
 
         // Collect test function metadata before we modify the IR


### PR DESCRIPTION
## Summary
- Test files compile with full src/ contract context via `lower_with_context()`
- Bytecode registry enables `deploy!(Counter)` from imported contracts
- Function signatures enable typed method dispatch (`c.increment()` → ExtCall)
- Constructor signatures enable compile-time arg validation for deploy!
- Deployed contracts auto-registered in `vm.contracts` by PVM Create instruction

## Test plan
- [x] All 29 test suites pass (1,779 tests)
- [x] No warnings in changed files
- [x] Verified injection order: external sigs before lower_file, local defs override
- [x] Verified type alignment: FnSig matches lower_with_context params
- [x] Verified deploy flow: PVM Create auto-registers bytecode
- [x] Verified empty registry case: equivalent to plain lower()