### PR TITLE
feat: contract events, WebSocket provider, TransactionResponse, Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,6 +3542,7 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "ethnum",
+ "futures-util",
  "hex",
  "pyde-account",
  "pyde-crypto",
@@ -3552,6 +3553,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -4658,6 +4660,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,6 +4910,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4968,6 +5003,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/pyde-rust-sdk/Cargo.toml
+++ b/crates/pyde-rust-sdk/Cargo.toml
@@ -10,9 +10,11 @@ pyde-crypto = { path = "../crypto" }
 pyde-tx = { path = "../tx" }
 pyde-account = { path = "../account" }
 
-# Async HTTP
+# Async HTTP + WebSocket
 reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "sync"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+futures-util = "0.3"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -47,6 +47,9 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Decoding Write Return Data](#decoding-write-return-data)
   - [The Value Enum](#the-value-enum)
   - [Decoding Return Values](#decoding-return-values)
+  - [Contract Events](#contract-events)
+  - [Interface (Standalone ABI)](#interface-standalone-abi)
+- [WebSocket Provider](#websocket-provider)
 - [Events & Logs](#events--logs)
 - [Error Handling](#error-handling)
   - [Error Variants](#error-variants)
@@ -741,6 +744,76 @@ let raw   = decode_bytes(&bytes);    // Option<Vec<u8>>
 let nums  = decode_vec_u64(&bytes);     // Option<Vec<u64>>
 let flags = decode_vec_bool(&bytes);    // Option<Vec<bool>>
 let addrs = decode_vec_address(&bytes); // Option<Vec<[u8; 32]>>
+```
+
+---
+
+### Contract Events
+
+Query and decode contract events using the ABI.
+
+```rust
+// Query historical events (decoded with named args)
+let transfers = contract.query_filter("Transfer", Some(0), Some(1000)).await?;
+for e in &transfers {
+    println!("{}: {:?}", e.name, e.args);
+}
+
+// Parse a single raw log
+let decoded = contract.parse_log(&raw_log);
+
+// Get topic0 hash for building custom filters
+let topic = contract.get_event_topic("Transfer");
+```
+
+### Interface (Standalone ABI)
+
+Encode/decode without a contract address or provider.
+
+```rust
+let iface = Interface::from_artifact("out/Counter.json")?;
+
+// Encode calldata
+let data = iface.encode_function_data("deposit", &json!({"amount": 500}))?;
+
+// Decode return value
+let val = iface.decode_function_result("get_count", &bytes);
+
+// Parse logs
+let event = iface.parse_log(&raw_log);
+```
+
+---
+
+## WebSocket Provider
+
+Real-time subscriptions via WebSocket.
+
+```rust
+let ws = WsProvider::connect("ws://127.0.0.1:8546").await?;
+
+// Subscribe to new block headers
+let mut blocks = ws.subscribe_new_heads().await?;
+tokio::spawn(async move {
+    while let Ok(header) = blocks.recv().await {
+        println!("New block: {}", header.slot);
+    }
+});
+
+// Subscribe to pending transactions
+let mut pending = ws.subscribe_pending_transactions().await?;
+
+// Subscribe to contract event logs
+let mut logs = ws.subscribe_logs(&LogFilter {
+    address: Some("0xcontract...".into()),
+    ..Default::default()
+}).await?;
+
+// Standard queries also work
+let balance = ws.get_balance(&addr).await?;
+
+// Cleanup
+ws.close().await;
 ```
 
 ---

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -1,7 +1,7 @@
 use crate::client::Provider;
 use crate::contract::compute_selector;
 use crate::error::{Result, SdkError};
-use crate::types::{Address, Receipt};
+use crate::types::{Address, Log, LogFilter, Receipt};
 use crate::wallet::Wallet;
 use std::collections::HashMap;
 
@@ -89,6 +89,30 @@ pub struct AbiEnumVariant {
     pub discriminant: u32,
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct AbiEvent {
+    pub name: String,
+    #[serde(default)]
+    pub fields: Vec<AbiEventField>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct AbiEventField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(default)]
+    pub indexed: bool,
+}
+
+/// Decoded event log with named args.
+#[derive(Debug, Clone)]
+pub struct EventLog {
+    pub name: String,
+    pub args: HashMap<String, Value>,
+    pub log: Log,
+}
+
 // ============================================================================
 // Contract — ABI-aware interface
 // ============================================================================
@@ -98,6 +122,8 @@ pub struct Contract<'a> {
     provider: &'a Provider,
     wallet: Option<&'a Wallet>,
     functions: HashMap<String, AbiFunction>,
+    events: HashMap<String, AbiEvent>,
+    events_by_topic: HashMap<String, AbiEvent>,
     structs: HashMap<String, AbiStructDef>,
     enums: HashMap<String, AbiEnumDef>,
 }
@@ -142,12 +168,25 @@ impl<'a> Contract<'a> {
             }
         }
 
-        Ok(Self { address, provider, wallet: None, functions, structs, enums })
+        let mut events = HashMap::new();
+        let mut events_by_topic = HashMap::new();
+        if let Some(evs) = abi.get("events").and_then(|v| v.as_array()) {
+            for ev in evs {
+                if let Ok(def) = serde_json::from_value::<AbiEvent>(ev.clone()) {
+                    let sel = compute_selector(&def.name);
+                    let topic0 = format!("0x{:08x}{}", sel, "0".repeat(56));
+                    events_by_topic.insert(topic0, def.clone());
+                    events.insert(def.name.clone(), def);
+                }
+            }
+        }
+
+        Ok(Self { address, provider, wallet: None, functions, events, events_by_topic, structs, enums })
     }
 
     /// Create minimal contract (no ABI).
     pub fn new(address: Address, provider: &'a Provider) -> Self {
-        Self { address, provider, wallet: None, functions: HashMap::new(), structs: HashMap::new(), enums: HashMap::new() }
+        Self { address, provider, wallet: None, functions: HashMap::new(), events: HashMap::new(), events_by_topic: HashMap::new(), structs: HashMap::new(), enums: HashMap::new() }
     }
 
     /// Bind a wallet for write operations.
@@ -224,6 +263,72 @@ impl<'a> Contract<'a> {
         let receipt = wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await?;
         let ret_type = self.functions.get(method).map(|f| f.returns.clone()).unwrap_or_default();
         Ok(ContractReceipt::new(receipt, ret_type))
+    }
+
+    // ========================================================================
+    // Events
+    // ========================================================================
+
+    /// Query historical event logs, decoded into typed EventLog objects.
+    pub async fn query_filter(&self, event_name: &str, from_block: Option<u64>, to_block: Option<u64>) -> Result<Vec<EventLog>> {
+        let ev = self.events.get(event_name)
+            .ok_or_else(|| SdkError::InvalidResponse(format!("Unknown event '{}'", event_name)))?;
+
+        let sel = compute_selector(event_name);
+        let topic0 = format!("0x{:08x}{}", sel, "0".repeat(56));
+
+        let logs = self.provider.get_logs(&LogFilter {
+            from_block,
+            to_block,
+            address: Some(crate::types::format_address(&self.address)),
+            topics: Some(vec![Some(vec![topic0])]),
+        }).await?;
+
+        Ok(logs.into_iter().map(|log| self.decode_event_log(ev, log)).collect())
+    }
+
+    /// Parse a raw Log into a decoded EventLog. Returns None if the event is unknown.
+    pub fn parse_log(&self, log: &Log) -> Option<EventLog> {
+        if log.topics.is_empty() { return None; }
+        let ev = self.events_by_topic.get(&log.topics[0])?;
+        Some(self.decode_event_log(ev, log.clone()))
+    }
+
+    /// Get the topic0 hash for an event name.
+    pub fn get_event_topic(&self, event_name: &str) -> String {
+        let sel = compute_selector(event_name);
+        format!("0x{:08x}{}", sel, "0".repeat(56))
+    }
+
+    fn decode_event_log(&self, ev: &AbiEvent, log: Log) -> EventLog {
+        let mut args = HashMap::new();
+        let data_hex = log.data.trim_start_matches("0x");
+        let data = hex::decode(data_hex).unwrap_or_default();
+
+        // Non-indexed fields in data
+        let mut offset = 0;
+        for field in &ev.fields {
+            if !field.indexed && offset < data.len() {
+                let (val, read) = self.decode_value(&data, &field.ty, offset);
+                args.insert(field.name.clone(), val);
+                offset += read;
+            }
+        }
+
+        // Indexed fields in topics[1..N]
+        let mut topic_idx = 1;
+        for field in &ev.fields {
+            if field.indexed && topic_idx < log.topics.len() {
+                let topic_hex = log.topics[topic_idx].trim_start_matches("0x");
+                if let Ok(topic_bytes) = hex::decode(topic_hex) {
+                    let (val, _) = self.decode_value(&topic_bytes, &field.ty, 0);
+                    args.insert(field.name.clone(), val);
+                }
+                topic_idx += 1;
+            }
+        }
+
+        EventLog { name: ev.name.clone(), args, log }
     }
 
     // ========================================================================
@@ -577,6 +682,59 @@ impl<'a> Contract<'a> {
 
 /// Parse comma-separated tuple types, handling nested generics.
 /// e.g. "u64, Vec<String>, (u8, bool)" → ["u64", "Vec<String>", "(u8, bool)"]
+// ============================================================================
+// Interface — standalone ABI encoder/decoder
+// ============================================================================
+
+/// Standalone ABI encoder/decoder (no contract address or provider needed).
+pub struct Interface {
+    json: String,
+}
+
+impl Interface {
+    /// Load from a build artifact JSON file.
+    pub fn from_artifact(path: &str) -> std::result::Result<Self, String> {
+        let json = std::fs::read_to_string(path)
+            .map_err(|e| format!("read artifact: {}", e))?;
+        Ok(Self { json })
+    }
+
+    /// Load from ABI JSON string.
+    pub fn from_json(json: &str) -> Self {
+        Self { json: json.to_string() }
+    }
+
+    /// Encode a function call to calldata bytes.
+    pub fn encode_function_data(&self, method: &str, args: &serde_json::Value) -> Result<Vec<u8>> {
+        let provider = Provider::new("http://localhost:0");
+        let contract = Contract::from_json(&self.json, [0u8; 32], &provider)?;
+        contract.encode_call(method, args)
+    }
+
+    /// Decode function return data using the ABI return type.
+    pub fn decode_function_result(&self, method: &str, data: &[u8]) -> Option<Value> {
+        let provider = Provider::new("http://localhost:0");
+        let contract = Contract::from_json(&self.json, [0u8; 32], &provider).ok()?;
+        let fn_def = contract.functions.get(method)?;
+        let ret = fn_def.returns.as_str();
+        if ret == "()" || ret == "unit" { return None; }
+        Some(contract.decode_value(data, ret, 0).0)
+    }
+
+    /// Parse a raw Log into a decoded EventLog.
+    pub fn parse_log(&self, log: &Log) -> Option<EventLog> {
+        let provider = Provider::new("http://localhost:0");
+        let contract = Contract::from_json(&self.json, [0u8; 32], &provider).ok()?;
+        contract.parse_log(log)
+    }
+
+    /// Get the topic0 hash for an event name.
+    pub fn get_event_topic(&self, event_name: &str) -> String {
+        let sel = compute_selector(event_name);
+        format!("0x{:08x}{}", sel, "0".repeat(56))
+    }
+}
+
 // ============================================================================
 // ContractReceipt — receipt with ABI-aware return data decoding
 // ============================================================================

--- a/crates/pyde-rust-sdk/src/client.rs
+++ b/crates/pyde-rust-sdk/src/client.rs
@@ -114,19 +114,20 @@ impl Provider {
     // Transaction submission
     // ========================================================================
 
-    /// Send a signed transaction. Returns the tx hash.
-    pub async fn send_transaction(&self, tx: &Transaction) -> Result<[u8; 32]> {
+    /// Send a signed transaction. Returns a TransactionResponse with hash and wait().
+    pub async fn send_transaction(&self, tx: &Transaction) -> Result<TransactionResponse<'_>> {
         let tx_bytes = tx.to_bytes();
         let result = self.rpc("pyde_sendRawTransaction", &[
             json_str(&format!("0x{}", hex::encode(&tx_bytes))),
         ]).await?;
-        parse_tx_hash(&result)
+        let hash = parse_tx_hash(&result)?;
+        Ok(TransactionResponse { hash, provider: self })
     }
 
     /// Send a signed transaction and wait for the receipt.
     pub async fn send_and_wait(&self, tx: &Transaction, timeout_ms: u64) -> Result<Receipt> {
-        let hash = self.send_transaction(tx).await?;
-        self.wait_for_receipt(&hash, timeout_ms).await
+        let tx_resp = self.send_transaction(tx).await?;
+        tx_resp.wait(timeout_ms).await
     }
 
     // ========================================================================
@@ -209,6 +210,25 @@ impl Provider {
 // ============================================================================
 // Parsing helpers
 // ============================================================================
+
+/// Pending transaction handle returned by send_transaction().
+pub struct TransactionResponse<'a> {
+    /// Transaction hash.
+    pub hash: [u8; 32],
+    provider: &'a Provider,
+}
+
+impl<'a> TransactionResponse<'a> {
+    /// Transaction hash as 0x-prefixed hex string.
+    pub fn hash_hex(&self) -> String {
+        format!("0x{}", hex::encode(self.hash))
+    }
+
+    /// Wait for the transaction to be included in a block.
+    pub async fn wait(&self, timeout_ms: u64) -> Result<Receipt> {
+        self.provider.wait_for_receipt(&self.hash, timeout_ms).await
+    }
+}
 
 fn json_str(s: &str) -> serde_json::Value {
     serde_json::Value::String(s.to_string())

--- a/crates/pyde-rust-sdk/src/lib.rs
+++ b/crates/pyde-rust-sdk/src/lib.rs
@@ -31,10 +31,11 @@ pub mod contract;
 pub mod error;
 pub mod types;
 pub mod wallet;
+pub mod ws;
 
 // Top-level re-exports for convenience
-pub use abi::{Contract, ContractReceipt, Value};
-pub use client::Provider;
+pub use abi::{Contract, ContractReceipt, EventLog, Interface, Value};
+pub use client::{Provider, TransactionResponse};
 pub use contract::{compute_selector, ContractCall, DeployData};
 pub use contract::{
     decode_address, decode_bool, decode_bytes, decode_string,
@@ -51,3 +52,4 @@ pub use types::{
     Address, Receipt, Log, LogFilter, BlockHeader, FeeData,
 };
 pub use wallet::{Keystore, SignerProvider, Wallet};
+pub use ws::WsProvider;

--- a/crates/pyde-rust-sdk/src/types.rs
+++ b/crates/pyde-rust-sdk/src/types.rs
@@ -94,7 +94,7 @@ pub struct Log {
 }
 
 /// Log filter for querying events.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LogFilter {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/pyde-rust-sdk/src/ws.rs
+++ b/crates/pyde-rust-sdk/src/ws.rs
@@ -1,0 +1,204 @@
+use crate::error::{Result, SdkError};
+use crate::types::{BlockHeader, Log, LogFilter};
+use futures_util::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{broadcast, Mutex, oneshot};
+
+type WsStream = tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+>;
+
+/// WebSocket JSON-RPC provider with subscription support.
+///
+/// ```rust,ignore
+/// let ws = WsProvider::connect("ws://127.0.0.1:8546").await?;
+///
+/// // Subscribe to new blocks
+/// let mut blocks = ws.subscribe_new_heads().await?;
+/// tokio::spawn(async move {
+///     while let Ok(header) = blocks.recv().await {
+///         println!("New block: {}", header.slot);
+///     }
+/// });
+///
+/// // Standard queries also work
+/// let balance = ws.get_balance(&addr).await?;
+///
+/// ws.close().await;
+/// ```
+pub struct WsProvider {
+    sender: Arc<Mutex<futures_util::stream::SplitSink<WsStream, tokio_tungstenite::tungstenite::Message>>>,
+    rpc_id: Arc<Mutex<u64>>,
+    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+    new_heads_tx: broadcast::Sender<BlockHeader>,
+    pending_tx_tx: broadcast::Sender<String>,
+    logs_tx: broadcast::Sender<Log>,
+    _handle: tokio::task::JoinHandle<()>,
+}
+
+impl WsProvider {
+    /// Connect to a WebSocket JSON-RPC endpoint.
+    pub async fn connect(url: &str) -> Result<Self> {
+        let (ws, _) = tokio_tungstenite::connect_async(url)
+            .await
+            .map_err(|e| SdkError::Connection(format!("WebSocket connect: {}", e)))?;
+
+        let (sink, mut stream) = ws.split();
+        let sender = Arc::new(Mutex::new(sink));
+        let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (new_heads_tx, _) = broadcast::channel(64);
+        let (pending_tx_tx, _) = broadcast::channel(64);
+        let (logs_tx, _) = broadcast::channel(256);
+
+        let pending_clone = pending.clone();
+        let heads_tx = new_heads_tx.clone();
+        let ptx_tx = pending_tx_tx.clone();
+        let ltx = logs_tx.clone();
+
+        let handle = tokio::spawn(async move {
+            while let Some(msg) = stream.next().await {
+                let msg = match msg {
+                    Ok(tokio_tungstenite::tungstenite::Message::Text(t)) => t,
+                    _ => continue,
+                };
+                let data: serde_json::Value = match serde_json::from_str(&msg) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                // Subscription notification
+                if data.get("method").is_some() {
+                    let result = data.get("params").and_then(|p| p.get("result"));
+                    let method = data["method"].as_str().unwrap_or("");
+
+                    if let Some(result) = result {
+                        if method.contains("subscription") {
+                            // Try as block header
+                            if let Ok(header) = serde_json::from_value::<BlockHeader>(result.clone()) {
+                                let _ = heads_tx.send(header);
+                            }
+                            // Try as log
+                            else if let Ok(log) = serde_json::from_value::<Log>(result.clone()) {
+                                let _ = ltx.send(log);
+                            }
+                            // Try as pending tx hash
+                            else if let Some(hash) = result.as_str() {
+                                let _ = ptx_tx.send(hash.to_string());
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // RPC response
+                if let Some(id) = data.get("id").and_then(|v| v.as_u64()) {
+                    let mut map = pending_clone.lock().await;
+                    if let Some(tx) = map.remove(&id) {
+                        let _ = tx.send(data);
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            sender,
+            rpc_id: Arc::new(Mutex::new(0)),
+            pending,
+            new_heads_tx,
+            pending_tx_tx,
+            logs_tx,
+            _handle: handle,
+        })
+    }
+
+    // ========================================================================
+    // Subscriptions
+    // ========================================================================
+
+    /// Subscribe to new block headers.
+    pub async fn subscribe_new_heads(&self) -> Result<broadcast::Receiver<BlockHeader>> {
+        self.rpc("pyde_subscribe", &[serde_json::json!("newHeads")]).await?;
+        Ok(self.new_heads_tx.subscribe())
+    }
+
+    /// Subscribe to pending transactions.
+    pub async fn subscribe_pending_transactions(&self) -> Result<broadcast::Receiver<String>> {
+        self.rpc("pyde_subscribePending", &[]).await?;
+        Ok(self.pending_tx_tx.subscribe())
+    }
+
+    /// Subscribe to contract event logs matching a filter.
+    pub async fn subscribe_logs(&self, filter: &LogFilter) -> Result<broadcast::Receiver<Log>> {
+        self.rpc("pyde_subscribeLogs", &[serde_json::to_value(filter).unwrap_or_default()]).await?;
+        Ok(self.logs_tx.subscribe())
+    }
+
+    // ========================================================================
+    // Standard queries (same as HTTP Provider)
+    // ========================================================================
+
+    pub async fn get_balance(&self, address: &[u8; 32]) -> Result<u128> {
+        let result = self.rpc("pyde_getBalance", &[serde_json::json!(format!("0x{}", hex::encode(address)))]).await?;
+        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
+        Ok(u128::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+    }
+
+    pub async fn get_block_number(&self) -> Result<u64> {
+        let result = self.rpc("pyde_blockNumber", &[]).await?;
+        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
+        Ok(u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+    }
+
+    pub async fn get_chain_id(&self) -> Result<u64> {
+        let result = self.rpc("pyde_chainId", &[]).await?;
+        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
+        Ok(u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+    }
+
+    // ========================================================================
+    // Cleanup
+    // ========================================================================
+
+    /// Close the WebSocket connection.
+    pub async fn close(&self) {
+        let mut sink = self.sender.lock().await;
+        let _ = sink.close().await;
+    }
+
+    // ========================================================================
+    // Internal
+    // ========================================================================
+
+    async fn rpc(&self, method: &str, params: &[serde_json::Value]) -> Result<serde_json::Value> {
+        let id = {
+            let mut id = self.rpc_id.lock().await;
+            *id += 1;
+            *id
+        };
+
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        {
+            let mut sink = self.sender.lock().await;
+            sink.send(tokio_tungstenite::tungstenite::Message::Text(msg.to_string()))
+                .await
+                .map_err(|e| SdkError::Connection(format!("WS send: {}", e)))?;
+        }
+
+        let result = rx.await.map_err(|_| SdkError::Connection("WS response channel closed".into()))?;
+        if let Some(err) = result.get("error") {
+            return Err(SdkError::Rpc(err.to_string()));
+        }
+        Ok(result)
+    }
+}


### PR DESCRIPTION
## Summary
- contract.query_filter(), parse_log(), get_event_topic() — ABI-decoded events
- WsProvider with subscribe_new_heads, subscribe_pending_transactions, subscribe_logs
- send_transaction returns TransactionResponse with hash + wait()
- Standalone Interface for ABI encode/decode without contract instance
- ContractReceipt with decode_return_data()
- tokio-tungstenite + futures-util dependencies
- README updated with all new sections