### PR TITLE
feat: pyde call and pyde tx commands

### DIFF
--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -116,6 +116,31 @@ pub enum Command {
         network: String,
     },
 
+    /// Call a contract function (read-only, no signing needed).
+    /// Example: `pyde-dev call 0xaddr get_count() --network devnet`
+    Call {
+        /// Contract address (hex).
+        address: String,
+
+        /// Function call: `method()` or `method(arg1, arg2)`.
+        function: String,
+
+        /// Network name.
+        #[arg(short, long, default_value = "devnet")]
+        network: String,
+    },
+
+    /// Check transaction status/receipt.
+    /// Example: `pyde-dev tx 0xtxhash --network devnet`
+    Tx {
+        /// Transaction hash (hex).
+        hash: String,
+
+        /// Network name.
+        #[arg(short, long, default_value = "devnet")]
+        network: String,
+    },
+
     /// Generate documentation from source contracts.
     Doc,
 

--- a/crates/pyde-dev/src/console.rs
+++ b/crates/pyde-dev/src/console.rs
@@ -299,6 +299,83 @@ fn rpc_call(
     Ok(json.get("result").cloned().unwrap_or(serde_json::Value::Null))
 }
 
+// ============================================================================
+// One-shot CLI commands (used by main.rs dispatch)
+// ============================================================================
+
+/// `pyde-dev call <address> <function>(<args>) --network devnet`
+pub fn cmd_call(address: &str, function: &str, network: &str) -> Result<(), String> {
+    let (config, _) = crate::project::load_config()?;
+    let net = config.networks.get(network)
+        .ok_or_else(|| format!("network '{}' not found in pyde.toml", network))?;
+
+    let (method, method_args) = parse_function(function)?;
+    let selector = compute_selector(&method);
+    let mut calldata = selector.to_be_bytes().to_vec();
+    for arg in &method_args {
+        calldata.extend_from_slice(&encode_arg(arg));
+    }
+
+    let client = reqwest::blocking::Client::new();
+    let params = serde_json::json!({
+        "from": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "to": address,
+        "data": format!("0x{}", hex::encode(&calldata)),
+    });
+    let result = rpc_call(&client, &net.rpc_url, "pyde_call", &[params])?;
+    let hex = result.as_str().unwrap_or("0x0");
+    let hex_clean = hex.trim_start_matches("0x");
+    if let Ok(val) = u128::from_str_radix(hex_clean, 16) {
+        println!("  {}", val);
+    } else {
+        println!("  {}", hex);
+    }
+    Ok(())
+}
+
+/// `pyde-dev tx <hash> --network devnet`
+pub fn cmd_tx(hash: &str, network: &str) -> Result<(), String> {
+    let (config, _) = crate::project::load_config()?;
+    let net = config.networks.get(network)
+        .ok_or_else(|| format!("network '{}' not found in pyde.toml", network))?;
+
+    let client = reqwest::blocking::Client::new();
+    let result = rpc_call(&client, &net.rpc_url, "pyde_getTransactionReceipt", &[json_str(hash)])?;
+
+    if result.is_null() {
+        println!("  Receipt not found (tx may be pending or invalid)");
+    } else {
+        let success = result.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+        let gas = result.get("gasUsed").and_then(|v| v.as_str()).unwrap_or("0");
+        let return_data = result.get("returnData").and_then(|v| v.as_str()).unwrap_or("");
+
+        println!("  Status:     {}", if success { "Success" } else { "Reverted" });
+        println!("  Gas Used:   {}", gas);
+        if !return_data.is_empty() && return_data != "0x" {
+            println!("  Return:     {}", return_data);
+        }
+        let fee_paid = result.get("feePaid").and_then(|v| v.as_str()).unwrap_or("0");
+        println!("  Fee Paid:   {} quanta", fee_paid);
+    }
+    Ok(())
+}
+
+/// Parse `method(arg1, arg2)` into (method, [args]).
+fn parse_function(input: &str) -> Result<(String, Vec<String>), String> {
+    if let Some(paren_start) = input.find('(') {
+        let method = input[..paren_start].trim().to_string();
+        let args_str = input[paren_start + 1..].trim_end_matches(')').trim();
+        let args = if args_str.is_empty() {
+            vec![]
+        } else {
+            args_str.split(',').map(|s| s.trim().to_string()).collect()
+        };
+        Ok((method, args))
+    } else {
+        Ok((input.trim().to_string(), vec![]))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -49,6 +49,12 @@ fn main() {
         Command::Transfer { to, amount, wallet: wallet_name, network } => {
             wallet::cmd_transfer(&to, amount, &wallet_name, &network)
         }
+        Command::Call { address, function, network } => {
+            console::cmd_call(&address, &function, &network)
+        }
+        Command::Tx { hash, network } => {
+            console::cmd_tx(&hash, &network)
+        }
         Command::Fmt => fmt::run(),
         Command::Doc => doc::run(),
         Command::Clean => clean::run(),


### PR DESCRIPTION
## Summary

- `pyde-dev call <address> <method>(<args>)` — read-only contract call via pyde_call RPC
- `pyde-dev tx <hash>` — show receipt: status, gas, fee, return data

Completes M11.4 CLI wallet milestone.