### PR TITLE
fix: audit fixes + performance optimizations

### DIFF
--- a/crates/pyde-rust-sdk/Cargo.toml
+++ b/crates/pyde-rust-sdk/Cargo.toml
@@ -12,7 +12,7 @@ pyde-account = { path = "../account" }
 
 # Async HTTP + WebSocket
 reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1", features = ["time", "sync"] }
+tokio = { version = "1", features = ["time", "sync", "macros"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
 

--- a/crates/pyde-rust-sdk/README.md
+++ b/crates/pyde-rust-sdk/README.md
@@ -1116,8 +1116,10 @@ crates/pyde-rust-sdk/
 │   ├── wallet.rs      — Wallet (keygen, keystore, signing)
 │   ├── abi.rs         — Contract (ABI-aware reads, Value enum)
 │   ├── contract.rs    — ContractCall/DeployData builders, decoders
-│   ├── types.rs       — Receipt, Log, Address, re-exports
-│   └── error.rs       — SdkError enum, Result type alias
+│   ├── types.rs       — Receipt, Log, Address, hex/unit utils
+│   ├── error.rs       — SdkError enum with codes, revert reason decoding
+│   ├── signer.rs      — Signer trait (Wallet implements it)
+│   └── ws.rs          — WebSocket provider with subscriptions
 ```
 
 Dependencies:

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -190,6 +190,18 @@ impl<'a> Contract<'a> {
         Self { address, provider, wallet: None, functions: HashMap::new(), events: HashMap::new(), events_by_topic: HashMap::new(), structs: HashMap::new(), enums: HashMap::new() }
     }
 
+    /// Register a function manually (when no artifact is available).
+    pub fn add_function(&mut self, name: &str, params: Vec<AbiParam>, returns: &str, view: bool, payable: bool) {
+        self.functions.insert(name.to_string(), AbiFunction {
+            name: name.to_string(),
+            params,
+            returns: returns.to_string(),
+            view,
+            payable,
+            constructor: false,
+        });
+    }
+
     /// Bind a wallet for write operations.
     pub fn connect(mut self, wallet: &'a Wallet) -> Self {
         self.wallet = Some(wallet);
@@ -263,7 +275,7 @@ impl<'a> Contract<'a> {
         let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
         let receipt = wallet.send_call_with_value(self.provider, &self.address, calldata, value, gas_limit).await?;
         let ret_type = self.functions.get(method).map(|f| f.returns.clone()).unwrap_or_default();
-        Ok(ContractReceipt::new(receipt, ret_type))
+        Ok(ContractReceipt::new(receipt, ret_type, self.structs.clone(), self.enums.clone()))
     }
 
     // ========================================================================
@@ -280,8 +292,7 @@ impl<'a> Contract<'a> {
         ))?;
         let empty = serde_json::json!({});
         let calldata = self.encode_call(method, args.unwrap_or(&empty))?;
-        let nonce = self.provider.get_nonce(wallet.address()).await?;
-        let chain_id = self.provider.get_chain_id().await?;
+        let (nonce, chain_id) = self.provider.get_nonce_and_chain_id(wallet.address()).await?;
 
         Ok(Transaction {
             from: *wallet.address(),
@@ -722,7 +733,11 @@ impl<'a> Contract<'a> {
 
 /// Standalone ABI encoder/decoder (no contract address or provider needed).
 pub struct Interface {
-    json: String,
+    functions: HashMap<String, AbiFunction>,
+    events: HashMap<String, AbiEvent>,
+    events_by_topic: HashMap<String, AbiEvent>,
+    structs: HashMap<String, AbiStructDef>,
+    enums: HashMap<String, AbiEnumDef>,
 }
 
 impl Interface {
@@ -730,36 +745,59 @@ impl Interface {
     pub fn from_artifact(path: &str) -> std::result::Result<Self, String> {
         let json = std::fs::read_to_string(path)
             .map_err(|e| format!("read artifact: {}", e))?;
-        Ok(Self { json })
+        Self::from_json_str(&json).map_err(|e| format!("{}", e))
     }
 
     /// Load from ABI JSON string.
     pub fn from_json(json: &str) -> Self {
-        Self { json: json.to_string() }
+        Self::from_json_str(json).unwrap_or_else(|_| Self {
+            functions: HashMap::new(), events: HashMap::new(),
+            events_by_topic: HashMap::new(), structs: HashMap::new(), enums: HashMap::new(),
+        })
+    }
+
+    fn from_json_str(json: &str) -> Result<Self> {
+        let provider = Provider::new("http://localhost:0");
+        let contract = Contract::from_json(json, [0u8; 32], &provider)?;
+        Ok(Self {
+            functions: contract.functions.clone(),
+            events: contract.events.clone(),
+            events_by_topic: contract.events_by_topic.clone(),
+            structs: contract.structs.clone(),
+            enums: contract.enums.clone(),
+        })
+    }
+
+    fn make_contract(&self) -> Contract<'static> {
+        // SAFETY: We only use decode_value/encode_call which don't touch provider.
+        // The provider reference is never actually used in encoding/decoding.
+        let provider = Box::leak(Box::new(Provider::new("http://localhost:0")));
+        let mut c = Contract::new([0u8; 32], provider);
+        c.functions = self.functions.clone();
+        c.structs = self.structs.clone();
+        c.enums = self.enums.clone();
+        c
     }
 
     /// Encode a function call to calldata bytes.
     pub fn encode_function_data(&self, method: &str, args: &serde_json::Value) -> Result<Vec<u8>> {
-        let provider = Provider::new("http://localhost:0");
-        let contract = Contract::from_json(&self.json, [0u8; 32], &provider)?;
+        let contract = self.make_contract();
         contract.encode_call(method, args)
     }
 
     /// Decode function return data using the ABI return type.
     pub fn decode_function_result(&self, method: &str, data: &[u8]) -> Option<Value> {
-        let provider = Provider::new("http://localhost:0");
-        let contract = Contract::from_json(&self.json, [0u8; 32], &provider).ok()?;
-        let fn_def = contract.functions.get(method)?;
+        let fn_def = self.functions.get(method)?;
         let ret = fn_def.returns.as_str();
         if ret == "()" || ret == "unit" { return None; }
-        Some(contract.decode_value(data, ret, 0).0)
+        let c = self.make_contract();
+        Some(c.decode_value(data, ret, 0).0)
     }
 
     /// Parse a raw Log into a decoded EventLog.
     pub fn parse_log(&self, log: &Log) -> Option<EventLog> {
-        let provider = Provider::new("http://localhost:0");
-        let contract = Contract::from_json(&self.json, [0u8; 32], &provider).ok()?;
-        contract.parse_log(log)
+        let c = self.make_contract();
+        c.parse_log(log)
     }
 
     /// Get the topic0 hash for an event name.
@@ -778,22 +816,25 @@ impl Interface {
 pub struct ContractReceipt {
     pub receipt: Receipt,
     ret_type: String,
+    structs: HashMap<String, AbiStructDef>,
+    enums: HashMap<String, AbiEnumDef>,
 }
 
 impl ContractReceipt {
-    fn new(receipt: Receipt, ret_type: String) -> Self {
-        Self { receipt, ret_type }
+    fn new(receipt: Receipt, ret_type: String, structs: HashMap<String, AbiStructDef>, enums: HashMap<String, AbiEnumDef>) -> Self {
+        Self { receipt, ret_type, structs, enums }
     }
 
-    /// Decode returnData using the ABI return type.
+    /// Decode returnData using the ABI return type (including structs/enums).
     /// Returns None if returnData is absent (ephemeral — only available right after execution).
     pub fn decode_return_data(&self) -> Option<Value> {
         let bytes = self.receipt.return_bytes();
         if bytes.is_empty() { return None; }
         if self.ret_type.is_empty() || self.ret_type == "()" || self.ret_type == "unit" { return None; }
-        // Use a dummy contract for decoding (no ABI needed for primitive types)
         let provider = crate::client::Provider::new("http://localhost:0");
-        let contract = Contract::new([0u8; 32], &provider);
+        let mut contract = Contract::new([0u8; 32], &provider);
+        contract.structs = self.structs.clone();
+        contract.enums = self.enums.clone();
         Some(contract.decode_value(&bytes, &self.ret_type, 0).0)
     }
 }

--- a/crates/pyde-rust-sdk/src/client.rs
+++ b/crates/pyde-rust-sdk/src/client.rs
@@ -20,6 +20,7 @@ pub struct Provider {
     rpc_url: String,
     client: reqwest::Client,
     retries: u32,
+    cached_chain_id: std::sync::Mutex<Option<u64>>,
 }
 
 impl Provider {
@@ -32,7 +33,7 @@ impl Provider {
             .timeout(options.timeout)
             .build()
             .unwrap_or_default();
-        Self { rpc_url: rpc_url.to_string(), client, retries: options.retries }
+        Self { rpc_url: rpc_url.to_string(), client, retries: options.retries, cached_chain_id: std::sync::Mutex::new(None) }
     }
 
     // ========================================================================
@@ -56,8 +57,22 @@ impl Provider {
     }
 
     pub async fn get_chain_id(&self) -> Result<u64> {
+        if let Some(id) = *self.cached_chain_id.lock().unwrap() {
+            return Ok(id);
+        }
         let result = self.rpc("pyde_chainId", &[]).await?;
-        parse_hex_u64(&result)
+        let id = parse_hex_u64(&result)?;
+        *self.cached_chain_id.lock().unwrap() = Some(id);
+        Ok(id)
+    }
+
+    /// Fetch nonce and chainId in parallel (saves one round trip).
+    pub async fn get_nonce_and_chain_id(&self, address: &Address) -> Result<(u64, u64)> {
+        let (nonce, chain_id) = tokio::join!(
+            self.get_nonce(address),
+            self.get_chain_id()
+        );
+        Ok((nonce?, chain_id?))
     }
 
     pub async fn get_block_number(&self) -> Result<u64> {
@@ -242,10 +257,13 @@ impl Provider {
             .await
             .map_err(|e| SdkError::Connection(e.to_string()))?;
 
-        let results: Vec<serde_json::Value> = resp
+        let mut results: Vec<serde_json::Value> = resp
             .json()
             .await
             .map_err(|e| SdkError::InvalidResponse(e.to_string()))?;
+
+        // Sort by id to match request order (JSON-RPC allows arbitrary response order)
+        results.sort_by_key(|r| r.get("id").and_then(|v| v.as_u64()).unwrap_or(0));
 
         results.into_iter().map(|r| {
             if let Some(err) = r.get("error") {

--- a/crates/pyde-rust-sdk/src/types.rs
+++ b/crates/pyde-rust-sdk/src/types.rs
@@ -261,6 +261,7 @@ pub const PYDE_DECIMALS: u32 = 9;
 /// parse_units("100", 18)  // Ok(100_000_000_000_000_000_000)
 /// ```
 pub fn parse_units(value: &str, decimals: u32) -> std::result::Result<u128, String> {
+    if decimals > 38 { return Err(format!("decimals {} exceeds u128 precision (max 38)", decimals)); }
     let trimmed = value.trim();
     let negative = trimmed.starts_with('-');
     if negative {
@@ -297,6 +298,7 @@ pub fn parse_units(value: &str, decimals: u32) -> std::result::Result<u128, Stri
 /// format_units(1_000_000, 9)      // "0.001"
 /// ```
 pub fn format_units(value: u128, decimals: u32) -> String {
+    if decimals > 38 { return format!("{}", value); } // 10^39 overflows u128
     let divisor = 10u128.pow(decimals);
     let whole = value / divisor;
     let remainder = value % divisor;

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -107,6 +107,21 @@ impl Wallet {
         encrypt_keystore(&self.public_key, &self.secret_key, &self.address, password)
     }
 
+    /// Save wallet as encrypted keystore to a file.
+    pub fn save_keystore(&self, path: &std::path::Path, password: &str) -> Result<()> {
+        let keystore = self.to_keystore(password)?;
+        let json = serde_json::to_string_pretty(&keystore)
+            .map_err(|e| SdkError::Signing(format!("serialize: {}", e)))?;
+        std::fs::write(path, json)
+            .map_err(|e| SdkError::Signing(format!("write: {}", e)))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
+    }
+
     // ========================================================================
     // Accessors
     // ========================================================================
@@ -160,8 +175,7 @@ impl Wallet {
 
     /// Build, sign, send a native transfer. Returns receipt (errors on revert).
     pub async fn transfer(&self, provider: &Provider, to: &Address, amount: u128) -> Result<Receipt> {
-        let nonce = provider.get_nonce(&self.address).await?;
-        let chain_id = provider.get_chain_id().await?;
+        let (nonce, chain_id) = provider.get_nonce_and_chain_id(&self.address).await?;
 
         let mut tx = Transaction {
             from: self.address, to: *to, value: amount, data: vec![],
@@ -191,8 +205,7 @@ impl Wallet {
     pub async fn send_call_with_value(
         &self, provider: &Provider, to: &Address, data: Vec<u8>, value: u128, gas_limit: u64,
     ) -> Result<Receipt> {
-        let nonce = provider.get_nonce(&self.address).await?;
-        let chain_id = provider.get_chain_id().await?;
+        let (nonce, chain_id) = provider.get_nonce_and_chain_id(&self.address).await?;
 
         let mut tx = Transaction {
             from: self.address, to: *to, value, data,
@@ -225,8 +238,7 @@ impl Wallet {
     pub async fn deploy_with_value(
         &self, provider: &Provider, deploy_data: Vec<u8>, value: u128, gas_limit: u64,
     ) -> Result<Receipt> {
-        let nonce = provider.get_nonce(&self.address).await?;
-        let chain_id = provider.get_chain_id().await?;
+        let (nonce, chain_id) = provider.get_nonce_and_chain_id(&self.address).await?;
 
         let mut tx = Transaction {
             from: self.address, to: [0u8; 32], value, data: deploy_data,

--- a/crates/pyde-rust-sdk/src/ws.rs
+++ b/crates/pyde-rust-sdk/src/ws.rs
@@ -141,20 +141,23 @@ impl WsProvider {
 
     pub async fn get_balance(&self, address: &[u8; 32]) -> Result<u128> {
         let result = self.rpc("pyde_getBalance", &[serde_json::json!(format!("0x{}", hex::encode(address)))]).await?;
-        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
-        Ok(u128::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+        let s = result.as_str().unwrap_or("0x0");
+        u128::from_str_radix(s.trim_start_matches("0x"), 16)
+            .map_err(|e| SdkError::InvalidResponse(format!("bad balance: {}", e)))
     }
 
     pub async fn get_block_number(&self) -> Result<u64> {
         let result = self.rpc("pyde_blockNumber", &[]).await?;
-        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
-        Ok(u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+        let s = result.as_str().unwrap_or("0x0");
+        u64::from_str_radix(s.trim_start_matches("0x"), 16)
+            .map_err(|e| SdkError::InvalidResponse(format!("bad block number: {}", e)))
     }
 
     pub async fn get_chain_id(&self) -> Result<u64> {
         let result = self.rpc("pyde_chainId", &[]).await?;
-        let s = result.get("result").and_then(|v| v.as_str()).unwrap_or("0x0");
-        Ok(u64::from_str_radix(s.trim_start_matches("0x"), 16).unwrap_or(0))
+        let s = result.as_str().unwrap_or("0x0");
+        u64::from_str_radix(s.trim_start_matches("0x"), 16)
+            .map_err(|e| SdkError::InvalidResponse(format!("bad chain id: {}", e)))
     }
 
     // ========================================================================
@@ -199,6 +202,6 @@ impl WsProvider {
         if let Some(err) = result.get("error") {
             return Err(SdkError::Rpc(err.to_string()));
         }
-        Ok(result)
+        Ok(result.get("result").cloned().unwrap_or(serde_json::Value::Null))
     }
 }


### PR DESCRIPTION
## Summary
- batch() sorts responses by JSON-RPC id
- ContractReceipt carries struct/enum defs for correct decode
- WS provider .result extraction fixed
- format_units/parse_units overflow guard
- Contract::add_function, Wallet::save_keystore added
- Parallel get_nonce+get_chain_id (tokio::join!), cached chain_id
- Interface parses ABI once at construction
- README Architecture section updated