### PR TITLE
feat: Rust SDK full type coverage, decode safety, production hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,11 +1302,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3442,16 +3444,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyde-crypto-wasm"
+version = "0.1.0"
+dependencies = [
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
+ "hex",
+ "pyde-crypto",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "pyde-dev"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "clap",
  "ethnum",
  "glob",
  "hex",
  "otic",
+ "pyde-account",
  "pyde-crypto",
+ "pyde-tx",
  "pyde-vm",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -3495,6 +3515,7 @@ dependencies = [
  "libp2p",
  "metrics",
  "metrics-exporter-prometheus",
+ "otic",
  "pyde-account",
  "pyde-aot",
  "pyde-consensus",
@@ -3513,6 +3534,24 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "pyde-rust-sdk"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "ethnum",
+ "hex",
+ "pyde-account",
+ "pyde-crypto",
+ "pyde-tx",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -46,6 +46,7 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Keystore Encryption](#keystore-encryption)
   - [File Permissions](#file-permissions)
   - [Post-Quantum Cryptography](#post-quantum-cryptography)
+- [Utility Functions](#utility-functions)
 - [Architecture](#architecture)
 
 ---
@@ -65,7 +66,8 @@ tokio = { version = "1", features = ["full"] }
 ## Getting Started
 
 ```rust
-use pyde_rust_sdk::{Provider, Wallet, ContractCall};
+use pyde_rust_sdk::{Provider, Wallet, Contract};
+use serde_json::json;
 
 #[tokio::main]
 async fn main() -> pyde_rust_sdk::Result<()> {
@@ -81,8 +83,15 @@ async fn main() -> pyde_rust_sdk::Result<()> {
     println!("Balance: {} quanta", balance);
 
     // 4. Transfer tokens
-    let receipt = wallet.transfer(&provider, &recipient, 1_000_000).await?;
+    let to = pyde_rust_sdk::parse_address("0x00bb...")?;
+    let receipt = wallet.transfer(&provider, &to, 1_000_000).await?;
     println!("Tx hash: {}", receipt.tx_hash);
+
+    // 5. Interact with a contract (load ABI from build artifact)
+    let contract = Contract::from_artifact("out/Counter.json", addr, &provider)?
+        .connect(&wallet);
+    let count = contract.read("get_count", &json!({})).await?;
+    contract.write("increment", &json!({}), 100_000_000).await?;
 
     Ok(())
 }
@@ -138,15 +147,17 @@ if let Some(b) = block {
 Execute a contract function without creating a transaction. No gas consumed.
 
 ```rust
-let calldata = ContractCall::new("get_count").build();
+// Using Contract (recommended)
+let contract = Contract::from_artifact("out/Counter.json", addr, &provider)?;
+let count = contract.read("get_count", &json!({})).await?; // Value::U64(42)
+
+// Low-level (manual calldata)
 let result = provider.call(&contract_addr, &calldata).await?; // Vec<u8>
-let count = decode_u64(&result);  // Some(42)
 ```
 
 ### Gas Estimation
 
 ```rust
-let calldata = ContractCall::new("deposit").arg_u64(500).build();
 let gas = provider.estimate_gas(&contract_addr, &calldata).await?; // u64
 ```
 
@@ -240,13 +251,14 @@ println!("Fee: {} quanta", receipt.fee_paid);
 ### Calling a Contract Function
 
 ```rust
+// Using Contract (recommended — validates args against ABI)
+let contract = Contract::from_artifact("out/Contract.json", addr, &provider)?
+    .connect(&wallet);
+let receipt = contract.write("deposit", &json!({"amount": 500}), 100_000_000).await?;
+
+// Low-level (manual calldata + wallet)
 let calldata = ContractCall::new("deposit").arg_u64(500).build();
-let receipt = wallet.send_call(
-    &provider,
-    &contract_addr,
-    calldata,
-    100_000_000,  // gas limit
-).await?;
+let receipt = wallet.send_call(&provider, &contract_addr, calldata, 100_000_000).await?;
 ```
 
 ### Deploying a Contract
@@ -290,18 +302,29 @@ let receipt = provider.send_and_wait(&signed_tx, 10_000).await?;
 
 ## Contract Interaction
 
-### Building Calldata
+> **Recommended**: Use `Contract::from_artifact()` with `.read()` / `.write()` for ABI-aware
+> interaction with validation. The `ContractCall` builder below is for low-level / dynamic use
+> when you don't have an artifact.
+
+### Low-Level Calldata Builder
 
 ```rust
 // No args
 ContractCall::new("increment").build();
 
-// GP types (8 bytes)
+// Unsigned GP types (8 bytes LE, zero-extended)
 ContractCall::new("set_u8").arg_u8(255).build();
 ContractCall::new("set_u16").arg_u16(1000).build();
 ContractCall::new("set_u32").arg_u32(100000).build();
 ContractCall::new("set_u64").arg_u64(42).build();
-ContractCall::new("set_i64").arg_i64(-1).build();
+
+// Signed GP types (8 bytes LE, sign-extended)
+ContractCall::new("set_i8").arg_i8(-1).build();
+ContractCall::new("set_i16").arg_i16(-500).build();
+ContractCall::new("set_i32").arg_i32(-1_000_000).build();
+ContractCall::new("set_i64").arg_i64(-42).build();
+
+// Bool
 ContractCall::new("set_active").arg_bool(true).build();
 
 // Address (32 bytes)
@@ -437,9 +460,16 @@ struct/enum definitions, validates args before broadcast, auto-encodes and decod
 ```rust
 use serde_json::json;
 
-// Load from build artifact (gets all functions, structs, enums)
+// Load from build artifact file (gets all functions, structs, enums)
 let contract = Contract::from_artifact("out/MyContract.json", addr, &provider)?
     .connect(&wallet);
+
+// Or load from a raw ABI JSON string
+let contract = Contract::from_json(&abi_json_string, addr, &provider)?
+    .connect(&wallet);
+
+// Or create a minimal contract (no ABI — for low-level use)
+let contract = Contract::new(addr, &provider);
 
 // Read — auto-decoded return value
 let count = contract.read("get_count", &json!({})).await?;    // Value::U64(42)
@@ -489,23 +519,35 @@ Return values are decoded into a `Value` enum supporting all Pyde types.
 ```rust
 pub enum Value {
     U64(u64),
+    I64(i64),
     U128(u128),
+    I128(i128),
     U256(ethnum::U256),
+    I256(ethnum::I256),
     Bool(bool),
     Address([u8; 32]),
     String(String),
     Bytes(Vec<u8>),
     Vec(Vec<Value>),
     Struct(HashMap<String, Value>),
+    Enum(String),        // variant name
     Unit,
 }
 
-// Accessors
+// Accessors — each returns Option<T>
 value.as_u64()       // Option<u64>
-value.as_string()    // Option<&str>
+value.as_i64()       // Option<i64>
+value.as_u128()      // Option<u128>
+value.as_i128()      // Option<i128>
+value.as_u256()      // Option<U256>
+value.as_i256()      // Option<I256>
 value.as_bool()      // Option<bool>
+value.as_address()   // Option<&[u8; 32]>
+value.as_string()    // Option<&str>
+value.as_bytes()     // Option<&[u8]>
 value.as_vec()       // Option<&[Value]>
 value.as_struct()    // Option<&HashMap<String, Value>>
+value.as_enum()      // Option<&str>  (variant name)
 
 // Struct field access
 value.field("name")  // Option<&Value>
@@ -519,12 +561,26 @@ value.index(0)       // Option<&Value>
 Manual decoders for raw return bytes.
 
 ```rust
-let count = decode_u64(&bytes);     // Option<u64>
-let big = decode_u256(&bytes);      // Option<U256>
-let flag = decode_bool(&bytes);     // Option<bool>
-let addr = decode_address(&bytes);  // Option<[u8; 32]>
-let name = decode_string(&bytes);   // Option<String>
-let amt = decode_u128(&bytes);      // Option<u128>
+// GP integers
+let count = decode_u64(&bytes);      // Option<u64>
+let neg   = decode_i64(&bytes);      // Option<i64>
+
+// Wide integers
+let amt   = decode_u128(&bytes);     // Option<u128>
+let sneg  = decode_i128(&bytes);     // Option<i128>
+let big   = decode_u256(&bytes);     // Option<U256>
+let sbig  = decode_i256(&bytes);     // Option<I256>
+
+// Other types
+let flag  = decode_bool(&bytes);     // Option<bool>
+let addr  = decode_address(&bytes);  // Option<[u8; 32]>
+let name  = decode_string(&bytes);   // Option<String>
+let raw   = decode_bytes(&bytes);    // Option<Vec<u8>>
+
+// Vec decoders
+let nums  = decode_vec_u64(&bytes);     // Option<Vec<u64>>
+let flags = decode_vec_bool(&bytes);    // Option<Vec<bool>>
+let addrs = decode_vec_address(&bytes); // Option<Vec<[u8; 32]>>
 ```
 
 ---
@@ -668,6 +724,23 @@ All cryptographic operations are post-quantum safe:
 - **Signing**: FALCON-512 (lattice-based, NIST standard)
 - **Hashing**: Poseidon2 (ZK-friendly algebraic hash)
 - **Encryption**: AES-256-GCM (Grover-resistant at 128-bit equivalent)
+
+---
+
+## Utility Functions
+
+```rust
+use pyde_rust_sdk::{parse_address, format_address, compute_selector};
+
+// Parse a hex address string to [u8; 32]
+let addr = parse_address("0xaabb...")?;
+
+// Format a [u8; 32] address as 0x-prefixed hex
+let hex = format_address(&addr);  // "0xaabb..."
+
+// Compute FNV-1a function selector (same as Otigen compiler)
+let selector = compute_selector("get_count");  // 0xd9e32bf7
+```
 
 ---
 

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -16,6 +16,7 @@ pub enum Value {
     U128(u128),
     I128(i128),
     U256(ethnum::U256),
+    I256(ethnum::I256),
     Bool(bool),
     Address([u8; 32]),
     String(String),
@@ -30,7 +31,9 @@ impl Value {
     pub fn as_u64(&self) -> Option<u64> { if let Value::U64(v) = self { Some(*v) } else { None } }
     pub fn as_i64(&self) -> Option<i64> { if let Value::I64(v) = self { Some(*v) } else { None } }
     pub fn as_u128(&self) -> Option<u128> { if let Value::U128(v) = self { Some(*v) } else { None } }
+    pub fn as_i128(&self) -> Option<i128> { if let Value::I128(v) = self { Some(*v) } else { None } }
     pub fn as_u256(&self) -> Option<ethnum::U256> { if let Value::U256(v) = self { Some(*v) } else { None } }
+    pub fn as_i256(&self) -> Option<ethnum::I256> { if let Value::I256(v) = self { Some(*v) } else { None } }
     pub fn as_bool(&self) -> Option<bool> { if let Value::Bool(v) = self { Some(*v) } else { None } }
     pub fn as_address(&self) -> Option<&[u8; 32]> { if let Value::Address(v) = self { Some(v) } else { None } }
     pub fn as_string(&self) -> Option<&str> { if let Value::String(v) = self { Some(v) } else { None } }
@@ -203,25 +206,37 @@ impl<'a> Contract<'a> {
 
     fn encode_value(&self, buf: &mut Vec<u8>, value: &serde_json::Value, ty: &str, path: &str) -> Result<()> {
         match ty {
-            "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" => {
-                let n = value.as_i64().or_else(|| value.as_u64().map(|v| v as i64))
+            "u8" | "u16" | "u32" | "u64" => {
+                let n = value.as_u64()
                     .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected {}, got {:?}", path, ty, value)))?;
-                self.validate_int_range(n as i128, ty, path)?;
-                if ty.starts_with('i') {
-                    buf.extend_from_slice(&(n as u64).to_le_bytes());
-                } else {
-                    buf.extend_from_slice(&(n as u64).to_le_bytes());
-                }
-            }
-            "u128" | "i128" => {
-                let n = parse_json_u128(value)
-                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected {}", path, ty)))?;
+                self.validate_uint_range(n, ty, path)?;
                 buf.extend_from_slice(&n.to_le_bytes());
             }
-            "u256" | "i256" => {
-                let n = parse_json_u128(value).unwrap_or(0) as u128;
-                let val = ethnum::U256::from(n);
-                buf.extend_from_slice(&val.to_le_bytes());
+            "i8" | "i16" | "i32" | "i64" => {
+                let n = value.as_i64()
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected {}, got {:?}", path, ty, value)))?;
+                self.validate_int_range(n, ty, path)?;
+                buf.extend_from_slice(&n.to_le_bytes());
+            }
+            "u128" => {
+                let n = parse_json_u128(value)
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected u128", path)))?;
+                buf.extend_from_slice(&n.to_le_bytes());
+            }
+            "i128" => {
+                let n = parse_json_i128(value)
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected i128", path)))?;
+                buf.extend_from_slice(&n.to_le_bytes());
+            }
+            "u256" => {
+                let n = parse_json_u256(value)
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected u256", path)))?;
+                buf.extend_from_slice(&n.to_le_bytes());
+            }
+            "i256" => {
+                let n = parse_json_i256(value)
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected i256", path)))?;
+                buf.extend_from_slice(&n.to_le_bytes());
             }
             "bool" => {
                 let b = value.as_bool()
@@ -240,6 +255,17 @@ impl<'a> Contract<'a> {
                 let bytes = s.as_bytes();
                 buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
                 buf.extend_from_slice(bytes);
+                let pad = (8 - (bytes.len() % 8)) % 8;
+                buf.extend(std::iter::repeat(0u8).take(pad));
+            }
+            "Bytes" | "bytes" => {
+                let s = value.as_str()
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected hex string for Bytes", path)))?;
+                let hex = s.trim_start_matches("0x");
+                let bytes = ::hex::decode(hex)
+                    .map_err(|e| SdkError::InvalidResponse(format!("{}: bad hex for Bytes: {}", path, e)))?;
+                buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+                buf.extend_from_slice(&bytes);
                 let pad = (8 - (bytes.len() % 8)) % 8;
                 buf.extend(std::iter::repeat(0u8).take(pad));
             }
@@ -290,10 +316,21 @@ impl<'a> Contract<'a> {
         Ok(())
     }
 
-    fn validate_int_range(&self, n: i128, ty: &str, path: &str) -> Result<()> {
-        let (min, max): (i128, i128) = match ty {
-            "u8" => (0, 255), "u16" => (0, 65535), "u32" => (0, 4294967295), "u64" => (0, i64::MAX as i128),
-            "i8" => (-128, 127), "i16" => (-32768, 32767), "i32" => (-2147483648, 2147483647), "i64" => (i64::MIN as i128, i64::MAX as i128),
+    fn validate_uint_range(&self, n: u64, ty: &str, path: &str) -> Result<()> {
+        let max: u64 = match ty {
+            "u8" => 255, "u16" => 65535, "u32" => 4294967295, "u64" => u64::MAX,
+            _ => return Ok(()),
+        };
+        if n > max {
+            return Err(SdkError::InvalidResponse(format!("{}: value {} out of range for {} (0 to {})", path, n, ty, max)));
+        }
+        Ok(())
+    }
+
+    fn validate_int_range(&self, n: i64, ty: &str, path: &str) -> Result<()> {
+        let (min, max): (i64, i64) = match ty {
+            "i8" => (-128, 127), "i16" => (-32768, 32767),
+            "i32" => (-2147483648, 2147483647), "i64" => (i64::MIN, i64::MAX),
             _ => return Ok(()),
         };
         if n < min || n > max {
@@ -320,9 +357,17 @@ impl<'a> Contract<'a> {
                 if data.len() < offset + 16 { return (Value::U128(0), 16); }
                 (Value::U128(u128::from_le_bytes(data[offset..offset+16].try_into().unwrap())), 16)
             }
-            "u256" | "i256" => {
+            "i128" => {
+                if data.len() < offset + 16 { return (Value::I128(0), 16); }
+                (Value::I128(i128::from_le_bytes(data[offset..offset+16].try_into().unwrap())), 16)
+            }
+            "u256" => {
                 if data.len() < offset + 32 { return (Value::U256(ethnum::U256::ZERO), 32); }
                 (Value::U256(ethnum::U256::from_le_bytes(data[offset..offset+32].try_into().unwrap())), 32)
+            }
+            "i256" => {
+                if data.len() < offset + 32 { return (Value::I256(ethnum::I256::ZERO), 32); }
+                (Value::I256(ethnum::I256::from_le_bytes(data[offset..offset+32].try_into().unwrap())), 32)
             }
             "bool" => {
                 if data.len() < offset + 8 { return (Value::Bool(false), 8); }
@@ -337,20 +382,37 @@ impl<'a> Contract<'a> {
             "String" => {
                 if data.len() < offset + 8 { return (Value::String(String::new()), 8); }
                 let len = u64::from_le_bytes(data[offset..offset+8].try_into().unwrap()) as usize;
-                let s = if data.len() >= offset + 8 + len {
-                    std::string::String::from_utf8_lossy(&data[offset+8..offset+8+len]).to_string()
-                } else { String::new() };
+                let end = match (offset + 8).checked_add(len) {
+                    Some(e) if e <= data.len() => e,
+                    _ => return (Value::String(String::new()), 8),
+                };
+                let s = std::string::String::from_utf8_lossy(&data[offset+8..end]).to_string();
                 let aligned = 8 + len + ((8 - (len % 8)) % 8);
                 (Value::String(s), aligned)
+            }
+            "Bytes" | "bytes" => {
+                if data.len() < offset + 8 { return (Value::Bytes(vec![]), 8); }
+                let len = u64::from_le_bytes(data[offset..offset+8].try_into().unwrap()) as usize;
+                let end = match (offset + 8).checked_add(len) {
+                    Some(e) if e <= data.len() => e,
+                    _ => return (Value::Bytes(vec![]), 8),
+                };
+                let bytes = data[offset+8..end].to_vec();
+                let aligned = 8 + len + ((8 - (len % 8)) % 8);
+                (Value::Bytes(bytes), aligned)
             }
             _ if ty.starts_with("Vec<") && ty.ends_with('>') => {
                 let elem_type = &ty[4..ty.len()-1];
                 if data.len() < offset + 24 { return (Value::Vec(vec![]), 24); }
                 let byte_len = u64::from_le_bytes(data[offset..offset+8].try_into().unwrap()) as usize;
                 let count = u64::from_le_bytes(data[offset+8..offset+16].try_into().unwrap()) as usize;
+                // Clamp count to prevent OOM from malformed data
+                let max_elems = data.len().saturating_sub(offset + 24);
+                let safe_count = count.min(max_elems);
                 let mut cursor = offset + 24;
-                let mut items = Vec::with_capacity(count);
-                for _ in 0..count {
+                let mut items = Vec::with_capacity(safe_count);
+                for _ in 0..safe_count {
+                    if cursor >= data.len() { break; }
                     let (val, read) = self.decode_value(data, elem_type, cursor);
                     items.push(val);
                     cursor += read;
@@ -387,7 +449,48 @@ impl<'a> Contract<'a> {
 
 fn parse_json_u128(v: &serde_json::Value) -> Option<u128> {
     v.as_u64().map(|n| n as u128)
-        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        .or_else(|| v.as_str().and_then(|s| {
+            if let Some(hex) = s.strip_prefix("0x") {
+                u128::from_str_radix(hex, 16).ok()
+            } else {
+                s.parse().ok()
+            }
+        }))
+}
+
+fn parse_json_i128(v: &serde_json::Value) -> Option<i128> {
+    v.as_i64().map(|n| n as i128)
+        .or_else(|| v.as_u64().map(|n| n as i128))
+        .or_else(|| v.as_str().and_then(|s| {
+            if let Some(hex) = s.strip_prefix("0x") {
+                u128::from_str_radix(hex, 16).ok().map(|n| n as i128)
+            } else {
+                s.parse().ok()
+            }
+        }))
+}
+
+fn parse_json_u256(v: &serde_json::Value) -> Option<ethnum::U256> {
+    v.as_u64().map(|n| ethnum::U256::from(n))
+        .or_else(|| v.as_str().and_then(|s| {
+            if let Some(hex) = s.strip_prefix("0x") {
+                ethnum::U256::from_str_radix(hex, 16).ok()
+            } else {
+                s.parse::<ethnum::U256>().ok()
+            }
+        }))
+}
+
+fn parse_json_i256(v: &serde_json::Value) -> Option<ethnum::I256> {
+    v.as_i64().map(|n| ethnum::I256::from(n))
+        .or_else(|| v.as_u64().map(|n| ethnum::I256::from(n as i128)))
+        .or_else(|| v.as_str().and_then(|s| {
+            if let Some(hex) = s.strip_prefix("0x") {
+                ethnum::U256::from_str_radix(hex, 16).ok().map(|n| ethnum::I256::from_le_bytes(n.to_le_bytes()))
+            } else {
+                s.parse::<ethnum::I256>().ok()
+            }
+        }))
 }
 
 #[cfg(test)]
@@ -433,9 +536,11 @@ mod tests {
     fn encode_validates_int_range() {
         let p = dummy_provider();
         let c = Contract::from_json(&test_abi_json(), [0; 32], &p).unwrap();
+        // Negative value for u64 → rejected as not a valid u64
         let r = c.encode_call("deposit", &serde_json::json!({"amount": -1}));
         assert!(r.is_err());
-        assert!(r.unwrap_err().to_string().contains("out of range"));
+        let err = r.unwrap_err().to_string();
+        assert!(err.contains("expected u64") || err.contains("out of range"), "got: {}", err);
     }
 
     #[test]
@@ -525,5 +630,81 @@ mod tests {
         let data = 1u64.to_le_bytes();
         let (v, _) = c.decode_value(&data, "Status", 0);
         assert_eq!(v.as_enum(), Some("Banned"));
+    }
+
+    #[test]
+    fn encode_u64_full_range() {
+        // u64::MAX should be accepted (was previously capped at i64::MAX)
+        let p = dummy_provider();
+        let json = test_abi_json();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let r = c.encode_call("deposit", &serde_json::json!({"amount": u64::MAX}));
+        assert!(r.is_ok());
+        let data = r.unwrap();
+        let val = u64::from_le_bytes(data[4..12].try_into().unwrap());
+        assert_eq!(val, u64::MAX);
+    }
+
+    #[test]
+    fn encode_decode_i128() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"v","type":"i128"}],"returns":"i128","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        // Encode negative i128
+        let data = c.encode_call("set", &serde_json::json!({"v": -500})).unwrap();
+        // Decode it back
+        let (val, _) = c.decode_value(&data[4..], "i128", 0);
+        assert_eq!(val.as_i128(), Some(-500));
+    }
+
+    #[test]
+    fn encode_decode_u256() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"v","type":"u256"}],"returns":"u256","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        // u256 from hex string (above u128 range)
+        let big = "340282366920938463463374607431768211456"; // 2^128
+        let data = c.encode_call("set", &serde_json::json!({"v": big})).unwrap();
+        let (val, _) = c.decode_value(&data[4..], "u256", 0);
+        assert_eq!(val.as_u256(), Some(ethnum::U256::from(1u128) << 128));
+    }
+
+    #[test]
+    fn encode_decode_i256_negative() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"v","type":"i256"}],"returns":"i256","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let data = c.encode_call("set", &serde_json::json!({"v": -1})).unwrap();
+        let (val, _) = c.decode_value(&data[4..], "i256", 0);
+        assert_eq!(val.as_i256(), Some(ethnum::I256::from(-1i64)));
+    }
+
+    #[test]
+    fn u128_rejects_negative() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"v","type":"u128"}],"returns":"()","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let r = c.encode_call("set", &serde_json::json!({"v": -1}));
+        assert!(r.is_err());
     }
 }

--- a/crates/pyde-rust-sdk/src/contract.rs
+++ b/crates/pyde-rust-sdk/src/contract.rs
@@ -347,15 +347,17 @@ pub fn decode_address(data: &[u8]) -> Option<Address> {
 /// Decode a length-prefixed string: [len:8 LE][utf8 bytes].
 pub fn decode_string(data: &[u8]) -> Option<String> {
     let len = decode_u64(data)? as usize;
-    if data.len() < 8 + len { return None; }
-    String::from_utf8(data[8..8 + len].to_vec()).ok()
+    let total = 8_usize.checked_add(len)?;
+    if data.len() < total { return None; }
+    String::from_utf8(data[8..total].to_vec()).ok()
 }
 
 /// Decode length-prefixed bytes: [len:8 LE][raw bytes].
 pub fn decode_bytes(data: &[u8]) -> Option<Vec<u8>> {
     let len = decode_u64(data)? as usize;
-    if data.len() < 8 + len { return None; }
-    Some(data[8..8 + len].to_vec())
+    let total = 8_usize.checked_add(len)?;
+    if data.len() < total { return None; }
+    Some(data[8..total].to_vec())
 }
 
 /// Decode Vec<u64>: [byte_len:8][count:8][cap:8][elements...].
@@ -363,11 +365,12 @@ pub fn decode_vec_u64(data: &[u8]) -> Option<Vec<u64>> {
     if data.len() < 24 { return None; }
     let _byte_len = decode_u64(data)? as usize;
     let count = decode_u64(&data[8..])? as usize;
-    let _cap = decode_u64(&data[16..])?;
+    // Clamp count against physically available data to prevent OOM/overflow
+    let max_count = (data.len().saturating_sub(24)) / 8;
+    if count > max_count { return None; }
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let offset = 24 + i * 8;
-        if data.len() < offset + 8 { return None; }
         result.push(u64::from_le_bytes(data[offset..offset + 8].try_into().ok()?));
     }
     Some(result)
@@ -383,10 +386,11 @@ pub fn decode_vec_address(data: &[u8]) -> Option<Vec<Address>> {
     if data.len() < 24 { return None; }
     let _byte_len = decode_u64(data)? as usize;
     let count = decode_u64(&data[8..])? as usize;
+    let max_count = (data.len().saturating_sub(24)) / 32;
+    if count > max_count { return None; }
     let mut result = Vec::with_capacity(count);
     for i in 0..count {
         let offset = 24 + i * 32;
-        if data.len() < offset + 32 { return None; }
         let mut addr = [0u8; 32];
         addr.copy_from_slice(&data[offset..offset + 32]);
         result.push(addr);

--- a/crates/pyde-rust-sdk/src/lib.rs
+++ b/crates/pyde-rust-sdk/src/lib.rs
@@ -43,5 +43,5 @@ pub use contract::{
     decode_vec_u64, decode_vec_bool, decode_vec_address,
 };
 pub use error::{Result, SdkError};
-pub use types::{format_address, parse_address, Address, Receipt, Log, LogFilter};
+pub use types::{format_address, parse_address, Address, Receipt, Log, LogFilter, BlockHeader};
 pub use wallet::{Keystore, SignerProvider, Wallet};


### PR DESCRIPTION
## Summary
- Fix u64 range validation (was capped at i64::MAX, now u64::MAX), split unsigned/signed parsing
- Fix i128 encoding for negative values, u256/i256 to full 256-bit precision
- Add i128, i256, Bytes decode paths + Value::I256 variant with accessors
- Add Bytes encode path for full encode/decode symmetry
- Guard all decoders against usize overflow from malicious length prefixes (checked_add)
- Clamp Vec capacity against available data to prevent OOM from crafted input
- Add hex string support for parse_json_i128/i256, export BlockHeader
- Remove duplicate unsafe Bytes decode arm (safe version was shadowed)
- 34 tests (5 new), README fully updated with all public exports documented