### PR TITLE
feat: ephemeral return_data in transaction receipts

### DIFF
--- a/crates/node/src/receipt_store.rs
+++ b/crates/node/src/receipt_store.rs
@@ -114,6 +114,7 @@ mod tests {
             fee_validator: 0,
             logs: vec![],
             state_root: H256::zero(),
+            return_data: vec![],
         }
     }
 
@@ -163,6 +164,7 @@ mod tests {
                 LogEntry { address: [0xDD; 32], topics: vec![], data: vec![4, 5] },
             ],
             state_root: H256::zero(),
+            return_data: vec![],
         };
         store.insert_block_receipts(5, vec![receipt]);
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -786,7 +786,7 @@ async fn parse_call_object(
 }
 
 fn receipt_to_json(receipt: &Receipt) -> serde_json::Value {
-    serde_json::json!({
+    let mut json = serde_json::json!({
         "txHash": format!("0x{}", hex::encode(receipt.tx_hash)),
         "success": receipt.success,
         "gasUsed": format!("0x{:x}", receipt.gas_used),
@@ -799,7 +799,14 @@ fn receipt_to_json(receipt: &Receipt) -> serde_json::Value {
             "topics": l.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
             "data": format!("0x{}", hex::encode(&l.data)),
         })).collect::<Vec<_>>(),
-    })
+    });
+    // Include return_data if non-empty (ephemeral — not persisted to disk)
+    if !receipt.return_data.is_empty() {
+        json["returnData"] = serde_json::Value::String(
+            format!("0x{}", hex::encode(&receipt.return_data))
+        );
+    }
+    json
 }
 
 /// Read balance from Account bytes (try Account::from_bytes, fall back to raw u128).
@@ -888,6 +895,7 @@ mod tests {
             fee_validator: 210000,
             logs: vec![],
             state_root: sparse_merkle_tree::H256::zero(),
+            return_data: vec![],
         };
         let json = receipt_to_json(&receipt);
         assert_eq!(json["success"], true);

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -23,9 +23,7 @@ pub struct TestSection {
 
 impl Default for TestSection {
     fn default() -> Self {
-        Self {
-            verbosity: 0,
-        }
+        Self { verbosity: 0 }
     }
 }
 
@@ -66,24 +64,32 @@ pub struct NetworkConfig {
     pub chain_id: u64,
 }
 
-fn default_true() -> bool { true }
-fn default_src() -> String { "src".into() }
-fn default_test() -> String { "test".into() }
-fn default_out() -> String { "out".into() }
+fn default_true() -> bool {
+    true
+}
+fn default_src() -> String {
+    "src".into()
+}
+fn default_test() -> String {
+    "test".into()
+}
+fn default_out() -> String {
+    "out".into()
+}
 
 /// Find pyde.toml by walking up from the current directory.
 /// Returns (config, project_root_dir).
 pub fn load_config() -> Result<(ProjectConfig, PathBuf), String> {
-    let mut dir = std::env::current_dir()
-        .map_err(|e| format!("cannot read current directory: {}", e))?;
+    let mut dir =
+        std::env::current_dir().map_err(|e| format!("cannot read current directory: {}", e))?;
 
     loop {
         let config_path = dir.join("pyde.toml");
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)
                 .map_err(|e| format!("cannot read {}: {}", config_path.display(), e))?;
-            let config: ProjectConfig = toml::from_str(&content)
-                .map_err(|e| format!("invalid pyde.toml: {}", e))?;
+            let config: ProjectConfig =
+                toml::from_str(&content).map_err(|e| format!("invalid pyde.toml: {}", e))?;
             return Ok((config, dir));
         }
         if !dir.pop() {

--- a/crates/tx/src/execution.rs
+++ b/crates/tx/src/execution.rs
@@ -42,6 +42,10 @@ pub struct Receipt {
     pub logs: Vec<LogEntry>,
     /// Post-execution state root (if available).
     pub state_root: H256,
+    /// Ephemeral return data from execution (NOT persisted to disk).
+    /// Available in the RPC response immediately after execution,
+    /// pruned with the receipt after MAX_RECEIPT_SLOTS.
+    pub return_data: Vec<u8>,
 }
 
 /// A log entry in the receipt.
@@ -184,6 +188,7 @@ pub fn generate_receipt(
     base_fee: u128,
     logs: Vec<LogEntry>,
     state_root: H256,
+    return_data: Vec<u8>,
 ) -> Receipt {
     let fee = distribute_fee(effective_gas, base_fee);
     Receipt {
@@ -197,6 +202,7 @@ pub fn generate_receipt(
         fee_validator: fee.validator,
         logs,
         state_root,
+        return_data,
     }
 }
 
@@ -378,6 +384,7 @@ mod tests {
             base_fee,
             logs.clone(),
             H256::zero(),
+            vec![],
         );
 
         assert!(receipt.success);
@@ -397,7 +404,7 @@ mod tests {
     fn failed_tx_receipt() {
         let tx = make_tx(0, 21_000);
         let receipt = generate_receipt(
-            &tx, false, 21_000, 0, 21_000, 100, vec![], H256::zero(),
+            &tx, false, 21_000, 0, 21_000, 100, vec![], H256::zero(), vec![],
         );
         assert!(!receipt.success);
         assert_eq!(receipt.gas_used, 21_000);

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -162,7 +162,7 @@ pub fn execute_transaction(
         .map_err(|e| PipelineError::ExecutionFailed(e))?;
 
     // 6. PVM execution (if contract call or deployment)
-    let (success, gas_used, gas_refund, logs) = match tx.tx_type {
+    let (success, gas_used, gas_refund, logs, return_data) = match tx.tx_type {
         TransactionType::Standard if tx.to != ZERO_ADDRESS => {
             // Contract call
             match load_code(smt, &tx.to) {
@@ -172,7 +172,7 @@ pub fn execute_transaction(
                 }
                 None => {
                     tracing::debug!(to = hex::encode(tx.to), "simple transfer (no code at recipient)");
-                    (true, 21_000u64, 0u64, vec![])
+                    (true, 21_000u64, 0u64, vec![], vec![])
                 }
             }
         }
@@ -233,7 +233,7 @@ pub fn execute_transaction(
                         contract = hex::encode(new_addr),
                         "executing constructor"
                     );
-                    let (success, gas, _, logs) = execute_in_pvm(
+                    let (success, gas, _, logs, _) = execute_in_pvm(
                         &constructor_tx, &sender, constructor, smt, block_ctx,
                     );
                     if !success {
@@ -258,11 +258,11 @@ pub fn execute_transaction(
                 (tx.data.clone(), 32_000u64)
             };
 
-            (true, gas_used, 0u64, vec![])
+            (true, gas_used, 0u64, vec![], vec![])
         }
         _ => {
             // Simple transfer or batch (batch deferred)
-            (true, 21_000u64, 0u64, vec![])
+            (true, 21_000u64, 0u64, vec![], vec![])
         }
     };
 
@@ -312,6 +312,7 @@ pub fn execute_transaction(
         block_ctx.base_fee,
         logs,
         state_root,
+        return_data,
     );
 
     Ok(receipt)
@@ -325,7 +326,7 @@ fn execute_in_pvm(
     code: &[u8],
     smt: &mut PydeSMT,
     block_ctx: &BlockContext,
-) -> (bool, u64, u64, Vec<LogEntry>) {
+) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
     let ctx = ExecutionContext {
         caller: tx.from,
         self_address: tx.to,
@@ -374,7 +375,7 @@ fn execute_in_pvm(
     }));
 
     if vm.load(code).is_err() {
-        return (false, tx.gas_limit, 0, vec![]);
+        return (false, tx.gas_limit, 0, vec![], vec![]);
     }
 
     let output = vm.execute();
@@ -424,7 +425,8 @@ fn execute_in_pvm(
         })
         .collect();
 
-    (success, output.gas_used as u64, output.gas_refund, logs)
+    let return_data = vm.return_data.clone();
+    (success, output.gas_used as u64, output.gas_refund, logs, return_data)
 }
 
 /// Execute a block of transactions using parallel group scheduling.


### PR DESCRIPTION
## Summary
- Add `return_data: Vec<u8>` to Receipt — captures function return values and revert data
- Included in `receipt_to_json` RPC response when non-empty (`returnData` field)
- NOT persisted to disk — in-memory ReceiptStore, pruned with receipt
- Enables script runner to read return values after broadcast