### PR TITLE
feat: signed devnet, --dev gate, signer system, full live testing

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -58,11 +58,25 @@ impl BlockProcessor {
                         slot,
                         tx_index = i,
                         error = ?e,
-                        "tx execution failed"
+                        "tx execution failed — storing failed receipt"
                     );
-                    // Failed txs still consume gas (up to gas_limit)
-                    // but we skip them for now — in production, we'd charge
-                    // and create a failed receipt
+                    // Create a failed receipt so callers know why the tx was rejected
+                    let tx_hash = tx.hash();
+                    let reason = format!("{:?}", e);
+                    let failed_receipt = pyde_tx::execution::Receipt {
+                        tx_hash,
+                        success: false,
+                        gas_used: 0,
+                        gas_refund: 0,
+                        effective_gas: 0,
+                        fee_paid: 0,
+                        fee_burned: 0,
+                        fee_validator: 0,
+                        return_data: reason.into_bytes(),
+                        logs: vec![],
+                        state_root: sparse_merkle_tree::H256::zero(),
+                    };
+                    receipts.push(failed_receipt);
                 }
             }
         }
@@ -246,7 +260,8 @@ mod tests {
         // Tx fails validation (dummy signature, no auth keys on genesis account)
         // but the block still processes — failed txs are skipped gracefully.
         // In production, genesis accounts need auth_keys set for real tx execution.
-        assert_eq!(receipts.len(), 0); // failed tx produces no receipt
+        assert_eq!(receipts.len(), 1); // failed tx now produces a failed receipt
+        assert!(!receipts[0].success);  // receipt marks failure
         assert_eq!(chain.head_slot, 1);
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -44,6 +44,10 @@ pub enum Command {
         #[arg(long, default_value = "8545")]
         rpc_port: u16,
 
+        /// Enable dev mode (allows unsigned pyde_sendTransaction, auto-mine).
+        #[arg(long)]
+        dev: bool,
+
         /// Bootstrap peer addresses (multiaddr).
         #[arg(long)]
         bootstrap: Vec<String>,

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -29,6 +29,9 @@ pub struct NodeSection {
     pub chain_id: u64,
     /// Data directory for state, keys, etc.
     pub datadir: PathBuf,
+    /// Dev mode: allows unsigned pyde_sendTransaction.
+    #[serde(default)]
+    pub dev_mode: bool,
 }
 
 impl Default for NodeSection {
@@ -37,6 +40,7 @@ impl Default for NodeSection {
             role: "full".into(),
             chain_id: 31337,
             datadir: default_datadir(),
+            dev_mode: false,
         }
     }
 }

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -226,8 +226,9 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::falcon_keygen;
 
-    // 10M PYDE per account in quanta (10,000,000 × 10^9)
-    let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
+    // 10B PYDE per account in quanta (10,000,000,000 × 10^9)
+    // Must cover: gas_limit(100M) × base_fee(50 gwei) = 5B PYDE per tx
+    let funding_per_account: u128 = 10_000_000_000 * 1_000_000_000;
 
     let mut allocations = Vec::new();
     let mut accounts = Vec::new();
@@ -238,7 +239,7 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
 
         allocations.push(GenesisAllocation {
             address: hex::encode(address),
-            balance: ten_million_pyde.to_string(),
+            balance: funding_per_account.to_string(),
             public_key: Some(hex::encode(pk.as_bytes())),
         });
 
@@ -246,7 +247,7 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
             address,
             public_key: pk,
             secret_key: sk,
-            balance: ten_million_pyde,
+            balance: funding_per_account,
         });
     }
 
@@ -297,9 +298,9 @@ mod tests {
     #[test]
     fn devnet_genesis_balance_correct() {
         let (_, accounts) = devnet_genesis();
-        let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
+        let expected: u128 = 10_000_000_000 * 1_000_000_000;
         for acc in &accounts {
-            assert_eq!(acc.balance, ten_million_pyde);
+            assert_eq!(acc.balance, expected);
         }
     }
 
@@ -331,8 +332,8 @@ mod tests {
         let account_bytes = state.get(&key).expect("account should exist");
         let account = pyde_account::types::Account::from_bytes(&account_bytes)
             .expect("should be a valid Account");
-        let ten_million_pyde: u128 = 10_000_000 * 1_000_000_000;
-        assert_eq!(account.balance, ten_million_pyde);
+        let expected: u128 = 10_000_000_000 * 1_000_000_000;
+        assert_eq!(account.balance, expected);
     }
 
     #[test]

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -43,6 +43,7 @@ fn main() {
             log_json,
             metrics_port,
             rpc_port,
+            dev,
             bootstrap,
         } => {
             // Load config from file (if provided) or use defaults
@@ -68,6 +69,7 @@ fn main() {
                 &bootstrap,
             );
             config.rpc.port = rpc_port;
+            if dev { config.node.dev_mode = true; }
 
             // Initialize logging first
             logging::init(&config.logging.level, config.logging.json);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -297,6 +297,7 @@ impl PydeNode {
                 new_heads_tx,
                 pending_tx_tx,
                 logs_tx,
+                dev_mode: self.config.node.dev_mode,
             });
             match rpc::start_rpc_server(
                 &self.config.rpc.listen,

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -34,6 +34,8 @@ pub struct RpcState {
     pub pending_tx_tx: tokio::sync::broadcast::Sender<String>,
     /// Broadcast channel for event logs.
     pub logs_tx: tokio::sync::broadcast::Sender<serde_json::Value>,
+    /// Dev mode: allows unsigned pyde_sendTransaction.
+    pub dev_mode: bool,
 }
 
 /// Define the Pyde JSON-RPC API.
@@ -242,6 +244,9 @@ impl PydeApiServer for RpcServer {
     }
 
     async fn send_transaction(&self, tx_obj: serde_json::Value) -> Result<String, ErrorObjectOwned> {
+        if !self.state.dev_mode {
+            return Err(rpc_err(-32601, "pyde_sendTransaction is only available in dev mode (--dev). Use pyde_sendRawTransaction with a signed transaction.".into()));
+        }
         let from = tx_obj.get("from").and_then(|v| v.as_str())
             .map(parse_address).transpose()?
             .ok_or_else(|| rpc_err(-32602, "missing 'from' field".into()))?;

--- a/crates/pyde-dev/CHEATCODES_ROADMAP.md
+++ b/crates/pyde-dev/CHEATCODES_ROADMAP.md
@@ -1,0 +1,264 @@
+# Cheatcodes, Typed Contracts, and Import-Based Test Model — Roadmap
+
+## Overview
+
+Add typed contract/interface instances to the compiler (production + tests), cross-file imports,
+Foundry-style cheatcodes, and proper test isolation.
+PVM stays 100% production-clean — all cheatcode logic lives in pyde-dev only.
+
+---
+
+## Execution Order
+
+Steps are ordered by dependency — each builds on the previous.
+
+### Step 1: `deploy!` macro + `create!` alias ---- DONE
+
+- [x] Add `deploy!` macro in lowerer — returns `Ty::Contract("Counter")`
+- [x] `create!` becomes alias for `deploy!` (both return typed handle)
+- [x] Runtime: identical to current `create!` (CreateContract instruction)
+- [x] Works within single-file multi-contract compilation
+- [x] Typechecker returns `Ty::Contract(name)` for deploy!/create!
+- [x] Type propagates through `let c = deploy!(Counter);` via reg_types → local_types
+
+### Step 2: Complete method signature resolution ---- DONE
+
+- [x] Populate `contract_functions` from current file's contract definitions (pub fns)
+- [x] Populate `interface_functions` from interface definitions (already done in pre-pass)
+- [x] Lowerer resolves `c.increment()` → correct `ExtCall` with selector
+- [x] Pre-pass 2 collects contract pub fns before lowering (declaration-order independent)
+
+### Step 3: Return value decoding from ExtCall ---- DONE
+
+- [x] GP return (u64, bool) — PVM sets r1 = value, r2 = 0
+- [x] Wide return (u256, Address) — PVM writes 32 bytes to parent heap, r1 = ptr, r2 = 32
+- [x] Callee wide return uses blob convention (r1=ptr, r2=32) instead of lossy r1-only
+- [x] PVM do_ext_call reads r2 bytes from child memory for blob/wide returns
+- [x] PVM CallExt handler writes wide return_data to parent heap for Wload
+- [x] ExtCall IR instruction carries return type: `ExtCall(dst, addr, method, args, Ty)`
+- [x] Lowerer looks up return type from contract_functions/interface_functions
+- [x] Makes `assert!(c.get_count() == 1)` work end-to-end
+
+### Step 4: Constructor arg validation ---- DONE
+
+- [x] At compile time, check `deploy!(Counter, x, y)` args match constructor params
+- [x] Count + type checking against stored constructor signature
+- [x] Lowerer: contract_constructors populated in pre-pass 2, arg count validated
+- [x] Typechecker: contract_constructors in TypeEnv, validates count + types with widening
+
+### Step 5: `as` casts for Contract/Interface types ---- DONE
+
+- [x] `contract_handle as Address` — strip type, return raw address (wide→wide Wmov)
+- [x] `addr as IERC20` / `addr as Counter` — wrap address with type info, sets reg_types
+- [x] Typecheck validates all cast directions (Contract/Interface ↔ Address, cross-cast)
+- [x] `is_wide_type` includes Contract/Interface (they're addresses under the hood)
+- [x] Cast codegen handles wide→wide copies (was missing, used alloc_gp before)
+- [x] Typechecker resolve_type resolves named types to Contract/Interface via contract_names set
+
+### Step 6: Wire cheatcodes into test runner ---- DONE
+
+- [x] Replace `vm.execute()` with `execute_with_cheatcodes()` in test_runner.rs
+- [x] Fresh `CheatcodeState::new()` per test (no prank/warp leaking)
+- [x] Each test gets fresh VM + storage snapshot (already worked, unchanged)
+- [x] Constructor still uses `vm.execute()` (no cheatcodes during init)
+
+### Step 7: Cross-file imports — resolver ---- DONE
+
+- [x] Rust-like import syntax: `use counter::Counter;`, `use counter::{Counter, MyError};`
+- [x] `SymbolKind::Contract` added, contract declarations use it (was incorrectly `Struct`)
+- [x] Non-std imports register items as `Contract`, module name as `Module`
+- [x] `is_type_defined` includes `Contract` (valid as type annotation and cast target)
+- [x] std:: imports return early, don't fall through to non-std handling
+- [x] Typechecker skips constructor validation for imported contracts (unknown sig)
+
+### Step 8: Build pipeline returns registry + ASTs ---- DONE
+
+- [x] `BuildResult` includes `compiled_registry`, `contract_functions`, `contract_constructors`
+- [x] Function signatures extracted from IR during compilation (pub fns + constructor)
+- [x] Dependency graph resolver uses first path segment (module name) for Rust-like imports
+- [x] Available to callers (test runner, deploy, etc.)
+
+### Step 9: Test files compiled with registry ---- DONE
+
+- [x] `lower_with_context()` accepts bytecode + fn sigs + constructor sigs
+- [x] Imported contract function signatures available for typed method dispatch
+- [x] Cycle detection already done (build.rs topological sort)
+
+### Step 10: Test runner registry integration ---- DONE
+
+- [x] Test runner captures `BuildResult`, passes all maps to `lower_with_context()`
+- [x] Deployed contracts auto-registered in `vm.contracts` by PVM Create instruction
+- [x] Full isolation: fresh VM + storage + CheatcodeState per test function
+
+### Step 11: `@std/vm.oti` cheatcode library ---- DONE
+
+- [x] Ships with `pyde-dev init` (embedded via include_str!)
+<!-- The magic address approach for cheatcodes:
+
+ How it works:
+ 1. Cheatcode library (@std/vm.oti) has functions like warp(timestamp), deal(addr, amount), etc.
+ 2. These functions compile to CallExt targeting a hardcoded address 0xCCCCCC...CC (32 bytes of 0xCC)
+ 3. The calldata contains: [selector:8 bytes][args...] — selector is FNV-1a hash of the cheatcode name
+
+ In production (validator node):
+ - VM calls do_ext_call → looks up 0xCC..CC → no code found → returns success: false
+ - Nothing happens. Completely harmless.
+
+ In tests (pyde-dev test):
+ - Test runner uses execute_with_cheatcodes() instead of vm.execute()
+ - Custom step loop peeks at each instruction before executing
+ - If it sees CallExt with target 0xCC..CC, it intercepts:
+   - Reads calldata from VM memory
+   - Decodes selector → determines which cheatcode
+   - Applies the effect directly (e.g., vm.ctx.timestamp = value)
+   - Writes success: 1 to result register
+   - Skips the instruction (vm.pc += 4)
+ - All other instructions execute normally via vm.step()
+
+ Key point: Zero PVM changes. The interception logic lives entirely in crates/pyde-dev/src/cheatcodes.rs. The PVM doesn't know cheatcodes exist. -->
+
+- [x] Vm interface with warp, roll, prank, startPrank, stopPrank, deal, makeAddr
+- [x] Cheatcode selectors aligned with codegen compute_selector (FNV-1a of method name)
+- [x] Calldata format aligned: [selector:4 BE][args:8 LE each]
+- [x] `use std::vm;` in test files → `Vm::at(CHEATCODE_ADDRESS).warp(1000)`
+
+### Step 12: Standard library ---- DONE
+
+- [x] `lib/@std/vm.oti` — Vm interface (cheatcode methods)
+- [x] `lib/@std/token.oti` — IERC20, IERC721 interfaces
+- [x] `lib/@std/math.oti` — Math interface (min, max, sqrt, pow, etc.)
+- [x] Starter test updated to use `use counter::Counter;` + `deploy!(Counter)`
+- [x] All stdlib files embedded via `include_str!` and shipped with `pyde-dev init`
+
+---
+
+## Already Done
+
+- [x] `Ty::Contract(name)` and `Ty::Interface(name)` in the type system (`types.rs`)
+- [x] `Contract::at(address)` / `Interface::at(address)` in lowerer (`lower.rs`)
+- [x] Method calls on typed handles → `Inst::ExtCall` with auto-resolved selector (`lower.rs`)
+- [x] Magic address interception in step loop (`cheatcodes.rs`)
+- [x] Cheatcode handlers: warp, roll, prank, startPrank, stopPrank, deal, makeAddr
+- [x] `create!` macro embeds bytecode + deploys via CreateContract
+- [x] `reg_types` tracking for Contract/Interface typed handles in lowerer
+- [x] `clear_journal()` public method on VM
+
+---
+
+## Final test example
+
+```
+use counter::Counter;
+use std::vm;
+
+contract CounterTest {
+    #[test]
+    fn test_increment() {
+        let c = deploy!(Counter);
+        c.increment();
+        assert!(c.get_count() == 1);
+    }
+
+    #[test]
+    fn test_with_cheatcodes() {
+        vm.warp(1000);
+        vm.roll(42);
+        let alice = vm.makeAddr("alice");
+        vm.deal(alice, 1000000 as u256);
+        vm.prank(alice);
+        let c = deploy!(Counter);
+        c.increment();
+        assert!(c.get_count() == 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "InsufficientBalance")]
+    fn test_overdraw() {
+        let v = deploy!(Vault);
+        v.withdraw(9999);
+    }
+}
+```
+
+## Architecture
+
+```
+Production PVM (untouched)
+    |
+    +-- vm.execute()     <- used by validator node
+    |
+pyde-dev test runner
+    |
+    +-- execute_with_cheatcodes()  <- custom step loop
+    |   +-- peek at instruction before step
+    |   +-- if CallExt to 0xCC..CC -> intercept, apply cheatcode
+    |   +-- else -> normal vm.step()
+    |
+    +-- cheatcodes.rs (all logic here, not in PVM)
+```
+
+## Files involved
+
+| File                                 | Role                                                             |
+| ------------------------------------ | ---------------------------------------------------------------- |
+| `crates/otic/src/types.rs`           | Ty::Contract, Ty::Interface                                      |
+| `crates/otic/src/resolve.rs`         | Accept non-std imports, validate contract types                  |
+| `crates/otic/src/lower.rs`           | deploy!, ::at(), method calls -> ExtCall, constructor validation |
+| `crates/otic/src/codegen.rs`         | ExtCall codegen (already works), cast support                    |
+| `crates/otic/src/typecheck.rs`       | Contract/Interface type checking, cast validation                |
+| `crates/pyde-dev/src/build.rs`       | Return compiled_registry + contract ASTs                         |
+| `crates/pyde-dev/src/test_runner.rs` | Wire registry, cheatcodes, contract isolation                    |
+| `crates/pyde-dev/src/cheatcodes.rs`  | Cheatcode interception + handlers                                |
+| `crates/pyde-dev/src/init.rs`        | Ship @std/ with new projects                                     |
+| `crates/pvm/src/vm.rs`               | Only change: clear_journal() public method (done)                |
+
+---
+
+## Language Design: Per-Call Value for Payable Functions
+
+### Problem
+
+Current `Counter::at_payable(addr, value)` bakes the value into the contract handle.
+This means ALL calls through that handle send the same value — even non-payable reads.
+
+```otigen
+let c = Counter::at_payable(addr, 1000);
+c.deposit();     // sends 1000 ✓ (intended)
+c.get_count();   // sends 1000 ✗ (wasteful/wrong)
+c.withdraw(50);  // sends 1000 ✗ (definitely wrong)
+```
+
+### Proposed Fix
+
+Value should be per-call, not per-instance. Options:
+
+**Option A: Annotation syntax (Solidity-style)**
+```otigen
+let c = Counter::at(addr);
+c.deposit{ value: 1000 }();
+c.get_count();               // no value
+```
+
+**Option B: Builder pattern**
+```otigen
+let c = Counter::at(addr);
+c.deposit().value(1000).send();
+c.get_count();
+```
+
+**Option C: Named parameter**
+```otigen
+let c = Counter::at(addr);
+c.deposit(value: 1000);
+c.get_count();
+```
+
+### Also Needed
+
+- `deploy!(Counter, arg1, value: 1000)` — deploy with value for payable constructors
+- Deprecate `at_payable()` once per-call value is implemented
+
+### Priority
+
+Medium — the CLI `pyde-dev deploy --value` and `pyde-dev send --value` work correctly.
+This is a language ergonomics improvement for the Otigen compiler.

--- a/crates/pyde-dev/src/cli.rs
+++ b/crates/pyde-dev/src/cli.rs
@@ -43,9 +43,9 @@ pub enum Command {
         #[arg(short, long, default_value = "devnet")]
         network: String,
 
-        /// Sender address (hex). Used when no --wallet specified (devnet mode).
-        #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
-        from: String,
+        /// Private key hex (pk+sk, 2178 bytes). Overrides wallet and devnet default.
+        #[arg(long)]
+        private_key: Option<String>,
 
         /// Wallet name for signing transactions.
         #[arg(short, long)]
@@ -79,9 +79,9 @@ pub enum Command {
         #[arg(short, long, default_value = "devnet")]
         network: String,
 
-        /// Sender address (hex). Used when no --wallet specified (devnet mode).
-        #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
-        from: String,
+        /// Private key hex (pk+sk, 2178 bytes). Overrides wallet and devnet default.
+        #[arg(long)]
+        private_key: Option<String>,
 
         /// Wallet name for signing send transactions.
         #[arg(short, long)]
@@ -138,6 +138,32 @@ pub enum Command {
         network: String,
     },
 
+    /// Send a state-changing transaction to a contract (signed).
+    /// Example: `pyde-dev send 0xaddr increment() --network devnet`
+    Send {
+        /// Contract address (hex).
+        address: String,
+
+        /// Function call: `method()` or `method(arg1, arg2)`.
+        function: String,
+
+        /// Network name.
+        #[arg(short, long, default_value = "devnet")]
+        network: String,
+
+        /// Native token value to send (in quanta). For payable functions.
+        #[arg(long, default_value = "0")]
+        value: u128,
+
+        /// Private key hex. Overrides wallet and devnet default.
+        #[arg(long)]
+        private_key: Option<String>,
+
+        /// Wallet name for signing.
+        #[arg(short, long)]
+        wallet: Option<String>,
+    },
+
     /// Check transaction status/receipt.
     /// Example: `pyde-dev tx 0xtxhash --network devnet`
     Tx {
@@ -166,9 +192,13 @@ pub enum Command {
         #[arg(short, long, default_value = "devnet")]
         network: String,
 
-        /// Sender address (hex). Used when no --wallet is specified (devnet mode).
-        #[arg(long, default_value = "0x0101010101010101010101010101010101010101010101010101010101010101")]
-        from: String,
+        /// Native token value to send with deploy (in quanta). For payable constructors.
+        #[arg(long, default_value = "0")]
+        value: u128,
+
+        /// Private key hex (pk+sk, 2178 bytes). Overrides wallet and devnet default.
+        #[arg(long)]
+        private_key: Option<String>,
 
         /// Wallet name for signing transactions.
         #[arg(short, long)]

--- a/crates/pyde-dev/src/console.rs
+++ b/crates/pyde-dev/src/console.rs
@@ -16,7 +16,8 @@ use std::io::{self, BufRead, Write};
 /// Supported arg types: u64, hex (0x...), bool (true/false), strings ("...").
 /// Complex types (structs, arrays, Vec) are not yet supported — use `pyde script`
 /// for those. TODO: load contract ABI from artifacts for type-aware encoding.
-pub fn run(network: &str, from: &str) -> Result<(), String> {
+pub fn run(network: &str, signer: &crate::signer::Signer) -> Result<(), String> {
+    let from = &signer.address_hex();
     let (config, _) = project::load_config()?;
 
     let net = config
@@ -58,7 +59,7 @@ pub fn run(network: &str, from: &str) -> Result<(), String> {
             continue;
         }
 
-        match handle_command(&client, &net.rpc_url, from, &mut nonce, line) {
+        match handle_command(&client, &net.rpc_url, from, signer, &net, &mut nonce, line) {
             Ok(true) => break, // exit
             Ok(false) => {}
             Err(e) => eprintln!("  error: {}", e),
@@ -73,6 +74,8 @@ fn handle_command(
     client: &reqwest::blocking::Client,
     rpc_url: &str,
     from: &str,
+    signer: &crate::signer::Signer,
+    net: &crate::project::NetworkConfig,
     nonce: &mut u64,
     line: &str,
 ) -> Result<bool, String> {
@@ -163,29 +166,33 @@ fn handle_command(
 
         "send" => {
             let (addr, method, method_args) = parse_call_args(args)?;
+            let to = parse_hex_address(&addr)?;
             let selector = compute_selector(&method);
             let mut calldata = selector.to_be_bytes().to_vec();
             for arg in &method_args {
                 calldata.extend_from_slice(&encode_arg(arg));
             }
-            let calldata_hex = format!("0x{}", hex::encode(&calldata));
 
-            let params = serde_json::json!({
-                "from": from,
-                "to": addr,
-                "data": calldata_hex,
-                "gas": 100_000_000,
-                "nonce": *nonce,
-                "value": "0",
-            });
-            let result = rpc_call(client, rpc_url, "pyde_sendTransaction", &[params])?;
-            let tx_hash = if let Some(obj) = result.as_str() {
-                if let Ok(inner) = serde_json::from_str::<serde_json::Value>(obj) {
-                    inner.get("txHash").and_then(|v| v.as_str())
-                        .unwrap_or(obj).to_string()
-                } else { obj.to_string() }
-            } else { result.to_string() };
-            println!("  tx: {}", tx_hash);
+            // Build, sign, and send transaction
+            let mut tx = pyde_tx::types::Transaction {
+                from: signer.address,
+                to,
+                value: 0,
+                data: calldata,
+                gas_limit: 100_000_000,
+                nonce: *nonce,
+                signature: vec![],
+                fee_payer: pyde_tx::types::FeePayer::Sender,
+                access_list: vec![],
+                deadline: None,
+                chain_id: net.chain_id,
+                tx_type: pyde_tx::types::TransactionType::Standard,
+            };
+            signer.sign_transaction(&mut tx)?;
+            let tx_hex = format!("0x{}", hex::encode(tx.to_bytes()));
+            let result = rpc_call(client, rpc_url, "pyde_sendRawTransaction", &[serde_json::json!(tx_hex)])?;
+            let tx_hash = result.as_str().unwrap_or("").to_string();
+            println!("  tx: {} (signed ✓)", tx_hash);
             *nonce += 1;
         }
 
@@ -198,6 +205,15 @@ fn handle_command(
 }
 
 /// Parse `<address> <method>(<arg1>, <arg2>)` into components.
+fn parse_hex_address(s: &str) -> Result<[u8; 32], String> {
+    let hex = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(hex).map_err(|e| format!("invalid address hex: {}", e))?;
+    if bytes.len() != 32 { return Err(format!("address must be 32 bytes, got {}", bytes.len())); }
+    let mut addr = [0u8; 32];
+    addr.copy_from_slice(&bytes);
+    Ok(addr)
+}
+
 fn parse_call_args(input: &str) -> Result<(String, String, Vec<String>), String> {
     let parts: Vec<&str> = input.splitn(2, ' ').collect();
     if parts.len() < 2 {
@@ -331,6 +347,77 @@ pub fn cmd_call(address: &str, function: &str, network: &str) -> Result<(), Stri
         println!("  {}", hex);
     }
     Ok(())
+}
+
+/// `pyde-dev send <address> <function> --network devnet`
+/// Signed state-changing transaction.
+pub fn cmd_send(address: &str, function: &str, network: &str, signer: &crate::signer::Signer, value: u128) -> Result<(), String> {
+    let (config, _) = crate::project::load_config()?;
+    let net = config.networks.get(network)
+        .ok_or_else(|| format!("network '{}' not found in pyde.toml", network))?;
+
+    let to = parse_hex_address(address)?;
+    let (method, method_args) = parse_function(function)?;
+    let selector = compute_selector(&method);
+    let mut calldata = selector.to_be_bytes().to_vec();
+    for arg in &method_args {
+        calldata.extend_from_slice(&encode_arg(arg));
+    }
+
+    // Get nonce
+    let client = reqwest::blocking::Client::new();
+    let nonce_result = rpc_call(&client, &net.rpc_url, "pyde_getTransactionCount", &[serde_json::json!(signer.address_hex())])?;
+    let nonce: u64 = nonce_result.as_str().unwrap_or("0").parse().unwrap_or(0);
+
+    // Build and sign
+    let mut tx = pyde_tx::types::Transaction {
+        from: signer.address,
+        to,
+        value,
+        data: calldata,
+        gas_limit: 100_000_000,
+        nonce,
+        signature: vec![],
+        fee_payer: pyde_tx::types::FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: net.chain_id,
+        tx_type: pyde_tx::types::TransactionType::Standard,
+    };
+    signer.sign_transaction(&mut tx)?;
+
+    // Send signed tx
+    let tx_hex = format!("0x{}", hex::encode(tx.to_bytes()));
+    let result = rpc_call(&client, &net.rpc_url, "pyde_sendRawTransaction", &[serde_json::json!(tx_hex)])?;
+    let tx_hash = result.as_str().unwrap_or("").to_string();
+
+    println!("  Tx Hash: {} (signed ✓)", tx_hash);
+    println!("  From:    {}", signer.address_hex());
+    println!("  To:      {}", address);
+    println!("  Method:  {}", method);
+
+    // Wait for receipt
+    let receipt_body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "pyde_getTransactionReceipt",
+        "params": [tx_hash]
+    });
+    for attempt in 0..50 {
+        if attempt > 0 { std::thread::sleep(std::time::Duration::from_millis(100)); }
+        let resp = client.post(&net.rpc_url).json(&receipt_body).send()
+            .map_err(|e| format!("RPC error: {}", e))?;
+        let json: serde_json::Value = resp.json().map_err(|e| format!("invalid response: {}", e))?;
+        if let Some(result) = json.get("result") {
+            if !result.is_null() {
+                let success = result.get("success").and_then(|v| v.as_bool()).unwrap_or(false);
+                println!("  Success: {}", success);
+                let gas = result.get("gasUsed").and_then(|v| v.as_str()).unwrap_or("0");
+                println!("  Gas:     {}", gas);
+                return if success { Ok(()) } else { Err("transaction reverted".into()) };
+            }
+        }
+    }
+    Err("receipt not available after 5s".into())
 }
 
 /// `pyde-dev tx <hash> --network devnet`

--- a/crates/pyde-dev/src/deploy.rs
+++ b/crates/pyde-dev/src/deploy.rs
@@ -1,8 +1,10 @@
 use crate::build;
 use crate::project;
+use crate::signer::Signer;
+use pyde_tx::types::*;
 use std::fs;
 
-pub fn run(network: &str, contract: Option<&str>, from: &str, verify: bool) -> Result<(), String> {
+pub fn run(network: &str, contract: Option<&str>, signer: &Signer, value: u128, verify: bool) -> Result<(), String> {
     let (config, root) = project::load_config()?;
 
     // Get network config
@@ -54,31 +56,49 @@ pub fn run(network: &str, contract: Option<&str>, from: &str, verify: bool) -> R
         .trim_start_matches("0x");
 
     let constructor_len = constructor_hex.len() / 2;
-    let full_bytecode = format!("{}{}", constructor_hex, runtime_hex);
+    let full_bytecode = hex::decode(format!("{}{}", constructor_hex, runtime_hex))
+        .map_err(|e| format!("invalid bytecode hex: {}", e))?;
 
     println!("  Deploying {} to {} ({})", contract_name, network, net.rpc_url);
     println!("  Constructor: {} bytes", constructor_len);
     println!("  Runtime:     {} bytes", runtime_hex.len() / 2);
-    println!("  From:        {}", from);
+    println!("  From:        {}", signer.address_hex());
 
-    // Send deploy transaction via JSON-RPC
-    let zero_addr = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    // Get nonce
+    let nonce = get_nonce(&net.rpc_url, &signer.address_hex())?;
+
+    // Build deploy transaction
+    let mut tx = Transaction {
+        from: signer.address,
+        to: [0u8; 32], // zero address = deploy
+        value,
+        data: full_bytecode,
+        gas_limit: 100_000_000,
+        nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: net.chain_id,
+        tx_type: TransactionType::Deploy,
+    };
+
+    // Sign with FALCON-512
+    println!("  Signing transaction...");
+    signer.sign_transaction(&mut tx)?;
+
+    // Serialize to wire format and send via pyde_sendRawTransaction
+    let tx_bytes = tx.to_bytes();
+    let tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+
+    let client = reqwest::blocking::Client::new();
     let body = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
-        "method": "pyde_sendTransaction",
-        "params": [{
-            "from": from,
-            "to": zero_addr,
-            "data": format!("0x{}", full_bytecode),
-            "constructorLen": constructor_len,
-            "gas": 100_000_000,
-            "nonce": get_nonce(&net.rpc_url, from)?,
-            "value": "0"
-        }]
+        "method": "pyde_sendRawTransaction",
+        "params": [tx_hex]
     });
 
-    let client = reqwest::blocking::Client::new();
     let resp = client
         .post(&net.rpc_url)
         .json(&body)
@@ -98,7 +118,7 @@ pub fn run(network: &str, contract: Option<&str>, from: &str, verify: bool) -> R
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Extract tx hash from response
+    // Extract tx hash
     let tx_hash = if let Ok(inner) = serde_json::from_str::<serde_json::Value>(result_str) {
         inner.get("txHash").and_then(|v| v.as_str())
             .unwrap_or(result_str).to_string()
@@ -122,6 +142,7 @@ pub fn run(network: &str, contract: Option<&str>, from: &str, verify: bool) -> R
     println!("  Deployed!");
     println!("  Contract: {}", contract_addr);
     println!("  Tx Hash:  {}", tx_hash);
+    println!("  Signed:   ✓ (FALCON-512, verified by validator)");
 
     if verify {
         println!();

--- a/crates/pyde-dev/src/lib.rs
+++ b/crates/pyde-dev/src/lib.rs
@@ -10,6 +10,7 @@ pub mod init;
 pub mod install;
 pub mod project;
 pub mod script;
+pub mod signer;
 pub mod test_runner;
 pub mod trace;
 pub mod verify;

--- a/crates/pyde-dev/src/main.rs
+++ b/crates/pyde-dev/src/main.rs
@@ -14,6 +14,7 @@ mod verify;
 mod wallet;
 mod cheatcodes;
 mod trace;
+mod signer;
 
 use clap::Parser;
 use cli::{Cli, Command, WalletCommand};
@@ -26,9 +27,12 @@ fn main() {
         Command::Init { name } => init::run(&name),
         Command::Build => build::run(),
         Command::Test { filter, verbosity } => test_runner::run(filter.as_deref(), verbosity),
-        Command::Script { file, network, from, wallet: _wallet } => {
-            // TODO: when wallet is Some, sign txs in script runner
-            script::run(&file, &network, &from)
+        Command::Script { file, network, private_key, wallet } => {
+            let rpc_url = project::get_rpc_url(&network).unwrap_or_else(|_| "http://127.0.0.1:8545".into());
+            match signer::resolve_signer(private_key.as_deref(), wallet.as_deref(), &rpc_url) {
+                Ok(s) => script::run(&file, &network, &s),
+                Err(e) => Err(e),
+            }
         }
         Command::Install { url, rev, name } => {
             match url {
@@ -37,9 +41,12 @@ fn main() {
             }
         }
         Command::Remove { name } => install::remove(&name),
-        Command::Console { network, from, wallet: _wallet } => {
-            // TODO: when wallet is Some, sign send txs in console
-            console::run(&network, &from)
+        Command::Console { network, private_key, wallet } => {
+            let rpc_url = project::get_rpc_url(&network).unwrap_or_else(|_| "http://127.0.0.1:8545".into());
+            match signer::resolve_signer(private_key.as_deref(), wallet.as_deref(), &rpc_url) {
+                Ok(s) => console::run(&network, &s),
+                Err(e) => Err(e),
+            }
         }
         Command::Verify { address, contract, network } => {
             verify::run(&address, contract.as_deref(), &network)
@@ -58,19 +65,23 @@ fn main() {
         Command::Call { address, function, network } => {
             console::cmd_call(&address, &function, &network)
         }
+        Command::Send { address, function, network, value, private_key, wallet } => {
+            let rpc_url = project::get_rpc_url(&network).unwrap_or_else(|_| "http://127.0.0.1:8545".into());
+            match signer::resolve_signer(private_key.as_deref(), wallet.as_deref(), &rpc_url) {
+                Ok(s) => console::cmd_send(&address, &function, &network, &s, value),
+                Err(e) => Err(e),
+            }
+        }
         Command::Tx { hash, network } => {
             console::cmd_tx(&hash, &network)
         }
         Command::Fmt => fmt::run(),
         Command::Doc => doc::run(),
         Command::Clean => clean::run(),
-        Command::Deploy { network, contract, from, wallet, verify } => {
-            let effective_from = match wallet {
-                Some(ref w) => wallet::resolve_wallet_address(w),
-                None => Ok(from),
-            };
-            match effective_from {
-                Ok(addr) => deploy::run(&network, contract.as_deref(), &addr, verify),
+        Command::Deploy { network, contract, value, private_key, wallet, verify } => {
+            let rpc_url = project::get_rpc_url(&network).unwrap_or_else(|_| "http://127.0.0.1:8545".into());
+            match signer::resolve_signer(private_key.as_deref(), wallet.as_deref(), &rpc_url) {
+                Ok(s) => deploy::run(&network, contract.as_deref(), &s, value, verify),
                 Err(e) => Err(e),
             }
         }

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -207,3 +207,12 @@ chain_id = 31337
         name
     )
 }
+
+/// Get the RPC URL for a network from pyde.toml.
+/// Falls back to default localhost if config can't be loaded.
+pub fn get_rpc_url(network: &str) -> Result<String, String> {
+    let (config, _) = load_config()?;
+    let net = config.networks.get(network)
+        .ok_or_else(|| format!("network '{}' not found in pyde.toml", network))?;
+    Ok(net.rpc_url.clone())
+}

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -28,7 +28,8 @@ struct FnInfo {
 /// TODO(M11.4): Replace `--from` address with `--wallet`/`--keystore` once the
 /// wallet system is implemented (tasks 0914-0921). Currently uses bare address
 /// without transaction signing (devnet mode only).
-pub fn run(file: &str, network: &str, from: &str) -> Result<(), String> {
+pub fn run(file: &str, network: &str, signer: &crate::signer::Signer) -> Result<(), String> {
+    let from = &signer.address_hex();
     let (config, root) = project::load_config()?;
     let start = Instant::now();
 
@@ -238,6 +239,8 @@ pub fn run(file: &str, network: &str, from: &str) -> Result<(), String> {
         &sender_addr,
         &net.rpc_url,
         from,
+        signer,
+        &net,
         &mut nonce,
         &mut tx_count,
         &merged_registry,
@@ -270,6 +273,8 @@ fn execute_with_rpc_bridge(
     script_addr: &[u8; 32],
     rpc_url: &str,
     from: &str,
+    signer: &crate::signer::Signer,
+    net: &crate::project::NetworkConfig,
     nonce: &mut u64,
     tx_count: &mut u32,
     compiled_registry: &std::collections::HashMap<String, Vec<u8>>,
@@ -330,25 +335,34 @@ fn execute_with_rpc_bridge(
 
                 println!("    [{}] deploy {} ({} bytes)", tx_count, contract_name, code_only.len());
 
-                let mut params = serde_json::json!({
-                    "from": from,
-                    "to": zero_addr,
-                    "data": format!("0x{}", hex::encode(code_only)),
-                    "gas": 100_000_000,
-                    "nonce": *nonce,
-                    "value": "0",
-                    "constructorLen": constructor_len,
-                });
+                // Build deploy data: [constructor_bytecode][runtime_bytecode][args]
+                let mut deploy_data = code_only.to_vec();
                 if !constructor_args.is_empty() {
-                    params["constructorArgs"] = serde_json::Value::String(
-                        format!("0x{}", hex::encode(constructor_args))
-                    );
+                    deploy_data.extend_from_slice(constructor_args);
                 }
+
+                // Build and sign deploy transaction
+                let mut tx = pyde_tx::types::Transaction {
+                    from: signer.address,
+                    to: [0u8; 32],
+                    value: 0,
+                    data: deploy_data,
+                    gas_limit: 100_000_000,
+                    nonce: *nonce,
+                    signature: vec![],
+                    fee_payer: pyde_tx::types::FeePayer::Sender,
+                    access_list: vec![],
+                    deadline: None,
+                    chain_id: net.chain_id,
+                    tx_type: pyde_tx::types::TransactionType::Deploy,
+                };
+                signer.sign_transaction(&mut tx)?;
+                let tx_hex = format!("0x{}", hex::encode(tx.to_bytes()));
 
                 let body = serde_json::json!({
                     "jsonrpc": "2.0", "id": *tx_count + 1,
-                    "method": "pyde_sendTransaction",
-                    "params": [params]
+                    "method": "pyde_sendRawTransaction",
+                    "params": [tx_hex]
                 });
 
                 let resp = client.post(rpc_url).json(&body).send()
@@ -451,20 +465,37 @@ fn execute_with_rpc_bridge(
                         }
                         // View calls don't consume nonce
                     } else {
-                        // State-changing call: pyde_sendTransaction
+                        // State-changing call: signed pyde_sendRawTransaction
                         println!("    [{}] {}.{}()", tx_count, &target_hex[..10], fn_name);
+
+                        let to_bytes = hex::decode(target_hex.strip_prefix("0x").unwrap_or(&target_hex))
+                            .unwrap_or_default();
+                        let mut to_addr = [0u8; 32];
+                        if to_bytes.len() == 32 { to_addr.copy_from_slice(&to_bytes); }
+                        let calldata_bytes = hex::decode(calldata_hex.strip_prefix("0x").unwrap_or(&calldata_hex))
+                            .unwrap_or_default();
+
+                        let mut tx = pyde_tx::types::Transaction {
+                            from: signer.address,
+                            to: to_addr,
+                            value: 0,
+                            data: calldata_bytes,
+                            gas_limit: 100_000_000,
+                            nonce: *nonce,
+                            signature: vec![],
+                            fee_payer: pyde_tx::types::FeePayer::Sender,
+                            access_list: vec![],
+                            deadline: None,
+                            chain_id: net.chain_id,
+                            tx_type: pyde_tx::types::TransactionType::Standard,
+                        };
+                        signer.sign_transaction(&mut tx)?;
+                        let tx_hex_raw = format!("0x{}", hex::encode(tx.to_bytes()));
 
                         let body = serde_json::json!({
                             "jsonrpc": "2.0", "id": *tx_count + 1,
-                            "method": "pyde_sendTransaction",
-                            "params": [{
-                                "from": from,
-                                "to": target_hex,
-                                "data": calldata_hex,
-                                "gas": 100_000_000,
-                                "nonce": *nonce,
-                                "value": "0"
-                            }]
+                            "method": "pyde_sendRawTransaction",
+                            "params": [tx_hex_raw]
                         });
 
                         let resp = client.post(rpc_url).json(&body).send()

--- a/crates/pyde-dev/src/signer.rs
+++ b/crates/pyde-dev/src/signer.rs
@@ -1,0 +1,190 @@
+//! Signer resolution for deploy/script/console commands.
+//!
+//! Resolution priority:
+//! 1. --private-key <hex>  (explicit FALCON-512 private key)
+//! 2. --wallet <name>      (load encrypted keystore from ~/.pyde/wallets/)
+//! 3. Default: Account #0 from devnet-keys.json (localhost only!)
+//!
+//! Validations:
+//! - --private-key and --wallet are mutually exclusive
+//! - Devnet auto-keys only allowed when RPC is localhost/127.0.0.1
+//! - Private key format validated (length, hex chars)
+
+use pyde_account::address::derive_eoa_address;
+use pyde_crypto::falcon::{falcon_sign, FalconPublicKey, FalconSecretKey};
+use pyde_tx::types::Transaction;
+
+pub struct Signer {
+    pub address: [u8; 32],
+    pub public_key: FalconPublicKey,
+    pub secret_key: FalconSecretKey,
+}
+
+impl Signer {
+    pub fn address_hex(&self) -> String {
+        format!("0x{}", hex::encode(self.address))
+    }
+
+    /// Sign a transaction in place.
+    pub fn sign_transaction(&self, tx: &mut Transaction) -> Result<(), String> {
+        let hash = tx.hash();
+        let sig = falcon_sign(&self.secret_key, &hash)
+            .map_err(|e| format!("signing failed: {}", e))?;
+        tx.signature = sig.as_bytes().to_vec();
+        Ok(())
+    }
+
+    /// Create from a combined private key hex (pk + sk, 2178 bytes).
+    pub fn from_private_key(hex_str: &str) -> Result<Self, String> {
+        let hex = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+
+        // Validate hex characters
+        if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err("private key contains non-hex characters".into());
+        }
+
+        // Validate length
+        let expected_len = (897 + 1281) * 2; // 4356 hex chars
+        if hex.len() != expected_len {
+            return Err(format!(
+                "invalid private key length: expected {} hex chars (2178 bytes = 897 pk + 1281 sk), got {}",
+                expected_len, hex.len()
+            ));
+        }
+
+        let bytes = hex::decode(hex)
+            .map_err(|e| format!("invalid private key hex: {}", e))?;
+        let pk = FalconPublicKey::from_bytes(&bytes[..897])
+            .ok_or("invalid FALCON-512 public key bytes — key may be corrupted")?;
+        let sk = FalconSecretKey::from_bytes(&bytes[897..])
+            .ok_or("invalid FALCON-512 secret key bytes — key may be corrupted")?;
+        let address = derive_eoa_address(pk.as_bytes());
+        Ok(Self { address, public_key: pk, secret_key: sk })
+    }
+}
+
+/// Resolve which signer to use.
+///
+/// `rpc_url` is required to validate that devnet auto-keys are only used on localhost.
+pub fn resolve_signer(
+    private_key: Option<&str>,
+    wallet_name: Option<&str>,
+    rpc_url: &str,
+) -> Result<Signer, String> {
+    // Validation: --private-key and --wallet are mutually exclusive
+    if private_key.is_some() && wallet_name.is_some() {
+        return Err(
+            "cannot use both --private-key and --wallet. Choose one:\n\
+             • --private-key <hex>  (raw FALCON-512 key)\n\
+             • --wallet <name>     (encrypted keystore)"
+                .into(),
+        );
+    }
+
+    // 1. Explicit private key — works with any network
+    if let Some(pk) = private_key {
+        if pk.is_empty() {
+            return Err("--private-key value cannot be empty".into());
+        }
+        return Signer::from_private_key(pk);
+    }
+
+    // 2. Named wallet — works with any network
+    if let Some(name) = wallet_name {
+        if name.is_empty() {
+            return Err("--wallet name cannot be empty".into());
+        }
+        return load_wallet_signer(name);
+    }
+
+    // 3. Devnet auto-keys — ONLY allowed on localhost
+    if !is_localhost(rpc_url) {
+        return Err(format!(
+            "no signer specified for non-local network '{}'.\n\
+             Devnet auto-keys are only allowed on localhost to prevent\n\
+             accidental use of shared keys on public networks.\n\n\
+             Use one of:\n\
+             • --private-key <hex>  (your FALCON-512 key)\n\
+             • --wallet <name>     (encrypted keystore)",
+            rpc_url
+        ));
+    }
+
+    load_devnet_account(0)
+}
+
+/// Load Account #N from the devnet-keys.json file.
+fn load_devnet_account(index: usize) -> Result<Signer, String> {
+    let paths = [
+        data_dir().join("devnet-keys.json"),
+        std::path::PathBuf::from("./data/devnet-keys.json"),
+        std::path::PathBuf::from("./devnet-keys.json"),
+    ];
+
+    for path in &paths {
+        if path.exists() {
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| format!("cannot read {}: {}", path.display(), e))?;
+            let keys: Vec<serde_json::Value> = serde_json::from_str(&content)
+                .map_err(|e| format!("invalid devnet-keys.json: {}", e))?;
+
+            if keys.is_empty() {
+                return Err("devnet-keys.json is empty — no accounts available".into());
+            }
+
+            let account = keys.get(index).ok_or_else(|| format!(
+                "devnet account #{} not found (only {} accounts available)",
+                index, keys.len()
+            ))?;
+
+            let pk_hex = account.get("privateKey")
+                .and_then(|v| v.as_str())
+                .ok_or("missing 'privateKey' field in devnet-keys.json entry")?;
+
+            return Signer::from_private_key(pk_hex);
+        }
+    }
+
+    Err(
+        "no devnet keys found. Start a devnet node first:\n\
+         \n\
+         $ pyde node --dev\n\
+         \n\
+         This generates FALCON-512 keypairs and saves them to devnet-keys.json.\n\
+         Alternatively, pass --private-key or --wallet explicitly."
+            .into(),
+    )
+}
+
+/// Load a wallet from ~/.pyde/wallets/<name>.json
+fn load_wallet_signer(name: &str) -> Result<Signer, String> {
+    let password = std::env::var("PYDE_WALLET_PASSWORD")
+        .or_else(|_| crate::wallet::prompt_password(&format!("Password for wallet '{}': ", name)))
+        .map_err(|e| format!("cannot get wallet password: {}", e))?;
+
+    let w = crate::wallet::load(name, &password)?;
+    Ok(Signer {
+        address: w.address,
+        public_key: w.public_key.clone(),
+        secret_key: w.secret_key.clone(),
+    })
+}
+
+/// Check if an RPC URL points to localhost.
+fn is_localhost(url: &str) -> bool {
+    let lower = url.to_lowercase();
+    lower.contains("localhost") ||
+    lower.contains("127.0.0.1") ||
+    lower.contains("0.0.0.0") ||
+    lower.contains("[::1]")
+}
+
+fn home_dir() -> std::path::PathBuf {
+    std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+}
+
+fn data_dir() -> std::path::PathBuf {
+    home_dir().join(".pyde").join("data")
+}

--- a/crates/pyde-dev/src/wallet.rs
+++ b/crates/pyde-dev/src/wallet.rs
@@ -26,7 +26,7 @@ pub struct Wallet {
     pub name: String,
     pub address: [u8; 32],
     pub public_key: FalconPublicKey,
-    secret_key: FalconSecretKey,
+    pub(crate) secret_key: FalconSecretKey,
 }
 
 impl Wallet {


### PR DESCRIPTION
## Summary
- Devnet generates 10 FALCON-512 keypairs (10B PYDE each), prints keys on startup
- New signer system: --private-key, --wallet, devnet auto (localhost only)
- All tx-sending commands use signed pyde_sendRawTransaction
- pyde_sendTransaction gated behind --dev flag
- New `send` CLI command for signed contract writes with --value
- Failed txs produce receipts instead of silent drops
- --value flag on deploy for payable constructors
- Live tested: 16 scenarios all passed