### PR TITLE
feat: pyde install/remove with git packages, lock file, and build integration

### DIFF
--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -879,7 +879,7 @@ impl Resolver {
 
             Expr::MacroCall(name, args, span) => {
                 // Built-in macros: require!, revert!, cross_call!, raw_call!
-                let known_macros = ["require", "revert", "assert", "cross_call", "raw_call", "create"];
+                let known_macros = ["require", "revert", "assert", "cross_call", "raw_call", "create", "deploy"];
                 if !known_macros.contains(&name.name.as_str()) {
                     self.error(
                         format!("unknown macro '{}!'", name.name),

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -1318,12 +1318,14 @@ impl TypeChecker {
                         // deploy!(ContractName, args...) → Ty::Contract("ContractName")
                         // First arg is the contract name (path expression).
                         if let Some(MacroArg::Positional(first)) = args.first() {
-                            if let Expr::Path(segments, _) = first {
-                                let contract_name = segments
-                                    .iter()
-                                    .map(|s| s.name.as_str())
-                                    .collect::<Vec<_>>()
-                                    .join("::");
+                            let contract_name_opt = if let Expr::Path(segments, _) = first {
+                                Some(segments.iter().map(|s| s.name.as_str()).collect::<Vec<_>>().join("::"))
+                            } else if let Expr::Ident(ident) = first {
+                                Some(ident.name.clone())
+                            } else {
+                                None
+                            };
+                            if let Some(contract_name) = contract_name_opt {
 
                                 // Validate constructor args (count + types)
                                 let user_arg_types = &arg_types[1..]; // skip contract name

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -94,12 +94,28 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
         ));
     }
 
-    // Find all .oti files
+    // Find all .oti files in src/
     let pattern = format!("{}/**/*.oti", src_dir.display());
-    let files: Vec<PathBuf> = glob::glob(&pattern)
+    let mut files: Vec<PathBuf> = glob::glob(&pattern)
         .map_err(|e| format!("glob error: {}", e))?
         .filter_map(|r| r.ok())
         .collect();
+
+    // Also scan lib/*/src/**/*.oti for installed packages (skip @std)
+    let lib_dir = root.join("lib");
+    if lib_dir.exists() {
+        let lib_pattern = format!("{}/**/src/**/*.oti", lib_dir.display());
+        let lib_files: Vec<PathBuf> = glob::glob(&lib_pattern)
+            .map_err(|e| format!("glob error: {}", e))?
+            .filter_map(|r| r.ok())
+            .filter(|p| {
+                // Skip @std/ (standard library, not compiled as source)
+                !p.to_string_lossy().contains("/@std/")
+                    && !p.to_string_lossy().contains("\\@std\\")
+            })
+            .collect();
+        files.extend(lib_files);
+    }
 
     if files.is_empty() {
         return Err(format!("no .oti files found in {}", src_dir.display()));
@@ -120,7 +136,7 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     }
 
     // Build dependency graph from `use` statements
-    let dep_graph = build_dependency_graph(&sources, &src_dir)?;
+    let dep_graph = build_dependency_graph(&sources, &src_dir, &lib_dir)?;
 
     // Pre-scan: collect module exports for qualified path validation
     let mut module_exports: HashMap<String, ModuleExports> = HashMap::new();
@@ -165,7 +181,36 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
         if let Ok(rel) = path.strip_prefix(&src_dir) {
             let rel_no_ext = rel.with_extension("");
             if let Some(rel_str) = rel_no_ext.to_str() {
-                module_exports.insert(rel_str.replace('\\', "/"), exports);
+                module_exports.insert(rel_str.replace('\\', "/"), exports.clone());
+            }
+        }
+        // For lib packages: register as "package_name" so `use package::Contract` works.
+        // Also register underscore variant (oti-math-lib → oti_math_lib).
+        if let Ok(rel) = path.strip_prefix(&lib_dir) {
+            let components: Vec<&str> = rel.components()
+                .filter_map(|c| c.as_os_str().to_str())
+                .collect();
+            if components.len() >= 3 && components[1] == "src" {
+                let pkg = components[0];
+                let pkg_us = pkg.replace('-', "_");
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    module_exports.entry(pkg.to_string())
+                        .or_insert_with(|| exports.clone());
+                    module_exports.entry(pkg_us.clone())
+                        .or_insert_with(|| exports.clone());
+                    if components.len() > 3 {
+                        let sub = components[2..components.len()-1].join("/");
+                        module_exports.insert(
+                            format!("{}/{}", pkg, sub),
+                            exports.clone(),
+                        );
+                    }
+                    // Also register "pkg_name/stem" for direct file access
+                    module_exports.insert(
+                        format!("{}/{}", pkg, stem),
+                        exports,
+                    );
+                }
             }
         }
     }
@@ -423,9 +468,10 @@ fn run_frontend(path: &Path, source: &str, module_exports: &HashMap<String, Modu
 fn build_dependency_graph(
     sources: &[(PathBuf, String, String)],
     src_dir: &Path,
+    lib_dir: &Path,
 ) -> Result<Vec<Vec<usize>>, String> {
     // Map module paths to file indices.
-    // Supports both flat (counter → src/counter.oti) and nested (events/event → src/events/event.oti).
+    // Supports flat (counter → src/counter.oti), nested (events/event), and lib packages.
     let mut name_to_idx: HashMap<String, usize> = HashMap::new();
     for (idx, (path, _, _)) in sources.iter().enumerate() {
         // Register by file stem (flat: "counter")
@@ -436,9 +482,25 @@ fn build_dependency_graph(
         if let Ok(rel) = path.strip_prefix(src_dir) {
             let rel_no_ext = rel.with_extension("");
             if let Some(rel_str) = rel_no_ext.to_str() {
-                // Normalize path separators to forward slash
                 let normalized = rel_str.replace('\\', "/");
                 name_to_idx.insert(normalized, idx);
+            }
+        }
+        // Register lib packages: lib/pkg/src/File.oti → "pkg" and "pkg/file"
+        // Also register underscore variant (oti-math-lib → oti_math_lib).
+        if let Ok(rel) = path.strip_prefix(lib_dir) {
+            let components: Vec<&str> = rel.components()
+                .filter_map(|c| c.as_os_str().to_str())
+                .collect();
+            if components.len() >= 3 && components[1] == "src" {
+                let pkg = components[0];
+                let pkg_us = pkg.replace('-', "_");
+                name_to_idx.entry(pkg.to_string()).or_insert(idx);
+                name_to_idx.entry(pkg_us.clone()).or_insert(idx);
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    name_to_idx.insert(format!("{}/{}", pkg, stem), idx);
+                    name_to_idx.insert(format!("{}/{}", pkg_us, stem), idx);
+                }
             }
         }
     }
@@ -495,7 +557,7 @@ fn build_dependency_graph(
                     } else {
                         let rel = path.strip_prefix(src_dir).unwrap_or(path);
                         return Err(format!(
-                            "error in {}: cannot resolve import '{}' — no {}.oti found in src/",
+                            "error in {}: cannot resolve import '{}' — no {}.oti found in src/ or lib/",
                             rel.display(),
                             import
                                 .path

--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -48,6 +48,27 @@ pub enum Command {
         from: String,
     },
 
+    /// Install a package from a git URL, or restore all from pyde.lock.
+    /// Run with no arguments to restore all dependencies from the lock file.
+    Install {
+        /// Git repository URL (omit to restore all from pyde.lock).
+        url: Option<String>,
+
+        /// Branch, tag, or commit hash (default: main).
+        #[arg(short, long)]
+        rev: Option<String>,
+
+        /// Override package name (default: repo name from URL).
+        #[arg(short, long)]
+        name: Option<String>,
+    },
+
+    /// Remove an installed package.
+    Remove {
+        /// Package name to remove.
+        name: String,
+    },
+
     /// Generate documentation from source contracts.
     Doc,
 

--- a/crates/pyde-dev/src/init.rs
+++ b/crates/pyde-dev/src/init.rs
@@ -41,8 +41,11 @@ pub fn run(name: &str) -> Result<(), String> {
         .map_err(|e| format!("cannot write math.oti: {}", e))?;
 
     // Write .gitignore
-    fs::write(root.join(".gitignore"), "out/\n")
-        .map_err(|e| format!("cannot write .gitignore: {}", e))?;
+    fs::write(
+        root.join(".gitignore"),
+        "# Build artifacts\nout/\n\n# Installed packages (restored via pyde install)\nlib/\n!lib/@std/\n",
+    )
+    .map_err(|e| format!("cannot write .gitignore: {}", e))?;
 
     println!("  Initialized project '{}'", name);
     println!();

--- a/crates/pyde-dev/src/install.rs
+++ b/crates/pyde-dev/src/install.rs
@@ -1,0 +1,381 @@
+use crate::project::{self, Dependency};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command as Cmd;
+
+/// Locked package entry (exact commit pinned).
+#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+struct LockedPackage {
+    name: String,
+    git: String,
+    rev: String,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
+struct LockFile {
+    #[serde(default, rename = "package")]
+    packages: Vec<LockedPackage>,
+}
+
+/// Install a single package from a git URL, or restore all from lock file.
+pub fn run(url: &str, rev: Option<&str>, name_override: Option<&str>) -> Result<(), String> {
+    // `pyde install` (no url) → restore all deps from lock file
+    if url == "__restore__" {
+        return restore_all();
+    }
+
+    let (_, root) = project::load_config()?;
+    let pkg_name = name_override
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| parse_repo_name(url));
+
+    if pkg_name.is_empty() {
+        return Err("cannot determine package name from URL — use --name".into());
+    }
+
+    let lib_dir = root.join("lib");
+    let pkg_dir = lib_dir.join(&pkg_name);
+
+    if pkg_dir.exists() {
+        return Err(format!(
+            "'{}' is already installed. Remove it first with `pyde-dev remove {}`",
+            pkg_name, pkg_name,
+        ));
+    }
+
+    fs::create_dir_all(&lib_dir)
+        .map_err(|e| format!("cannot create lib/: {}", e))?;
+
+    println!("  Installing {} from {}", pkg_name, url);
+
+    // Clone
+    clone_repo(url, rev, &pkg_dir)?;
+
+    // Capture exact commit hash BEFORE removing .git/
+    let pinned_rev = get_head_commit(&pkg_dir).unwrap_or_else(|| {
+        rev.unwrap_or("main").to_string()
+    });
+
+    // Remove .git/ (no nested repos)
+    let git_dir = pkg_dir.join(".git");
+    if git_dir.exists() {
+        let _ = fs::remove_dir_all(&git_dir);
+    }
+
+    // Verify
+    if !pkg_dir.join("src").exists() && !has_oti_files(&pkg_dir) {
+        let _ = fs::remove_dir_all(&pkg_dir);
+        return Err(format!(
+            "'{}' has no src/ directory or .oti files — not a valid Pyde package",
+            pkg_name
+        ));
+    }
+
+    // Update pyde.toml
+    let dep = Dependency {
+        git: url.to_string(),
+        rev: rev.map(|s| s.to_string()),
+    };
+    update_toml(&root, &pkg_name, &dep)?;
+
+    // Update pyde.lock
+    update_lock(&root, &pkg_name, url, &pinned_rev)?;
+
+    let oti_count = count_oti_files(&pkg_dir);
+    println!("  Installed {} ({} .oti files, pinned at {})", pkg_name, oti_count, &pinned_rev[..7.min(pinned_rev.len())]);
+
+    Ok(())
+}
+
+/// Restore all dependencies from pyde.lock.
+fn restore_all() -> Result<(), String> {
+    let (_, root) = project::load_config()?;
+    let lock = load_lock(&root);
+
+    if lock.packages.is_empty() {
+        println!("  No dependencies to install (pyde.lock is empty)");
+        return Ok(());
+    }
+
+    let lib_dir = root.join("lib");
+    fs::create_dir_all(&lib_dir)
+        .map_err(|e| format!("cannot create lib/: {}", e))?;
+
+    for pkg in &lock.packages {
+        let pkg_dir = lib_dir.join(&pkg.name);
+        if pkg_dir.exists() {
+            println!("  {} — already installed, skipping", pkg.name);
+            continue;
+        }
+
+        println!("  Installing {} from {} (rev {})", pkg.name, pkg.git, &pkg.rev[..7.min(pkg.rev.len())]);
+        clone_repo(&pkg.git, Some(&pkg.rev), &pkg_dir)?;
+
+        let git_dir = pkg_dir.join(".git");
+        if git_dir.exists() {
+            let _ = fs::remove_dir_all(&git_dir);
+        }
+    }
+
+    println!("  Restored {} packages from pyde.lock", lock.packages.len());
+    Ok(())
+}
+
+/// Remove an installed package.
+pub fn remove(name: &str) -> Result<(), String> {
+    let (_, root) = project::load_config()?;
+    let pkg_dir = root.join("lib").join(name);
+
+    if !pkg_dir.exists() {
+        return Err(format!("package '{}' is not installed", name));
+    }
+    if name.starts_with('@') {
+        return Err(format!("cannot remove built-in package '{}'", name));
+    }
+
+    fs::remove_dir_all(&pkg_dir)
+        .map_err(|e| format!("cannot remove {}: {}", pkg_dir.display(), e))?;
+
+    remove_from_toml(&root, name)?;
+    remove_from_lock(&root, name)?;
+
+    println!("  Removed {}", name);
+    Ok(())
+}
+
+// ============================================================================
+// Git helpers
+// ============================================================================
+
+fn clone_repo(url: &str, rev: Option<&str>, dest: &Path) -> Result<(), String> {
+    let branch = rev.unwrap_or("main");
+    let status = Cmd::new("git")
+        .args(["clone", "--depth", "1", "--branch", branch, url, &dest.to_string_lossy()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| format!("failed to run git: {}", e))?;
+
+    if !status.success() {
+        // Retry without --branch (commit hash or default branch differs)
+        let status2 = Cmd::new("git")
+            .args(["clone", "--depth", "1", url, &dest.to_string_lossy()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map_err(|e| format!("failed to run git: {}", e))?;
+
+        if !status2.success() {
+            return Err(format!("git clone failed for {}", url));
+        }
+
+        if let Some(r) = rev {
+            let checkout = Cmd::new("git")
+                .args(["-C", &dest.to_string_lossy(), "checkout", r])
+                .status()
+                .map_err(|e| format!("git checkout failed: {}", e))?;
+            if !checkout.success() {
+                let _ = fs::remove_dir_all(dest);
+                return Err(format!("git checkout '{}' failed", r));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_head_commit(repo_dir: &Path) -> Option<String> {
+    let output = Cmd::new("git")
+        .args(["-C", &repo_dir.to_string_lossy(), "rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+// ============================================================================
+// Lock file
+// ============================================================================
+
+fn load_lock(root: &Path) -> LockFile {
+    let lock_path = root.join("pyde.lock");
+    if let Ok(content) = fs::read_to_string(&lock_path) {
+        toml::from_str(&content).unwrap_or_default()
+    } else {
+        LockFile::default()
+    }
+}
+
+fn save_lock(root: &Path, lock: &LockFile) -> Result<(), String> {
+    let content = toml::to_string_pretty(lock)
+        .map_err(|e| format!("cannot serialize lock file: {}", e))?;
+    fs::write(root.join("pyde.lock"), content)
+        .map_err(|e| format!("cannot write pyde.lock: {}", e))
+}
+
+fn update_lock(root: &Path, name: &str, git: &str, rev: &str) -> Result<(), String> {
+    let mut lock = load_lock(root);
+    // Remove existing entry if present
+    lock.packages.retain(|p| p.name != name);
+    lock.packages.push(LockedPackage {
+        name: name.to_string(),
+        git: git.to_string(),
+        rev: rev.to_string(),
+    });
+    save_lock(root, &lock)
+}
+
+fn remove_from_lock(root: &Path, name: &str) -> Result<(), String> {
+    let mut lock = load_lock(root);
+    lock.packages.retain(|p| p.name != name);
+    save_lock(root, &lock)
+}
+
+// ============================================================================
+// URL / file helpers
+// ============================================================================
+
+fn parse_repo_name(url: &str) -> String {
+    let url = url.trim_end_matches('/');
+    url.rsplit('/').next().unwrap_or("").trim_end_matches(".git").to_string()
+}
+
+fn has_oti_files(dir: &Path) -> bool {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && path.extension().map(|e| e == "oti").unwrap_or(false) {
+                return true;
+            }
+            if path.is_dir() && has_oti_files(&path) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn count_oti_files(dir: &Path) -> usize {
+    let mut count = 0;
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && path.extension().map(|e| e == "oti").unwrap_or(false) {
+                count += 1;
+            }
+            if path.is_dir() {
+                count += count_oti_files(&path);
+            }
+        }
+    }
+    count
+}
+
+// ============================================================================
+// pyde.toml manipulation
+// ============================================================================
+
+fn update_toml(root: &Path, name: &str, dep: &Dependency) -> Result<(), String> {
+    let toml_path = root.join("pyde.toml");
+    let content = fs::read_to_string(&toml_path)
+        .map_err(|e| format!("cannot read pyde.toml: {}", e))?;
+
+    let dep_line = format_dep_line(name, dep);
+    let new_content = if content.contains("[dependencies]") {
+        if let Some(idx) = content.find("[dependencies]") {
+            let after = idx + "[dependencies]".len();
+            let rest = &content[after..];
+            let insert_at = if let Some(next_section) = rest.find("\n[") {
+                after + next_section
+            } else {
+                content.len()
+            };
+            format!("{}{}\n{}", &content[..insert_at], dep_line, &content[insert_at..])
+        } else {
+            content
+        }
+    } else {
+        format!("{}\n[dependencies]\n{}\n", content.trim_end(), dep_line)
+    };
+
+    fs::write(&toml_path, new_content)
+        .map_err(|e| format!("cannot write pyde.toml: {}", e))
+}
+
+fn remove_from_toml(root: &Path, name: &str) -> Result<(), String> {
+    let toml_path = root.join("pyde.toml");
+    let content = fs::read_to_string(&toml_path)
+        .map_err(|e| format!("cannot read pyde.toml: {}", e))?;
+    let prefix = format!("{} = ", name);
+    let new_content: String = content
+        .lines()
+        .filter(|line| !line.starts_with(&prefix))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&toml_path, format!("{}\n", new_content.trim_end()))
+        .map_err(|e| format!("cannot write pyde.toml: {}", e))
+}
+
+fn format_dep_line(name: &str, dep: &Dependency) -> String {
+    if let Some(ref rev) = dep.rev {
+        format!("{} = {{ git = \"{}\", rev = \"{}\" }}", name, dep.git, rev)
+    } else {
+        format!("{} = {{ git = \"{}\" }}", name, dep.git)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_repo_name_https() {
+        assert_eq!(parse_repo_name("https://github.com/user/my-lib.git"), "my-lib");
+    }
+
+    #[test]
+    fn parse_repo_name_no_git_suffix() {
+        assert_eq!(parse_repo_name("https://github.com/user/my-lib"), "my-lib");
+    }
+
+    #[test]
+    fn parse_repo_name_trailing_slash() {
+        assert_eq!(parse_repo_name("https://github.com/user/my-lib/"), "my-lib");
+    }
+
+    #[test]
+    fn parse_repo_name_ssh() {
+        assert_eq!(parse_repo_name("git@github.com:user/my-lib.git"), "my-lib");
+    }
+
+    #[test]
+    fn format_dep_line_with_rev() {
+        let dep = Dependency { git: "https://github.com/user/lib.git".into(), rev: Some("v1.0".into()) };
+        assert_eq!(format_dep_line("mylib", &dep), "mylib = { git = \"https://github.com/user/lib.git\", rev = \"v1.0\" }");
+    }
+
+    #[test]
+    fn format_dep_line_no_rev() {
+        let dep = Dependency { git: "https://github.com/user/lib.git".into(), rev: None };
+        assert_eq!(format_dep_line("mylib", &dep), "mylib = { git = \"https://github.com/user/lib.git\" }");
+    }
+
+    #[test]
+    fn lock_file_roundtrip() {
+        let lock = LockFile {
+            packages: vec![
+                LockedPackage { name: "foo".into(), git: "https://example.com/foo".into(), rev: "abc123".into() },
+                LockedPackage { name: "bar".into(), git: "https://example.com/bar".into(), rev: "def456".into() },
+            ],
+        };
+        let s = toml::to_string_pretty(&lock).unwrap();
+        let parsed: LockFile = toml::from_str(&s).unwrap();
+        assert_eq!(parsed.packages.len(), 2);
+        assert_eq!(parsed.packages[0].name, "foo");
+        assert_eq!(parsed.packages[1].rev, "def456");
+    }
+}

--- a/crates/pyde-dev/src/lib.rs
+++ b/crates/pyde-dev/src/lib.rs
@@ -6,6 +6,7 @@ pub mod deploy;
 pub mod doc;
 pub mod fmt;
 pub mod init;
+pub mod install;
 pub mod project;
 pub mod script;
 pub mod test_runner;

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -5,6 +5,7 @@ mod build;
 mod clean;
 mod doc;
 mod fmt;
+mod install;
 mod script;
 mod test_runner;
 mod deploy;
@@ -23,6 +24,13 @@ fn main() {
         Command::Build => build::run(),
         Command::Test { filter, verbosity } => test_runner::run(filter.as_deref(), verbosity),
         Command::Script { file, network, from } => script::run(&file, &network, &from),
+        Command::Install { url, rev, name } => {
+            match url {
+                Some(u) => install::run(&u, rev.as_deref(), name.as_deref()),
+                None => install::run("__restore__", None, None),
+            }
+        }
+        Command::Remove { name } => install::remove(&name),
         Command::Fmt => fmt::run(),
         Command::Doc => doc::run(),
         Command::Clean => clean::run(),

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -11,6 +11,15 @@ pub struct ProjectConfig {
     pub testing: TestSection,
     #[serde(default)]
     pub networks: HashMap<String, NetworkConfig>,
+    #[serde(default)]
+    pub dependencies: HashMap<String, Dependency>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Dependency {
+    pub git: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]


### PR DESCRIPTION
## Summary

- `pyde install <git-url>` — shallow clone to lib/, pin exact commit in pyde.lock
- `pyde install` (no args) — restore all deps from pyde.lock
- `pyde remove <name>` — delete from lib/, pyde.toml, pyde.lock
- Build discovers lib packages, resolves imports with hyphen-to-underscore mapping
- .gitignore updated to ignore lib/ (keeps @std/)

## Changes

- **install.rs** (new) — git clone, lock file, toml update, 7 unit tests
- **project.rs** — `Dependency` struct, `[dependencies]` config section
- **cli.rs** — `Install` and `Remove` commands
- **build.rs** — scan `lib/*/src/**/*.oti`, register modules in dep graph
- **init.rs** — .gitignore ignores `out/` and `lib/` (keeps `!lib/@std/`)
- **resolve.rs** — add `deploy!` to known macros
- **typecheck.rs** — handle `Expr::Ident` in deploy! validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)