### PR TITLE
feat: qualified paths and module export validation

### DIFF
--- a/crates/otic/src/ast.rs
+++ b/crates/otic/src/ast.rs
@@ -280,8 +280,9 @@ pub enum Type {
     Vec(Box<Type>, Span),
     /// `Map<Address, u256>`
     Map(Box<Type>, Box<Type>, Span),
-    /// User-defined type: struct name, enum name
-    Named(Ident),
+    /// User-defined type: struct, enum, contract, interface, type alias.
+    /// Supports qualified paths: `types::TokenId`, `event::Deposit`.
+    Named(Vec<Ident>),
     /// `(u256, u256)`
     Tuple(Vec<Type>, Span),
 }
@@ -387,7 +388,8 @@ pub struct ReturnStmt {
 
 #[derive(Clone, Debug)]
 pub struct EmitStmt {
-    pub event_name: Ident,
+    /// Event name, possibly module-qualified: `Deposit` or `event::Deposit`.
+    pub event_name: Vec<Ident>,
     pub fields: Vec<FieldInit>,
     pub span: Span,
 }

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -316,23 +316,25 @@ impl Lowerer {
             ast::Type::Array(elem, size, _) => Ty::Array(Box::new(self.resolve_ty(elem)), *size),
             ast::Type::Vec(elem, _) => Ty::Vec(Box::new(self.resolve_ty(elem))),
             ast::Type::Map(key, val, _) => Ty::Map(Box::new(self.resolve_ty(key)), Box::new(self.resolve_ty(val))),
-            ast::Type::Named(ident) => {
+            ast::Type::Named(path) => {
+                // Flatten qualified path: module::Type → just "Type"
+                let name = path.last().map(|i| i.name.as_str()).unwrap_or("");
                 // Check for primitive type names (parser may emit Named instead of Primitive for casts)
-                match ident.name.as_str() {
+                match name {
                     "u8" => Ty::U8, "u16" => Ty::U16, "u32" => Ty::U32, "u64" => Ty::U64,
                     "u128" => Ty::U128, "u256" => Ty::U256,
                     "i8" => Ty::I8, "i16" => Ty::I16, "i32" => Ty::I32, "i64" => Ty::I64,
                     "i128" => Ty::I128, "i256" => Ty::I256,
                     "bool" => Ty::Bool, "Address" => Ty::Address, "String" => Ty::StringTy,
                     _ => {
-                        if self.enum_defs.contains_key(&ident.name) {
-                            Ty::Enum(ident.name.clone())
-                        } else if self.interface_functions.contains_key(&ident.name) {
-                            Ty::Interface(ident.name.clone())
-                        } else if self.contract_functions.contains_key(&ident.name) {
-                            Ty::Contract(ident.name.clone())
+                        if self.enum_defs.contains_key(name) {
+                            Ty::Enum(name.to_string())
+                        } else if self.interface_functions.contains_key(name) {
+                            Ty::Interface(name.to_string())
+                        } else if self.contract_functions.contains_key(name) {
+                            Ty::Contract(name.to_string())
                         } else {
-                            Ty::Struct(ident.name.clone())
+                            Ty::Struct(name.to_string())
                         }
                     }
                 }
@@ -783,7 +785,9 @@ impl Lowerer {
         let field_regs: Vec<Reg> = e.fields.iter()
             .map(|f| self.lower_expr(&f.value))
             .collect();
-        self.emit(Inst::Emit(e.event_name.name.clone(), field_regs));
+        // Flatten qualified path: event::Deposit → "Deposit"
+        let event_name = e.event_name.last().map(|i| i.name.clone()).unwrap_or_default();
+        self.emit(Inst::Emit(event_name, field_regs));
     }
 
     fn lower_for(&mut self, f: &ForStmt) {

--- a/crates/otic/src/parser.rs
+++ b/crates/otic/src/parser.rs
@@ -632,10 +632,13 @@ impl Parser {
                         self.expect_gt()?;
                         Ok(Type::Map(Box::new(key), Box::new(val), span))
                     }
-                    // Named type (struct, enum, etc.)
+                    // Named type: struct, enum, contract, or qualified path (types::TokenId)
                     _ => {
-                        let ident = self.expect_ident()?;
-                        Ok(Type::Named(ident))
+                        let mut path = vec![self.expect_ident()?];
+                        while self.eat(&TokenKind::ColonColon) {
+                            path.push(self.expect_ident()?);
+                        }
+                        Ok(Type::Named(path))
                     }
                 }
             }
@@ -790,7 +793,11 @@ impl Parser {
     fn parse_emit_stmt(&mut self) -> Result<Stmt, ()> {
         let start = self.peek_span();
         self.expect(&TokenKind::Emit)?;
-        let event_name = self.expect_ident()?;
+        // Parse event name as a path: `Deposit` or `event::Deposit`
+        let mut event_name = vec![self.expect_ident()?];
+        while self.eat(&TokenKind::ColonColon) {
+            event_name.push(self.expect_ident()?);
+        }
         self.expect(&TokenKind::LBrace)?;
 
         let mut fields = Vec::new();

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -117,6 +117,11 @@ impl Scope {
 // Resolver
 // ============================================================================
 
+/// External module exports: module_path → set of exported symbol names.
+/// Used to validate qualified access (event::Deposit) and distinguish
+/// module imports from item imports.
+pub type ExternalModuleExports = HashMap<String, Vec<String>>;
+
 pub struct Resolver {
     scopes: Vec<Scope>,
     errors: Vec<ResolveError>,
@@ -130,6 +135,8 @@ pub struct Resolver {
     builtin_fns: Vec<&'static str>,
     /// Known built-in globals (msg, block, tx).
     builtin_globals: Vec<&'static str>,
+    /// External module exports for qualified path validation.
+    module_exports: ExternalModuleExports,
 }
 
 impl Resolver {
@@ -147,6 +154,15 @@ impl Resolver {
             ],
             builtin_fns: vec!["hash", "address", "gas_remaining", "bytes", "sig_verify", "sig_recover"],
             builtin_globals: vec!["msg", "block", "tx"],
+            module_exports: HashMap::new(),
+        }
+    }
+
+    /// Create a resolver with external module exports for qualified path validation.
+    pub fn with_exports(exports: ExternalModuleExports) -> Self {
+        Self {
+            module_exports: exports,
+            ..Self::new()
         }
     }
 
@@ -260,6 +276,18 @@ impl Resolver {
             }
         }
         None
+    }
+
+    /// Check if a module path exists in external exports.
+    fn is_known_module(&self, path: &str) -> bool {
+        self.module_exports.contains_key(path)
+    }
+
+    /// Check if an item is exported by a module.
+    fn is_exported(&self, module_path: &str, item_name: &str) -> bool {
+        self.module_exports.get(module_path)
+            .map(|exports| exports.iter().any(|e| e == item_name))
+            .unwrap_or(false)
     }
 
     fn is_type_defined(&self, name: &str) -> bool {
@@ -552,28 +580,66 @@ impl Resolver {
         // everything before is the module path.
 
         if import.path.len() >= 2 && import.items.is_empty() {
-            // Single import: use module::path::Item;
-            // All preceding segments form the module path, last is the imported item.
-            for segment in &import.path[..import.path.len() - 1] {
-                if self.lookup(&segment.name).is_none() {
-                    self.declare(&segment.name, SymbolKind::Module, segment.span);
+            // Check if the FULL path is a known module (module import: `use events::event;`)
+            // or the last segment is an item (item import: `use events::event::Deposit;`)
+            let full_path = import.path.iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("/");
+            let all_but_last = import.path[..import.path.len() - 1].iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("/");
+
+            if self.is_known_module(&full_path) {
+                // Module import: `use events::event;` — register all as Module
+                for segment in &import.path {
+                    if self.lookup(&segment.name).is_none() {
+                        self.declare(&segment.name, SymbolKind::Module, segment.span);
+                    }
                 }
+            } else {
+                // Item import: `use events::event::Deposit;` — last is item
+                for segment in &import.path[..import.path.len() - 1] {
+                    if self.lookup(&segment.name).is_none() {
+                        self.declare(&segment.name, SymbolKind::Module, segment.span);
+                    }
+                }
+                let item = &import.path[import.path.len() - 1];
+                // Validate the item is actually exported (if we know the module)
+                if !all_but_last.is_empty() && self.is_known_module(&all_but_last) {
+                    if !self.is_exported(&all_but_last, &item.name) {
+                        self.error(
+                            format!("'{}' is not exported from module '{}'", item.name, all_but_last.replace('/', "::")),
+                            item.span,
+                        );
+                    }
+                }
+                self.declare(&item.name, SymbolKind::Contract, item.span);
             }
-            // Last segment is the imported type/contract
-            let item = &import.path[import.path.len() - 1];
-            self.declare(&item.name, SymbolKind::Contract, item.span);
             return;
         }
 
         if !import.items.is_empty() {
             // Grouped import: use module::path::{Item1, Item2};
             // ALL path segments are module path.
+            let module_path = import.path.iter()
+                .map(|s| s.name.as_str())
+                .collect::<Vec<_>>()
+                .join("/");
             for segment in &import.path {
                 if self.lookup(&segment.name).is_none() {
                     self.declare(&segment.name, SymbolKind::Module, segment.span);
                 }
             }
             for item in &import.items {
+                // Validate each item is actually exported (if we know the module)
+                if self.is_known_module(&module_path) && !self.is_exported(&module_path, &item.name) {
+                    self.error(
+                        format!("'{}' is not exported from module '{}'", item.name, module_path.replace('/', "::")),
+                        item.span,
+                    );
+                }
                 self.declare(&item.name, SymbolKind::Contract, item.span);
             }
             return;
@@ -591,12 +657,22 @@ impl Resolver {
 
     fn resolve_type(&mut self, ty: &Type) {
         match ty {
-            Type::Named(ident) => {
-                if !self.is_type_defined(&ident.name) {
-                    self.error(
-                        format!("undefined type '{}'", ident.name),
-                        ident.span,
-                    );
+            Type::Named(path) => {
+                // For qualified paths (types::TokenId), check that at least the first
+                // segment is a known module or the last segment is a known type.
+                let name = path.last().map(|i| i.name.as_str()).unwrap_or("");
+                let span = path.last().map(|i| i.span).unwrap_or(path[0].span);
+                if path.len() == 1 {
+                    if !self.is_type_defined(name) {
+                        self.error(format!("undefined type '{}'", name), span);
+                    }
+                } else {
+                    // Qualified: check first segment is a known module
+                    let module = &path[0].name;
+                    if self.lookup(module).is_none() {
+                        self.error(format!("undefined module '{}'", module), path[0].span);
+                    }
+                    // The actual type resolution (module::Item → Item) happens in the lowerer
                 }
             }
             Type::Array(elem, _, _) => self.resolve_type(elem),
@@ -670,12 +746,20 @@ impl Resolver {
                 }
             }
             Stmt::Emit(e) => {
-                // Verify event name exists
-                if self.lookup(&e.event_name.name).is_none() {
-                    self.error(
-                        format!("undefined event '{}'", e.event_name.name),
-                        e.event_name.span,
-                    );
+                // Verify event name exists (simple or qualified)
+                let empty = String::new();
+                let event_name = e.event_name.last().map(|i| &i.name).unwrap_or(&empty);
+                let span = e.event_name.last().map(|i| i.span).unwrap_or(e.span);
+                if e.event_name.len() == 1 {
+                    if self.lookup(event_name).is_none() {
+                        self.error(format!("undefined event '{}'", event_name), span);
+                    }
+                } else {
+                    // Qualified: check first segment is a known module
+                    let module = &e.event_name[0].name;
+                    if self.lookup(module).is_none() {
+                        self.error(format!("undefined module '{}'", module), e.event_name[0].span);
+                    }
                 }
                 for field in &e.fields {
                     self.resolve_expr(&field.value);

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -209,22 +209,25 @@ impl TypeChecker {
                 Box::new(self.resolve_type(key)),
                 Box::new(self.resolve_type(val)),
             ),
-            Type::Named(ident) => {
-                // Check type aliases first
-                if let Some(ty) = self.env.type_aliases.get(&ident.name) {
+            Type::Named(path) => {
+                // For qualified paths (module::Type), resolve the last segment.
+                // The module prefix is validated by the resolver; here we just
+                // need the concrete type name.
+                let name = path.last().map(|i| i.name.as_str()).unwrap_or("");
+                if let Some(ty) = self.env.type_aliases.get(name) {
                     return ty.clone();
                 }
-                if self.env.struct_defs.contains_key(&ident.name) {
-                    return Ty::Struct(ident.name.clone());
+                if self.env.struct_defs.contains_key(name) {
+                    return Ty::Struct(name.to_string());
                 }
-                if self.env.enum_defs.contains_key(&ident.name) {
-                    return Ty::Enum(ident.name.clone());
+                if self.env.enum_defs.contains_key(name) {
+                    return Ty::Enum(name.to_string());
                 }
-                if self.env.interface_defs.contains_key(&ident.name) {
-                    return Ty::Interface(ident.name.clone());
+                if self.env.interface_defs.contains_key(name) {
+                    return Ty::Interface(name.to_string());
                 }
-                if self.env.contract_names.contains(&ident.name) {
-                    return Ty::Contract(ident.name.clone());
+                if self.env.contract_names.contains(name) {
+                    return Ty::Contract(name.to_string());
                 }
                 Ty::Unknown
             }
@@ -799,13 +802,15 @@ impl TypeChecker {
     }
 
     fn check_emit(&mut self, e: &EmitStmt) {
-        if let Some(event_fields) = self.env.event_defs.get(&e.event_name.name).cloned() {
+        // Resolve qualified event name: event::Deposit → "Deposit"
+        let event_name = e.event_name.last().map(|i| i.name.as_str()).unwrap_or("");
+        if let Some(event_fields) = self.env.event_defs.get(event_name).cloned() {
             // Check field count
             if e.fields.len() != event_fields.len() {
                 self.error(
                     format!(
                         "event '{}' expects {} fields, found {}",
-                        e.event_name.name,
+                        event_name,
                         event_fields.len(),
                         e.fields.len()
                     ),

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -16,6 +16,45 @@ struct BuildCache {
 /// Function signature: (name, params, return_type).
 pub type FnSig = (String, Vec<(String, otic::types::Ty)>, otic::types::Ty);
 
+/// Exported symbols from a module (file).
+#[derive(Clone, Debug, Default)]
+pub struct ModuleExports {
+    /// Public contract names.
+    pub contracts: Vec<String>,
+    /// Public interface names.
+    pub interfaces: Vec<String>,
+    /// Event names (events are always public).
+    pub events: Vec<String>,
+    /// Error names (errors are always public).
+    pub errors: Vec<String>,
+    /// Public struct names.
+    pub structs: Vec<String>,
+    /// Enum names (enums are always public).
+    pub enums: Vec<String>,
+    /// Public constant names.
+    pub consts: Vec<String>,
+    /// Type alias names.
+    pub type_aliases: Vec<String>,
+    /// Public standalone function names (utility/helper functions outside contracts).
+    /// Contract pub methods are NOT included — they're ABI methods, not module exports.
+    pub functions: Vec<String>,
+}
+
+impl ModuleExports {
+    /// Check if a name is exported by this module.
+    pub fn has(&self, name: &str) -> bool {
+        self.contracts.iter().any(|n| n == name)
+            || self.interfaces.iter().any(|n| n == name)
+            || self.events.iter().any(|n| n == name)
+            || self.errors.iter().any(|n| n == name)
+            || self.structs.iter().any(|n| n == name)
+            || self.enums.iter().any(|n| n == name)
+            || self.consts.iter().any(|n| n == name)
+            || self.type_aliases.iter().any(|n| n == name)
+            || self.functions.iter().any(|n| n == name)
+    }
+}
+
 /// Result of building the project.
 pub struct BuildResult {
     pub contracts: Vec<(String, String)>, // (contract_name, artifact_path)
@@ -27,6 +66,8 @@ pub struct BuildResult {
     pub contract_functions: HashMap<String, Vec<FnSig>>,
     /// Contract name → constructor param list (for deploy! arg validation).
     pub contract_constructors: HashMap<String, Vec<(String, otic::types::Ty)>>,
+    /// Module path → exported symbols (for qualified access validation).
+    pub module_exports: HashMap<String, ModuleExports>,
 }
 
 pub fn run() -> Result<(), String> {
@@ -81,6 +122,54 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     // Build dependency graph from `use` statements
     let dep_graph = build_dependency_graph(&sources, &src_dir)?;
 
+    // Pre-scan: collect module exports for qualified path validation
+    let mut module_exports: HashMap<String, ModuleExports> = HashMap::new();
+    for (path, source, _) in &sources {
+        let (tokens, _) = otic::lexer::Lexer::new(source).tokenize();
+        let (file, _) = otic::parser::Parser::new(tokens).parse();
+        let mut exports = ModuleExports::default();
+
+        for item in &file.items {
+            match item {
+                otic::ast::Item::Contract(c) => exports.contracts.push(c.name.name.clone()),
+                otic::ast::Item::Interface(i) => exports.interfaces.push(i.name.name.clone()),
+                otic::ast::Item::Struct(s) => exports.structs.push(s.name.name.clone()),
+                otic::ast::Item::Enum(e) => exports.enums.push(e.name.name.clone()),
+                otic::ast::Item::Error(e) => exports.errors.push(e.name.name.clone()),
+                otic::ast::Item::Const(c) if c.is_pub => exports.consts.push(c.name.name.clone()),
+                otic::ast::Item::TypeAlias(t) => exports.type_aliases.push(t.name.name.clone()),
+                // Only standalone pub functions are module-exportable (not contract methods)
+                otic::ast::Item::Function(f) if f.is_pub => exports.functions.push(f.name.name.clone()),
+                _ => {}
+            }
+            // Collect items from within contracts (events, errors, structs — NOT functions)
+            // Contract pub functions are ABI methods, not module-level exports.
+            // They're callable via deploy!() + typed dispatch, not via qualified paths.
+            if let otic::ast::Item::Contract(c) = item {
+                for ci in &c.items {
+                    match ci {
+                        otic::ast::ContractItem::Event(e) => exports.events.push(e.name.name.clone()),
+                        otic::ast::ContractItem::Error(e) => exports.errors.push(e.name.name.clone()),
+                        otic::ast::ContractItem::Struct(s) => exports.structs.push(s.name.name.clone()),
+                        otic::ast::ContractItem::Enum(e) => exports.enums.push(e.name.name.clone()),
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // Register by both file stem and relative path
+        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+            module_exports.insert(stem.to_string(), exports.clone());
+        }
+        if let Ok(rel) = path.strip_prefix(&src_dir) {
+            let rel_no_ext = rel.with_extension("");
+            if let Some(rel_str) = rel_no_ext.to_str() {
+                module_exports.insert(rel_str.replace('\\', "/"), exports);
+            }
+        }
+    }
+
     // Topological sort (detect cycles)
     let compile_order = topological_sort(&dep_graph, &sources)?;
 
@@ -106,12 +195,14 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     let mut compiled_registry: HashMap<String, Vec<u8>> = HashMap::new();
     let mut contract_functions: HashMap<String, Vec<FnSig>> = HashMap::new();
     let mut contract_constructors: HashMap<String, Vec<(String, otic::types::Ty)>> = HashMap::new();
+    let mut module_exports: HashMap<String, ModuleExports> = HashMap::new();
     let mut result = BuildResult {
         contracts: Vec::new(),
         total_bytecode: 0,
         compiled_registry: HashMap::new(),
         contract_functions: HashMap::new(),
         contract_constructors: HashMap::new(),
+        module_exports: HashMap::new(),
     };
     let mut had_errors = false;
 
@@ -134,7 +225,7 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
         }
 
         // Run frontend: lex → parse → resolve → typecheck → safety
-        if let Err(msg) = run_frontend(path, source) {
+        if let Err(msg) = run_frontend(path, source, &module_exports) {
             eprintln!("{}", msg);
             had_errors = true;
             continue;
@@ -222,6 +313,7 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     result.compiled_registry = compiled_registry;
     result.contract_functions = contract_functions;
     result.contract_constructors = contract_constructors;
+    result.module_exports = module_exports;
 
     // Save build cache
     save_cache(&cache_path, &new_cache);
@@ -233,7 +325,7 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
 }
 
 /// Run the otic frontend pipeline. Returns Err with formatted diagnostics on failure.
-fn run_frontend(path: &Path, source: &str) -> Result<(), String> {
+fn run_frontend(path: &Path, source: &str, module_exports: &HashMap<String, ModuleExports>) -> Result<(), String> {
     let path_str = path.to_string_lossy();
     let mut diagnostics = Vec::new();
 
@@ -265,7 +357,23 @@ fn run_frontend(path: &Path, source: &str) -> Result<(), String> {
         return Err(otic::diagnostic::format_diagnostics(&diagnostics, source));
     }
 
-    let resolve_result = otic::resolve::Resolver::new().resolve(&file);
+    // Convert ModuleExports to resolver's format (module_path → Vec<exported_name>)
+    let resolver_exports: otic::resolve::ExternalModuleExports = module_exports.iter()
+        .map(|(path, exports)| {
+            let mut names = Vec::new();
+            names.extend(exports.contracts.iter().cloned());
+            names.extend(exports.interfaces.iter().cloned());
+            names.extend(exports.events.iter().cloned());
+            names.extend(exports.errors.iter().cloned());
+            names.extend(exports.structs.iter().cloned());
+            names.extend(exports.enums.iter().cloned());
+            names.extend(exports.consts.iter().cloned());
+            names.extend(exports.type_aliases.iter().cloned());
+            names.extend(exports.functions.iter().cloned());
+            (path.clone(), names)
+        })
+        .collect();
+    let resolve_result = otic::resolve::Resolver::with_exports(resolver_exports).resolve(&file);
     for err in &resolve_result.errors {
         diagnostics.push(otic::diagnostic::Diagnostic {
             level: otic::diagnostic::Level::Error,


### PR DESCRIPTION
## Summary
- Module-qualified access in all name positions (types, emit, casts, args, returns, generics)
- AST: EmitStmt and Type::Named support Vec<Ident> paths
- Resolver validates imports against module exports (item existence check)
- Distinguishes module imports vs item imports via module_exports map
- ModuleExports pre-scan: all exportable symbols per file
- Contract pub methods excluded from exports (ABI methods, not module-level)
- Standalone pub functions included as module exports
- Lowerer flattens qualified names to simple names — codegen/IR unchanged

## Test plan
- [x] All 1,811 tests pass
- [x] No warnings in any changed file
- [x] All type positions support qualified paths via parse_type()
- [x] Export validation: items checked against module's actual exports