### PR TITLE
feat: test verbosity configurable in pyde.toml

### DIFF
--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -8,7 +8,25 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub compiler: CompilerSection,
     #[serde(default)]
+    pub testing: TestSection,
+    #[serde(default)]
     pub networks: HashMap<String, NetworkConfig>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(default)]
+pub struct TestSection {
+    /// Default verbosity for execution traces (0=silent, 1=calls, 2=storage, 3=full).
+    /// CLI -v flag overrides this.
+    pub verbosity: u8,
+}
+
+impl Default for TestSection {
+    fn default() -> Self {
+        Self {
+            verbosity: 0,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -87,6 +105,9 @@ optimize = true
 src = "src"
 test = "test"
 out = "out"
+
+[testing]
+verbosity = 0    # 0=silent, 1=calls, 2=storage, 3=full traces
 
 [networks.devnet]
 rpc_url = "http://127.0.0.1:8545"

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -7,8 +7,11 @@ use std::fs;
 use std::time::Instant;
 
 pub fn run(filter: Option<&str>, verbosity: u8) -> Result<(), String> {
-    let trace_verbosity = Verbosity::from_count(verbosity);
     let (config, root) = project::load_config()?;
+
+    // Resolve verbosity: CLI flag overrides pyde.toml config
+    let effective_verbosity = if verbosity > 0 { verbosity } else { config.testing.verbosity };
+    let trace_verbosity = Verbosity::from_count(effective_verbosity);
 
     // Build src/ contracts first (tests may depend on them)
     println!("  Building contracts...");


### PR DESCRIPTION
## Summary
- Add `[testing]` section to pyde.toml with `verbosity` setting (0-3)
- CLI `-v` flag overrides config value, config used when CLI is 0
- Default template includes the new section