### PR TITLE
feat: script runner with RPC bridge and ABI encoding for complex types

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -418,26 +418,25 @@ impl PydeApiServer for RpcServer {
         let success = output.outcome == pyde_vm::vm::Outcome::Success;
 
         if success {
-            // Check r2 for blob return (Struct/Vec/String): r1=pointer, r2=byte_length
+            // Return value convention:
+            // - GP return (u64, bool): r1 = value, r2 = 0
+            // - Wide return (u256, Address): stored at heap, r1 = ptr, r2 = 32
+            // - Blob return (String, Vec, Struct): r1 = ptr, r2 = len
+            // Format: numeric values as BE hex (matches Ethereum convention).
             let r2 = vm.cpu.read_gp(2);
-            if r2 > 0 {
-                let r1 = vm.cpu.read_gp(1) as usize;
-                let len = r2 as usize;
-                // Read serialized blob from VM memory
-                let blob = vm.memory.load_bytes(r1, len);
+            let r1 = vm.cpu.read_gp(1);
+            if r2 == 32 {
+                // Wide return (u256/Address): 32 bytes on heap, return as BE hex
+                let blob = vm.memory.load_bytes(r1 as usize, 32);
+                let val = ethnum::U256::from_le_bytes(blob.try_into().unwrap_or([0u8; 32]));
+                Ok(format!("0x{:x}", val))
+            } else if r2 > 0 {
+                // Blob return (String, Vec, Struct): raw serialized bytes
+                let blob = vm.memory.load_bytes(r1 as usize, r2 as usize);
                 Ok(format!("0x{}", hex::encode(blob)))
             } else {
-                // Check wide register w0 for Address/u256 returns
-                let w0 = vm.cpu.read_wide(0);
-                if w0 != ethnum::U256::ZERO {
-                    // Wide return: format as full 32-byte hex
-                    let bytes = w0.to_le_bytes();
-                    Ok(format!("0x{}", hex::encode(bytes)))
-                } else {
-                    // GP return: r1
-                    let return_value = vm.cpu.read_gp(1);
-                    Ok(format!("0x{:x}", return_value))
-                }
+                // GP return: r1 as integer
+                Ok(format!("0x{:x}", r1))
             }
         } else {
             Err(rpc_err(-32000, format!("execution failed: {:?}", output.outcome)))

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -315,27 +315,8 @@ impl PydeApiServer for RpcServer {
             tx_type,
         };
 
-        // Compute tx hash
-        let tx_bytes = crate::wire::encode_transaction(&tx);
-        let tx_hash = pyde_crypto::poseidon2::poseidon2_hash(&tx_bytes).to_bytes();
-
-        // For deploy txs, compute the contract address.
-        // Use Account.nonce (always 0 in devnet since pipeline doesn't increment Account.nonce).
-        // This matches what the pipeline uses: derive_create_address(&from, sender.nonce).
-        let contract_address = if tx_type == pyde_tx::types::TransactionType::Deploy {
-            // Read the account nonce from state (matches pipeline's sender.nonce)
-            let state = self.state.state.read().await;
-            let balance_key = pyde_state::keys::balance_key(&from);
-            let account_nonce = state.get(&balance_key)
-                .and_then(|b| pyde_account::types::Account::from_bytes(&b))
-                .map(|a| a.nonce)
-                .unwrap_or(0);
-            drop(state);
-            let addr = pyde_account::address::derive_create_address(&from, account_nonce);
-            Some(format!("0x{}", hex::encode(addr)))
-        } else {
-            None
-        };
+        // Compute tx hash (must match tx.hash() used in receipt generation)
+        let tx_hash = tx.hash();
 
         // Add to pending tx queue
         let mut pending = self.state.pending_txs.write().await;
@@ -343,22 +324,18 @@ impl PydeApiServer for RpcServer {
         let queue_size = pending.len();
         drop(pending);
 
+        let tx_hash_hex = format!("0x{}", hex::encode(tx_hash));
         info!(
-            tx_hash = hex::encode(tx_hash),
+            tx_hash = %tx_hash_hex,
             queue_size,
-            contract = ?contract_address,
             "transaction accepted into pending queue"
         );
 
-        // Return tx hash + contract address for deploys
-        if let Some(addr) = contract_address {
-            Ok(serde_json::json!({
-                "txHash": format!("0x{}", hex::encode(tx_hash)),
-                "contractAddress": addr,
-            }).to_string())
-        } else {
-            Ok(format!("0x{}", hex::encode(tx_hash)))
-        }
+        // Return tx hash only. For deploys, the contract address is in the
+        // receipt's returnData (authoritative, computed at execution time).
+        Ok(serde_json::json!({
+            "txHash": tx_hash_hex,
+        }).to_string())
     }
 
     async fn send_raw_transaction(&self, tx_hex: String) -> Result<String, ErrorObjectOwned> {
@@ -367,7 +344,7 @@ impl PydeApiServer for RpcServer {
             .map_err(|e| rpc_err(-32602, format!("invalid tx hex: {}", e)))?;
         let tx = crate::wire::decode_transaction(&tx_bytes)
             .map_err(|e| rpc_err(-32602, format!("invalid tx encoding: {}", e)))?;
-        let tx_hash = pyde_crypto::poseidon2::poseidon2_hash(&tx_bytes).to_bytes();
+        let tx_hash = tx.hash();
 
         let mut pending = self.state.pending_txs.write().await;
         pending.push(tx);
@@ -515,7 +492,29 @@ impl PydeApiServer for RpcServer {
             state_guard.get(&smt_key)
         }));
         let output = vm.execute();
-        Ok(format!("0x{:x}", output.gas_used))
+
+        // Return actual function output (not gas_used).
+        // Uses same r1/r2 convention as do_ext_call and pipeline return_data capture.
+        let return_data = if output.outcome == pyde_vm::vm::Outcome::Success {
+            let r2 = vm.cpu.read_gp(2);
+            if r2 > 0 {
+                // Blob/wide return: r1 = pointer, r2 = length
+                let ptr = vm.cpu.read_gp(1) as usize;
+                let len = (r2 as usize).min(pyde_vm::memory::MEMORY_SIZE);
+                if ptr + len <= pyde_vm::memory::MEMORY_SIZE {
+                    vm.memory.load_bytes(ptr, len)
+                } else {
+                    vm.cpu.read_gp(1).to_le_bytes().to_vec()
+                }
+            } else {
+                // GP return: r1 = value (8 bytes LE)
+                vm.cpu.read_gp(1).to_le_bytes().to_vec()
+            }
+        } else {
+            vec![]
+        };
+
+        Ok(format!("0x{}", hex::encode(&return_data)))
     }
 
     async fn get_transaction_receipt(&self, tx_hash: String) -> Result<serde_json::Value, ErrorObjectOwned> {

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -2125,13 +2125,11 @@ impl CodeGen {
                 } else if blob_return {
                     // Blob return (String, Vec, Struct, Bytes): callee set r1=ptr, r2=len.
                     // The blob data is in child memory — PVM's do_ext_call copied it to
-                    // parent heap at r12. Unflatten from (r1, r2) into destination.
+                    // parent heap at r12. Unflatten from r1 (src) into rd (dst).
                     let rd = self.alloc_gp(*dst);
                     // r1 = heap pointer to blob data, r2 = blob length
-                    // Set r12 past the blob for future allocations
-                    self.emit_op(Opcode::Add, 12, 1, 2); // r12 = r1 + r2
-                    // Unflatten from r1 into destination register
-                    self.emit_unflatten(ret_ty, rd, 1);
+                    // Unflatten: src=r1 (blob pointer), dst=rd
+                    self.emit_unflatten(ret_ty, 1, rd);
                 } else {
                     // GP return (u64, bool, etc.): PVM set r1 = value
                     let rd = self.alloc_gp(*dst);
@@ -2220,23 +2218,64 @@ impl CodeGen {
                 // and sets blob_reg = r12, then advances r12.
                 // Now r12 is right after the blob — perfect for appending args.
 
-                // Write constructor args (LE u64 each) after the blob
-                for (i, (arg, _ty)) in args.iter().enumerate() {
-                    let ra = self.get_reg(*arg);
-                    self.emit_store(ra, 12, (i as i32) * 8);
-                }
-                let args_size = (args.len() as u32) * 8;
+                // Write constructor args after the blob.
+                // r12 points to right after the blob — append args here.
+                let has_blob_args = args.iter().any(|(_, ty)| matches!(ty,
+                    Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_)));
 
-                // Restore blob pointer from stack
-                self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = blob pointer (restored)
+                if !has_blob_args {
+                    // All fixed-size: use static offsets (original path)
+                    for (i, (arg, _ty)) in args.iter().enumerate() {
+                        let ra = self.get_reg(*arg);
+                        self.emit_store(ra, 12, (i as i32) * 8);
+                    }
+                    let args_size = (args.len() as u32) * 8;
 
-                // Total length = blob_size (r12 - rb) + args_size
-                // r14 = r12 - r15 (blob size)
-                self.emit_op(Opcode::Sub, 14, 12, 15);
-                // r14 += args_size (total deploy data length)
-                if args_size > 0 {
-                    self.emit_op(Opcode::Addi, 14, 14, args_size);
-                    self.emit_op(Opcode::Addi, 12, 12, args_size); // advance heap past args
+                    self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = blob pointer
+                    self.emit_op(Opcode::Sub, 14, 12, 15); // r14 = blob_size
+                    if args_size > 0 {
+                        self.emit_op(Opcode::Addi, 14, 14, args_size);
+                        self.emit_op(Opcode::Addi, 12, 12, args_size);
+                    }
+                } else {
+                    // Has blob args: get_reg for each arg FIRST (into safe regs
+                    // or stack), then serialize. emit_flatten clobbers r14/r15.
+                    // Strategy: push all arg values to stack, then pop and serialize.
+                    let mut arg_info: Vec<(Ty, bool)> = Vec::new();
+                    for (arg, ty) in args.iter().rev() {
+                        // Push args in reverse so first arg pops first
+                        let r = self.get_reg(*arg);
+                        self.emit_op(Opcode::Push, r, 0, 0);
+                        let is_blob = matches!(ty,
+                            Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_));
+                        arg_info.push((ty.clone(), is_blob));
+                    }
+                    arg_info.reverse(); // back to original order
+
+                    for (ty, is_blob) in &arg_info {
+                        // Pop arg value into r11 (safe from emit_flatten's r14/r15)
+                        self.emit_op(Opcode::Pop, 11, 0, 0);
+                        if matches!(ty, Ty::StringTy | Ty::Bytes) {
+                            self.emit_flatten(ty, 11);
+                        } else if matches!(ty, Ty::Vec(_) | Ty::Struct(_)) {
+                            // Wrap with byte_len prefix
+                            self.emit_op(Opcode::Push, 12, 0, 0); // save start
+                            self.emit_op(Opcode::Addi, 12, 12, 8);
+                            self.emit_flatten(ty, 11);
+                            self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = start
+                            self.emit_op(Opcode::Addi, 14, 15, 8);
+                            self.emit_op(Opcode::Sub, 14, 12, 14);
+                            self.emit_store(14, 15, 0);
+                        } else if !is_blob {
+                            // GP arg
+                            self.emit_store(11, 12, 0);
+                            self.emit_op(Opcode::Addi, 12, 12, 8);
+                        }
+                    }
+
+                    // Pop blob pointer, compute total length
+                    self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = blob pointer
+                    self.emit_op(Opcode::Sub, 14, 12, 15); // r14 = total length
                 }
 
                 // Create: wd = new address, rs1 = blob pointer (r15), imm[3:0] = length register (r14)

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -1999,27 +1999,34 @@ impl CodeGen {
 
             Inst::ExtCall(dst, addr, method, args, ret_ty) => {
                 let wide_return = is_wide_type(ret_ty);
+                let blob_return = matches!(ret_ty, Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_));
                 let ra = self.get_reg(*addr);
 
-                // Write calldata to heap: [selector(4 BE bytes)][arg0(8 LE)][arg1(8 LE)]...
-                // Selector: FNV-1a hash stored as BE bytes in calldata (dispatch
-                // loads with W32 LE and compares against selector.swap_bytes()).
+                // Save calldata start for dynamic length calculation
+                self.emit_op(Opcode::Push, 12, 0, 0); // save r12 = calldata start
+
+                // Write calldata to heap: [selector(4 BE bytes)][arg0][arg1]...
                 let selector = compute_selector(method);
-                // Store selector bytes in BE order to match the dispatch convention
                 let sel_be = selector.to_be_bytes();
-                let sel_as_le_u32 = u32::from_le_bytes(sel_be); // reinterpret BE bytes as LE u32
+                let sel_as_le_u32 = u32::from_le_bytes(sel_be);
                 self.load_u32_to_reg(15, sel_as_le_u32);
                 let sel_imm = encode_mem_immediate(0, MemWidth::W32).unwrap();
                 self.emit(encode(Opcode::Store, 15, 12, sel_imm));
 
                 // Write args after selector (offset 4)
-                // Wide args (Address, u256) get 32 bytes via Wstore.
-                // GP args get 8 bytes via Store.
+                // GP args: 8 bytes via Store. Wide args: 32 bytes via Wstore.
+                // Blob args (String, Vec, Struct, Bytes): [byte_len:8][flat data].
                 let mut arg_offset: i32 = 4;
-                for arg in args.iter() {
-                    let r = self.get_reg(*arg);
-                    if self.regs.is_wide(*arg) {
+                let mut has_blob_args = false;
+                for (arg, ty) in args.iter() {
+                    let is_blob = matches!(ty,
+                        Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_));
+                    if is_blob {
+                        has_blob_args = true;
+                    }
+                    if is_wide_type(ty) {
                         // Wide arg: 32 bytes
+                        let r = self.get_reg(*arg);
                         if arg_offset != 0 {
                             self.emit_op(Opcode::Addi, 15, 12, arg_offset as u32 & 0x3FFFF);
                             self.emit_op(Opcode::Wstore, r, 15, 0);
@@ -2027,16 +2034,75 @@ impl CodeGen {
                             self.emit_op(Opcode::Wstore, r, 12, 0);
                         }
                         arg_offset += 32;
+                    } else if matches!(ty, Ty::StringTy | Ty::Bytes) {
+                        // String/Bytes: emit_flatten already writes [byte_len:8][data]
+                        // which is exactly what the callee expects. No wrapping needed.
+                        if arg_offset > 0 {
+                            self.emit_op(Opcode::Addi, 12, 12, arg_offset as u32 & 0x3FFFF);
+                            arg_offset = 0;
+                        }
+                        // Move arg to safe register — emit_flatten clobbers r14/r15
+                        let r = self.get_reg(*arg);
+                        if r == 14 || r == 15 {
+                            self.emit_op(Opcode::Add, 11, r, 0);
+                            self.emit_flatten(ty, 11);
+                        } else {
+                            self.emit_flatten(ty, r);
+                        }
+                    } else if matches!(ty, Ty::Vec(_) | Ty::Struct(_)) {
+                        // Vec/Struct: callee expects [byte_len:8][flat data].
+                        // emit_flatten writes raw fields/elements (no byte_len prefix).
+                        // Wrap with byte_len placeholder → flatten → patch.
+                        if arg_offset > 0 {
+                            self.emit_op(Opcode::Addi, 12, 12, arg_offset as u32 & 0x3FFFF);
+                            arg_offset = 0;
+                        }
+                        // Move arg to safe register — emit_flatten clobbers r14/r15
+                        let r = self.get_reg(*arg);
+                        let safe_r = if r == 14 || r == 15 {
+                            self.emit_op(Opcode::Add, 11, r, 0); 11
+                        } else { r };
+                        self.emit_op(Opcode::Push, 12, 0, 0); // save start for byte_len patch
+                        self.emit_op(Opcode::Addi, 12, 12, 8); // skip byte_len placeholder
+                        self.emit_flatten(ty, safe_r);
+                        // Compute byte_len = r12 - (start + 8), patch it
+                        self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = start
+                        self.emit_op(Opcode::Addi, 14, 15, 8); // r14 = data_start
+                        self.emit_op(Opcode::Sub, 14, 12, 14); // r14 = byte_len
+                        self.emit_store(14, 15, 0); // patch byte_len at start
                     } else {
                         // GP arg: 8 bytes
+                        let r = self.get_reg(*arg);
                         self.emit_store(r, 12, arg_offset);
                         arg_offset += 8;
                     }
                 }
-                let calldata_len = arg_offset as u32;
+                // Compute calldata length: if blob args present, length is dynamic (r12 - start)
+                // Otherwise it's a compile-time constant.
+                if has_blob_args {
+                    // r12 is already past all data; calldata_len = r12 - calldata_start
+                    // We need the original calldata start (before selector). It was r12 at entry.
+                    // But r12 has been modified. Use a different approach:
+                    // We'll compute length via register at CallExt time.
+                    // For now, advance past any trailing fixed offset
+                    if arg_offset > 0 {
+                        self.emit_op(Opcode::Addi, 12, 12, arg_offset as u32 & 0x3FFFF);
+                    }
+                }
+                let static_calldata_len = if !has_blob_args { arg_offset as u32 } else { 0 };
 
                 // Set up CallExt: rd=target(wide), rs1=calldata_ptr(r12), imm=len/gas/result
-                self.emit_op(Opcode::Addi, 14, 0, calldata_len); // r14 = calldata len
+                // Pop the calldata start we saved before the selector write.
+                self.emit_op(Opcode::Pop, 14, 0, 0); // r14 = calldata_start
+                if has_blob_args {
+                    // Dynamic length: r14 = r12 - calldata_start
+                    self.emit_op(Opcode::Sub, 14, 12, 14); // r14 = total calldata len
+                    // Restore r12 to calldata start for the CallExt rs1 operand
+                    self.emit_op(Opcode::Sub, 12, 12, 14); // r12 = calldata start
+                } else {
+                    // Static length — r14 is the calldata_start (not needed), overwrite with len
+                    self.emit_op(Opcode::Addi, 14, 0, static_calldata_len);
+                }
                 self.emit_op(Opcode::Caller, 15, 0, 2); // r15 = gas_remaining
                 let imm = (14 & 0xF)           // len_reg = r14
                     | ((15 & 0xF) << 4)         // gas_reg = r15
@@ -2047,7 +2113,7 @@ impl CodeGen {
                 self.emit_op(Opcode::Pop, 13, 0, 0); // restore spill base
 
                 // Advance heap past calldata
-                self.emit_op(Opcode::Addi, 12, 12, calldata_len);
+                self.emit_op(Opcode::Add, 12, 12, 14); // r12 += calldata_len
 
                 if wide_return {
                     // Wide return (u256, Address): PVM wrote 32 bytes to parent heap
@@ -2056,6 +2122,16 @@ impl CodeGen {
                     self.emit_op(Opcode::Wload, wd, 1, 0);
                     // Advance heap past the 32-byte return data
                     self.emit_op(Opcode::Addi, 12, 12, 32);
+                } else if blob_return {
+                    // Blob return (String, Vec, Struct, Bytes): callee set r1=ptr, r2=len.
+                    // The blob data is in child memory — PVM's do_ext_call copied it to
+                    // parent heap at r12. Unflatten from (r1, r2) into destination.
+                    let rd = self.alloc_gp(*dst);
+                    // r1 = heap pointer to blob data, r2 = blob length
+                    // Set r12 past the blob for future allocations
+                    self.emit_op(Opcode::Add, 12, 1, 2); // r12 = r1 + r2
+                    // Unflatten from r1 into destination register
+                    self.emit_unflatten(ret_ty, rd, 1);
                 } else {
                     // GP return (u64, bool, etc.): PVM set r1 = value
                     let rd = self.alloc_gp(*dst);
@@ -2145,7 +2221,7 @@ impl CodeGen {
                 // Now r12 is right after the blob — perfect for appending args.
 
                 // Write constructor args (LE u64 each) after the blob
-                for (i, arg) in args.iter().enumerate() {
+                for (i, (arg, _ty)) in args.iter().enumerate() {
                     let ra = self.get_reg(*arg);
                     self.emit_store(ra, 12, (i as i32) * 8);
                 }

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -2041,7 +2041,10 @@ impl CodeGen {
                 let imm = (14 & 0xF)           // len_reg = r14
                     | ((15 & 0xF) << 4)         // gas_reg = r15
                     | ((13 & 0xF) << 8); // result_reg = r13
+                // Save r13 (spill base) — CallExt overwrites it with success flag
+                self.emit_op(Opcode::Push, 13, 0, 0);
                 self.emit_op(Opcode::CallExt, ra, 12, imm);
+                self.emit_op(Opcode::Pop, 13, 0, 0); // restore spill base
 
                 // Advance heap past calldata
                 self.emit_op(Opcode::Addi, 12, 12, calldata_len);
@@ -2113,7 +2116,10 @@ impl CodeGen {
                 let imm = (14 & 0xF)           // len_reg = r14
                     | ((15 & 0xF) << 4)         // gas_reg = r15
                     | ((13 & 0xF) << 8); // result_reg = r13
+                // Save r13 (spill base) — CallExt overwrites it with success flag
+                self.emit_op(Opcode::Push, 13, 0, 0);
                 self.emit_op(Opcode::CallExt, rt, 12, imm);
+                self.emit_op(Opcode::Pop, 13, 0, 0); // restore spill base
 
                 // Advance heap past calldata
                 self.emit_op(Opcode::Addi, 12, 12, calldata_len);

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -729,24 +729,29 @@ impl CodeGen {
                         8,
                     );
                     self.emit_op(Opcode::Memcpy, 12, memory::REG_SCRATCH_0, 15);
+                    // Compute align8(byte_len) and advance heap
                     self.emit_op(Opcode::Addi, 14, 15, 7);
                     self.emit_op(Opcode::Addi, 15, 0, 3);
                     self.emit_op(Opcode::Shr, 14, 14, 15);
                     self.emit_op(Opcode::Shl, 14, 14, 15);
                     self.emit_op(Opcode::Add, 12, 12, 14);
-                    self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0);
+                    // Save align8(byte_len) before restoring cursor
+                    self.emit_op(Opcode::Push, 14, 0, 0);
+                    // Restore cursor: old_cursor + 8 (byte_len field) + align8 (data)
+                    self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = align8(byte_len)
+                    self.emit_op(Opcode::Pop, memory::REG_SCRATCH_0, 0, 0); // r14 = old cursor
                     self.emit_op(
                         Opcode::Addi,
                         memory::REG_SCRATCH_0,
                         memory::REG_SCRATCH_0,
                         8,
-                    );
+                    ); // cursor += 8 (past byte_len)
                     self.emit_op(
                         Opcode::Add,
                         memory::REG_SCRATCH_0,
                         memory::REG_SCRATCH_0,
-                        14,
-                    );
+                        15,
+                    ); // cursor += align8(byte_len)
                 } else if is_wide_type(ty) {
                     self.emit_op(Opcode::Wload, phys, memory::REG_SCRATCH_0, 0);
                     self.emit_op(
@@ -2025,13 +2030,21 @@ impl CodeGen {
                         has_blob_args = true;
                     }
                     if is_wide_type(ty) {
-                        // Wide arg: 32 bytes
+                        // Wide arg: 32 bytes via Wstore
                         let r = self.get_reg(*arg);
+                        // If the value is in a GP register (e.g., small u256 literal),
+                        // widen it to a wide register first.
+                        let wr = if !self.regs.is_wide(*arg) {
+                            self.emit_op(Opcode::Widen, WIDE_SCRATCH, r, 0);
+                            WIDE_SCRATCH
+                        } else {
+                            r
+                        };
                         if arg_offset != 0 {
                             self.emit_op(Opcode::Addi, 15, 12, arg_offset as u32 & 0x3FFFF);
-                            self.emit_op(Opcode::Wstore, r, 15, 0);
+                            self.emit_op(Opcode::Wstore, wr, 15, 0);
                         } else {
-                            self.emit_op(Opcode::Wstore, r, 12, 0);
+                            self.emit_op(Opcode::Wstore, wr, 12, 0);
                         }
                         arg_offset += 32;
                     } else if matches!(ty, Ty::StringTy | Ty::Bytes) {

--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -273,8 +273,8 @@ pub enum Inst {
     /// `%dst = method_call %obj, "method", [args...]`
     MethodCall(Reg, Reg, String, Vec<Reg>),
 
-    /// `ext_call %interface_addr, "method", [args...], return_type`
-    ExtCall(Reg, Reg, String, Vec<Reg>, Ty),
+    /// `ext_call %interface_addr, "method", [(arg, type)...], return_type`
+    ExtCall(Reg, Reg, String, Vec<(Reg, Ty)>, Ty),
 
     /// `%dst = hash [args...]`
     Hash(Reg, Vec<Reg>),
@@ -322,7 +322,7 @@ pub enum Inst {
 
     /// `%addr = create %deploy_blob, [constructor_args...]` — deploy a new contract.
     /// deploy_blob holds the deploy-format bytes. Returns Address.
-    CreateContract(Reg, Reg, Vec<Reg>),
+    CreateContract(Reg, Reg, Vec<(Reg, Ty)>),
 
     /// `br @label` — unconditional jump
     Jump(Label),
@@ -489,7 +489,7 @@ impl fmt::Display for Inst {
                 write!(f, "{} = {}.{}({})", dst, obj, method, args_str.join(", "))
             }
             Inst::ExtCall(dst, addr, method, args, ret_ty) => {
-                let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
+                let args_str: Vec<String> = args.iter().map(|(r, t)| format!("{}:{}", r, t)).collect();
                 write!(f, "{}: {} = ext_call {}, \"{}\"({})", dst, ret_ty, addr, method, args_str.join(", "))
             }
             Inst::Hash(dst, args) => {
@@ -534,7 +534,7 @@ impl fmt::Display for Inst {
                 write!(f, "{} = raw_call {}({})", dst, target, args_str.join(", "))
             }
             Inst::CreateContract(dst, blob, args) => {
-                let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
+                let args_str: Vec<String> = args.iter().map(|(r, t)| format!("{}:{}", r, t)).collect();
                 write!(f, "{} = create({}, [{}])", dst, blob, args_str.join(", "))
             }
             Inst::Jump(label) => write!(f, "jump {}", label),

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -196,6 +196,22 @@ impl Lowerer {
         self.reg_types.insert(reg.0, ty);
     }
 
+    /// If the argument is a hex literal, re-emit it as an Address constant
+    /// so the byte order is correct (hex digits = BE, PVM addresses = LE bytes).
+    fn ensure_address_bytes(&mut self, addr_reg: Reg, args: &[Expr]) -> Reg {
+        // Check if the first argument is an integer literal (hex address)
+        if let Some(Expr::Literal(Literal::Int(v), _)) = args.first() {
+            if *v > ethnum::U256::from(u64::MAX) {
+                // Convert numeric value to raw address bytes (BE → LE)
+                let be_bytes = v.to_be_bytes();
+                let new_reg = self.alloc_reg();
+                self.emit(Inst::Const(new_reg, IrConst::Address(be_bytes)));
+                return new_reg;
+            }
+        }
+        addr_reg
+    }
+
     /// Look up the type of a register (Contract/Interface handles).
     fn get_reg_type(&self, reg: Reg) -> Option<&Ty> {
         self.reg_types.get(&reg.0)
@@ -875,7 +891,13 @@ impl Lowerer {
             Expr::Literal(lit, _) => {
                 let dst = self.alloc_reg();
                 let val = match lit {
-                    Literal::Int(v) => IrConst::Int(*v, Ty::U64),
+                    Literal::Int(v) => {
+                        if *v > ethnum::U256::from(u64::MAX) {
+                            IrConst::Int(*v, Ty::U256)
+                        } else {
+                            IrConst::Int(*v, Ty::U64)
+                        }
+                    }
                     Literal::String(s) => IrConst::String(s.clone()),
                     Literal::Bool(b) => IrConst::Bool(*b),
                 };
@@ -1114,16 +1136,20 @@ impl Lowerer {
                             // Interface::at(address) → typed interface handle
                             if member == "at" && self.interface_functions.contains_key(type_name) {
                                 if let Some(addr_reg) = arg_regs.first() {
-                                    // at() is a no-op at runtime — just tracks the type
-                                    self.set_local_type_for_reg(*addr_reg, Ty::Interface(type_name.to_string()));
-                                    return *addr_reg;
+                                    // at() is a no-op at runtime — just tracks the type.
+                                    // If the arg is a hex literal, convert to address bytes
+                                    // so the byte order is correct (hex = BE, PVM = LE bytes).
+                                    let reg = self.ensure_address_bytes(*addr_reg, args);
+                                    self.set_local_type_for_reg(reg, Ty::Interface(type_name.to_string()));
+                                    return reg;
                                 }
                             }
                             // Contract::at(address) → typed contract handle
                             if member == "at" && self.contract_functions.contains_key(type_name) {
                                 if let Some(addr_reg) = arg_regs.first() {
-                                    self.set_local_type_for_reg(*addr_reg, Ty::Contract(type_name.to_string()));
-                                    return *addr_reg;
+                                    let reg = self.ensure_address_bytes(*addr_reg, args);
+                                    self.set_local_type_for_reg(reg, Ty::Contract(type_name.to_string()));
+                                    return reg;
                                 }
                             }
                         }
@@ -1350,9 +1376,11 @@ impl Lowerer {
 
                         let dst = self.alloc_reg();
 
-                        // First arg must be a contract name (path expression)
+                        // First arg must be a contract name (path or ident)
                         let contract_name = if let Some(Expr::Path(segments, _)) = positional.first() {
                             segments.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join("::")
+                        } else if let Some(Expr::Ident(ident)) = positional.first() {
+                            ident.name.clone()
                         } else {
                             self.emit(Inst::Comment("deploy! requires a contract name".into()));
                             return dst;
@@ -1497,7 +1525,13 @@ impl Lowerer {
                         Pattern::Literal(lit, _) => {
                             let pat_reg = self.alloc_reg();
                             let val = match lit {
-                                Literal::Int(v) => IrConst::Int(*v, Ty::U64),
+                                Literal::Int(v) => {
+                                    if *v > ethnum::U256::from(u64::MAX) {
+                                        IrConst::Int(*v, Ty::U256)
+                                    } else {
+                                        IrConst::Int(*v, Ty::U64)
+                                    }
+                                }
                                 Literal::String(s) => IrConst::String(s.clone()),
                                 Literal::Bool(b) => IrConst::Bool(*b),
                             };

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -233,6 +233,21 @@ impl Lowerer {
         Ty::U64
     }
 
+    /// Look up parameter types for a method on a contract or interface.
+    fn lookup_method_param_types(&self, type_name: &str, method_name: &str) -> Vec<Ty> {
+        if let Some(fns) = self.contract_functions.get(type_name) {
+            if let Some((_, params, _)) = fns.iter().find(|(n, _, _)| n == method_name) {
+                return params.iter().map(|(_, ty)| ty.clone()).collect();
+            }
+        }
+        if let Some(fns) = self.interface_functions.get(type_name) {
+            if let Some((_, params, _)) = fns.iter().find(|(n, _, _)| n == method_name) {
+                return params.iter().map(|(_, ty)| ty.clone()).collect();
+            }
+        }
+        vec![]
+    }
+
     /// Infer the type of an expression (best-effort, for local_types tracking).
     fn infer_expr_type(&self, expr: &ast::Expr) -> Option<Ty> {
         use crate::ast::Expr;
@@ -1116,7 +1131,11 @@ impl Lowerer {
                                 Some(Ty::Contract(ref name)) | Some(Ty::Interface(ref name)) => {
                                     // Typed contract/interface call → ExtCall
                                     let ret_ty = self.lookup_method_return_type(name, &method.name);
-                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), arg_regs, ret_ty));
+                                    let param_types = self.lookup_method_param_types(name, &method.name);
+                                    let typed_args: Vec<(Reg, Ty)> = arg_regs.iter().zip(
+                                        param_types.iter().chain(std::iter::repeat(&Ty::U64))
+                                    ).map(|(r, t)| (*r, t.clone())).collect();
+                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), typed_args, ret_ty));
                                 }
                                 _ => {
                                     self.emit(Inst::MethodCall(dst, obj_reg, method.name.clone(), arg_regs));
@@ -1356,8 +1375,10 @@ impl Lowerer {
 
                         if let Some(method) = method_name {
                             // Emit as ExtCall with the method name (codegen writes selector)
-                            // No type info available for raw_call — default to GP return
-                            self.emit(Inst::ExtCall(dst, target, method, param_regs, Ty::U64));
+                            // No type info available for raw_call — default args to GP
+                            let typed_params: Vec<(Reg, Ty)> = param_regs.iter()
+                                .map(|r| (*r, Ty::U64)).collect();
+                            self.emit(Inst::ExtCall(dst, target, method, typed_params, Ty::U64));
                         } else {
                             // No method name: emit as raw call (no selector)
                             self.emit(Inst::RawCall(dst, target, param_regs));
@@ -1413,18 +1434,22 @@ impl Lowerer {
                             )));
                         }
 
-                        // Lower constructor args (positional[1..])
+                        // Lower constructor args (positional[1..]) with type info
                         let arg_regs: Vec<Reg> = user_args.iter()
                             .map(|e| self.lower_expr(e))
                             .collect();
+                        let ctor_params = self.contract_constructors.get(&contract_name).cloned()
+                            .unwrap_or_default();
+                        let typed_args: Vec<(Reg, Ty)> = arg_regs.iter().zip(
+                            ctor_params.iter().map(|(_, ty)| ty).chain(std::iter::repeat(&Ty::U64))
+                        ).map(|(r, t)| (*r, t.clone())).collect();
 
                         // Emit: store deploy bytes as a constant blob
                         let blob_reg = self.alloc_reg();
                         self.emit(Inst::Const(blob_reg, IrConst::Bytes(deploy_bytes)));
 
-                        // CreateContract(dst, blob_reg, [arg_regs...])
-                        // The codegen will write blob + args to heap and emit Create.
-                        self.emit(Inst::CreateContract(dst, blob_reg, arg_regs));
+                        // CreateContract(dst, blob_reg, [(arg, type)...])
+                        self.emit(Inst::CreateContract(dst, blob_reg, typed_args));
 
                         // Tag the result register as Ty::Contract so method calls
                         // on the handle (e.g. c.increment()) resolve to ExtCall.

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -299,7 +299,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
         Inst::Builtin(_, _) => {}
         Inst::Call(_, _, args) => { for a in args { used.insert(*a); } }
         Inst::MethodCall(_, obj, _, args) => { used.insert(*obj); for a in args { used.insert(*a); } }
-        Inst::ExtCall(_, addr, _, args, _) => { used.insert(*addr); for a in args { used.insert(*a); } }
+        Inst::ExtCall(_, addr, _, args, _) => { used.insert(*addr); for (a, _) in args { used.insert(*a); } }
         Inst::Hash(_, args) => { for a in args { used.insert(*a); } }
         Inst::StructInit(_, _, fields) => { for (_, r) in fields { used.insert(*r); } }
         Inst::FieldGet(_, obj, _, _) => { used.insert(*obj); }
@@ -317,7 +317,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
             for a in args { used.insert(*a); }
         }
         Inst::RawCall(_, target, args) => { used.insert(*target); for a in args { used.insert(*a); } }
-        Inst::CreateContract(_, blob, args) => { used.insert(*blob); for a in args { used.insert(*a); } }
+        Inst::CreateContract(_, blob, args) => { used.insert(*blob); for (a, _) in args { used.insert(*a); } }
         Inst::Jump(_) => {}
         Inst::Branch(cond, _, _) => { used.insert(*cond); }
         Inst::Return(Some(val)) => { used.insert(*val); }

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1267,11 +1267,19 @@ impl Vm {
     }
 
     /// Derive a storage key from a slot and the contract's address.
-    /// key = poseidon2(slot_bytes ++ address_bytes)
+    /// Uses domain-separated format matching `pyde_state::keys::storage_slot_key`:
+    /// key = Poseidon2(address || 0x04 || slot_bytes)
     pub fn derive_storage_key(&self, slot: U256) -> U256 {
-        let mut buf = [0u8; 64]; // 32 (slot) + 32 (address)
-        buf[..32].copy_from_slice(&slot.to_le_bytes());
-        buf[32..64].copy_from_slice(&self.ctx.self_address);
+        let slot_bytes = slot.to_le_bytes();
+        // Trim trailing zero bytes to match canonical encoding
+        // (u64 slots produce 8 bytes, full U256 slots produce 32)
+        let significant_len = 32 - slot_bytes.iter().rev().take_while(|&&b| b == 0).count();
+        let slot_len = significant_len.max(8); // at least 8 bytes (u64 width)
+
+        let mut buf = Vec::with_capacity(33 + slot_len);
+        buf.extend_from_slice(&self.ctx.self_address); // 32 bytes
+        buf.push(0x04); // STORAGE_SLOT discriminator
+        buf.extend_from_slice(&slot_bytes[..slot_len]);
         let hash = pyde_crypto::poseidon2::poseidon2_hash(&buf);
         U256::from_le_bytes(hash.to_bytes())
     }

--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -33,6 +33,21 @@ pub enum Command {
     /// Auto-format all .oti files in src/ and test/.
     Fmt,
 
+    /// Run a deployment/migration script.
+    /// Format: `file.oti:ContractName` (e.g., `Deploy.oti:Erc20Deploy`).
+    Script {
+        /// Script file and optional contract: `file.oti` or `file.oti:ContractName`.
+        file: String,
+
+        /// Network name (must be defined in pyde.toml [networks]).
+        #[arg(short, long, default_value = "devnet")]
+        network: String,
+
+        /// Sender address (hex).
+        #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
+        from: String,
+    },
+
     /// Generate documentation from source contracts.
     Doc,
 

--- a/crates/pyde-dev/src/deploy.rs
+++ b/crates/pyde-dev/src/deploy.rs
@@ -132,22 +132,25 @@ pub fn run(network: &str, contract: Option<&str>, from: &str) -> Result<(), Stri
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Parse the result (may be nested JSON string)
-    let (tx_hash, contract_addr) = if let Ok(inner) =
-        serde_json::from_str::<serde_json::Value>(result_str)
-    {
-        let tx = inner
-            .get("txHash")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        let addr = inner
-            .get("contractAddress")
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-        (tx.to_string(), addr.to_string())
+    // Extract tx hash from response
+    let tx_hash = if let Ok(inner) = serde_json::from_str::<serde_json::Value>(result_str) {
+        inner.get("txHash").and_then(|v| v.as_str())
+            .unwrap_or(result_str).to_string()
     } else {
-        (result_str.to_string(), "unknown".to_string())
+        result_str.to_string()
     };
+
+    // Poll receipt for the authoritative contract address
+    println!("  Waiting for receipt...");
+    let receipt = poll_receipt(&client, &net.rpc_url, &tx_hash)?;
+    let success = receipt.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+    if !success {
+        return Err("deploy transaction reverted".into());
+    }
+    let contract_addr = receipt.get("returnData")
+        .and_then(|v| v.as_str())
+        .map(|s| if s.starts_with("0x") { s.to_string() } else { format!("0x{}", s) })
+        .unwrap_or_else(|| "unknown".to_string());
 
     println!();
     println!("  Deployed!");
@@ -155,6 +158,36 @@ pub fn run(network: &str, contract: Option<&str>, from: &str) -> Result<(), Stri
     println!("  Tx Hash:  {}", tx_hash);
 
     Ok(())
+}
+
+/// Poll `pyde_getTransactionReceipt` until the receipt is available.
+fn poll_receipt(
+    client: &reqwest::blocking::Client,
+    rpc_url: &str,
+    tx_hash: &str,
+) -> Result<serde_json::Value, String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "pyde_getTransactionReceipt",
+        "params": [tx_hash]
+    });
+    for attempt in 0..50 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let resp = client.post(rpc_url).json(&body).send()
+            .map_err(|e| format!("RPC error polling receipt: {}", e))?;
+        let json: serde_json::Value = resp.json()
+            .map_err(|e| format!("invalid receipt response: {}", e))?;
+        if json.get("error").is_none() {
+            if let Some(result) = json.get("result") {
+                if !result.is_null() {
+                    return Ok(result.clone());
+                }
+            }
+        }
+    }
+    Err(format!("receipt not available after 5s for tx {}", tx_hash))
 }
 
 /// Get the current nonce for an address via RPC.

--- a/crates/pyde-dev/src/lib.rs
+++ b/crates/pyde-dev/src/lib.rs
@@ -7,5 +7,6 @@ pub mod doc;
 pub mod fmt;
 pub mod init;
 pub mod project;
+pub mod script;
 pub mod test_runner;
 pub mod trace;

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -5,6 +5,7 @@ mod build;
 mod clean;
 mod doc;
 mod fmt;
+mod script;
 mod test_runner;
 mod deploy;
 mod cheatcodes;
@@ -21,6 +22,7 @@ fn main() {
         Command::Init { name } => init::run(&name),
         Command::Build => build::run(),
         Command::Test { filter, verbosity } => test_runner::run(filter.as_deref(), verbosity),
+        Command::Script { file, network, from } => script::run(&file, &network, &from),
         Command::Fmt => fmt::run(),
         Command::Doc => doc::run(),
         Command::Clean => clean::run(),

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -1,0 +1,851 @@
+//! Script runner: PVM orchestrator with RPC bridge.
+//!
+//! The PVM runs the script's internal logic (math, variables, control flow).
+//! Every external operation (deploy, call) is intercepted and forwarded to
+//! the actual chain via RPC. Return values come from real chain execution.
+//!
+//! Usage:
+//!   pyde-dev script Deploy.oti --network devnet
+//!   pyde-dev script Deploy.oti:TokenDeploy --network devnet --from 0x...
+
+use crate::build;
+use crate::project;
+use ethnum::U256;
+use otic::types::Ty;
+use pyde_vm::isa::Opcode;
+use pyde_vm::vm::{ExecResult, Outcome, Vm};
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+
+/// Function metadata for view/non-view detection and return type handling.
+struct FnInfo {
+    name: String,
+    is_view: bool,
+    return_ty: Ty,
+}
+
+/// TODO(M11.4): Replace `--from` address with `--wallet`/`--keystore` once the
+/// wallet system is implemented (tasks 0914-0921). Currently uses bare address
+/// without transaction signing (devnet mode only).
+pub fn run(file: &str, network: &str, from: &str) -> Result<(), String> {
+    let (config, root) = project::load_config()?;
+    let start = Instant::now();
+
+    // Parse file:Contract format
+    let (file_part, contract_filter) = if let Some(colon_pos) = file.rfind(':') {
+        let f = &file[..colon_pos];
+        let c = &file[colon_pos + 1..];
+        if c.is_empty() || colon_pos == 1 {
+            (file, None)
+        } else {
+            (f, Some(c.to_string()))
+        }
+    } else {
+        (file, None)
+    };
+
+    // Resolve script file path
+    let script_path = if Path::new(file_part).exists() {
+        file_part.to_string()
+    } else {
+        let in_script_dir = root.join("script").join(file_part);
+        if in_script_dir.exists() {
+            in_script_dir.to_string_lossy().to_string()
+        } else {
+            return Err(format!("script file not found: {}", file_part));
+        }
+    };
+
+    // Get network config
+    let net = config
+        .networks
+        .get(network)
+        .ok_or_else(|| {
+            let available: Vec<&String> = config.networks.keys().collect();
+            format!(
+                "network '{}' not found in pyde.toml (available: {})",
+                network,
+                if available.is_empty() { "none".to_string() }
+                else { available.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ") }
+            )
+        })?
+        .clone();
+
+    // Build src/ contracts first
+    println!("  Building contracts...");
+    let build_result = build::build_project(&config, &root)?;
+    println!();
+
+    // Read and compile the script
+    let source = fs::read_to_string(&script_path)
+        .map_err(|e| format!("cannot read {}: {}", script_path, e))?;
+
+    let (tokens, lex_errors) = otic::lexer::Lexer::new(&source).tokenize();
+    if !lex_errors.is_empty() {
+        return Err(format!("script has lex errors: {:?}", lex_errors[0]));
+    }
+
+    let (ast, parse_errors) = otic::parser::Parser::new(tokens).parse();
+    if !parse_errors.is_empty() {
+        return Err(format!("script has parse errors: {:?}", parse_errors[0]));
+    }
+
+    // Compile script using compile_all (handles multi-contract files + inline deploy!).
+    // Merge build registry so deploy!(ImportedContract) also works.
+    let all_compiled = otic::compile_all(&source);
+
+    // Find the target contract
+    let target_name = contract_filter.as_deref()
+        .or_else(|| {
+            // Auto-detect: find the last contract (usually the script contract)
+            all_compiled.last().map(|(name, _)| name.as_str())
+        })
+        .ok_or_else(|| format!("no contracts found in {}", script_path))?
+        .to_string();
+
+    if !all_compiled.iter().any(|(name, _)| name == &target_name) {
+        return Err(format!("contract '{}' not found in {}", target_name, script_path));
+    }
+
+    // Re-lower the target contract with external registries for deploy! of imported contracts
+    let mut merged_registry = build_result.compiled_registry.clone();
+    // Add inline-compiled contracts to registry
+    for (name, contract) in &all_compiled {
+        if name != &target_name {
+            let clen = contract.constructor_bytecode.len() as u32;
+            let rlen = contract.runtime_bytecode.len() as u32;
+            let mut deploy = Vec::with_capacity(8 + clen as usize + rlen as usize);
+            deploy.extend_from_slice(&clen.to_le_bytes());
+            deploy.extend_from_slice(&rlen.to_le_bytes());
+            deploy.extend_from_slice(&contract.constructor_bytecode);
+            deploy.extend_from_slice(&contract.runtime_bytecode);
+            merged_registry.insert(name.clone(), deploy);
+        }
+    }
+
+    // Re-lower with merged registry to get correct IR for the script contract
+    let mut single = otic::ast::SourceFile { items: Vec::new() };
+    for item in &ast.items {
+        match item {
+            otic::ast::Item::Contract(c) if c.name.name == target_name => {
+                single.items.push(item.clone());
+            }
+            otic::ast::Item::Contract(_) => {}
+            _ => single.items.push(item.clone()),
+        }
+    }
+    let mut ir = otic::lower::lower_with_context(
+        &single,
+        &merged_registry,
+        &build_result.contract_functions,
+        &build_result.contract_constructors,
+    );
+    otic::optimize::optimize(&mut ir);
+
+    // Find entry point
+    let entry_fn = ir.functions.iter().find(|f| f.is_pub && !f.is_constructor);
+    if entry_fn.is_none() {
+        return Err(format!("no pub function found in {}", target_name));
+    }
+
+    let codegen = otic::codegen::CodeGen::new();
+    let compiled = codegen.generate(&ir);
+
+    let sender_addr = parse_address(from)?;
+
+    println!("  Running script: {}", script_path);
+    println!("  Network: {} ({})", network, net.rpc_url);
+    println!("  From: {}", from);
+
+    // Fetch sender nonce
+    let mut nonce = fetch_nonce(&net.rpc_url, from)?;
+    println!("  Nonce: {}", nonce);
+    println!();
+
+    // Run constructor if present
+    let constructor_storage = if !compiled.constructor_bytecode.is_empty() {
+        let ctx = pyde_vm::vm::ExecutionContext {
+            caller: sender_addr,
+            self_address: sender_addr,
+            ..Default::default()
+        };
+        let mut vm = Vm::with_gas_limit_and_context(100_000_000, ctx);
+        if let Err(e) = vm.load(&compiled.constructor_bytecode) {
+            return Err(format!("script constructor load error: {:?}", e));
+        }
+        let output = vm.execute();
+        if output.outcome != Outcome::Success {
+            return Err(format!("script constructor failed: {:?}", output.outcome));
+        }
+        vm.storage.clone()
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    // Run the script with RPC bridge
+    let entry_name = ir.functions.iter()
+        .find(|f| f.is_pub && !f.is_constructor)
+        .unwrap()
+        .name
+        .clone();
+    let selector = otic::codegen::compute_selector(&entry_name);
+
+    let ctx = pyde_vm::vm::ExecutionContext {
+        caller: sender_addr,
+        self_address: sender_addr,
+        ..Default::default()
+    };
+    let mut vm = Vm::with_gas_limit_and_context(100_000_000, ctx);
+    vm.calldata = selector.to_be_bytes().to_vec();
+    if let Err(e) = vm.load(&compiled.runtime_bytecode) {
+        return Err(format!("script load error: {:?}", e));
+    }
+    vm.storage = constructor_storage;
+
+    // Build selector → function info map for view/non-view detection
+    let mut selector_info: std::collections::HashMap<u32, FnInfo> = std::collections::HashMap::new();
+    for (_, fns) in &build_result.contract_functions {
+        for (name, _params, ret_ty) in fns {
+            let sel = otic::codegen::compute_selector(name);
+            selector_info.insert(sel, FnInfo {
+                name: name.clone(),
+                is_view: false, // contract_functions doesn't track is_view — conservative default
+                return_ty: ret_ty.clone(),
+            });
+        }
+    }
+    // Also check IR for view functions
+    for func in &ir.functions {
+        if func.is_view {
+            let sel = otic::codegen::compute_selector(&func.name);
+            if let Some(info) = selector_info.get_mut(&sel) {
+                info.is_view = true;
+            } else {
+                selector_info.insert(sel, FnInfo {
+                    name: func.name.clone(),
+                    is_view: true,
+                    return_ty: func.return_ty.clone(),
+                });
+            }
+        }
+    }
+
+    // Execute with RPC bridge
+    let mut tx_count = 0u32;
+    let outcome = execute_with_rpc_bridge(
+        &mut vm,
+        &sender_addr,
+        &net.rpc_url,
+        from,
+        &mut nonce,
+        &mut tx_count,
+        &merged_registry,
+        &selector_info,
+    )?;
+
+    match outcome {
+        Outcome::Success => {
+            println!("\n  Script completed ({} transactions sent)", tx_count);
+        }
+        Outcome::Revert => {
+            return Err(format!("script reverted after {} transactions", tx_count));
+        }
+        other => {
+            return Err(format!("script failed: {:?} after {} transactions", other, tx_count));
+        }
+    }
+
+    let elapsed = start.elapsed();
+    println!("  Done ({:.2}s)", elapsed.as_secs_f64());
+    Ok(())
+}
+
+/// Execute the script PVM with an RPC bridge for external operations.
+///
+/// When the PVM hits Create or CallExt, the operation is forwarded to the
+/// chain via RPC. Return values are injected back into PVM registers.
+fn execute_with_rpc_bridge(
+    vm: &mut Vm,
+    script_addr: &[u8; 32],
+    rpc_url: &str,
+    from: &str,
+    nonce: &mut u64,
+    tx_count: &mut u32,
+    compiled_registry: &std::collections::HashMap<String, Vec<u8>>,
+    selector_info: &std::collections::HashMap<u32, FnInfo>,
+) -> Result<Outcome, String> {
+    vm.clear_journal();
+    let client = reqwest::blocking::Client::new();
+    let zero_addr = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    loop {
+        let idx = (vm.pc / 4) as usize;
+        let maybe_instr = vm.decoded_cache().get(idx).copied();
+
+        if let Some(d) = maybe_instr {
+            // Intercept Create (deploy!) → forward to chain
+            if d.opcode == Opcode::Create {
+                // Save heap pointer — reclaim after RPC (deploy data no longer needed)
+                let heap_before = vm.cpu.read_gp(12);
+                let code_ptr = vm.cpu.read_gp(d.rs1) as u32;
+                let len_reg = (d.rs2_or_imm & 0xF) as u8;
+                let code_len = vm.cpu.read_gp(len_reg) as usize;
+
+                let init_code = vm.memory.checked_read_slice(code_ptr, code_len)
+                    .map_err(|_| "failed to read deploy bytecode from memory")?;
+
+                // Match against build registry for the contract name
+                let contract_name = find_contract_name(&init_code, compiled_registry);
+
+                // Deploy data is already [clen(4 LE)][rlen(4 LE)][constructor][runtime][args].
+                // Extract clen so the RPC doesn't double-wrap the header.
+                let constructor_len = if init_code.len() >= 4 {
+                    u32::from_le_bytes(init_code[..4].try_into().unwrap_or([0; 4]))
+                } else {
+                    0
+                };
+                // Strip the [clen][rlen] header — RPC will re-add it
+                let raw_code = if init_code.len() >= 8 { &init_code[8..] } else { &init_code[..] };
+                let data_hex = hex::encode(raw_code);
+                // Constructor args come after constructor + runtime
+                let runtime_len = if init_code.len() >= 8 {
+                    u32::from_le_bytes(init_code[4..8].try_into().unwrap_or([0; 4]))
+                } else {
+                    0
+                };
+                let args_start = (constructor_len + runtime_len) as usize;
+                let constructor_args_hex = if args_start < raw_code.len() {
+                    hex::encode(&raw_code[args_start..])
+                } else {
+                    String::new()
+                };
+
+                println!("    [{}] deploy {} ({} bytes)", tx_count, contract_name, raw_code.len());
+
+                let mut params = serde_json::json!({
+                    "from": from,
+                    "to": zero_addr,
+                    "data": format!("0x{}", data_hex),
+                    "gas": 100_000_000,
+                    "nonce": *nonce,
+                    "value": "0",
+                    "constructorLen": constructor_len,
+                });
+                if !constructor_args_hex.is_empty() {
+                    params["constructorArgs"] = serde_json::Value::String(
+                        format!("0x{}", constructor_args_hex)
+                    );
+                }
+
+                let body = serde_json::json!({
+                    "jsonrpc": "2.0", "id": *tx_count + 1,
+                    "method": "pyde_sendTransaction",
+                    "params": [params]
+                });
+
+                let resp = client.post(rpc_url).json(&body).send()
+                    .map_err(|e| format!("RPC error: {} — is the node running?", e))?;
+                let resp_json: serde_json::Value = resp.json()
+                    .map_err(|e| format!("invalid RPC response: {}", e))?;
+
+                if let Some(err) = resp_json.get("error") {
+                    return Err(format!("deploy failed: {}", err));
+                }
+
+                // Extract tx hash from response, then poll receipt for authoritative address.
+                // The receipt's returnData contains the actual deployed contract address (32 bytes).
+                let result_str = resp_json.get("result").and_then(|v| v.as_str()).unwrap_or("");
+                let tx_hash = if let Ok(inner) = serde_json::from_str::<serde_json::Value>(result_str) {
+                    inner.get("txHash").and_then(|v| v.as_str())
+                        .unwrap_or(result_str).to_string()
+                } else {
+                    result_str.to_string()
+                };
+
+                let contract_addr = poll_receipt_for_address(&client, rpc_url, &tx_hash)?;
+                println!("         → 0x{}", hex::encode(&contract_addr[..4]));
+
+                // Write contract address back to PVM wide register
+                vm.cpu.write_wide(d.rd, U256::from_le_bytes(contract_addr));
+                // Register the deployed bytecode locally so subsequent CallExts
+                // to this address during simulation can be identified
+                vm.contracts.insert(contract_addr, vec![]);
+
+                *nonce += 1;
+                *tx_count += 1;
+                // Reclaim heap used for deploy bytecode setup
+                vm.cpu.write_gp(12, heap_before);
+                vm.pc += 4;
+                continue;
+            }
+
+            // Intercept CallExt → forward to chain
+            if d.opcode == Opcode::CallExt {
+                let target: [u8; 32] = vm.cpu.read_wide(d.rd).to_le_bytes();
+
+                // Skip internal calls (to script itself) and cheatcode address
+                if target != *script_addr && target != [0xCC; 32] {
+                    let calldata_ptr = vm.cpu.read_gp(d.rs1) as u32;
+                    let len_reg = (d.rs2_or_imm & 0xF) as u8;
+                    let calldata_len = vm.cpu.read_gp(len_reg) as usize;
+                    let result_reg = ((d.rs2_or_imm >> 8) & 0xF) as u8;
+                    // Save heap pointer — reclaim after RPC (calldata no longer needed)
+                    let heap_before = vm.cpu.read_gp(12);
+
+                    let calldata = vm.memory.checked_read_slice(calldata_ptr, calldata_len)
+                        .map_err(|_| "failed to read calldata from memory")?;
+                    let target_hex = format!("0x{}", hex::encode(target));
+                    let calldata_hex = format!("0x{}", hex::encode(&calldata));
+
+                    // Extract selector to determine view vs state-changing
+                    let selector = if calldata.len() >= 4 {
+                        u32::from_be_bytes(calldata[..4].try_into().unwrap_or([0; 4]))
+                    } else {
+                        0
+                    };
+                    let fn_info = selector_info.get(&selector);
+                    let is_view = fn_info.map(|f| f.is_view).unwrap_or(false);
+                    let fn_name = fn_info.map(|f| f.name.as_str()).unwrap_or("unknown");
+
+                    if is_view {
+                        // View call: pyde_call (read-only, no nonce, no state change)
+                        println!("    [view] {}.{}()", &target_hex[..10], fn_name);
+
+                        let body = serde_json::json!({
+                            "jsonrpc": "2.0", "id": *tx_count + 1,
+                            "method": "pyde_call",
+                            "params": [{
+                                "from": from,
+                                "to": target_hex,
+                                "data": calldata_hex,
+                            }]
+                        });
+
+                        let resp = client.post(rpc_url).json(&body).send()
+                            .map_err(|e| format!("RPC error: {}", e))?;
+                        let resp_json: serde_json::Value = resp.json()
+                            .map_err(|e| format!("invalid RPC response: {}", e))?;
+
+                        if let Some(err) = resp_json.get("error") {
+                            println!("           → FAILED: {}", err);
+                            vm.cpu.write_gp(result_reg, 0);
+                        } else {
+                            // pyde_call returns result directly as hex string
+                            let result_hex = resp_json.get("result")
+                                .and_then(|v| v.as_str()).unwrap_or("0x");
+                            let return_data = hex::decode(
+                                result_hex.strip_prefix("0x").unwrap_or(result_hex)
+                            ).unwrap_or_default();
+
+                            inject_return_data(vm, &return_data, fn_info);
+                            vm.cpu.write_gp(result_reg, 1);
+                            println!("           → {} bytes", return_data.len());
+                        }
+                        // View calls don't consume nonce
+                    } else {
+                        // State-changing call: pyde_sendTransaction
+                        println!("    [{}] {}.{}()", tx_count, &target_hex[..10], fn_name);
+
+                        let body = serde_json::json!({
+                            "jsonrpc": "2.0", "id": *tx_count + 1,
+                            "method": "pyde_sendTransaction",
+                            "params": [{
+                                "from": from,
+                                "to": target_hex,
+                                "data": calldata_hex,
+                                "gas": 100_000_000,
+                                "nonce": *nonce,
+                                "value": "0"
+                            }]
+                        });
+
+                        let resp = client.post(rpc_url).json(&body).send()
+                            .map_err(|e| format!("RPC error: {}", e))?;
+                        let resp_json: serde_json::Value = resp.json()
+                            .map_err(|e| format!("invalid RPC response: {}", e))?;
+
+                        if let Some(err) = resp_json.get("error") {
+                            println!("         → FAILED: {}", err);
+                            vm.cpu.write_gp(result_reg, 0);
+                        } else {
+                            // Poll receipt for authoritative return data
+                            let result_str = resp_json.get("result")
+                                .and_then(|v| v.as_str()).unwrap_or("");
+                            let tx_hash = extract_tx_hash(result_str);
+                            let (success, return_data) = poll_receipt_for_return_data(&client, rpc_url, &tx_hash);
+                            if success {
+                                inject_return_data(vm, &return_data, fn_info);
+                                vm.cpu.write_gp(result_reg, 1);
+                                println!("         → ok");
+                            } else {
+                                println!("         → REVERTED");
+                                vm.cpu.write_gp(result_reg, 0);
+                            }
+                        }
+
+                        *nonce += 1;
+                        *tx_count += 1;
+                    }
+                    // Reclaim heap used for calldata setup — the RPC already read it
+                    vm.cpu.write_gp(12, heap_before);
+                    vm.pc += 4;
+                    continue;
+                }
+            }
+        }
+
+        // Normal PVM step (internal logic)
+        match vm.step() {
+            Ok(Some(ExecResult::Halt)) => {
+                vm.clear_journal();
+                return Ok(Outcome::Success);
+            }
+            Ok(Some(ExecResult::Revert)) => {
+                vm.clear_journal();
+                return Ok(Outcome::Revert);
+            }
+            Ok(None) => {}
+            Err(pyde_vm::cpu::Trap::OutOfGas) => {
+                vm.clear_journal();
+                return Ok(Outcome::OutOfGas);
+            }
+            Err(trap) => {
+                let pc = vm.pc;
+                let idx = (pc / 4) as usize;
+                let d_info = vm.decoded_cache().get(idx).map(|d| format!("{:?} rd={} rs1={} rs2={}", d.opcode, d.rd, d.rs1, d.rs2_or_imm));
+                eprintln!("  TRAP at pc={} (idx {}): {:?} instr={:?}", pc, idx, trap, d_info);
+                if let Some(d) = vm.decoded_cache().get(idx) {
+                    let base = vm.cpu.read_gp(d.rs1);
+                    let off = d.rs2_or_imm as i32 as i64;
+                    eprintln!("  Store target: r{}={:#x} + offset {} = {:#x}", d.rs1, base, off, base as i64 + off);
+                    eprintln!("  Store value: r{}={:#x}", d.rd, vm.cpu.read_gp(d.rd));
+                }
+                eprintln!("  r12(heap)={:#x}", vm.cpu.read_gp(12));
+                vm.clear_journal();
+                return Ok(Outcome::Trap(trap));
+            }
+        }
+    }
+}
+
+/// Inject return data from RPC response back into PVM registers/memory.
+/// Handles GP (u64, bool), wide (u256, Address), and blob (Vec, String, struct) returns.
+fn inject_return_data(vm: &mut Vm, return_data: &[u8], fn_info: Option<&FnInfo>) {
+    if return_data.is_empty() {
+        vm.cpu.write_gp(1, 0);
+        vm.cpu.write_gp(2, 0);
+        return;
+    }
+
+    let is_wide = fn_info.map(|f| matches!(f.return_ty, Ty::U256 | Ty::I256 | Ty::Address | Ty::Contract(_) | Ty::Interface(_))).unwrap_or(false);
+    let is_blob = fn_info.map(|f| matches!(f.return_ty, Ty::Vec(_) | Ty::StringTy | Ty::Bytes | Ty::Struct(_))).unwrap_or(false);
+
+    if is_wide && return_data.len() >= 32 {
+        // Wide return: write 32 bytes to heap, r1 = ptr, r2 = 32
+        let heap = vm.cpu.read_gp(12) as u32;
+        let _ = vm.memory.checked_write_slice(heap, &return_data[..32]);
+        vm.cpu.write_gp(1, heap as u64);
+        vm.cpu.write_gp(2, 32);
+    } else if is_blob {
+        // Blob return: write full data to heap, r1 = ptr, r2 = len
+        let heap = vm.cpu.read_gp(12) as u32;
+        let _ = vm.memory.checked_write_slice(heap, return_data);
+        vm.cpu.write_gp(1, heap as u64);
+        vm.cpu.write_gp(2, return_data.len() as u64);
+    } else {
+        // GP return: r1 = value (first 8 bytes LE), r2 = 0
+        let mut buf = [0u8; 8];
+        let len = return_data.len().min(8);
+        buf[..len].copy_from_slice(&return_data[..len]);
+        vm.cpu.write_gp(1, u64::from_le_bytes(buf));
+        vm.cpu.write_gp(2, 0);
+    }
+}
+
+/// Extract txHash from a sendTransaction result string.
+fn extract_tx_hash(result_str: &str) -> String {
+    if let Ok(inner) = serde_json::from_str::<serde_json::Value>(result_str) {
+        inner.get("txHash").and_then(|v| v.as_str())
+            .unwrap_or(result_str).to_string()
+    } else {
+        result_str.to_string()
+    }
+}
+
+/// Poll `pyde_getTransactionReceipt` until the receipt is available, then
+/// extract the contract address from returnData (32 bytes for deploy txs).
+fn poll_receipt_for_address(
+    client: &reqwest::blocking::Client,
+    rpc_url: &str,
+    tx_hash: &str,
+) -> Result<[u8; 32], String> {
+    let receipt = poll_receipt(client, rpc_url, tx_hash)?;
+    let success = receipt.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+    if !success {
+        return Err(format!("deploy transaction reverted (tx {})", tx_hash));
+    }
+    let return_data_hex = receipt.get("returnData")
+        .and_then(|v| v.as_str()).unwrap_or("");
+    let hex = return_data_hex.strip_prefix("0x").unwrap_or(return_data_hex);
+    if hex.len() == 64 {
+        parse_address(&format!("0x{}", hex))
+    } else {
+        Err(format!("deploy receipt missing contract address in returnData (got {} bytes)", hex.len() / 2))
+    }
+}
+
+/// Poll receipt and extract returnData for non-deploy calls.
+/// Returns (success, return_data).
+fn poll_receipt_for_return_data(
+    client: &reqwest::blocking::Client,
+    rpc_url: &str,
+    tx_hash: &str,
+) -> (bool, Vec<u8>) {
+    let receipt = match poll_receipt(client, rpc_url, tx_hash) {
+        Ok(r) => r,
+        Err(_) => return (false, vec![]),
+    };
+    let success = receipt.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+    let hex_str = receipt.get("returnData")
+        .and_then(|v| v.as_str()).unwrap_or("");
+    let hex = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    (success, hex::decode(hex).unwrap_or_default())
+}
+
+/// Poll `pyde_getTransactionReceipt` with retries until the receipt appears.
+fn poll_receipt(
+    client: &reqwest::blocking::Client,
+    rpc_url: &str,
+    tx_hash: &str,
+) -> Result<serde_json::Value, String> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "pyde_getTransactionReceipt",
+        "params": [tx_hash]
+    });
+    for attempt in 0..50 {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        let resp = client.post(rpc_url).json(&body).send()
+            .map_err(|e| format!("RPC error polling receipt: {}", e))?;
+        let json: serde_json::Value = resp.json()
+            .map_err(|e| format!("invalid receipt response: {}", e))?;
+        if json.get("error").is_none() {
+            if let Some(result) = json.get("result") {
+                if !result.is_null() {
+                    return Ok(result.clone());
+                }
+            }
+        }
+    }
+    Err(format!("receipt not available after 5s for tx {}", tx_hash))
+}
+
+/// Find a contract name by matching deploy bytecode against the build registry.
+fn find_contract_name(
+    init_code: &[u8],
+    registry: &std::collections::HashMap<String, Vec<u8>>,
+) -> String {
+    for (name, deploy_bytes) in registry {
+        if deploy_bytes == init_code {
+            return name.clone();
+        }
+        // Also check if init_code starts with deploy_bytes (may have args appended)
+        if init_code.len() >= deploy_bytes.len() && &init_code[..deploy_bytes.len()] == deploy_bytes.as_slice() {
+            return name.clone();
+        }
+    }
+    "unknown".to_string()
+}
+
+fn fetch_nonce(rpc_url: &str, address: &str) -> Result<u64, String> {
+    let client = reqwest::blocking::Client::new();
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "pyde_getTransactionCount",
+        "params": [address]
+    });
+    let resp = client.post(rpc_url).json(&body).send()
+        .map_err(|e| format!("cannot fetch nonce: {}", e))?;
+    let json: serde_json::Value = resp.json()
+        .map_err(|e| format!("invalid nonce response: {}", e))?;
+    json.get("result").and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| "failed to parse nonce".into())
+}
+
+fn parse_address(hex: &str) -> Result<[u8; 32], String> {
+    let hex = hex.strip_prefix("0x").unwrap_or(hex);
+    if hex.len() != 64 {
+        return Err(format!("invalid address: expected 64 hex chars, got {}", hex.len()));
+    }
+    let bytes = hex::decode(hex).map_err(|e| format!("invalid address hex: {}", e))?;
+    let mut addr = [0u8; 32];
+    addr.copy_from_slice(&bytes);
+    Ok(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========== parse_address ==========
+
+    #[test]
+    fn parse_address_valid() {
+        let hex = "0x0101010101010101010101010101010101010101010101010101010101010101";
+        let addr = parse_address(hex).unwrap();
+        assert_eq!(addr, [0x01; 32]);
+    }
+
+    #[test]
+    fn parse_address_no_prefix() {
+        let hex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let addr = parse_address(hex).unwrap();
+        assert_eq!(addr, [0xAA; 32]);
+    }
+
+    #[test]
+    fn parse_address_invalid_length() {
+        assert!(parse_address("0x1234").is_err());
+    }
+
+    #[test]
+    fn parse_address_invalid_hex() {
+        let bad = "0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG";
+        assert!(parse_address(bad).is_err());
+    }
+
+    // ========== find_contract_name ==========
+
+    #[test]
+    fn find_contract_name_exact_match() {
+        let mut registry = std::collections::HashMap::new();
+        registry.insert("Counter".to_string(), vec![1, 2, 3, 4]);
+        assert_eq!(find_contract_name(&[1, 2, 3, 4], &registry), "Counter");
+    }
+
+    #[test]
+    fn find_contract_name_prefix_match() {
+        let mut registry = std::collections::HashMap::new();
+        registry.insert("Counter".to_string(), vec![1, 2, 3, 4]);
+        // init_code has deploy bytes + constructor args appended
+        assert_eq!(find_contract_name(&[1, 2, 3, 4, 5, 6], &registry), "Counter");
+    }
+
+    #[test]
+    fn find_contract_name_no_match() {
+        let registry = std::collections::HashMap::new();
+        assert_eq!(find_contract_name(&[1, 2, 3], &registry), "unknown");
+    }
+
+    // ========== extract_tx_hash ==========
+
+    #[test]
+    fn extract_tx_hash_from_json() {
+        let result = r#"{"txHash":"0xaabb"}"#;
+        assert_eq!(extract_tx_hash(result), "0xaabb");
+    }
+
+    #[test]
+    fn extract_tx_hash_plain_string() {
+        assert_eq!(extract_tx_hash("0xdeadbeef"), "0xdeadbeef");
+    }
+
+    #[test]
+    fn extract_tx_hash_with_contract_address() {
+        let result = r#"{"txHash":"0x1234","contractAddress":"0xabcd"}"#;
+        assert_eq!(extract_tx_hash(result), "0x1234");
+    }
+
+    // ========== inject_return_data ==========
+
+    #[test]
+    fn inject_gp_return() {
+        let mut vm = Vm::new();
+        vm.memory.heap_alloc(1024).unwrap(); // make heap space
+        let info = FnInfo { name: "get".into(), is_view: true, return_ty: Ty::U64 };
+        let data = 42u64.to_le_bytes().to_vec();
+        inject_return_data(&mut vm, &data, Some(&info));
+        assert_eq!(vm.cpu.read_gp(1), 42);
+        assert_eq!(vm.cpu.read_gp(2), 0);
+    }
+
+    #[test]
+    fn inject_wide_return() {
+        let mut vm = Vm::new();
+        // Need heap space — advance past code section
+        vm.cpu.write_gp(12, pyde_vm::memory::HEAP_START as u64);
+        let info = FnInfo { name: "get".into(), is_view: true, return_ty: Ty::U256 };
+        let mut data = vec![0u8; 32];
+        data[0] = 0xAB;
+        data[31] = 0xCD;
+        inject_return_data(&mut vm, &data, Some(&info));
+        assert_eq!(vm.cpu.read_gp(1), pyde_vm::memory::HEAP_START as u64);
+        assert_eq!(vm.cpu.read_gp(2), 32);
+    }
+
+    #[test]
+    fn inject_blob_return() {
+        let mut vm = Vm::new();
+        vm.cpu.write_gp(12, pyde_vm::memory::HEAP_START as u64);
+        let info = FnInfo { name: "get".into(), is_view: true, return_ty: Ty::StringTy };
+        let data = b"hello world".to_vec();
+        inject_return_data(&mut vm, &data, Some(&info));
+        assert_eq!(vm.cpu.read_gp(1), pyde_vm::memory::HEAP_START as u64);
+        assert_eq!(vm.cpu.read_gp(2), 11); // "hello world" = 11 bytes
+    }
+
+    #[test]
+    fn deploy_macro_produces_create_instruction() {
+        // Verify that deploy!(Counter) actually produces CreateContract IR
+        // when Counter is in the compiled_contracts registry
+        let src = r#"
+            contract DeployScript {
+                pub fn run() {
+                    let c = deploy!(Counter);
+                }
+            }
+        "#;
+        let mut registry = std::collections::HashMap::new();
+        registry.insert("Counter".to_string(), vec![0x01, 0x02, 0x03, 0x04]);
+
+        let (tokens, _) = otic::lexer::Lexer::new(src).tokenize();
+        let (ast, _) = otic::parser::Parser::new(tokens).parse();
+        let ir = otic::lower::lower_with_context(
+            &ast,
+            &registry,
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+        );
+
+        // Check that at least one function has a CreateContract instruction
+        let has_create = ir.functions.iter().any(|f| {
+            f.blocks.iter().any(|b| {
+                b.instructions.iter().any(|inst| {
+                    let s = format!("{}", inst);
+                    s.contains("create(") || s.contains("create_contract")
+                })
+            })
+        });
+        // Debug: print all instructions
+        for func in &ir.functions {
+            for block in &func.blocks {
+                for inst in &block.instructions {
+                    eprintln!("  IR: {}", inst);
+                }
+            }
+        }
+        assert!(has_create, "deploy!(Counter) should produce a CreateContract instruction");
+    }
+
+    #[test]
+    fn inject_empty_return() {
+        let mut vm = Vm::new();
+        inject_return_data(&mut vm, &[], None);
+        assert_eq!(vm.cpu.read_gp(1), 0);
+        assert_eq!(vm.cpu.read_gp(2), 0);
+    }
+}

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -306,10 +306,16 @@ fn execute_with_rpc_bridge(
                 let runtime_len = if init_code.len() >= 8 {
                     u32::from_le_bytes(init_code[4..8].try_into().unwrap_or([0; 4]))
                 } else { 0 };
-                let code_end = 8 + constructor_len as usize + runtime_len as usize;
+                // The blob constant is 8-byte aligned in PVM memory, so
+                // actual blob end may be up to 7 bytes past clen+rlen.
+                let raw_code_len = constructor_len as usize + runtime_len as usize;
+                let aligned_code_len = (raw_code_len + 7) & !7;
+                let code_end = 8 + aligned_code_len;
                 // data = constructor + runtime ONLY (no args, no header)
-                let code_only = if init_code.len() >= code_end {
-                    &init_code[8..code_end]
+                // Send the raw (unaligned) code to the RPC
+                let raw_end = 8 + raw_code_len;
+                let code_only = if init_code.len() >= raw_end {
+                    &init_code[8..raw_end]
                 } else if init_code.len() >= 8 {
                     &init_code[8..]
                 } else {

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -298,43 +298,44 @@ fn execute_with_rpc_bridge(
                 // Match against build registry for the contract name
                 let contract_name = find_contract_name(&init_code, compiled_registry);
 
-                // Deploy data is already [clen(4 LE)][rlen(4 LE)][constructor][runtime][args].
-                // Extract clen so the RPC doesn't double-wrap the header.
+                // Deploy data is [clen(4 LE)][rlen(4 LE)][constructor][runtime][args].
+                // Split into code (constructor+runtime) and args for the RPC.
                 let constructor_len = if init_code.len() >= 4 {
                     u32::from_le_bytes(init_code[..4].try_into().unwrap_or([0; 4]))
-                } else {
-                    0
-                };
-                // Strip the [clen][rlen] header — RPC will re-add it
-                let raw_code = if init_code.len() >= 8 { &init_code[8..] } else { &init_code[..] };
-                let data_hex = hex::encode(raw_code);
-                // Constructor args come after constructor + runtime
+                } else { 0 };
                 let runtime_len = if init_code.len() >= 8 {
                     u32::from_le_bytes(init_code[4..8].try_into().unwrap_or([0; 4]))
+                } else { 0 };
+                let code_end = 8 + constructor_len as usize + runtime_len as usize;
+                // data = constructor + runtime ONLY (no args, no header)
+                let code_only = if init_code.len() >= code_end {
+                    &init_code[8..code_end]
+                } else if init_code.len() >= 8 {
+                    &init_code[8..]
                 } else {
-                    0
+                    &init_code[..]
                 };
-                let args_start = (constructor_len + runtime_len) as usize;
-                let constructor_args_hex = if args_start < raw_code.len() {
-                    hex::encode(&raw_code[args_start..])
+                // args = everything after constructor + runtime
+                let constructor_args = if init_code.len() > code_end {
+                    &init_code[code_end..]
                 } else {
-                    String::new()
+                    &[]
                 };
 
-                println!("    [{}] deploy {} ({} bytes)", tx_count, contract_name, raw_code.len());
+                println!("    [{}] deploy {} ({} bytes)", tx_count, contract_name, code_only.len());
 
                 let mut params = serde_json::json!({
                     "from": from,
                     "to": zero_addr,
-                    "data": format!("0x{}", data_hex),
+                    "data": format!("0x{}", hex::encode(code_only)),
                     "gas": 100_000_000,
                     "nonce": *nonce,
                     "value": "0",
                     "constructorLen": constructor_len,
                 });
-                if !constructor_args_hex.is_empty() {
+                if !constructor_args.is_empty() {
                     params["constructorArgs"] = serde_json::Value::String(
-                        format!("0x{}", constructor_args_hex)
+                        format!("0x{}", hex::encode(constructor_args))
                     );
                 }
 
@@ -511,17 +512,6 @@ fn execute_with_rpc_bridge(
                 return Ok(Outcome::OutOfGas);
             }
             Err(trap) => {
-                let pc = vm.pc;
-                let idx = (pc / 4) as usize;
-                let d_info = vm.decoded_cache().get(idx).map(|d| format!("{:?} rd={} rs1={} rs2={}", d.opcode, d.rd, d.rs1, d.rs2_or_imm));
-                eprintln!("  TRAP at pc={} (idx {}): {:?} instr={:?}", pc, idx, trap, d_info);
-                if let Some(d) = vm.decoded_cache().get(idx) {
-                    let base = vm.cpu.read_gp(d.rs1);
-                    let off = d.rs2_or_imm as i32 as i64;
-                    eprintln!("  Store target: r{}={:#x} + offset {} = {:#x}", d.rs1, base, off, base as i64 + off);
-                    eprintln!("  Store value: r{}={:#x}", d.rd, vm.cpu.read_gp(d.rd));
-                }
-                eprintln!("  r12(heap)={:#x}", vm.cpu.read_gp(12));
                 vm.clear_journal();
                 return Ok(Outcome::Trap(trap));
             }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -258,7 +258,7 @@ pub fn execute_transaction(
                 (tx.data.clone(), 32_000u64)
             };
 
-            (true, gas_used, 0u64, vec![], vec![])
+            (true, gas_used, 0u64, vec![], new_addr.to_vec())
         }
         _ => {
             // Simple transfer or batch (batch deferred)
@@ -507,10 +507,16 @@ pub fn pre_derive_access_list_keys(
 
         for raw_key in entry.reads.iter().chain(entry.writes.iter()) {
             let slot = U256::from_le_bytes(*raw_key);
-            // Derive storage key: Poseidon2(slot || target_address)
-            let mut buf = [0u8; 64];
-            buf[..32].copy_from_slice(&slot.to_le_bytes());
-            buf[32..64].copy_from_slice(target);
+            let slot_bytes = slot.to_le_bytes();
+            // Trim trailing zeros, minimum 8 bytes (u64 width)
+            let sig_len = 32 - slot_bytes.iter().rev().take_while(|&&b| b == 0).count();
+            let slot_len = sig_len.max(8);
+            // Derive storage key: Poseidon2(address || 0x04 || slot_bytes)
+            // Matches VM's derive_storage_key and pyde_state::keys::storage_slot_key
+            let mut buf = Vec::with_capacity(33 + slot_len);
+            buf.extend_from_slice(target);
+            buf.push(0x04); // STORAGE_SLOT discriminator
+            buf.extend_from_slice(&slot_bytes[..slot_len]);
             let hash = poseidon2_hash(&buf);
             let derived = U256::from_le_bytes(hash.to_bytes());
             allowed.insert(derived);
@@ -1221,5 +1227,79 @@ mod tests {
         let call_receipt = execute_transaction(&call_tx, &mut smt, &block_ctx).unwrap();
         assert!(call_receipt.success, "void call failed");
         // return_data exists (r1 value) but caller should ignore for void functions
+    }
+
+    #[test]
+    fn storage_slot_key_reads_correct_value_after_execution() {
+        // Deploy a contract, call set_value(42), then verify storage_slot_key can read it
+        let src = r#"
+            contract Counter {
+                storage { count: u64, }
+                #[constructor]
+                pub fn init() { self.count = 0; }
+                pub fn increment() { self.count = self.count + 1; }
+            }
+        "#;
+        let compiled = otic::compile_all(src);
+        let (_, contract) = &compiled[0];
+
+        let clen = contract.constructor_bytecode.len() as u32;
+        let rlen = contract.runtime_bytecode.len() as u32;
+        let mut deploy_data = Vec::new();
+        deploy_data.extend_from_slice(&clen.to_le_bytes());
+        deploy_data.extend_from_slice(&rlen.to_le_bytes());
+        deploy_data.extend_from_slice(&contract.constructor_bytecode);
+        deploy_data.extend_from_slice(&contract.runtime_bytecode);
+
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let mut smt = PydeSMT::new();
+        let block_ctx = make_block_ctx();
+        let sender_addr = setup_funded_account(&mut smt, &pk_bytes, 1_000_000_000_000);
+        let contract_addr = pyde_account::address::derive_create_address(&sender_addr, 0);
+
+        // Deploy
+        let deploy_tx = {
+            let mut tx = Transaction {
+                from: sender_addr, to: ZERO_ADDRESS, value: 0,
+                data: deploy_data, gas_limit: 100_000_000, nonce: 0,
+                signature: vec![], fee_payer: FeePayer::Sender,
+                access_list: vec![], deadline: None, chain_id: 1,
+                tx_type: TransactionType::Deploy,
+            };
+            let hash = tx.hash();
+            tx.signature = pyde_crypto::falcon::falcon_sign(&sk, &hash).unwrap().as_bytes().to_vec();
+            tx
+        };
+        let deploy_receipt = execute_transaction(&deploy_tx, &mut smt, &block_ctx).unwrap();
+        assert!(deploy_receipt.success, "deploy failed");
+
+        // Call increment() 3 times
+        for i in 0..3u64 {
+            let selector = otic::codegen::compute_selector("increment");
+            let call_tx = {
+                let mut tx = Transaction {
+                    from: sender_addr, to: contract_addr, value: 0,
+                    data: selector.to_be_bytes().to_vec(), gas_limit: 100_000_000, nonce: 1 + i,
+                    signature: vec![], fee_payer: FeePayer::Sender,
+                    access_list: vec![], deadline: None, chain_id: 1,
+                    tx_type: TransactionType::Standard,
+                };
+                let hash = tx.hash();
+                tx.signature = pyde_crypto::falcon::falcon_sign(&sk, &hash).unwrap().as_bytes().to_vec();
+                tx
+            };
+            let receipt = execute_transaction(&call_tx, &mut smt, &block_ctx).unwrap();
+            assert!(receipt.success, "increment {} failed", i);
+        }
+
+        // Verify storage via storage_slot_key (same key get_storage_at RPC uses)
+        let storage_key = pyde_state::keys::storage_slot_key(&contract_addr, 0);
+        let value = smt.get(&storage_key);
+        assert!(value.is_some(), "storage_slot_key should find the value");
+        let mut buf = [0u8; 8];
+        buf.copy_from_slice(&value.unwrap()[..8]);
+        let count = u64::from_le_bytes(buf);
+        assert_eq!(count, 3, "count should be 3 after 3 increments");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `pyde-dev script` command — Foundry-style script runner that executes Otigen scripts against a live chain via RPC bridge
- ABI encoding for complex types (String, Vec, Struct, u256) in cross-contract calls
- Multiple codegen and RPC fixes discovered during live testing

## Key changes

**Script runner** (`crates/pyde-dev/src/script.rs`):
- PVM orchestrator intercepts Create/CallExt, forwards to chain via RPC
- Polls receipts for authoritative contract addresses and return data
- Receipt success checks, heap reclaim, deploy data splitting with alignment
- 15 unit tests

**ABI encoding** (`crates/otic/src/codegen.rs`):
- ExtCall serializes String/Bytes via emit_flatten, Vec/Struct via byte_len prefix
- CreateContract blob args via stack-safe emit_flatten (push-all-pop-serialize)
- Blob return deserialization via emit_unflatten
- Fix calldata cursor doubling after String param decode
- Fix u256 GP-to-wide Widen for small literals in ExtCall args

**Codegen fixes**:
- Save/restore r13 (spill base) around all CallExt sites
- Integer literals > u64 emit as Ty::U256, address byte-swap for ::at()
- deploy!() handles Expr::Ident in addition to Expr::Path

**Node/RPC fixes** (`crates/node/src/rpc.rs`):
- tx hash consistency (tx.hash() everywhere)
- pyde_call returns actual function output, u256 as BE hex
- Deploy receipts include contract address in returnData
- pyde-dev deploy polls receipt for address

**Storage alignment** (`crates/pvm/src/vm.rs`, `crates/tx/src/pipeline.rs`):
- Domain-separated storage key derivation matching state keys
- Deploy return_data includes contract address

## Verified live

- deploy!(Vault, 1000, 5) — constructor args
- deploy!(Registry, "hello") — String constructor args
- set_all("multi", 42, true, 99_u256) — multi-type args, all values confirmed via pyde_call
- Vec<u64>, Vec<bool> args
- String returns chained as args to subsequent calls
- Nested calls: v.deposit(v.get_balance() + 100) → balance=2100
- Setter returns chained: deposit_and_report → deposit → withdraw_with_fee → deposit

🤖 Generated with [Claude Code](https://claude.com/claude-code)