### PR TITLE
feat: --wallet flag on deploy/script/console, file permissions 600/700

### DIFF
--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -43,9 +43,13 @@ pub enum Command {
         #[arg(short, long, default_value = "devnet")]
         network: String,
 
-        /// Sender address (hex).
+        /// Sender address (hex). Used when no --wallet specified (devnet mode).
         #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
         from: String,
+
+        /// Wallet name for signing transactions.
+        #[arg(short, long)]
+        wallet: Option<String>,
     },
 
     /// Install a package from a git URL, or restore all from pyde.lock.
@@ -75,9 +79,13 @@ pub enum Command {
         #[arg(short, long, default_value = "devnet")]
         network: String,
 
-        /// Sender address (hex).
+        /// Sender address (hex). Used when no --wallet specified (devnet mode).
         #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
         from: String,
+
+        /// Wallet name for signing send transactions.
+        #[arg(short, long)]
+        wallet: Option<String>,
     },
 
     /// Verify a deployed contract matches local source.

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -26,7 +26,10 @@ fn main() {
         Command::Init { name } => init::run(&name),
         Command::Build => build::run(),
         Command::Test { filter, verbosity } => test_runner::run(filter.as_deref(), verbosity),
-        Command::Script { file, network, from } => script::run(&file, &network, &from),
+        Command::Script { file, network, from, wallet: _wallet } => {
+            // TODO: when wallet is Some, sign txs in script runner
+            script::run(&file, &network, &from)
+        }
         Command::Install { url, rev, name } => {
             match url {
                 Some(u) => install::run(&u, rev.as_deref(), name.as_deref()),
@@ -34,7 +37,10 @@ fn main() {
             }
         }
         Command::Remove { name } => install::remove(&name),
-        Command::Console { network, from } => console::run(&network, &from),
+        Command::Console { network, from, wallet: _wallet } => {
+            // TODO: when wallet is Some, sign send txs in console
+            console::run(&network, &from)
+        }
         Command::Verify { address, contract, network } => {
             verify::run(&address, contract.as_deref(), &network)
         }
@@ -58,8 +64,15 @@ fn main() {
         Command::Fmt => fmt::run(),
         Command::Doc => doc::run(),
         Command::Clean => clean::run(),
-        Command::Deploy { network, contract, from, wallet: _, verify } => {
-            deploy::run(&network, contract.as_deref(), &from, verify)
+        Command::Deploy { network, contract, from, wallet, verify } => {
+            let effective_from = match wallet {
+                Some(ref w) => wallet::resolve_wallet_address(w),
+                None => Ok(from),
+            };
+            match effective_from {
+                Ok(addr) => deploy::run(&network, contract.as_deref(), &addr, verify),
+                Err(e) => Err(e),
+            }
         }
     };
 

--- a/crates/pyde-dev/src/wallet.rs
+++ b/crates/pyde-dev/src/wallet.rs
@@ -244,6 +244,13 @@ fn save_keystore(name: &str, keystore: &Keystore) -> Result<(), String> {
     fs::create_dir_all(&dir)
         .map_err(|e| format!("cannot create wallet dir: {}", e))?;
 
+    // Set directory permissions to 700 (owner only)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+    }
+
     let path = dir.join(format!("{}.json", name));
     if path.exists() {
         return Err(format!("wallet '{}' already exists", name));
@@ -253,6 +260,13 @@ fn save_keystore(name: &str, keystore: &Keystore) -> Result<(), String> {
         .map_err(|e| format!("serialize error: {}", e))?;
     fs::write(&path, json)
         .map_err(|e| format!("cannot write keystore: {}", e))?;
+
+    // Set file permissions to 600 (owner read/write only)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
 
     Ok(())
 }
@@ -277,6 +291,14 @@ pub fn prompt_password(prompt: &str) -> Result<String, String> {
         .read_line(&mut password)
         .map_err(|e| format!("cannot read password: {}", e))?;
     Ok(password.trim().to_string())
+}
+
+/// Load a wallet by name, prompt for password, return the address hex.
+/// Used by deploy/script/console when --wallet is specified.
+pub fn resolve_wallet_address(name: &str) -> Result<String, String> {
+    let password = prompt_password("  Enter wallet password: ")?;
+    let w = load(name, &password)?;
+    Ok(w.address_hex())
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- `deploy --wallet <name>`: resolves wallet address, deploys from wallet account
- `script/console --wallet`: flag accepted (tx signing integration TODO)
- Keystore files set to 600 (owner read/write only)
- Wallet directory set to 700 (owner only)