### PR TITLE
feat: deploy with named args, full type coverage, DX improvements

### DIFF
--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -18,9 +18,12 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
 - [Wallet](#wallet)
   - [Creating a Wallet](#creating-a-wallet)
   - [Restoring a Wallet](#restoring-a-wallet)
+  - [Provider Binding (connect)](#provider-binding-connect)
   - [Encrypted Keystore](#encrypted-keystore)
   - [Exporting Keys](#exporting-keys)
-  - [Signing Transactions](#signing-transactions)
+  - [Validation](#validation)
+  - [Signing](#signing)
+- [Address Utilities](#address-utilities)
 - [Transactions](#transactions)
   - [Sending a Transfer](#sending-a-transfer)
   - [Calling a Contract Function](#calling-a-contract-function)
@@ -35,7 +38,10 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Structs & Tuples](#structs--tuples)
   - [Nested Types](#nested-types)
   - [Deploy Data with Constructor Args](#deploy-data-with-constructor-args)
-  - [ABI-Aware Reads](#abi-aware-reads)
+  - [ABI-Aware Contract (fromArtifact + connect)](#abi-aware-contract-fromartifact--connect)
+  - [Simulating Calls](#simulating-calls)
+  - [Gas Estimation (ABI-Aware)](#gas-estimation-abi-aware)
+  - [Payable Functions](#payable-functions)
   - [The Value Enum](#the-value-enum)
   - [Decoding Return Values](#decoding-return-values)
 - [Events & Logs](#events--logs)
@@ -47,6 +53,7 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [File Permissions](#file-permissions)
   - [Post-Quantum Cryptography](#post-quantum-cryptography)
 - [Utility Functions](#utility-functions)
+- [Unit Formatting](#unit-formatting)
 - [Architecture](#architecture)
 
 ---
@@ -90,8 +97,8 @@ async fn main() -> pyde_rust_sdk::Result<()> {
     // 5. Interact with a contract (load ABI from build artifact)
     let contract = Contract::from_artifact("out/Counter.json", addr, &provider)?
         .connect(&wallet);
-    let count = contract.read("get_count", &json!({})).await?;
-    contract.write("increment", &json!({}), 100_000_000).await?;
+    let count = contract.read("get_count", None).await?;
+    contract.write("increment", None, 100_000_000).await?;
 
     Ok(())
 }
@@ -149,7 +156,7 @@ Execute a contract function without creating a transaction. No gas consumed.
 ```rust
 // Using Contract (recommended)
 let contract = Contract::from_artifact("out/Counter.json", addr, &provider)?;
-let count = contract.read("get_count", &json!({})).await?; // Value::U64(42)
+let count = contract.read("get_count", None).await?; // Value::U64(42)
 
 // Low-level (manual calldata)
 let result = provider.call(&contract_addr, &calldata).await?; // Vec<u8>
@@ -191,6 +198,23 @@ let wallet = Wallet::from_keystore(Path::new("wallet.json"), "password")?;
 let wallet = Wallet::from_encrypted(&keystore, "password")?;
 ```
 
+### Provider Binding (connect)
+
+Bind a provider to the wallet for shorter method signatures.
+
+```rust
+let signer = wallet.connect(&provider);
+
+// Now call without passing provider
+let balance = signer.get_balance().await?;
+let nonce = signer.get_nonce().await?;
+let receipt = signer.transfer(&to, 1000).await?;
+let receipt = signer.send_call(&contract, data, gas).await?;
+let receipt = signer.send_call_with_value(&contract, data, value, gas).await?;
+let receipt = signer.deploy(deploy_data, gas).await?;
+let result = signer.call(&contract, &calldata).await?;
+```
+
 ### Encrypted Keystore
 
 Create and manage password-encrypted keystore files.
@@ -225,12 +249,57 @@ let restored = Wallet::from_private_key(&full)?;
 assert_eq!(wallet.address(), restored.address());
 ```
 
-### Signing Transactions
+### Validation
 
 ```rust
+// Validate a private key before importing
+Wallet::is_valid_private_key("0xabcdef...");  // true/false
+
+// Generate a random private key (without creating a full wallet)
+let pk = Wallet::generate_private_key()?;  // "0x..." (2178 bytes)
+let wallet = Wallet::from_private_key(&pk)?;
+```
+
+### Signing
+
+```rust
+// Sign a transaction in place
 let mut tx = Transaction { /* ... */ };
 wallet.sign_transaction(&mut tx)?;
-// tx.signature is now populated with FALCON-512 signature
+
+// Sign an arbitrary 32-byte message
+let msg = [0xAB; 32];
+let sig = wallet.sign(&msg)?;  // Vec<u8>
+```
+
+---
+
+## Address Utilities
+
+```rust
+use pyde_rust_sdk::{
+    parse_address, format_address, is_valid_address,
+    is_zero_address, address_eq, ZERO_ADDRESS,
+    is_valid_private_key,
+};
+
+// Zero address
+let zero = ZERO_ADDRESS;                          // [0u8; 32]
+assert!(is_zero_address(&zero));
+
+// Parse / format
+let addr = parse_address("0xaabb...")?;           // [u8; 32]
+let hex = format_address(&addr);                   // "0xaabb..."
+
+// Validation
+is_valid_address("0x" + &"ab".repeat(32));        // true
+is_valid_address("0xshort");                       // false
+
+// Equality
+address_eq(&addr1, &addr2);                        // bool
+
+// Private key validation
+is_valid_private_key("0x...");                     // true/false
 ```
 
 ---
@@ -254,7 +323,7 @@ println!("Fee: {} quanta", receipt.fee_paid);
 // Using Contract (recommended — validates args against ABI)
 let contract = Contract::from_artifact("out/Contract.json", addr, &provider)?
     .connect(&wallet);
-let receipt = contract.write("deposit", &json!({"amount": 500}), 100_000_000).await?;
+let receipt = contract.write("deposit", Some(&json!({"amount": 500})), 100_000_000).await?;
 
 // Low-level (manual calldata + wallet)
 let calldata = ContractCall::new("deposit").arg_u64(500).build();
@@ -264,13 +333,15 @@ let receipt = wallet.send_call(&provider, &contract_addr, calldata, 100_000_000)
 ### Deploying a Contract
 
 ```rust
-let deploy_data = DeployData::new(constructor_bytes, runtime_bytes)
-    .arg_u64(1000)   // constructor arg
-    .arg_u64(5)       // constructor arg
-    .build();
+let deploy_data = DeployData::from_artifact("out/Counter.json", &json!({
+    "initial_supply": 1000,
+}))?.build();
 
 let receipt = wallet.deploy(&provider, deploy_data, 100_000_000).await?;
-// Contract address in receipt.return_data
+let addr = receipt.contract_address(); // Option<[u8; 32]>
+
+// Deploy with value (payable constructor)
+let receipt = wallet.deploy_with_value(&provider, deploy_data, 1_000_000, 100_000_000).await?;
 ```
 
 ### SignerProvider (Convenience)
@@ -446,9 +517,24 @@ ContractCall::new("set_team")
 ### Deploy Data with Constructor Args
 
 ```rust
-let data = DeployData::new(constructor_bytecode, runtime_bytecode)
-    .arg_u64(initial_supply)
-    .arg_string("TokenName")
+// From artifact with named constructor args (recommended)
+let data = DeployData::from_artifact("out/Counter.json", &json!({
+    "initial_supply": 1000,
+    "name": "MyToken",
+    "owner": format!("0x{}", hex::encode(owner_addr)),
+}))?.build();
+
+// Constructor args are validated against the ABI
+DeployData::from_artifact("out/Counter.json", &json!({}))?;
+// Error: constructor: missing arg 'initial_supply' (u64)
+
+// No constructor args
+let data = DeployData::from_artifact("out/Simple.json", &json!({}))?.build();
+
+// From raw bytecodes with manual arg chaining (low-level)
+let data = DeployData::new(constructor_bytes, runtime_bytes)
+    .arg_u64(1000)
+    .arg_string("hello")
     .build();
 ```
 
@@ -472,43 +558,76 @@ let contract = Contract::from_json(&abi_json_string, addr, &provider)?
 let contract = Contract::new(addr, &provider);
 
 // Read — auto-decoded return value
-let count = contract.read("get_count", &json!({})).await?;    // Value::U64(42)
-let user = contract.read("get_user", &json!({})).await?;      // Value::Struct(...)
-let scores = contract.read("get_scores", &json!({})).await?;  // Value::Vec(...)
+let count = contract.read("get_count", None).await?;    // Value::U64(42)
+let user = contract.read("get_user", None).await?;      // Value::Struct(...)
+let scores = contract.read("get_scores", None).await?;  // Value::Vec(...)
 
 // Write — validated, encoded, signed, sent, waited
-contract.write("deposit", &json!({"amount": 500}), 100_000_000).await?;
+contract.write("deposit", Some(&json!({"amount": 500})), 100_000_000).await?;
 
-contract.write("set_user", &json!({
+contract.write("set_user", Some(&json!({
     "user": {"name": "alice", "age": 25, "active": true}
-}), 100_000_000).await?;
+})), 100_000_000).await?;
 
-contract.write("set_status", &json!({"status": "Active"}), 100_000_000).await?;
+contract.write("set_status", Some(&json!({"status": "Active"})), 100_000_000).await?;
 
-contract.write("set_scores", &json!({"scores": [100, 200, 300]}), 100_000_000).await?;
+contract.write("set_scores", Some(&json!({"scores": [100, 200, 300]})), 100_000_000).await?;
+```
+
+### Simulating Calls
+
+Static-call ANY function (view or setter) without sending a transaction.
+
+```rust
+// Simulate a setter to preview the return value
+let result = contract.simulate("deposit", Some(&json!({"amount": 500}))).await?;
+
+// Same as read() but the name makes intent clear for non-view functions
+let count = contract.simulate("get_count", None).await?;
+```
+
+### Gas Estimation (ABI-Aware)
+
+```rust
+let gas = contract.estimate_gas("deposit", Some(&json!({"amount": 500}))).await?;
+// Then use it:
+contract.write("deposit", Some(&json!({"amount": 500})), gas).await?;
+```
+
+### Payable Functions
+
+Send native tokens (value) with a contract call. Validates the `payable` attribute from the ABI.
+
+```rust
+// Send value with a payable function
+contract.write_with_value("deposit", Some(&json!({"amount": 500})), 1_000_000, gas).await?;
+
+// Non-payable function rejects value
+contract.write_with_value("withdraw", Some(&json!({"amount": 100})), 1, gas).await?;
+// Error: withdraw() is not payable — cannot send value
 ```
 
 ### Arg Validation (before broadcast)
 
 ```rust
 // Missing param → error
-contract.write("deposit", &json!({}), gas).await?;
+contract.write("deposit", None, gas).await?;
 // Error: deposit(): missing required param 'amount' (u64)
 
 // Wrong type → error
-contract.write("deposit", &json!({"amount": "hello"}), gas).await?;
+contract.write("deposit", Some(&json!({"amount": "hello"})), gas).await?;
 // Error: deposit().amount: expected u64, got "hello"
 
 // Out of range → error
-contract.write("deposit", &json!({"amount": -1}), gas).await?;
+contract.write("deposit", Some(&json!({"amount": -1})), gas).await?;
 // Error: deposit().amount: value -1 out of range for u64 (0 to ...)
 
 // Missing struct field → error
-contract.write("set_user", &json!({"user": {"name": "alice"}}), gas).await?;
+contract.write("set_user", Some(&json!({"user": {"name": "alice"}})), gas).await?;
 // Error: set_user().user: missing field 'age' for struct UserInfo
 
 // Unknown enum variant → error
-contract.write("set_status", &json!({"status": "Unknown"}), gas).await?;
+contract.write("set_status", Some(&json!({"status": "Unknown"})), gas).await?;
 // Error: set_status().status: unknown variant 'Unknown' for enum Status. Valid: Active, Banned
 ```
 
@@ -715,12 +834,14 @@ let wallet = Wallet::create_encrypted(Path::new("key.json"), "password")?;
 ### File Permissions
 
 On Unix systems, keystore files are automatically set to:
+
 - File: `600` (owner read/write only)
 - Directory: `700` (owner only)
 
 ### Post-Quantum Cryptography
 
 All cryptographic operations are post-quantum safe:
+
 - **Signing**: FALCON-512 (lattice-based, NIST standard)
 - **Hashing**: Poseidon2 (ZK-friendly algebraic hash)
 - **Encryption**: AES-256-GCM (Grover-resistant at 128-bit equivalent)
@@ -744,6 +865,34 @@ let selector = compute_selector("get_count");  // 0xd9e32bf7
 
 ---
 
+## Unit Formatting
+
+Convert between human-readable token amounts and raw integer units.
+1 PYDE = 10^9 quanta (default). Custom decimals supported.
+
+```rust
+use pyde_rust_sdk::{parse_units, format_units, parse_quanta, format_quanta};
+
+// Parse human-readable → raw (with custom decimals)
+let raw = parse_units("1.5", 9)?;    // 1_500_000_000
+let raw = parse_units("100", 18)?;   // 100_000_000_000_000_000_000
+let raw = parse_units("0.001", 9)?;  // 1_000_000
+
+// Format raw → human-readable
+let s = format_units(1_500_000_000, 9);   // "1.5"
+let s = format_units(1_000_000, 9);       // "0.001"
+
+// PYDE shortcuts (9 decimals)
+let raw = parse_quanta("2.5")?;           // 2_500_000_000
+let s = format_quanta(2_500_000_000);     // "2.5"
+
+// Custom token with 18 decimals
+let raw = parse_units("0.5", 18)?;
+let s = format_units(raw, 18);            // "0.5"
+```
+
+---
+
 ## Architecture
 
 ```
@@ -759,6 +908,7 @@ crates/pyde-rust-sdk/
 ```
 
 Dependencies:
+
 - **pyde-crypto** — FALCON-512 signatures, Poseidon2 hashing
 - **pyde-tx** — Transaction types, serialization, hashing
 - **pyde-account** — Address derivation

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -59,6 +59,8 @@ pub struct AbiFunction {
     #[serde(default)]
     pub view: bool,
     #[serde(default)]
+    pub payable: bool,
+    #[serde(default)]
     pub constructor: bool,
 }
 
@@ -156,17 +158,37 @@ impl<'a> Contract<'a> {
 
     pub fn address(&self) -> &Address { &self.address }
 
+    /// Encode a single value by ABI type. Used by DeployData for constructor args.
+    pub fn encode_value_public(&self, buf: &mut Vec<u8>, value: &serde_json::Value, ty: &str, path: &str) -> Result<()> {
+        self.encode_value(buf, value, ty, path)
+    }
+
     // ========================================================================
     // Read
     // ========================================================================
 
     /// Call a view function. Auto-encodes args, auto-decodes return.
-    pub async fn read(&self, method: &str, args: &serde_json::Value) -> Result<Value> {
-        let calldata = self.encode_call(method, args)?;
+    /// Pass `None` for functions that take no arguments.
+    pub async fn read(&self, method: &str, args: Option<&serde_json::Value>) -> Result<Value> {
+        let empty = serde_json::json!({});
+        let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
         let result = self.provider.call(&self.address, &calldata).await?;
         let fn_def = self.functions.get(method);
         let ret_type = fn_def.map(|f| f.returns.as_str()).unwrap_or("u64");
         Ok(self.decode_value(&result, ret_type, 0).0)
+    }
+
+    /// Static-call ANY function (view or setter) without sending a tx.
+    /// Simulates execution and returns the decoded return value.
+    pub async fn simulate(&self, method: &str, args: Option<&serde_json::Value>) -> Result<Value> {
+        self.read(method, args).await
+    }
+
+    /// Estimate gas for a contract call using the ABI.
+    pub async fn estimate_gas(&self, method: &str, args: Option<&serde_json::Value>) -> Result<u64> {
+        let empty = serde_json::json!({});
+        let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
+        self.provider.estimate_gas(&self.address, &calldata).await
     }
 
     // ========================================================================
@@ -174,12 +196,31 @@ impl<'a> Contract<'a> {
     // ========================================================================
 
     /// Send a state-changing tx. Validates args, encodes, signs, sends, waits.
-    pub async fn write(&self, method: &str, args: &serde_json::Value, gas_limit: u64) -> Result<Receipt> {
+    /// Pass `None` for functions that take no arguments.
+    pub async fn write(&self, method: &str, args: Option<&serde_json::Value>, gas_limit: u64) -> Result<Receipt> {
+        self.write_with_value(method, args, 0, gas_limit).await
+    }
+
+    /// Send a state-changing tx with native token value. Validates payable.
+    pub async fn write_with_value(
+        &self, method: &str, args: Option<&serde_json::Value>, value: u128, gas_limit: u64,
+    ) -> Result<Receipt> {
         let wallet = self.wallet.ok_or_else(|| SdkError::Signing(
             "No wallet connected. Use contract.connect(&wallet) first.".into()
         ))?;
-        let calldata = self.encode_call(method, args)?;
-        wallet.send_call(self.provider, &self.address, calldata, gas_limit).await
+        // Validate payable
+        if value > 0 {
+            if let Some(fn_def) = self.functions.get(method) {
+                if !fn_def.payable {
+                    return Err(SdkError::InvalidResponse(format!(
+                        "{}() is not payable — cannot send value", method
+                    )));
+                }
+            }
+        }
+        let empty = serde_json::json!({});
+        let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
+        wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await
     }
 
     // ========================================================================
@@ -269,6 +310,41 @@ impl<'a> Contract<'a> {
                 let pad = (8 - (bytes.len() % 8)) % 8;
                 buf.extend(std::iter::repeat(0u8).take(pad));
             }
+            // Tuple "(T1, T2, ...)" — sequential fields, no length prefix
+            _ if ty.starts_with('(') && ty.ends_with(')') => {
+                let inner = &ty[1..ty.len() - 1];
+                if inner.is_empty() || inner == "()" {
+                    // Unit tuple — no bytes
+                } else {
+                    let types = parse_tuple_types(inner);
+                    let arr = value.as_array()
+                        .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected array for tuple {}", path, ty)))?;
+                    if arr.len() != types.len() {
+                        return Err(SdkError::InvalidResponse(format!(
+                            "{}: tuple {} expects {} elements, got {}", path, ty, types.len(), arr.len()
+                        )));
+                    }
+                    for (i, (v, t)) in arr.iter().zip(types.iter()).enumerate() {
+                        self.encode_value(buf, v, t, &format!("{}.{}", path, i))?;
+                    }
+                }
+            }
+            // Array "[T; N]" — N sequential elements, no length prefix
+            _ if ty.starts_with('[') && ty.ends_with(']') => {
+                let inner = &ty[1..ty.len() - 1];
+                let (elem_type, count) = parse_array_type(inner)
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: bad array type '{}'", path, ty)))?;
+                let arr = value.as_array()
+                    .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected array for {}", path, ty)))?;
+                if arr.len() != count {
+                    return Err(SdkError::InvalidResponse(format!(
+                        "{}: array {} expects {} elements, got {}", path, ty, count, arr.len()
+                    )));
+                }
+                for (i, v) in arr.iter().enumerate() {
+                    self.encode_value(buf, v, elem_type, &format!("{}[{}]", path, i))?;
+                }
+            }
             _ if ty.starts_with("Vec<") && ty.ends_with('>') => {
                 let arr = value.as_array()
                     .ok_or_else(|| SdkError::InvalidResponse(format!("{}: expected array for {}", path, ty)))?;
@@ -308,6 +384,14 @@ impl<'a> Contract<'a> {
                             def.variants.iter().map(|v| v.name.as_str()).collect::<Vec<_>>().join(", ")
                         )))?;
                     buf.extend_from_slice(&(variant.discriminant as u64).to_le_bytes());
+                }
+                // Unknown type name → treat as Address (Contract/Interface types are addresses)
+                else if let Some(s) = value.as_str() {
+                    let addr = crate::types::parse_address(s)
+                        .map_err(|_| SdkError::InvalidResponse(format!(
+                            "{}: unknown type '{}', tried as Address but got invalid hex", path, ty
+                        )))?;
+                    buf.extend_from_slice(&addr);
                 } else {
                     return Err(SdkError::InvalidResponse(format!("{}: unsupported type '{}'", path, ty)));
                 }
@@ -401,6 +485,40 @@ impl<'a> Contract<'a> {
                 let aligned = 8 + len + ((8 - (len % 8)) % 8);
                 (Value::Bytes(bytes), aligned)
             }
+            // Tuple "(T1, T2, ...)" — sequential decode
+            _ if ty.starts_with('(') && ty.ends_with(')') => {
+                let inner = &ty[1..ty.len()-1];
+                if inner.is_empty() || inner == "()" {
+                    (Value::Unit, 0)
+                } else {
+                    let types = parse_tuple_types(inner);
+                    let mut cursor = offset;
+                    let mut items = Vec::with_capacity(types.len());
+                    for t in &types {
+                        let (val, read) = self.decode_value(data, t, cursor);
+                        items.push(val);
+                        cursor += read;
+                    }
+                    (Value::Vec(items), cursor - offset)
+                }
+            }
+            // Array "[T; N]" — N sequential elements
+            _ if ty.starts_with('[') && ty.ends_with(']') => {
+                let inner = &ty[1..ty.len()-1];
+                if let Some((elem_type, count)) = parse_array_type(inner) {
+                    let mut cursor = offset;
+                    let mut items = Vec::with_capacity(count);
+                    for _ in 0..count {
+                        if cursor >= data.len() { break; }
+                        let (val, read) = self.decode_value(data, elem_type, cursor);
+                        items.push(val);
+                        cursor += read;
+                    }
+                    (Value::Vec(items), cursor - offset)
+                } else {
+                    (Value::Bytes(data[offset..].to_vec()), data.len() - offset)
+                }
+            }
             _ if ty.starts_with("Vec<") && ty.ends_with('>') => {
                 let elem_type = &ty[4..ty.len()-1];
                 if data.len() < offset + 24 { return (Value::Vec(vec![]), 24); }
@@ -440,11 +558,51 @@ impl<'a> Contract<'a> {
                 } else if ty == "()" || ty == "unit" {
                     (Value::Unit, 0)
                 } else {
-                    (Value::Bytes(data[offset..].to_vec()), data.len() - offset)
+                    // Unknown type (Contract/Interface) → decode as Address (32 bytes)
+                    if data.len() >= offset + 32 {
+                        let mut addr = [0u8; 32];
+                        addr.copy_from_slice(&data[offset..offset+32]);
+                        (Value::Address(addr), 32)
+                    } else {
+                        (Value::Bytes(data[offset..].to_vec()), data.len() - offset)
+                    }
                 }
             }
         }
     }
+}
+
+/// Parse comma-separated tuple types, handling nested generics.
+/// e.g. "u64, Vec<String>, (u8, bool)" → ["u64", "Vec<String>", "(u8, bool)"]
+fn parse_tuple_types(s: &str) -> Vec<&str> {
+    let mut types = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                let t = s[start..i].trim();
+                if !t.is_empty() { types.push(t); }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let t = s[start..].trim();
+    if !t.is_empty() { types.push(t); }
+    types
+}
+
+/// Parse "[T; N]" inner string → (element_type, count).
+/// e.g. "u64; 3" → Some(("u64", 3))
+fn parse_array_type(s: &str) -> Option<(&str, usize)> {
+    let semi = s.rfind(';')?;
+    let elem = s[..semi].trim();
+    let count_str = s[semi + 1..].trim();
+    let count = count_str.parse().ok()?;
+    Some((elem, count))
 }
 
 fn parse_json_u128(v: &serde_json::Value) -> Option<u128> {
@@ -706,5 +864,68 @@ mod tests {
         let c = Contract::from_json(&json, [0; 32], &p).unwrap();
         let r = c.encode_call("set", &serde_json::json!({"v": -1}));
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn encode_tuple() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"pair","type":"(u64, bool)"}],"returns":"()","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let data = c.encode_call("set", &serde_json::json!({"pair": [42, true]})).unwrap();
+        assert_eq!(data.len(), 4 + 8 + 8); // selector + u64 + bool
+    }
+
+    #[test]
+    fn encode_decode_array() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"arr","type":"[u64; 3]"}],"returns":"[u64; 3]","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let data = c.encode_call("set", &serde_json::json!({"arr": [10, 20, 30]})).unwrap();
+        assert_eq!(data.len(), 4 + 3 * 8); // selector + 3 u64s
+        // Decode it back
+        let (val, _) = c.decode_value(&data[4..], "[u64; 3]", 0);
+        let items = val.as_vec().unwrap();
+        assert_eq!(items[0].as_u64(), Some(10));
+        assert_eq!(items[2].as_u64(), Some(30));
+    }
+
+    #[test]
+    fn encode_array_wrong_length() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"arr","type":"[u64; 3]"}],"returns":"()","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let r = c.encode_call("set", &serde_json::json!({"arr": [10, 20]}));
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("expects 3 elements"));
+    }
+
+    #[test]
+    fn encode_unknown_type_as_address() {
+        let p = dummy_provider();
+        let json = serde_json::json!({
+            "abi": {
+                "functions": [{"name":"set","params":[{"name":"c","type":"MyContract"}],"returns":"()","view":false}],
+                "structs": [], "enums": [],
+            }
+        }).to_string();
+        let c = Contract::from_json(&json, [0; 32], &p).unwrap();
+        let addr = format!("0x{}", "cc".repeat(32));
+        let data = c.encode_call("set", &serde_json::json!({"c": addr})).unwrap();
+        assert_eq!(data.len(), 4 + 32); // selector + address
     }
 }

--- a/crates/pyde-rust-sdk/src/contract.rs
+++ b/crates/pyde-rust-sdk/src/contract.rs
@@ -253,6 +253,13 @@ impl ContractCall {
 /// Build deploy transaction data.
 ///
 /// ```rust,ignore
+/// // From artifact with named constructor args (recommended)
+/// let data = DeployData::from_artifact("out/Counter.json", &json!({
+///     "initial_supply": 1000,
+///     "name": "MyToken"
+/// }))?.build();
+///
+/// // From raw bytecodes with manual args
 /// let data = DeployData::new(constructor_bytes, runtime_bytes)
 ///     .arg_u64(1000)
 ///     .build();
@@ -268,22 +275,106 @@ impl DeployData {
         Self { constructor, runtime, args: Vec::new() }
     }
 
+    /// Load from artifact JSON file with ABI-validated constructor args.
+    /// Pass empty json!({}) if the constructor takes no args.
+    pub fn from_artifact(path: &str, args: &serde_json::Value) -> std::result::Result<Self, String> {
+        let json = std::fs::read_to_string(path)
+            .map_err(|e| format!("read artifact: {}", e))?;
+        Self::from_json(&json, args)
+    }
+
+    /// Load from artifact JSON string with ABI-validated constructor args.
+    pub fn from_json(json: &str, args: &serde_json::Value) -> std::result::Result<Self, String> {
+        let v: serde_json::Value = serde_json::from_str(json)
+            .map_err(|e| format!("parse artifact: {}", e))?;
+        let constructor_hex = v.get("constructorBytecode")
+            .and_then(|v| v.as_str())
+            .ok_or("missing 'constructorBytecode' in artifact")?;
+        let runtime_hex = v.get("deployedBytecode")
+            .and_then(|v| v.as_str())
+            .ok_or("missing 'deployedBytecode' in artifact")?;
+        let constructor = hex::decode(constructor_hex.trim_start_matches("0x"))
+            .map_err(|e| format!("bad constructor hex: {}", e))?;
+        let runtime = hex::decode(runtime_hex.trim_start_matches("0x"))
+            .map_err(|e| format!("bad runtime hex: {}", e))?;
+
+        let mut deploy = Self::new(constructor, runtime);
+
+        // Encode constructor args from ABI if available
+        let abi = v.get("abi").unwrap_or(&v);
+        if let Some(fns) = abi.get("functions").and_then(|v| v.as_array()) {
+            if let Some(ctor) = fns.iter().find(|f| f.get("constructor").and_then(|v| v.as_bool()).unwrap_or(false)) {
+                if let Some(params) = ctor.get("params").and_then(|v| v.as_array()) {
+                    // Use a temporary Contract to leverage encode_value
+                    let provider = crate::client::Provider::new("http://localhost:0");
+                    let contract = crate::abi::Contract::from_json(json, [0u8; 32], &provider)
+                        .map_err(|e| format!("parse ABI: {}", e))?;
+                    for param in params {
+                        let name = param.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                        let ty = param.get("type").and_then(|v| v.as_str()).unwrap_or("u64");
+                        let val = args.get(name).ok_or_else(|| {
+                            format!("constructor: missing arg '{}' ({})", name, ty)
+                        })?;
+                        contract.encode_value_public(&mut deploy.args, val, ty, &format!("constructor.{}", name))
+                            .map_err(|e| format!("{}", e))?;
+                    }
+                }
+            }
+        }
+
+        Ok(deploy)
+    }
+
+    // GP integers (8 bytes LE)
+    pub fn arg_u8(self, val: u8) -> Self { self.arg_u64(val as u64) }
+    pub fn arg_u16(self, val: u16) -> Self { self.arg_u64(val as u64) }
+    pub fn arg_u32(self, val: u32) -> Self { self.arg_u64(val as u64) }
     pub fn arg_u64(mut self, val: u64) -> Self {
         self.args.extend_from_slice(&val.to_le_bytes());
         self
     }
-
+    pub fn arg_i8(self, val: i8) -> Self { self.arg_u64(val as i64 as u64) }
+    pub fn arg_i16(self, val: i16) -> Self { self.arg_u64(val as i64 as u64) }
+    pub fn arg_i32(self, val: i32) -> Self { self.arg_u64(val as i64 as u64) }
+    pub fn arg_i64(self, val: i64) -> Self { self.arg_u64(val as u64) }
     pub fn arg_bool(mut self, val: bool) -> Self {
         self.args.extend_from_slice(&(val as u64).to_le_bytes());
         self
     }
-
+    // Wide integers
+    pub fn arg_u128(mut self, val: u128) -> Self {
+        self.args.extend_from_slice(&val.to_le_bytes());
+        self
+    }
+    pub fn arg_i128(mut self, val: i128) -> Self {
+        self.args.extend_from_slice(&val.to_le_bytes());
+        self
+    }
+    pub fn arg_u256(mut self, val: ethnum::U256) -> Self {
+        self.args.extend_from_slice(&val.to_le_bytes());
+        self
+    }
+    pub fn arg_i256(mut self, val: ethnum::I256) -> Self {
+        self.args.extend_from_slice(&val.to_le_bytes());
+        self
+    }
+    // Address (32 bytes)
+    pub fn arg_address(mut self, val: crate::types::Address) -> Self {
+        self.args.extend_from_slice(&val);
+        self
+    }
+    // String (length-prefixed, 8-byte aligned)
     pub fn arg_string(mut self, val: &str) -> Self {
         let bytes = val.as_bytes();
         self.args.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
         self.args.extend_from_slice(bytes);
         let padding = (8 - (bytes.len() % 8)) % 8;
         self.args.extend(std::iter::repeat(0u8).take(padding));
+        self
+    }
+    // Raw bytes
+    pub fn arg_bytes(mut self, val: &[u8]) -> Self {
+        self.args.extend_from_slice(val);
         self
     }
 

--- a/crates/pyde-rust-sdk/src/lib.rs
+++ b/crates/pyde-rust-sdk/src/lib.rs
@@ -43,5 +43,10 @@ pub use contract::{
     decode_vec_u64, decode_vec_bool, decode_vec_address,
 };
 pub use error::{Result, SdkError};
-pub use types::{format_address, parse_address, Address, Receipt, Log, LogFilter, BlockHeader};
+pub use types::{
+    format_address, parse_address, is_valid_address, is_zero_address,
+    is_valid_private_key, address_eq, ZERO_ADDRESS,
+    parse_units, format_units, parse_quanta, format_quanta, PYDE_DECIMALS,
+    Address, Receipt, Log, LogFilter, BlockHeader,
+};
 pub use wallet::{Keystore, SignerProvider, Wallet};

--- a/crates/pyde-rust-sdk/src/types.rs
+++ b/crates/pyde-rust-sdk/src/types.rs
@@ -123,3 +123,99 @@ pub fn parse_address(s: &str) -> Result<Address, crate::SdkError> {
 pub fn format_address(addr: &Address) -> String {
     format!("0x{}", hex::encode(addr))
 }
+
+/// The zero address (32 zero bytes).
+pub const ZERO_ADDRESS: Address = [0u8; 32];
+
+/// Check if an address is the zero address.
+pub fn is_zero_address(addr: &Address) -> bool {
+    *addr == ZERO_ADDRESS
+}
+
+/// Validate a hex address string without parsing it.
+pub fn is_valid_address(s: &str) -> bool {
+    let hex = s.trim_start_matches("0x");
+    hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Check if two addresses are equal.
+pub fn address_eq(a: &Address, b: &Address) -> bool {
+    a == b
+}
+
+/// Validate a FALCON-512 private key hex (pk + sk combined, 2178 bytes).
+pub fn is_valid_private_key(hex: &str) -> bool {
+    let clean = hex.trim_start_matches("0x");
+    clean.len() == (897 + 1281) * 2 && clean.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+// ============================================================================
+// Unit formatting (1 PYDE = 10^9 quanta)
+// ============================================================================
+
+/// Default decimals for PYDE.
+pub const PYDE_DECIMALS: u32 = 9;
+
+/// Parse a human-readable amount to raw integer units.
+///
+/// ```rust,ignore
+/// parse_units("1.5", 9)   // Ok(1_500_000_000)
+/// parse_units("100", 18)  // Ok(100_000_000_000_000_000_000)
+/// ```
+pub fn parse_units(value: &str, decimals: u32) -> std::result::Result<u128, String> {
+    let trimmed = value.trim();
+    let negative = trimmed.starts_with('-');
+    if negative {
+        return Err("Negative values not supported for u128 units".into());
+    }
+
+    let parts: Vec<&str> = trimmed.split('.').collect();
+    if parts.len() > 2 { return Err(format!("Invalid numeric string: {}", value)); }
+
+    let whole = parts[0];
+    let fraction = if parts.len() == 2 { parts[1] } else { "" };
+
+    if fraction.len() > decimals as usize {
+        return Err(format!(
+            "Too many decimal places: \"{}\" has {} but only {} allowed",
+            value, fraction.len(), decimals
+        ));
+    }
+
+    // Validate chars
+    if !whole.chars().all(|c| c.is_ascii_digit()) || (!fraction.is_empty() && !fraction.chars().all(|c| c.is_ascii_digit())) {
+        return Err(format!("Invalid numeric string: {}", value));
+    }
+
+    let padded = format!("{:0<width$}", fraction, width = decimals as usize);
+    let combined = format!("{}{}", whole, padded);
+    combined.parse::<u128>().map_err(|e| format!("Overflow: {}", e))
+}
+
+/// Format raw integer units to a human-readable amount.
+///
+/// ```rust,ignore
+/// format_units(1_500_000_000, 9)  // "1.5"
+/// format_units(1_000_000, 9)      // "0.001"
+/// ```
+pub fn format_units(value: u128, decimals: u32) -> String {
+    let divisor = 10u128.pow(decimals);
+    let whole = value / divisor;
+    let remainder = value % divisor;
+
+    let frac_str = format!("{:0>width$}", remainder, width = decimals as usize);
+    let trimmed = frac_str.trim_end_matches('0');
+    let trimmed = if trimmed.is_empty() { "0" } else { trimmed };
+
+    format!("{}.{}", whole, trimmed)
+}
+
+/// Parse PYDE to quanta (9 decimals). `parse_quanta("1.5")` → `Ok(1_500_000_000)`
+pub fn parse_quanta(value: &str) -> std::result::Result<u128, String> {
+    parse_units(value, PYDE_DECIMALS)
+}
+
+/// Format quanta to PYDE (9 decimals). `format_quanta(1_500_000_000)` → `"1.5"`
+pub fn format_quanta(value: u128) -> String {
+    format_units(value, PYDE_DECIMALS)
+}

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -147,6 +147,13 @@ impl Wallet {
         Ok(())
     }
 
+    /// Sign an arbitrary 32-byte message. Returns signature bytes.
+    pub fn sign(&self, message: &[u8; 32]) -> Result<Vec<u8>> {
+        let sig = falcon_sign(&self.secret_key, message)
+            .map_err(|e| SdkError::Signing(format!("sign: {}", e)))?;
+        Ok(sig.as_bytes().to_vec())
+    }
+
     // ========================================================================
     // High-level helpers
     // ========================================================================
@@ -166,15 +173,29 @@ impl Wallet {
         send_and_check(provider, &tx).await
     }
 
+    /// Generate a random FALCON-512 private key hex (pk + sk combined).
+    /// Use with `Wallet::from_private_key()` to create a wallet later.
+    pub fn generate_private_key() -> Result<String> {
+        let wallet = Self::generate()?;
+        Ok(wallet.private_key_hex())
+    }
+
     /// Build, sign, send a contract call. Returns receipt (errors on revert).
     pub async fn send_call(
         &self, provider: &Provider, to: &Address, data: Vec<u8>, gas_limit: u64,
+    ) -> Result<Receipt> {
+        self.send_call_with_value(provider, to, data, 0, gas_limit).await
+    }
+
+    /// Build, sign, send a contract call with native token value.
+    pub async fn send_call_with_value(
+        &self, provider: &Provider, to: &Address, data: Vec<u8>, value: u128, gas_limit: u64,
     ) -> Result<Receipt> {
         let nonce = provider.get_nonce(&self.address).await?;
         let chain_id = provider.get_chain_id().await?;
 
         let mut tx = Transaction {
-            from: self.address, to: *to, value: 0, data,
+            from: self.address, to: *to, value, data,
             gas_limit, nonce, signature: vec![],
             fee_payer: FeePayer::Sender, access_list: vec![],
             deadline: None, chain_id, tx_type: TransactionType::Standard,
@@ -183,15 +204,32 @@ impl Wallet {
         send_and_check(provider, &tx).await
     }
 
+    /// Bind a provider for convenience. Returns a SignerProvider with shorter method signatures.
+    pub fn connect<'a>(&'a self, provider: &'a Provider) -> SignerProvider<'a> {
+        SignerProvider::new(self, provider)
+    }
+
+    /// Validate a FALCON-512 private key hex string (pk + sk, 2178 bytes).
+    pub fn is_valid_private_key(hex: &str) -> bool {
+        crate::types::is_valid_private_key(hex)
+    }
+
     /// Build, sign, send a contract deploy. Returns receipt (errors on revert).
     pub async fn deploy(
         &self, provider: &Provider, deploy_data: Vec<u8>, gas_limit: u64,
+    ) -> Result<Receipt> {
+        self.deploy_with_value(provider, deploy_data, 0, gas_limit).await
+    }
+
+    /// Build, sign, send a contract deploy with native token value (payable constructor).
+    pub async fn deploy_with_value(
+        &self, provider: &Provider, deploy_data: Vec<u8>, value: u128, gas_limit: u64,
     ) -> Result<Receipt> {
         let nonce = provider.get_nonce(&self.address).await?;
         let chain_id = provider.get_chain_id().await?;
 
         let mut tx = Transaction {
-            from: self.address, to: [0u8; 32], value: 0, data: deploy_data,
+            from: self.address, to: [0u8; 32], value, data: deploy_data,
             gas_limit, nonce, signature: vec![],
             fee_payer: FeePayer::Sender, access_list: vec![],
             deadline: None, chain_id, tx_type: TransactionType::Deploy,
@@ -220,8 +258,16 @@ impl<'a> SignerProvider<'a> {
         self.wallet.send_call(self.provider, to, data, gas_limit).await
     }
 
+    pub async fn send_call_with_value(&self, to: &Address, data: Vec<u8>, value: u128, gas_limit: u64) -> Result<Receipt> {
+        self.wallet.send_call_with_value(self.provider, to, data, value, gas_limit).await
+    }
+
     pub async fn deploy(&self, deploy_data: Vec<u8>, gas_limit: u64) -> Result<Receipt> {
         self.wallet.deploy(self.provider, deploy_data, gas_limit).await
+    }
+
+    pub async fn deploy_with_value(&self, deploy_data: Vec<u8>, value: u128, gas_limit: u64) -> Result<Receipt> {
+        self.wallet.deploy_with_value(self.provider, deploy_data, value, gas_limit).await
     }
 
     pub async fn get_balance(&self) -> Result<u128> {
@@ -407,5 +453,58 @@ mod tests {
         assert!(w.secret_key_hex().starts_with("0x"));
         assert_eq!(w.public_key_hex().len(), 2 + 897 * 2); // 0x + 897 bytes hex
         assert_eq!(w.secret_key_hex().len(), 2 + 1281 * 2); // 0x + 1281 bytes hex
+    }
+
+    #[test]
+    fn is_valid_private_key_check() {
+        let w = Wallet::generate().unwrap();
+        assert!(Wallet::is_valid_private_key(&w.private_key_hex()));
+        assert!(!Wallet::is_valid_private_key("0xdeadbeef"));
+        assert!(!Wallet::is_valid_private_key("not hex at all"));
+    }
+
+    #[test]
+    fn connect_returns_signer() {
+        let w = Wallet::generate().unwrap();
+        let p = crate::Provider::new("http://localhost:0");
+        let signer = w.connect(&p);
+        assert_eq!(signer.wallet.address(), w.address());
+    }
+
+    #[test]
+    fn address_utilities() {
+        use crate::types::*;
+        assert!(is_zero_address(&ZERO_ADDRESS));
+        assert!(!is_zero_address(&[0xAA; 32]));
+        let valid_addr = format!("0x{}", "ab".repeat(32));
+        assert!(is_valid_address(&valid_addr));
+        assert!(!is_valid_address("0xshort"));
+        let bad_addr = format!("0x{}", "zz".repeat(32));
+        assert!(!is_valid_address(&bad_addr));
+        assert!(address_eq(&[0xAA; 32], &[0xAA; 32]));
+        assert!(!address_eq(&[0xAA; 32], &[0xBB; 32]));
+    }
+
+    #[test]
+    fn unit_formatting() {
+        use crate::types::*;
+        // parse_units
+        assert_eq!(parse_units("100", 9).unwrap(), 100_000_000_000);
+        assert_eq!(parse_units("1.5", 9).unwrap(), 1_500_000_000);
+        assert_eq!(parse_units("0.001", 9).unwrap(), 1_000_000);
+        assert_eq!(parse_units("0", 9).unwrap(), 0);
+        assert!(parse_units("1.0000000001", 9).is_err()); // too many decimals
+        // format_units
+        assert_eq!(format_units(1_500_000_000, 9), "1.5");
+        assert_eq!(format_units(1_000_000, 9), "0.001");
+        assert_eq!(format_units(0, 9), "0.0");
+        assert_eq!(format_units(1_000_000_000, 9), "1.0");
+        // quanta shortcuts
+        assert_eq!(parse_quanta("2.5").unwrap(), 2_500_000_000);
+        assert_eq!(format_quanta(2_500_000_000), "2.5");
+        // custom decimals
+        assert_eq!(parse_units("1.0", 18).unwrap(), 1_000_000_000_000_000_000);
+        // roundtrip
+        assert_eq!(format_units(parse_units("123.456789", 9).unwrap(), 9), "123.456789");
     }
 }


### PR DESCRIPTION
## Summary
- DeployData::from_artifact with named constructor args (ABI-validated)
- deploy_with_value for payable constructors
- Tuple, Array, Contract/Interface type encode/decode
- contract.estimate_gas(), contract.simulate(), payable validation
- wallet.connect() returns SignerProvider, wallet.sign(message)
- Address utilities: ZERO_ADDRESS, is_zero_address, is_valid_address, address_eq
- Unit formatting: parse_units, format_units, parse_quanta, format_quanta
- Contract args now Option (None for no-arg functions)
- 42 tests (up from 34), README fully updated