### PR TITLE
feat: devnet generates real FALCON-512 keypairs

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -218,7 +218,7 @@ mod tests {
         let mut state = StateManager::open(&dir, 1024).unwrap();
 
         // Initialize genesis with funded accounts
-        let config = devnet_genesis();
+        let (config, _accounts) = devnet_genesis();
         let _genesis = initialize_genesis(&mut state, &config).unwrap();
 
         let mut chain = ChainState::genesis(state.root(), 31337);

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -196,29 +196,68 @@ pub fn initialize_genesis(
     Ok(block)
 }
 
-/// Create a default devnet genesis config with pre-funded accounts.
-pub fn devnet_genesis() -> GenesisConfig {
-    // 10 pre-funded accounts for development (each gets 10B PYDE)
-    // Must be large enough to cover gas_limit * base_fee for contract deploys.
-    // base_fee = 50 gwei, deploy gas ~500K → cost ~25M PYDE in quanta.
-    let ten_billion_pyde = "10000000000000000000"; // 10B PYDE in quanta (10^19)
+/// A devnet account with full keypair (for printing private keys on startup).
+pub struct DevnetAccount {
+    pub address: Address,
+    pub public_key: pyde_crypto::falcon::FalconPublicKey,
+    pub secret_key: pyde_crypto::falcon::FalconSecretKey,
+    pub balance: u128,
+}
+
+impl DevnetAccount {
+    /// Export combined private key (pk + sk) as 0x-prefixed hex.
+    /// Same format as Wallet.exportPrivateKey() in the SDKs.
+    pub fn private_key_hex(&self) -> String {
+        let mut bytes = Vec::with_capacity(897 + 1281);
+        bytes.extend_from_slice(self.public_key.as_bytes());
+        bytes.extend_from_slice(self.secret_key.as_bytes());
+        format!("0x{}", hex::encode(&bytes))
+    }
+
+    /// Address as 0x-prefixed hex.
+    pub fn address_hex(&self) -> String {
+        format!("0x{}", hex::encode(self.address))
+    }
+}
+
+/// Create a default devnet genesis config with 10 pre-funded accounts.
+/// Returns both the config AND the full keypairs (for printing private keys).
+pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
+    use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::falcon::falcon_keygen;
+
+    // 10M PYDE per account in quanta (10,000,000 × 10^9)
+    let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
 
     let mut allocations = Vec::new();
-    for i in 0u8..10 {
-        let address = hex::encode([i + 1; 32]);
+    let mut accounts = Vec::new();
+
+    for _ in 0..10 {
+        let (pk, sk) = falcon_keygen().expect("FALCON keygen failed");
+        let address = derive_eoa_address(pk.as_bytes());
+
         allocations.push(GenesisAllocation {
+            address: hex::encode(address),
+            balance: ten_million_pyde.to_string(),
+            public_key: Some(hex::encode(pk.as_bytes())),
+        });
+
+        accounts.push(DevnetAccount {
             address,
-            balance: ten_billion_pyde.to_string(),
-            public_key: None,
+            public_key: pk,
+            secret_key: sk,
+            balance: ten_million_pyde,
         });
     }
 
-    GenesisConfig {
-        chain_id: 31337, // devnet chain ID
+    let config = GenesisConfig {
+        chain_id: 31337,
         timestamp: 0,
         allocations,
         validators: Vec::new(),
-    }
+    };
+
+    (config, accounts)
 }
 
 fn parse_hex_address(hex_str: &str) -> Result<Address, String> {
@@ -239,14 +278,34 @@ mod tests {
 
     #[test]
     fn devnet_genesis_has_10_accounts() {
-        let config = devnet_genesis();
+        let (config, accounts) = devnet_genesis();
         assert_eq!(config.allocations.len(), 10);
+        assert_eq!(accounts.len(), 10);
         assert_eq!(config.chain_id, 31337);
+        // Each account should have a public key
+        for alloc in &config.allocations {
+            assert!(alloc.public_key.is_some());
+        }
+        // Private keys should be restorable
+        for acc in &accounts {
+            let pk_hex = acc.private_key_hex();
+            assert!(pk_hex.starts_with("0x"));
+            assert_eq!(pk_hex.len(), 2 + (897 + 1281) * 2); // 0x + 2178 bytes hex
+        }
+    }
+
+    #[test]
+    fn devnet_genesis_balance_correct() {
+        let (_, accounts) = devnet_genesis();
+        let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
+        for acc in &accounts {
+            assert_eq!(acc.balance, ten_million_pyde);
+        }
     }
 
     #[test]
     fn genesis_config_roundtrip() {
-        let config = devnet_genesis();
+        let (config, _) = devnet_genesis();
         let toml_str = config.to_toml();
         let parsed: GenesisConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.allocations.len(), 10);
@@ -256,35 +315,36 @@ mod tests {
     #[test]
     fn initialize_genesis_creates_state() {
         let mut state = StateManager::open(
-            &std::env::temp_dir().join("pyde-test-genesis-init"),
+            &std::env::temp_dir().join("pyde-test-genesis-init-v2"),
             1024,
         ).unwrap();
 
-        let config = devnet_genesis();
+        let (config, _) = devnet_genesis();
         let block = initialize_genesis(&mut state, &config).unwrap();
 
         assert_eq!(block.slot(), 0);
         assert!(!state.is_empty());
 
-        // Verify first account has balance (stored as full Account struct)
+        // Verify first account has balance
         let addr = parse_hex_address(&config.allocations[0].address).unwrap();
         let key = pyde_state::keys::balance_key(&addr);
         let account_bytes = state.get(&key).expect("account should exist");
         let account = pyde_account::types::Account::from_bytes(&account_bytes)
             .expect("should be a valid Account");
-        assert_eq!(account.balance, 10_000_000_000_000_000_000u128); // 10B PYDE
+        let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
+        assert_eq!(account.balance, ten_million_pyde);
     }
 
     #[test]
     fn genesis_rejects_non_empty_state() {
         let mut state = StateManager::open(
-            &std::env::temp_dir().join("pyde-test-genesis-reject"),
+            &std::env::temp_dir().join("pyde-test-genesis-reject-v2"),
             1024,
         ).unwrap();
 
-        let config = devnet_genesis();
-        initialize_genesis(&mut state, &config).unwrap(); // first time ok
-        let result = initialize_genesis(&mut state, &config); // second time fails
+        let (config, _) = devnet_genesis();
+        initialize_genesis(&mut state, &config).unwrap();
+        let result = initialize_genesis(&mut state, &config);
         assert!(result.is_err());
     }
 

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -31,7 +31,8 @@ fn main() {
             print!("{}", NodeConfig::default().to_toml());
         }
         Command::DefaultGenesis => {
-            print!("{}", genesis::devnet_genesis().to_toml());
+            let (config, _) = genesis::devnet_genesis();
+            print!("{}", config.to_toml());
         }
         Command::Run {
             role,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -77,7 +77,40 @@ impl PydeNode {
                 crate::genesis::GenesisConfig::load(&genesis_path)?
             } else {
                 info!("no genesis.toml found, using devnet defaults");
-                crate::genesis::devnet_genesis()
+                let (config, devnet_accounts) = crate::genesis::devnet_genesis();
+
+                // Print Anvil-style account info with private keys
+                info!("");
+                info!("==========================================");
+                info!("  Pyde Devnet");
+                info!("==========================================");
+                info!("");
+                info!("Available Accounts");
+                info!("==================");
+                for (i, acc) in devnet_accounts.iter().enumerate() {
+                    let pyde = acc.balance / 1_000_000_000;
+                    info!("  ({}) {} ({} PYDE)", i, acc.address_hex(), pyde);
+                }
+                info!("");
+                info!("Private Keys");
+                info!("==================");
+                for (i, acc) in devnet_accounts.iter().enumerate() {
+                    info!("  ({}) {}", i, acc.private_key_hex());
+                }
+                info!("");
+
+                // Save devnet keys for SDK usage
+                let keys_path = datadir.join("devnet-keys.json");
+                let keys_json: Vec<serde_json::Value> = devnet_accounts.iter().map(|acc| {
+                    serde_json::json!({
+                        "address": acc.address_hex(),
+                        "privateKey": acc.private_key_hex(),
+                        "balance": acc.balance.to_string(),
+                    })
+                }).collect();
+                let _ = std::fs::write(&keys_path, serde_json::to_string_pretty(&keys_json).unwrap_or_default());
+
+                config
             };
 
             // Auto-fund validator address with required stake for devnet
@@ -98,18 +131,9 @@ impl PydeNode {
             // Write genesis for reference
             let _ = std::fs::write(&genesis_path, genesis_config.to_toml());
 
-            // Print funded accounts (Anvil-style)
-            info!("");
-            info!("Available Accounts");
-            info!("==================");
-            for (i, alloc) in genesis_config.allocations.iter().enumerate() {
-                let bal = alloc.balance_u128().unwrap_or(0);
-                let pyde = bal / 1_000_000_000; // quanta to PYDE (approx)
-                info!("  ({}) 0x{} ({} PYDE)", i, alloc.address, pyde);
-            }
-            info!("");
             info!("Chain ID: {}", genesis_config.chain_id);
             info!("Base Fee: {} quanta/gas", pyde_tx::fee::GENESIS_BASE_FEE);
+            info!("==========================================");
             info!("");
 
             let genesis_block = crate::genesis::initialize_genesis(&mut state, &genesis_config)?;


### PR DESCRIPTION
## Summary
- Generate 10 FALCON-512 keypairs at devnet genesis (was bare addresses without keys)
- Fund each with 10M PYDE (10,000,000 × 10^9 quanta)
- Print Anvil-style output on startup: addresses, private keys, balances
- Save devnet-keys.json for SDK live test usage
- All accounts have auth_keys set (real signature verification on every tx)