### PR TITLE
feat: typed errors, hex utils, getFeeData, ContractReceipt

### DIFF
--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -13,6 +13,8 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Chain Queries](#chain-queries)
   - [Account Queries](#account-queries)
   - [Block Queries](#block-queries)
+  - [Transaction Lookup](#transaction-lookup)
+  - [Fee Data](#fee-data)
   - [Static Calls](#static-calls)
   - [Gas Estimation](#gas-estimation)
 - [Wallet](#wallet)
@@ -42,12 +44,14 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Simulating Calls](#simulating-calls)
   - [Gas Estimation (ABI-Aware)](#gas-estimation-abi-aware)
   - [Payable Functions](#payable-functions)
+  - [Decoding Write Return Data](#decoding-write-return-data)
   - [The Value Enum](#the-value-enum)
   - [Decoding Return Values](#decoding-return-values)
 - [Events & Logs](#events--logs)
 - [Error Handling](#error-handling)
   - [Error Variants](#error-variants)
   - [Pattern Matching](#pattern-matching)
+- [Hex Utilities](#hex-utilities)
 - [Security](#security)
   - [Keystore Encryption](#keystore-encryption)
   - [File Permissions](#file-permissions)
@@ -147,6 +151,27 @@ let block = provider.get_block_by_number(42).await?;  // Option<BlockHeader>
 if let Some(b) = block {
     println!("Slot: {}, Proposer: {}", b.slot, b.proposer);
 }
+```
+
+### Transaction Lookup
+
+```rust
+let tx = provider.get_transaction(&tx_hash).await?; // Option<serde_json::Value>
+if let Some(tx) = tx {
+    println!("From: {}", tx["from"]);
+}
+```
+
+Note: `return_data` is ephemeral — only available in the receipt immediately after execution, not in transaction lookups.
+
+### Fee Data
+
+Get current network fee info (Pyde uses EIP-1559 with no tips).
+
+```rust
+let fees = provider.get_fee_data().await?;   // FeeData
+println!("Gas price: {}", fees.gas_price);    // u128 (quanta per gas)
+println!("Base fee: {}", fees.base_fee);      // same as gas_price in Pyde
 ```
 
 ### Static Calls
@@ -631,6 +656,22 @@ contract.write("set_status", Some(&json!({"status": "Unknown"})), gas).await?;
 // Error: set_status().status: unknown variant 'Unknown' for enum Status. Valid: Active, Banned
 ```
 
+### Decoding Write Return Data
+
+`Contract::write()` returns a `ContractReceipt` with `decode_return_data()` that
+auto-decodes using the ABI return type. Derefs to `Receipt` so all fields are accessible.
+
+```rust
+let receipt = contract.write("deposit", Some(&json!({"amount": 500})), gas).await?;
+println!("Success: {}", receipt.success);           // Receipt field via Deref
+
+let val = receipt.decode_return_data();              // Option<Value>
+// Returns None if return_data is absent or function returns ()
+```
+
+Note: `return_data` is ephemeral — only available in the receipt immediately after
+tx execution. It is not persisted on-chain.
+
 ### The Value Enum
 
 Return values are decoded into a `Value` enum supporting all Pyde types.
@@ -786,34 +827,66 @@ pub enum SdkError {
     Reverted { gas_used: u64, data: Vec<u8> },  // Tx executed but reverted
     InsufficientBalance { required: u128, available: u128 },
     InvalidAddress(String),      // Bad hex address format
+    InvalidArgument(String),     // Invalid argument to SDK method
     InvalidResponse(String),     // Malformed RPC response
 }
+
+// Helper methods
+error.code();            // "CALL_EXCEPTION", "CONNECTION_ERROR", etc.
+error.revert_reason();   // Some("require failed") — auto-decoded from return data
+error.is_revert();       // true if Reverted variant
 ```
 
 ### Pattern Matching
 
 ```rust
-match wallet.transfer(&provider, &to, amount).await {
+match contract.write("deposit", Some(&json!({"amount": 500})), gas).await {
     Ok(receipt) => {
         println!("Success! Gas: {}", receipt.gas());
+        if let Some(val) = receipt.decode_return_data() {
+            println!("Return: {:?}", val);
+        }
     }
-    Err(SdkError::Reverted { gas_used, data }) => {
-        println!("Reverted after {} gas", gas_used);
+    Err(ref e) if e.is_revert() => {
+        println!("Reverted! Reason: {:?}", e.revert_reason());
     }
-    Err(SdkError::Connection(msg)) => {
-        println!("Node unreachable: {}", msg);
-    }
-    Err(SdkError::Timeout(msg)) => {
-        println!("Timeout: {}", msg);
-    }
-    Err(SdkError::Signing(msg)) => {
-        println!("Signing error: {}", msg);
-    }
-    Err(SdkError::InsufficientBalance { required, available }) => {
-        println!("Need {} quanta but only have {}", required, available);
-    }
-    Err(e) => println!("Error: {}", e),
+    Err(SdkError::Connection(msg)) => println!("Node unreachable: {}", msg),
+    Err(SdkError::Timeout(msg)) => println!("Timeout: {}", msg),
+    Err(e) => println!("Error [{}]: {}", e.code(), e),
 }
+```
+
+---
+
+## Hex Utilities
+
+```rust
+use pyde_rust_sdk::{
+    is_hex_string, hexlify, get_bytes, to_be_hex,
+    concat_bytes, zero_pad_value, strip_zeros, data_length,
+};
+
+// Check if valid hex
+is_hex_string("0xdeadbeef");                  // true
+is_hex_string("0xgg");                         // false
+
+// Convert to/from hex
+let hex = hexlify(&[0xde, 0xad]);             // "0xdead"
+let bytes = get_bytes("0xdeadbeef")?;          // Vec<u8>
+
+// BigInt to big-endian hex (with optional width)
+to_be_hex(255, None);                          // "0xff"
+to_be_hex(255, Some(4));                       // "0x000000ff"
+
+// Concatenate
+let combined = concat_bytes(&[&[0xde, 0xad], &[0xbe, 0xef]]);
+
+// Pad / strip
+let padded = zero_pad_value(&[0xff], 4)?;     // [0, 0, 0, 0xff]
+let stripped = strip_zeros(&[0, 0, 0, 0xff]); // [0xff]
+
+// Length
+data_length("0xdeadbeef");                     // 4
 ```
 
 ---

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -197,14 +197,15 @@ impl<'a> Contract<'a> {
 
     /// Send a state-changing tx. Validates args, encodes, signs, sends, waits.
     /// Pass `None` for functions that take no arguments.
-    pub async fn write(&self, method: &str, args: Option<&serde_json::Value>, gas_limit: u64) -> Result<Receipt> {
+    /// Returns a `ContractReceipt` with a `decode_return_data()` method.
+    pub async fn write(&self, method: &str, args: Option<&serde_json::Value>, gas_limit: u64) -> Result<ContractReceipt> {
         self.write_with_value(method, args, 0, gas_limit).await
     }
 
     /// Send a state-changing tx with native token value. Validates payable.
     pub async fn write_with_value(
         &self, method: &str, args: Option<&serde_json::Value>, value: u128, gas_limit: u64,
-    ) -> Result<Receipt> {
+    ) -> Result<ContractReceipt> {
         let wallet = self.wallet.ok_or_else(|| SdkError::Signing(
             "No wallet connected. Use contract.connect(&wallet) first.".into()
         ))?;
@@ -220,7 +221,9 @@ impl<'a> Contract<'a> {
         }
         let empty = serde_json::json!({});
         let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
-        wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await
+        let receipt = wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await?;
+        let ret_type = self.functions.get(method).map(|f| f.returns.clone()).unwrap_or_default();
+        Ok(ContractReceipt::new(receipt, ret_type))
     }
 
     // ========================================================================
@@ -574,6 +577,40 @@ impl<'a> Contract<'a> {
 
 /// Parse comma-separated tuple types, handling nested generics.
 /// e.g. "u64, Vec<String>, (u8, bool)" → ["u64", "Vec<String>", "(u8, bool)"]
+// ============================================================================
+// ContractReceipt — receipt with ABI-aware return data decoding
+// ============================================================================
+
+/// Receipt from a Contract::write() call. Extends Receipt with ABI-aware decoding.
+/// Derefs to Receipt so all receipt fields are directly accessible.
+pub struct ContractReceipt {
+    pub receipt: Receipt,
+    ret_type: String,
+}
+
+impl ContractReceipt {
+    fn new(receipt: Receipt, ret_type: String) -> Self {
+        Self { receipt, ret_type }
+    }
+
+    /// Decode returnData using the ABI return type.
+    /// Returns None if returnData is absent (ephemeral — only available right after execution).
+    pub fn decode_return_data(&self) -> Option<Value> {
+        let bytes = self.receipt.return_bytes();
+        if bytes.is_empty() { return None; }
+        if self.ret_type.is_empty() || self.ret_type == "()" || self.ret_type == "unit" { return None; }
+        // Use a dummy contract for decoding (no ABI needed for primitive types)
+        let provider = crate::client::Provider::new("http://localhost:0");
+        let contract = Contract::new([0u8; 32], &provider);
+        Some(contract.decode_value(&bytes, &self.ret_type, 0).0)
+    }
+}
+
+impl std::ops::Deref for ContractReceipt {
+    type Target = Receipt;
+    fn deref(&self) -> &Receipt { &self.receipt }
+}
+
 fn parse_tuple_types(s: &str) -> Vec<&str> {
     let mut types = Vec::new();
     let mut depth = 0i32;

--- a/crates/pyde-rust-sdk/src/client.rs
+++ b/crates/pyde-rust-sdk/src/client.rs
@@ -96,6 +96,20 @@ impl Provider {
         parse_hex_u64(&result)
     }
 
+    /// Look up a transaction by its hash. Returns None if not found.
+    pub async fn get_transaction(&self, tx_hash: &[u8; 32]) -> Result<Option<serde_json::Value>> {
+        let result = self.rpc("pyde_getTransactionByHash", &[
+            json_str(&format!("0x{}", hex::encode(tx_hash))),
+        ]).await?;
+        if result.is_null() { Ok(None) } else { Ok(Some(result)) }
+    }
+
+    /// Get current fee data (base fee = gas price in Pyde's EIP-1559 model).
+    pub async fn get_fee_data(&self) -> Result<FeeData> {
+        let gas_price = self.get_gas_price().await?;
+        Ok(FeeData { gas_price, base_fee: gas_price })
+    }
+
     // ========================================================================
     // Transaction submission
     // ========================================================================

--- a/crates/pyde-rust-sdk/src/error.rs
+++ b/crates/pyde-rust-sdk/src/error.rs
@@ -12,7 +12,7 @@ pub enum SdkError {
     #[error("timeout: {0}")]
     Timeout(String),
 
-    #[error("transaction reverted (gas={gas_used})")]
+    #[error("{}", format_revert(.gas_used, .data))]
     Reverted { gas_used: u64, data: Vec<u8> },
 
     #[error("insufficient balance: need {required}, have {available}")]
@@ -21,8 +21,73 @@ pub enum SdkError {
     #[error("invalid address: {0}")]
     InvalidAddress(String),
 
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
     #[error("invalid response: {0}")]
     InvalidResponse(String),
 }
 
+impl SdkError {
+    /// Check if this error has the given code string.
+    pub fn code(&self) -> &'static str {
+        match self {
+            SdkError::Rpc(_) => "RPC_ERROR",
+            SdkError::Connection(_) => "CONNECTION_ERROR",
+            SdkError::Signing(_) => "SIGNING_ERROR",
+            SdkError::Timeout(_) => "TIMEOUT",
+            SdkError::Reverted { .. } => "CALL_EXCEPTION",
+            SdkError::InsufficientBalance { .. } => "INSUFFICIENT_FUNDS",
+            SdkError::InvalidAddress(_) => "INVALID_ARGUMENT",
+            SdkError::InvalidArgument(_) => "INVALID_ARGUMENT",
+            SdkError::InvalidResponse(_) => "INVALID_RESPONSE",
+        }
+    }
+
+    /// If this is a Reverted error, try to decode the revert reason string.
+    pub fn revert_reason(&self) -> Option<String> {
+        if let SdkError::Reverted { data, .. } = self {
+            decode_revert_reason(data)
+        } else {
+            None
+        }
+    }
+
+    /// Check if this is a revert (call exception).
+    pub fn is_revert(&self) -> bool {
+        matches!(self, SdkError::Reverted { .. })
+    }
+}
+
 pub type Result<T> = std::result::Result<T, SdkError>;
+
+/// Attempt to decode a revert reason from return data.
+fn decode_revert_reason(data: &[u8]) -> Option<String> {
+    if data.is_empty() { return None; }
+    // Try length-prefixed string: [len:8 LE][utf8 bytes]
+    if data.len() >= 8 {
+        let len = u64::from_le_bytes(data[..8].try_into().ok()?) as usize;
+        if len > 0 && len <= data.len() - 8 {
+            if let Ok(s) = std::str::from_utf8(&data[8..8 + len]) {
+                if s.chars().all(|c| !c.is_control() || c == '\n') {
+                    return Some(s.to_string());
+                }
+            }
+        }
+    }
+    // Try raw UTF-8
+    if let Ok(s) = std::str::from_utf8(data) {
+        if s.len() <= 256 && s.chars().all(|c| !c.is_control() || c == '\n') {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn format_revert(gas_used: &u64, data: &[u8]) -> String {
+    if let Some(reason) = decode_revert_reason(data) {
+        format!("transaction reverted: {} (gas={})", reason, gas_used)
+    } else {
+        format!("transaction reverted (gas={})", gas_used)
+    }
+}

--- a/crates/pyde-rust-sdk/src/lib.rs
+++ b/crates/pyde-rust-sdk/src/lib.rs
@@ -33,7 +33,7 @@ pub mod types;
 pub mod wallet;
 
 // Top-level re-exports for convenience
-pub use abi::{Contract, Value};
+pub use abi::{Contract, ContractReceipt, Value};
 pub use client::Provider;
 pub use contract::{compute_selector, ContractCall, DeployData};
 pub use contract::{
@@ -47,6 +47,7 @@ pub use types::{
     format_address, parse_address, is_valid_address, is_zero_address,
     is_valid_private_key, address_eq, ZERO_ADDRESS,
     parse_units, format_units, parse_quanta, format_quanta, PYDE_DECIMALS,
-    Address, Receipt, Log, LogFilter, BlockHeader,
+    is_hex_string, hexlify, get_bytes, to_be_hex, concat_bytes, zero_pad_value, strip_zeros, data_length,
+    Address, Receipt, Log, LogFilter, BlockHeader, FeeData,
 };
 pub use wallet::{Keystore, SignerProvider, Wallet};

--- a/crates/pyde-rust-sdk/src/types.rs
+++ b/crates/pyde-rust-sdk/src/types.rs
@@ -54,13 +54,32 @@ impl Receipt {
     pub fn decode_u64(&self) -> Option<u64> {
         crate::contract::decode_u64(&self.return_bytes())
     }
-
+    pub fn decode_i64(&self) -> Option<i64> {
+        crate::contract::decode_i64(&self.return_bytes())
+    }
+    pub fn decode_u128(&self) -> Option<u128> {
+        crate::contract::decode_u128(&self.return_bytes())
+    }
+    pub fn decode_i128(&self) -> Option<i128> {
+        crate::contract::decode_i128(&self.return_bytes())
+    }
+    pub fn decode_u256(&self) -> Option<ethnum::U256> {
+        crate::contract::decode_u256(&self.return_bytes())
+    }
+    pub fn decode_i256(&self) -> Option<ethnum::I256> {
+        crate::contract::decode_i256(&self.return_bytes())
+    }
     pub fn decode_bool(&self) -> Option<bool> {
         crate::contract::decode_bool(&self.return_bytes())
     }
-
+    pub fn decode_address(&self) -> Option<Address> {
+        crate::contract::decode_address(&self.return_bytes())
+    }
     pub fn decode_string(&self) -> Option<String> {
         crate::contract::decode_string(&self.return_bytes())
+    }
+    pub fn decode_bytes(&self) -> Option<Vec<u8>> {
+        crate::contract::decode_bytes(&self.return_bytes())
     }
 }
 
@@ -101,6 +120,15 @@ pub struct BlockHeader {
     pub state_root: String,
     #[serde(default)]
     pub tx_count: String,
+}
+
+/// Fee data from the network.
+#[derive(Debug, Clone)]
+pub struct FeeData {
+    /// Current gas price (same as base fee in Pyde's EIP-1559 model, no tips).
+    pub gas_price: u128,
+    /// Current base fee per gas unit.
+    pub base_fee: u128,
 }
 
 /// Parse a hex address string to [u8; 32].
@@ -147,6 +175,68 @@ pub fn address_eq(a: &Address, b: &Address) -> bool {
 pub fn is_valid_private_key(hex: &str) -> bool {
     let clean = hex.trim_start_matches("0x");
     clean.len() == (897 + 1281) * 2 && clean.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+// ============================================================================
+// Hex utilities
+// ============================================================================
+
+/// Check if a string is valid hex (with or without 0x prefix).
+pub fn is_hex_string(value: &str) -> bool {
+    let hex = value.trim_start_matches("0x");
+    !hex.is_empty() && hex.len() % 2 == 0 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Convert bytes to a 0x-prefixed hex string.
+pub fn hexlify(data: &[u8]) -> String {
+    format!("0x{}", hex::encode(data))
+}
+
+/// Convert a hex string to bytes.
+pub fn get_bytes(value: &str) -> std::result::Result<Vec<u8>, String> {
+    let hex_str = value.trim_start_matches("0x");
+    hex::decode(hex_str).map_err(|e| format!("Invalid hex: {}", e))
+}
+
+/// Convert a u128 to a 0x-prefixed big-endian hex string.
+pub fn to_be_hex(value: u128, width: Option<usize>) -> String {
+    let hex = format!("{:x}", value);
+    let padded = if let Some(w) = width {
+        format!("{:0>width$}", hex, width = w * 2)
+    } else if hex.len() % 2 != 0 {
+        format!("0{}", hex)
+    } else {
+        hex
+    };
+    format!("0x{}", padded)
+}
+
+/// Concatenate multiple byte slices.
+pub fn concat_bytes(values: &[&[u8]]) -> Vec<u8> {
+    let total: usize = values.iter().map(|v| v.len()).sum();
+    let mut result = Vec::with_capacity(total);
+    for v in values { result.extend_from_slice(v); }
+    result
+}
+
+/// Zero-pad bytes to a specific length (left-pad).
+pub fn zero_pad_value(data: &[u8], length: usize) -> std::result::Result<Vec<u8>, String> {
+    if data.len() > length { return Err(format!("Value {} bytes exceeds pad length {}", data.len(), length)); }
+    let mut padded = vec![0u8; length];
+    padded[length - data.len()..].copy_from_slice(data);
+    Ok(padded)
+}
+
+/// Strip leading zero bytes.
+pub fn strip_zeros(data: &[u8]) -> Vec<u8> {
+    let start = data.iter().position(|&b| b != 0).unwrap_or(data.len());
+    data[start..].to_vec()
+}
+
+/// Get byte length of a hex string.
+pub fn data_length(hex: &str) -> usize {
+    let h = hex.trim_start_matches("0x");
+    h.len() / 2
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- SdkError: code(), revert_reason(), is_revert(), InvalidArgument variant
- Hex utilities: is_hex_string, hexlify, get_bytes, to_be_hex, concat_bytes, zero_pad_value
- provider.get_transaction() and provider.get_fee_data()
- ContractReceipt with decode_return_data() — ABI-aware return decoding
- Full Receipt decode helpers for all types
- README updated with all new sections