### PR TITLE
feat: call overrides, batch RPC, populateTransaction, Signer trait

### DIFF
--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -17,6 +17,7 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Fee Data](#fee-data)
   - [Static Calls](#static-calls)
   - [Gas Estimation](#gas-estimation)
+  - [Batch RPC](#batch-rpc)
 - [Wallet](#wallet)
   - [Creating a Wallet](#creating-a-wallet)
   - [Restoring a Wallet](#restoring-a-wallet)
@@ -49,7 +50,9 @@ Rust SDK for interacting with the Pyde blockchain. Async RPC client, FALCON-512 
   - [Decoding Return Values](#decoding-return-values)
   - [Contract Events](#contract-events)
   - [Interface (Standalone ABI)](#interface-standalone-abi)
+  - [Populate Transaction](#populate-transaction)
 - [WebSocket Provider](#websocket-provider)
+- [Signer Trait](#signer-trait)
 - [Events & Logs](#events--logs)
 - [Error Handling](#error-handling)
   - [Error Variants](#error-variants)
@@ -193,7 +196,36 @@ let result = provider.call(&contract_addr, &calldata).await?; // Vec<u8>
 ### Gas Estimation
 
 ```rust
-let gas = provider.estimate_gas(&contract_addr, &calldata).await?; // u64
+// Basic
+let gas = provider.estimate_gas(&contract_addr, &calldata).await?;
+
+// With overrides (from, value, gas)
+let gas = provider.estimate_gas_with(&contract_addr, &calldata, Some(&CallOverrides {
+    from: Some(*wallet.address()),
+    value: Some(1_000_000),
+    ..Default::default()
+})).await?;
+```
+
+### Batch RPC
+
+Send multiple calls in a single HTTP request.
+
+```rust
+let results = provider.batch(&[
+    ("pyde_getBalance", &[json!(format_address(&addr))]),
+    ("pyde_getTransactionCount", &[json!(format_address(&addr))]),
+    ("pyde_chainId", &[]),
+]).await?;
+```
+
+The provider supports configurable timeout and retries:
+
+```rust
+let provider = Provider::with_options("http://127.0.0.1:8545", ProviderOptions {
+    timeout: std::time::Duration::from_secs(10),
+    retries: 3,
+});
 ```
 
 ---
@@ -785,6 +817,17 @@ let event = iface.parse_log(&raw_log);
 
 ---
 
+### Populate Transaction
+
+Build an unsigned transaction without sending.
+
+```rust
+let tx = contract.populate_transaction("deposit", Some(&json!({"amount": 500})), gas).await?;
+// Review or sign later: wallet.sign_transaction(&mut tx)?;
+```
+
+---
+
 ## WebSocket Provider
 
 Real-time subscriptions via WebSocket.
@@ -815,6 +858,30 @@ let balance = ws.get_balance(&addr).await?;
 // Cleanup
 ws.close().await;
 ```
+
+---
+
+## Signer Trait
+
+Abstract trait for custom signers (hardware wallets, remote signers).
+
+```rust
+use pyde_rust_sdk::Signer;
+
+struct HardwareSigner { /* ... */ }
+
+impl Signer for HardwareSigner {
+    fn address(&self) -> &Address { &self.addr }
+    fn sign_transaction(&self, tx: &mut Transaction) -> Result<()> {
+        // Your hardware wallet logic
+    }
+    fn sign(&self, message: &[u8; 32]) -> Result<Vec<u8>> {
+        // Your message signing logic
+    }
+}
+```
+
+`Wallet` implements the `Signer` trait.
 
 ---
 

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -2,6 +2,7 @@ use crate::client::Provider;
 use crate::contract::compute_selector;
 use crate::error::{Result, SdkError};
 use crate::types::{Address, Log, LogFilter, Receipt};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
 use crate::wallet::Wallet;
 use std::collections::HashMap;
 
@@ -263,6 +264,39 @@ impl<'a> Contract<'a> {
         let receipt = wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await?;
         let ret_type = self.functions.get(method).map(|f| f.returns.clone()).unwrap_or_default();
         Ok(ContractReceipt::new(receipt, ret_type))
+    }
+
+    // ========================================================================
+    // Populate (build unsigned tx without sending)
+    // ========================================================================
+
+    /// Build an unsigned Transaction for a contract call without sending.
+    /// Useful for multisig, offline signing, or tx review.
+    pub async fn populate_transaction(
+        &self, method: &str, args: Option<&serde_json::Value>, gas_limit: u64,
+    ) -> Result<Transaction> {
+        let wallet = self.wallet.ok_or_else(|| SdkError::Signing(
+            "No wallet connected. Use contract.connect(&wallet) first.".into()
+        ))?;
+        let empty = serde_json::json!({});
+        let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
+        let nonce = self.provider.get_nonce(wallet.address()).await?;
+        let chain_id = self.provider.get_chain_id().await?;
+
+        Ok(Transaction {
+            from: *wallet.address(),
+            to: self.address,
+            value: 0,
+            data: calldata,
+            gas_limit,
+            nonce,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id,
+            tx_type: TransactionType::Standard,
+        })
     }
 
     // ========================================================================

--- a/crates/pyde-rust-sdk/src/client.rs
+++ b/crates/pyde-rust-sdk/src/client.rs
@@ -1,18 +1,38 @@
 use crate::error::{Result, SdkError};
 use crate::types::*;
 
+/// Provider options for configuring HTTP behavior.
+pub struct ProviderOptions {
+    /// Request timeout (default: 30s).
+    pub timeout: std::time::Duration,
+    /// Number of retry attempts (default: 0).
+    pub retries: u32,
+}
+
+impl Default for ProviderOptions {
+    fn default() -> Self {
+        Self { timeout: std::time::Duration::from_secs(30), retries: 0 }
+    }
+}
+
 /// RPC client for interacting with a Pyde node.
 pub struct Provider {
     rpc_url: String,
     client: reqwest::Client,
+    retries: u32,
 }
 
 impl Provider {
     pub fn new(rpc_url: &str) -> Self {
-        Self {
-            rpc_url: rpc_url.to_string(),
-            client: reqwest::Client::new(),
-        }
+        Self::with_options(rpc_url, ProviderOptions::default())
+    }
+
+    pub fn with_options(rpc_url: &str, options: ProviderOptions) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(options.timeout)
+            .build()
+            .unwrap_or_default();
+        Self { rpc_url: rpc_url.to_string(), client, retries: options.retries }
     }
 
     // ========================================================================
@@ -76,22 +96,42 @@ impl Provider {
     // ========================================================================
 
     pub async fn call(&self, to: &Address, data: &[u8]) -> Result<Vec<u8>> {
-        let params = serde_json::json!({
-            "from": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        self.call_with(to, data, None).await
+    }
+
+    /// Static call with overrides (from, value, gas).
+    pub async fn call_with(&self, to: &Address, data: &[u8], overrides: Option<&CallOverrides>) -> Result<Vec<u8>> {
+        let mut params = serde_json::json!({
+            "from": overrides.and_then(|o| o.from.as_ref()).map(|a| format_address(a))
+                .unwrap_or_else(|| "0x".to_string() + &"00".repeat(32)),
             "to": format_address(to),
             "data": format!("0x{}", hex::encode(data)),
         });
+        if let Some(o) = overrides {
+            if let Some(v) = o.value { params["value"] = serde_json::json!(format!("0x{:x}", v)); }
+            if let Some(g) = o.gas_limit { params["gas"] = serde_json::json!(format!("0x{:x}", g)); }
+        }
         let result = self.rpc("pyde_call", &[params]).await?;
         let hex = result.as_str().unwrap_or("0x").trim_start_matches("0x");
         hex::decode(hex).map_err(|e| SdkError::InvalidResponse(format!("bad call result: {}", e)))
     }
 
     pub async fn estimate_gas(&self, to: &Address, data: &[u8]) -> Result<u64> {
-        let params = serde_json::json!({
-            "from": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        self.estimate_gas_with(to, data, None).await
+    }
+
+    /// Estimate gas with overrides (from, value, gas).
+    pub async fn estimate_gas_with(&self, to: &Address, data: &[u8], overrides: Option<&CallOverrides>) -> Result<u64> {
+        let mut params = serde_json::json!({
+            "from": overrides.and_then(|o| o.from.as_ref()).map(|a| format_address(a))
+                .unwrap_or_else(|| "0x".to_string() + &"00".repeat(32)),
             "to": format_address(to),
             "data": format!("0x{}", hex::encode(data)),
         });
+        if let Some(o) = overrides {
+            if let Some(v) = o.value { params["value"] = serde_json::json!(format!("0x{:x}", v)); }
+            if let Some(g) = o.gas_limit { params["gas"] = serde_json::json!(format!("0x{:x}", g)); }
+        }
         let result = self.rpc("pyde_estimateGas", &[params]).await?;
         parse_hex_u64(&result)
     }
@@ -180,6 +220,46 @@ impl Provider {
     // Internal RPC helper
     // ========================================================================
 
+    // ========================================================================
+    // Batch RPC
+    // ========================================================================
+
+    /// Send multiple RPC calls in a single HTTP request.
+    pub async fn batch(&self, calls: &[(&str, &[serde_json::Value])]) -> Result<Vec<serde_json::Value>> {
+        let bodies: Vec<_> = calls.iter().enumerate().map(|(i, (method, params))| {
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": i + 1,
+                "method": method,
+                "params": params,
+            })
+        }).collect();
+
+        let resp = self.client
+            .post(&self.rpc_url)
+            .json(&bodies)
+            .send()
+            .await
+            .map_err(|e| SdkError::Connection(e.to_string()))?;
+
+        let results: Vec<serde_json::Value> = resp
+            .json()
+            .await
+            .map_err(|e| SdkError::InvalidResponse(e.to_string()))?;
+
+        results.into_iter().map(|r| {
+            if let Some(err) = r.get("error") {
+                Err(SdkError::Rpc(err.to_string()))
+            } else {
+                Ok(r.get("result").cloned().unwrap_or(serde_json::Value::Null))
+            }
+        }).collect()
+    }
+
+    // ========================================================================
+    // Internal RPC helper
+    // ========================================================================
+
     async fn rpc(&self, method: &str, params: &[serde_json::Value]) -> Result<serde_json::Value> {
         let body = serde_json::json!({
             "jsonrpc": "2.0",
@@ -187,9 +267,26 @@ impl Provider {
             "method": method,
             "params": params,
         });
+
+        let mut last_err = SdkError::Connection("no attempts".into());
+        for attempt in 0..=self.retries {
+            match self.do_rpc(&body).await {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    last_err = e;
+                    if attempt < self.retries {
+                        tokio::time::sleep(std::time::Duration::from_millis(100 * (attempt as u64 + 1))).await;
+                    }
+                }
+            }
+        }
+        Err(last_err)
+    }
+
+    async fn do_rpc(&self, body: &serde_json::Value) -> Result<serde_json::Value> {
         let resp = self.client
             .post(&self.rpc_url)
-            .json(&body)
+            .json(body)
             .send()
             .await
             .map_err(|e| SdkError::Connection(e.to_string()))?;

--- a/crates/pyde-rust-sdk/src/lib.rs
+++ b/crates/pyde-rust-sdk/src/lib.rs
@@ -31,11 +31,12 @@ pub mod contract;
 pub mod error;
 pub mod types;
 pub mod wallet;
+pub mod signer;
 pub mod ws;
 
 // Top-level re-exports for convenience
 pub use abi::{Contract, ContractReceipt, EventLog, Interface, Value};
-pub use client::{Provider, TransactionResponse};
+pub use client::{Provider, ProviderOptions, TransactionResponse};
 pub use contract::{compute_selector, ContractCall, DeployData};
 pub use contract::{
     decode_address, decode_bool, decode_bytes, decode_string,
@@ -49,7 +50,8 @@ pub use types::{
     is_valid_private_key, address_eq, ZERO_ADDRESS,
     parse_units, format_units, parse_quanta, format_quanta, PYDE_DECIMALS,
     is_hex_string, hexlify, get_bytes, to_be_hex, concat_bytes, zero_pad_value, strip_zeros, data_length,
-    Address, Receipt, Log, LogFilter, BlockHeader, FeeData,
+    Address, Receipt, Log, LogFilter, BlockHeader, FeeData, CallOverrides,
 };
+pub use signer::Signer;
 pub use wallet::{Keystore, SignerProvider, Wallet};
 pub use ws::WsProvider;

--- a/crates/pyde-rust-sdk/src/signer.rs
+++ b/crates/pyde-rust-sdk/src/signer.rs
@@ -1,0 +1,16 @@
+use crate::error::Result;
+use crate::types::Address;
+use pyde_tx::types::Transaction;
+
+/// Abstract signer trait. Wallet implements this.
+/// Implement for hardware wallets, remote signers, or custodial signers.
+pub trait Signer {
+    /// The signer's address.
+    fn address(&self) -> &Address;
+
+    /// Sign a transaction in place (populates the signature field).
+    fn sign_transaction(&self, tx: &mut Transaction) -> Result<()>;
+
+    /// Sign an arbitrary 32-byte message. Returns signature bytes.
+    fn sign(&self, message: &[u8; 32]) -> Result<Vec<u8>>;
+}

--- a/crates/pyde-rust-sdk/src/types.rs
+++ b/crates/pyde-rust-sdk/src/types.rs
@@ -122,6 +122,14 @@ pub struct BlockHeader {
     pub tx_count: String,
 }
 
+/// Override params for call/estimate_gas.
+#[derive(Debug, Clone, Default)]
+pub struct CallOverrides {
+    pub from: Option<Address>,
+    pub value: Option<u128>,
+    pub gas_limit: Option<u64>,
+}
+
 /// Fee data from the network.
 #[derive(Debug, Clone)]
 pub struct FeeData {

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -287,6 +287,12 @@ impl<'a> SignerProvider<'a> {
 // Internal: send + check revert
 // ============================================================================
 
+impl crate::signer::Signer for Wallet {
+    fn address(&self) -> &Address { &self.address }
+    fn sign_transaction(&self, tx: &mut Transaction) -> Result<()> { self.sign_transaction(tx) }
+    fn sign(&self, message: &[u8; 32]) -> Result<Vec<u8>> { self.sign(message) }
+}
+
 async fn send_and_check(provider: &Provider, tx: &Transaction) -> Result<Receipt> {
     let receipt = provider.send_and_wait(tx, 10_000).await?;
     if !receipt.success {


### PR DESCRIPTION
## Summary
- call_with/estimate_gas_with accept CallOverrides
- contract.populate_transaction() for unsigned tx building
- provider.batch() for multiple RPCs in one request
- Provider::with_options() for timeout and retries
- Signer trait (Wallet implements it)
- README updated