### PR TITLE
feat: per-call value syntax, balance transfer, deploy! value support

### DIFF
--- a/crates/otic/src/ast.rs
+++ b/crates/otic/src/ast.rs
@@ -443,8 +443,9 @@ pub enum Expr {
     FieldAccess(Box<Expr>, Ident, Span),
     /// `arr[idx]`
     Index(Box<Expr>, Box<Expr>, Span),
-    /// `func(args)` or `obj.method(args)`
-    Call(Box<Expr>, Vec<Expr>, Span),
+    /// `func(args)` or `obj.method(args)` or `obj.method{ value: expr }(args)`
+    /// The optional 4th field is the value expression for payable calls.
+    Call(Box<Expr>, Vec<Expr>, Option<Box<Expr>>, Span),
     /// `path::to::item` — `IERC20::at`, `Address::ZERO`, `GameState::Pending`
     Path(Vec<Ident>, Span),
     /// `require!(cond, err)`, `revert!(err)`, `cross_call!(...)`, `raw_call!(...)`

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -2002,7 +2002,7 @@ impl CodeGen {
                 }
             }
 
-            Inst::ExtCall(dst, addr, method, args, ret_ty) => {
+            Inst::ExtCall(dst, addr, method, args, ret_ty, value_reg) => {
                 let wide_return = is_wide_type(ret_ty);
                 let blob_return = matches!(ret_ty, Ty::StringTy | Ty::Bytes | Ty::Vec(_) | Ty::Struct(_));
                 let ra = self.get_reg(*addr);
@@ -2011,17 +2011,21 @@ impl CodeGen {
                 self.emit_op(Opcode::Push, 12, 0, 0); // save r12 = calldata start
 
                 // Write calldata to heap: [selector(4 BE bytes)][arg0][arg1]...
-                let selector = compute_selector(method);
-                let sel_be = selector.to_be_bytes();
-                let sel_as_le_u32 = u32::from_le_bytes(sel_be);
-                self.load_u32_to_reg(15, sel_as_le_u32);
-                let sel_imm = encode_mem_immediate(0, MemWidth::W32).unwrap();
-                self.emit(encode(Opcode::Store, 15, 12, sel_imm));
+                // Empty method = value-only transfer (no selector, triggers #[receive])
+                let has_selector = !method.is_empty();
+                if has_selector {
+                    let selector = compute_selector(method);
+                    let sel_be = selector.to_be_bytes();
+                    let sel_as_le_u32 = u32::from_le_bytes(sel_be);
+                    self.load_u32_to_reg(15, sel_as_le_u32);
+                    let sel_imm = encode_mem_immediate(0, MemWidth::W32).unwrap();
+                    self.emit(encode(Opcode::Store, 15, 12, sel_imm));
+                }
 
-                // Write args after selector (offset 4)
+                // Write args after selector (offset 4 if selector, 0 if no selector)
                 // GP args: 8 bytes via Store. Wide args: 32 bytes via Wstore.
                 // Blob args (String, Vec, Struct, Bytes): [byte_len:8][flat data].
-                let mut arg_offset: i32 = 4;
+                let mut arg_offset: i32 = if has_selector { 4 } else { 0 };
                 let mut has_blob_args = false;
                 for (arg, ty) in args.iter() {
                     let is_blob = matches!(ty,
@@ -2120,6 +2124,17 @@ impl CodeGen {
                 let imm = (14 & 0xF)           // len_reg = r14
                     | ((15 & 0xF) << 4)         // gas_reg = r15
                     | ((13 & 0xF) << 8); // result_reg = r13
+                // Load call value into r8 (convention: r8 = msg.value for child)
+                // Only set r8 if value is explicitly provided — otherwise leave it alone
+                let has_value = value_reg.is_some();
+                if let Some(val_vreg) = value_reg {
+                    let val_r = self.get_reg(*val_vreg);
+                    if val_r != 8 {
+                        self.emit_op(Opcode::Add, 8, val_r, 0); // r8 = value
+                    }
+                }
+                // Add value flag to immediate
+                let imm = imm | if has_value { 1 << 13 } else { 0 };
                 // Save r13 (spill base) — CallExt overwrites it with success flag
                 self.emit_op(Opcode::Push, 13, 0, 0);
                 self.emit_op(Opcode::CallExt, ra, 12, imm);
@@ -2217,7 +2232,7 @@ impl CodeGen {
                 }
             }
 
-            Inst::CreateContract(dst, blob_reg, args) => {
+            Inst::CreateContract(dst, blob_reg, args, value_reg) => {
                 // The blob register holds an IrConst::Bytes value.
                 // At codegen time, the Const handler has already written the blob to heap.
                 // blob_reg points to the heap location of the deploy-format bytes.
@@ -2292,6 +2307,13 @@ impl CodeGen {
                 }
 
                 // Create: wd = new address, rs1 = blob pointer (r15), imm[3:0] = length register (r14)
+                // Load value into r8 if provided (same convention as CallExt)
+                if let Some(val_vreg) = value_reg {
+                    let val_r = self.get_reg(*val_vreg);
+                    if val_r != 8 {
+                        self.emit_op(Opcode::Add, 8, val_r, 0);
+                    }
+                }
                 self.emit_op(Opcode::Create, wd, 15, 14 & 0xF);
             }
 

--- a/crates/otic/src/ir.rs
+++ b/crates/otic/src/ir.rs
@@ -273,8 +273,8 @@ pub enum Inst {
     /// `%dst = method_call %obj, "method", [args...]`
     MethodCall(Reg, Reg, String, Vec<Reg>),
 
-    /// `ext_call %interface_addr, "method", [(arg, type)...], return_type`
-    ExtCall(Reg, Reg, String, Vec<(Reg, Ty)>, Ty),
+    /// `ext_call %interface_addr, "method", [(arg, type)...], return_type, optional_value_reg`
+    ExtCall(Reg, Reg, String, Vec<(Reg, Ty)>, Ty, Option<Reg>),
 
     /// `%dst = hash [args...]`
     Hash(Reg, Vec<Reg>),
@@ -322,7 +322,7 @@ pub enum Inst {
 
     /// `%addr = create %deploy_blob, [constructor_args...]` — deploy a new contract.
     /// deploy_blob holds the deploy-format bytes. Returns Address.
-    CreateContract(Reg, Reg, Vec<(Reg, Ty)>),
+    CreateContract(Reg, Reg, Vec<(Reg, Ty)>, Option<Reg>),
 
     /// `br @label` — unconditional jump
     Jump(Label),
@@ -488,9 +488,11 @@ impl fmt::Display for Inst {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
                 write!(f, "{} = {}.{}({})", dst, obj, method, args_str.join(", "))
             }
-            Inst::ExtCall(dst, addr, method, args, ret_ty) => {
+            Inst::ExtCall(dst, addr, method, args, ret_ty, value_reg) => {
                 let args_str: Vec<String> = args.iter().map(|(r, t)| format!("{}:{}", r, t)).collect();
-                write!(f, "{}: {} = ext_call {}, \"{}\"({})", dst, ret_ty, addr, method, args_str.join(", "))
+                let val = value_reg.map(|r| format!("{{ value: {} }}", r)).unwrap_or_default();
+                write!(f, "{}: {} = ext_call {}, \"{}\"{}{}", dst, ret_ty, addr, method, val,
+                    if args_str.is_empty() { "()".to_string() } else { format!("({})", args_str.join(", ")) })
             }
             Inst::Hash(dst, args) => {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
@@ -533,9 +535,10 @@ impl fmt::Display for Inst {
                 let args_str: Vec<String> = args.iter().map(|r| r.to_string()).collect();
                 write!(f, "{} = raw_call {}({})", dst, target, args_str.join(", "))
             }
-            Inst::CreateContract(dst, blob, args) => {
+            Inst::CreateContract(dst, blob, args, value_reg) => {
                 let args_str: Vec<String> = args.iter().map(|(r, t)| format!("{}:{}", r, t)).collect();
-                write!(f, "{} = create({}, [{}])", dst, blob, args_str.join(", "))
+                let val = value_reg.map(|r| format!("{{ value: {} }}", r)).unwrap_or_default();
+                write!(f, "{} = create({}{}, [{}])", dst, blob, val, args_str.join(", "))
             }
             Inst::Jump(label) => write!(f, "jump {}", label),
             Inst::Branch(cond, then_l, else_l) => write!(f, "br {}, {}, {}", cond, then_l, else_l),

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1082,7 +1082,7 @@ impl Lowerer {
                 dst
             }
 
-            Expr::Call(callee, args, _) => {
+            Expr::Call(callee, args, call_value, _) => {
                 let arg_regs: Vec<Reg> = args.iter().map(|a| self.lower_expr(a)).collect();
                 let dst = self.alloc_reg();
 
@@ -1135,7 +1135,8 @@ impl Lowerer {
                                     let typed_args: Vec<(Reg, Ty)> = arg_regs.iter().zip(
                                         param_types.iter().chain(std::iter::repeat(&Ty::U64))
                                     ).map(|(r, t)| (*r, t.clone())).collect();
-                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), typed_args, ret_ty));
+                                    let value_reg = call_value.as_ref().map(|v| self.lower_expr(v));
+                                    self.emit(Inst::ExtCall(dst, obj_reg, method.name.clone(), typed_args, ret_ty, value_reg));
                                 }
                                 _ => {
                                     self.emit(Inst::MethodCall(dst, obj_reg, method.name.clone(), arg_regs));
@@ -1341,12 +1342,25 @@ impl Lowerer {
                     }
                     "raw_call" => {
                         // raw_call!(target, "method_name", arg1, arg2, ...)
+                        // raw_call!(target, "method_name", arg1, value: expr)
                         // arg[0] = target address (Address expr)
                         // arg[1] = method name (string literal) — optional
-                        // arg[2..] = actual parameters
-                        let positional: Vec<&Expr> = args.iter().filter_map(|a| {
-                            if let MacroArg::Positional(e) = a { Some(e) } else { None }
-                        }).collect();
+                        // remaining = actual parameters
+                        // value: = optional named param for native token transfer
+                        let mut positional: Vec<&Expr> = Vec::new();
+                        let mut value_expr: Option<&Expr> = None;
+
+                        for arg in args {
+                            match arg {
+                                MacroArg::Named(key, val) if key.name == "value" => {
+                                    value_expr = Some(val);
+                                }
+                                MacroArg::Positional(e) => {
+                                    positional.push(e);
+                                }
+                                _ => { positional.push(match arg { MacroArg::Named(_, v) => v, MacroArg::Positional(v) => v }); }
+                            }
+                        }
 
                         let dst = self.alloc_reg();
                         if positional.is_empty() {
@@ -1355,6 +1369,7 @@ impl Lowerer {
                         }
 
                         let target = self.lower_expr(positional[0]);
+                        let value_reg = value_expr.map(|v| self.lower_expr(v));
 
                         // Try to extract method name from arg[1] if it's a string literal
                         let method_name = if positional.len() > 1 {
@@ -1374,26 +1389,38 @@ impl Lowerer {
                             .collect();
 
                         if let Some(method) = method_name {
-                            // Emit as ExtCall with the method name (codegen writes selector)
-                            // No type info available for raw_call — default args to GP
                             let typed_params: Vec<(Reg, Ty)> = param_regs.iter()
                                 .map(|r| (*r, Ty::U64)).collect();
-                            self.emit(Inst::ExtCall(dst, target, method, typed_params, Ty::U64));
+                            self.emit(Inst::ExtCall(dst, target, method, typed_params, Ty::U64, value_reg));
                         } else {
                             // No method name: emit as raw call (no selector)
-                            self.emit(Inst::RawCall(dst, target, param_regs));
+                            // If value provided, emit ExtCall with empty method for value transfer
+                            if let Some(val_r) = value_reg {
+                                self.emit(Inst::ExtCall(dst, target, String::new(), vec![], Ty::U64, Some(val_r)));
+                            } else {
+                                self.emit(Inst::RawCall(dst, target, param_regs));
+                            }
                         }
                         dst
                     }
                     "deploy" | "create" => {
-                        // deploy!(ContractName, arg1, arg2, ...) → Ty::Contract("ContractName")
+                        // deploy!(ContractName, arg1, arg2, ..., value: expr)
                         // create! is an alias for deploy!.
                         // Embeds the named contract's bytecode and deploys it.
                         // Constructor runs automatically with the provided args.
+                        // Optional value: param for payable constructors.
                         // Returns a typed contract handle (enables c.method() dispatch).
-                        let positional: Vec<&Expr> = args.iter().filter_map(|a| {
-                            if let MacroArg::Positional(e) = a { Some(e) } else { None }
-                        }).collect();
+                        let mut positional: Vec<&Expr> = Vec::new();
+                        let mut value_expr: Option<&Expr> = None;
+                        for arg in args {
+                            match arg {
+                                MacroArg::Named(key, val) if key.name == "value" => {
+                                    value_expr = Some(val);
+                                }
+                                MacroArg::Positional(e) => positional.push(e),
+                                _ => { if let MacroArg::Named(_, v) = arg { positional.push(v); } }
+                            }
+                        }
 
                         let dst = self.alloc_reg();
 
@@ -1448,8 +1475,9 @@ impl Lowerer {
                         let blob_reg = self.alloc_reg();
                         self.emit(Inst::Const(blob_reg, IrConst::Bytes(deploy_bytes)));
 
-                        // CreateContract(dst, blob_reg, [(arg, type)...])
-                        self.emit(Inst::CreateContract(dst, blob_reg, typed_args));
+                        // CreateContract(dst, blob_reg, [(arg, type)...], value)
+                        let value_reg = value_expr.map(|v| self.lower_expr(v));
+                        self.emit(Inst::CreateContract(dst, blob_reg, typed_args, value_reg));
 
                         // Tag the result register as Ty::Contract so method calls
                         // on the handle (e.g. c.increment()) resolve to ExtCall.

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -299,7 +299,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
         Inst::Builtin(_, _) => {}
         Inst::Call(_, _, args) => { for a in args { used.insert(*a); } }
         Inst::MethodCall(_, obj, _, args) => { used.insert(*obj); for a in args { used.insert(*a); } }
-        Inst::ExtCall(_, addr, _, args, _) => { used.insert(*addr); for (a, _) in args { used.insert(*a); } }
+        Inst::ExtCall(_, addr, _, args, _, _) => { used.insert(*addr); for (a, _) in args { used.insert(*a); } }
         Inst::Hash(_, args) => { for a in args { used.insert(*a); } }
         Inst::StructInit(_, _, fields) => { for (_, r) in fields { used.insert(*r); } }
         Inst::FieldGet(_, obj, _, _) => { used.insert(*obj); }
@@ -317,7 +317,7 @@ fn collect_used_regs(inst: &Inst, used: &mut HashSet<Reg>) {
             for a in args { used.insert(*a); }
         }
         Inst::RawCall(_, target, args) => { used.insert(*target); for a in args { used.insert(*a); } }
-        Inst::CreateContract(_, blob, args) => { used.insert(*blob); for (a, _) in args { used.insert(*a); } }
+        Inst::CreateContract(_, blob, args, _) => { used.insert(*blob); for (a, _) in args { used.insert(*a); } }
         Inst::Jump(_) => {}
         Inst::Branch(cond, _, _) => { used.insert(*cond); }
         Inst::Return(Some(val)) => { used.insert(*val); }
@@ -335,13 +335,13 @@ fn get_dest_reg(inst: &Inst) -> Option<Reg> {
         | Inst::StorageGet(dst, _) | Inst::StorageMapGet(dst, _, _)
         | Inst::StorageNestedMapGet(dst, _, _, _)
         | Inst::Builtin(dst, _) | Inst::Call(dst, _, _)
-        | Inst::MethodCall(dst, _, _, _) | Inst::ExtCall(dst, _, _, _, _)
+        | Inst::MethodCall(dst, _, _, _) | Inst::ExtCall(dst, _, _, _, _, _)
         | Inst::Hash(dst, _) | Inst::StructInit(dst, _, _)
         | Inst::FieldGet(dst, _, _, _) | Inst::IndexGet(dst, _, _)
         | Inst::MakeTuple(dst, _) | Inst::TupleGet(dst, _, _)
         | Inst::MakeArray(dst, _) | Inst::ArrayRepeat(dst, _, _)
         | Inst::MakeVec(dst, _)
-        | Inst::RawCall(dst, _, _) | Inst::CreateContract(dst, _, _) | Inst::Phi(dst, _) => Some(*dst),
+        | Inst::RawCall(dst, _, _) | Inst::CreateContract(dst, _, _, _) | Inst::Phi(dst, _) => Some(*dst),
         _ => None,
     }
 }
@@ -353,8 +353,8 @@ fn has_side_effects(inst: &Inst) -> bool {
         | Inst::StorageNestedMapSet(_, _, _, _)
         | Inst::IndexSet(_, _, _)
         | Inst::Emit(_, _) | Inst::Revert(_, _)
-        | Inst::CrossCall { .. } | Inst::RawCall(_, _, _) | Inst::CreateContract(_, _, _)
-        | Inst::Call(_, _, _) | Inst::MethodCall(_, _, _, _) | Inst::ExtCall(_, _, _, _, _)
+        | Inst::CrossCall { .. } | Inst::RawCall(_, _, _) | Inst::CreateContract(_, _, _, _)
+        | Inst::Call(_, _, _) | Inst::MethodCall(_, _, _, _) | Inst::ExtCall(_, _, _, _, _, _)
         | Inst::Jump(_) | Inst::Branch(_, _, _) | Inst::Return(_)
     )
 }

--- a/crates/otic/src/parser.rs
+++ b/crates/otic/src/parser.rs
@@ -988,12 +988,22 @@ impl Parser {
                         self.expect_ident()?
                     };
 
-                    // Check for method call: expr.field(args)
-                    if self.at(&TokenKind::LParen) {
+                    // Check for method call: expr.field(args) or expr.field{ value: v }(args)
+                    // Lookahead: only treat { as value annotation if tokens are { value :
+                    let has_value_annotation = self.at(&TokenKind::LBrace)
+                        && self.lookahead_is_value_annotation();
+                    if has_value_annotation || self.at(&TokenKind::LParen) {
+                        let call_value = if has_value_annotation {
+                            let v = self.parse_call_value_annotation()?;
+                            Some(Box::new(v))
+                        } else {
+                            None
+                        };
                         let args = self.parse_call_args()?;
                         expr = Expr::Call(
                             Box::new(Expr::FieldAccess(Box::new(expr), field, span)),
                             args,
+                            call_value,
                             span,
                         );
                     } else {
@@ -1012,13 +1022,38 @@ impl Parser {
                 TokenKind::LParen => {
                     let span = self.peek_span();
                     let args = self.parse_call_args()?;
-                    expr = Expr::Call(Box::new(expr), args, span);
+                    expr = Expr::Call(Box::new(expr), args, None, span);
                 }
                 _ => break,
             }
         }
 
         Ok(expr)
+    }
+
+    /// Check if the next tokens are `{ value :` (lookahead without consuming).
+    fn lookahead_is_value_annotation(&self) -> bool {
+        // Current token is `{`. Check if next is ident "value" and after that is `:`.
+        if self.pos + 2 >= self.tokens.len() { return false; }
+        let next = &self.tokens[self.pos + 1];
+        let after = &self.tokens[self.pos + 2];
+        matches!(&next.kind, TokenKind::Ident(name) if name == "value")
+            && matches!(after.kind, TokenKind::Colon)
+    }
+
+    /// Parse `{ value: expr }` annotation for payable calls.
+    fn parse_call_value_annotation(&mut self) -> Result<Expr, ()> {
+        self.expect(&TokenKind::LBrace)?;
+        let ident = self.expect_ident()?;
+        if ident.name != "value" {
+            self.error(format!("expected 'value' in call annotation, got '{}'", ident.name));
+            self.expect(&TokenKind::RBrace)?;
+            return Ok(Expr::Literal(Literal::Int(ethnum::U256::ZERO), ident.span));
+        }
+        self.expect(&TokenKind::Colon)?;
+        let value_expr = self.parse_expr()?;
+        self.expect(&TokenKind::RBrace)?;
+        Ok(value_expr)
     }
 
     fn parse_call_args(&mut self) -> Result<Vec<Expr>, ()> {
@@ -1133,7 +1168,7 @@ impl Parser {
             // Path followed by call: IERC20::at(token)
             if self.at(&TokenKind::LParen) {
                 let args = self.parse_call_args()?;
-                return Ok(Expr::Call(Box::new(Expr::Path(segments, span)), args, span));
+                return Ok(Expr::Call(Box::new(Expr::Path(segments, span)), args, None, span));
             }
 
             // Path followed by struct init: MyStruct { ... }
@@ -1647,7 +1682,7 @@ contract Token {
         if let Item::Contract(c) = &file.items[0] {
             if let ContractItem::Function(f) = &c.items[0] {
                 if let Stmt::Let(l) = &f.body.stmts[0] {
-                    assert!(matches!(l.initializer, Expr::Call(_, _, _)));
+                    assert!(matches!(l.initializer, Expr::Call(_, _, _, _)));
                 }
             }
         }
@@ -1862,7 +1897,7 @@ contract Token {
             if let ContractItem::Function(f) = &c.items[0] {
                 if let Stmt::Let(l) = &f.body.stmts[0] {
                     // Should be Call(FieldAccess(Binary(a, +, b), sqrt), [])
-                    assert!(matches!(l.initializer, Expr::Call(_, _, _)));
+                    assert!(matches!(l.initializer, Expr::Call(_, _, _, _)));
                 }
             }
         }

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -847,7 +847,7 @@ impl Resolver {
                 self.resolve_expr(index);
             }
 
-            Expr::Call(callee, args, _) => {
+            Expr::Call(callee, args, _, _) => {
                 self.resolve_expr(callee);
                 for arg in args {
                     self.resolve_expr(arg);

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -401,7 +401,7 @@ impl SafetyChecker {
 
     /// Check if a method call on a storage field is mutating (push, pop, etc.).
     fn is_storage_mutating_call(&self, expr: &Expr) -> bool {
-        if let Expr::Call(callee, _, _) = expr {
+        if let Expr::Call(callee, _, _, _) = expr {
             if let Expr::FieldAccess(obj, method, _) = callee.as_ref() {
                 let is_mutating_method = matches!(
                     method.name.as_str(),
@@ -451,7 +451,7 @@ impl SafetyChecker {
     /// Collect self.method() call targets from an expression.
     fn collect_calls_in_expr(&self, expr: &Expr, targets: &mut Vec<String>) {
         match expr {
-            Expr::Call(callee, args, _) => {
+            Expr::Call(callee, args, _, _) => {
                 // self.method(...) → record method name
                 if let Expr::FieldAccess(obj, method, _) = callee.as_ref() {
                     if matches!(obj.as_ref(), Expr::SelfExpr(_)) {
@@ -681,7 +681,7 @@ impl SafetyChecker {
             Expr::Index(obj, idx, _) => {
                 self.expr_accesses_msg_value(obj) || self.expr_accesses_msg_value(idx)
             }
-            Expr::Call(callee, args, _) => {
+            Expr::Call(callee, args, _, _) => {
                 self.expr_accesses_msg_value(callee)
                     || args.iter().any(|a| self.expr_accesses_msg_value(a))
             }

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -990,7 +990,7 @@ impl TypeChecker {
                 }
             }
 
-            Expr::Call(callee, args, span) => {
+            Expr::Call(callee, args, call_value, span) => {
                 // Infer all argument types
                 let arg_types: Vec<Ty> = args.iter().map(|arg| self.infer_expr(arg)).collect();
 
@@ -1236,19 +1236,7 @@ impl TypeChecker {
                                 ("bytes", "new" | "empty" | "from_hex") => Ty::Bytes,
                                 ("String", "new") => Ty::StringTy,
                                 // Interface::at(addr) → callable handle
-                                // Interface::at(addr) → callable handle (no value)
-                                // Interface::at_payable(addr, value) → callable handle (with value)
                                 (_, "at") => Ty::Unknown,
-                                (_, "at_payable") => {
-                                    if arg_types.len() != 2 {
-                                        self.error(
-                                            "at_payable() takes 2 arguments (address, value)"
-                                                .into(),
-                                            *span,
-                                        );
-                                    }
-                                    Ty::Unknown
-                                }
                                 // std::signature module
                                 ("signature", "verify") => Ty::Bool,
                                 ("signature", "recover") => Ty::Address,

--- a/crates/otic/tests/fixtures/programs/access/fee_manager.oti
+++ b/crates/otic/tests/fixtures/programs/access/fee_manager.oti
@@ -359,7 +359,7 @@ contract FeeManager {
 
         if protocol_amount > 0 {
             if token == Address::ZERO {
-                raw_call!(self.treasury, protocol_amount, bytes::empty());
+                raw_call!(self.treasury, value: protocol_amount);
             } else {
                 let erc20 = IERC20::at(token);
                 let success = erc20.transfer(self.treasury, protocol_amount);
@@ -373,7 +373,7 @@ contract FeeManager {
             let share = (distributable * recipient.share_bps) / BPS_DENOMINATOR;
             if share > 0 {
                 if token == Address::ZERO {
-                    raw_call!(recipient.recipient, share, bytes::empty());
+                    raw_call!(recipient.recipient, value: share);
                 } else {
                     let erc20 = IERC20::at(token);
                     let success = erc20.transfer(recipient.recipient, share);

--- a/crates/otic/tests/fixtures/programs/access/guardian.oti
+++ b/crates/otic/tests/fixtures/programs/access/guardian.oti
@@ -331,13 +331,13 @@ contract Guardian {
             EmergencyActionType::EmergencyWithdraw => {
                 // Emergency withdraw - send all balance to owner
                 if address(self).balance > 0 {
-                    raw_call!(self.owner, address(self).balance, bytes::empty());
+                    raw_call!(self.owner, value: address(self).balance);
                 }
             }
             EmergencyActionType::PauseContract => {
                 // Pause a protected contract via raw_call
                 if proposal.target != Address::ZERO {
-                    raw_call!(proposal.target, 0, bytes::empty());
+                    raw_call!(proposal.target, value: 0);
                 }
             }
         }

--- a/crates/otic/tests/fixtures/programs/access/time_lock_admin.oti
+++ b/crates/otic/tests/fixtures/programs/access/time_lock_admin.oti
@@ -204,7 +204,7 @@ contract TimeLockAdmin {
         self.executed_action_ids.push(action_id);
 
         // Execute the action
-        raw_call!(action.target, action.value, action.calldata);
+        raw_call!(action.target, action.calldata, value: action.value);
 
         emit ActionExecuted {
             action_id: action_id,

--- a/crates/otic/tests/fixtures/programs/defi/router.oti
+++ b/crates/otic/tests/fixtures/programs/defi/router.oti
@@ -312,7 +312,7 @@ contract SwapRouter {
         require!(amount_in > 0u256, ZeroAmount {});
 
         // Wrap native token — payable external call
-        IWPYDE::at_payable(self.wpyde, amount_in).deposit();
+        IWPYDE::at(self.wpyde).deposit{ value: amount_in }();
 
         let net_amount = self.deduct_router_fee(self.wpyde, amount_in);
 
@@ -367,7 +367,7 @@ contract SwapRouter {
 
         // Unwrap and send native
         raw_call!(self.wpyde, "withdraw(uint256)", wpyde_out);
-        raw_call!(msg.sender, wpyde_out);
+        raw_call!(msg.sender, value: wpyde_out);
 
         self.total_swaps = self.total_swaps + 1u256;
 

--- a/crates/otic/tests/fixtures/programs/defi/wrapped_token.oti
+++ b/crates/otic/tests/fixtures/programs/defi/wrapped_token.oti
@@ -121,7 +121,7 @@ contract WrappedToken {
         self.total_withdrawals = self.total_withdrawals + amount;
 
         // Transfer native token back to sender
-        raw_call!(msg.sender, amount);
+        raw_call!(msg.sender, value: amount);
 
         emit Withdrawal { account: msg.sender, amount: amount };
         emit Transfer { from: msg.sender, to: Address::ZERO, amount: amount };
@@ -155,7 +155,7 @@ contract WrappedToken {
         self.total_supply = self.total_supply - amount;
         self.total_withdrawals = self.total_withdrawals + amount;
 
-        raw_call!(to, amount);
+        raw_call!(to, value: amount);
 
         emit Withdrawal { account: msg.sender, amount: amount };
         emit Transfer { from: msg.sender, to: Address::ZERO, amount: amount };

--- a/crates/otic/tests/fixtures/programs/education/course_marketplace.oti
+++ b/crates/otic/tests/fixtures/programs/education/course_marketplace.oti
@@ -215,7 +215,7 @@ contract CourseMarketplace {
         self.platform_earnings += platform_cut;
         self.instructor_profiles[course.instructor].total_earnings += instructor_cut;
 
-        raw_call!(course.instructor, instructor_cut, bytes(""));
+        raw_call!(course.instructor, value: instructor_cut);
 
         emit StudentEnrolled { course_id: course_id, student: msg.sender };
     }
@@ -292,7 +292,7 @@ contract CourseMarketplace {
         self.enrollments[course_id][msg.sender].enrolled = false;
         self.courses[course_id].enrolled_count -= 1;
 
-        raw_call!(msg.sender, refund_amount, bytes(""));
+        raw_call!(msg.sender, value: refund_amount);
         emit RefundIssued { course_id: course_id, student: msg.sender, amount: refund_amount };
     }
 

--- a/crates/otic/tests/fixtures/programs/education/scholarship.oti
+++ b/crates/otic/tests/fixtures/programs/education/scholarship.oti
@@ -326,7 +326,7 @@ contract ScholarshipFund {
         self.grants[scholarship_id][recipient].total_disbursed += d.amount;
         self.total_disbursed += d.amount;
 
-        raw_call!(recipient, d.amount, bytes(""));
+        raw_call!(recipient, value: d.amount);
 
         emit DisbursementPaid {
             scholarship_id: scholarship_id,

--- a/crates/otic/tests/fixtures/programs/energy/energy_trading.oti
+++ b/crates/otic/tests/fixtures/programs/energy/energy_trading.oti
@@ -291,7 +291,7 @@ contract EnergyTrading {
         self.consumer_profiles[buy.maker].total_spent += total_cost;
         self.total_energy_traded_kwh += fill_amount;
 
-        raw_call!(sell.maker, seller_payment, bytes(""));
+        raw_call!(sell.maker, value: seller_payment);
 
         emit TradeExecuted {
             trade_id: trade_id,

--- a/crates/otic/tests/fixtures/programs/energy/renewable_certificates.oti
+++ b/crates/otic/tests/fixtures/programs/energy/renewable_certificates.oti
@@ -283,7 +283,7 @@ contract RECRegistry {
         self.bundled_sales[sale_id].buyer = msg.sender;
         self.bundled_sales[sale_id].completed = true;
 
-        raw_call!(sale.seller, msg.value, bytes(""));
+        raw_call!(sale.seller, value: msg.value);
     }
 
     #[view]

--- a/crates/otic/tests/fixtures/programs/finance/crowdfund.oti
+++ b/crates/otic/tests/fixtures/programs/finance/crowdfund.oti
@@ -266,7 +266,7 @@ contract Crowdfund {
         self.status = CampaignStatus::Successful;
         self.withdrawn = true;
 
-        raw_call!(self.creator, self.total_raised, bytes::empty());
+        raw_call!(self.creator, value: self.total_raised);
 
         emit FundsWithdrawn {
             creator: self.creator,
@@ -296,7 +296,7 @@ contract Crowdfund {
 
         self.claimed_refunds[msg.sender] = true;
 
-        raw_call!(msg.sender, amount, bytes::empty());
+        raw_call!(msg.sender, value: amount);
 
         emit RefundClaimed { contributor: msg.sender, amount: amount };
     }

--- a/crates/otic/tests/fixtures/programs/finance/escrow.oti
+++ b/crates/otic/tests/fixtures/programs/finance/escrow.oti
@@ -182,9 +182,9 @@ contract Escrow {
         entry.status = EscrowStatus::Released;
         self.escrows[escrow_id] = entry;
 
-        raw_call!(entry.seller, seller_amount, bytes::empty());
+        raw_call!(entry.seller, value: seller_amount);
         if platform_fee > 0 {
-            raw_call!(self.platform_treasury, platform_fee, bytes::empty());
+            raw_call!(self.platform_treasury, value: platform_fee);
         }
 
         emit EscrowReleased {
@@ -205,7 +205,7 @@ contract Escrow {
         entry.status = EscrowStatus::Refunded;
         self.escrows[escrow_id] = entry;
 
-        raw_call!(entry.buyer, entry.amount, bytes::empty());
+        raw_call!(entry.buyer, value: entry.amount);
 
         emit EscrowRefunded {
             escrow_id: escrow_id,
@@ -225,7 +225,7 @@ contract Escrow {
         entry.status = EscrowStatus::Refunded;
         self.escrows[escrow_id] = entry;
 
-        raw_call!(entry.buyer, entry.amount, bytes::empty());
+        raw_call!(entry.buyer, value: entry.amount);
 
         emit EscrowRefunded {
             escrow_id: escrow_id,
@@ -271,10 +271,10 @@ contract Escrow {
 
         let winner = if award_to_buyer { entry.buyer } else { entry.seller };
 
-        raw_call!(winner, remaining, bytes::empty());
-        raw_call!(entry.arbiter, arbiter_fee, bytes::empty());
+        raw_call!(winner, value: remaining);
+        raw_call!(entry.arbiter, value: arbiter_fee);
         if platform_fee > 0 {
-            raw_call!(self.platform_treasury, platform_fee, bytes::empty());
+            raw_call!(self.platform_treasury, value: platform_fee);
         }
 
         emit DisputeResolved {

--- a/crates/otic/tests/fixtures/programs/finance/insurance.oti
+++ b/crates/otic/tests/fixtures/programs/finance/insurance.oti
@@ -385,7 +385,7 @@ contract Insurance {
         self.claims[claim_id] = claim;
         self.pool_balance = self.pool_balance - claim.amount;
 
-        raw_call!(claim.claimant, claim.amount, bytes::empty());
+        raw_call!(claim.claimant, value: claim.amount);
 
         emit ClaimPaid {
             claim_id: claim_id,

--- a/crates/otic/tests/fixtures/programs/finance/invoice.oti
+++ b/crates/otic/tests/fixtures/programs/finance/invoice.oti
@@ -192,7 +192,7 @@ contract Invoice {
         // Transfer payment
         if inv.token == Address::ZERO {
             require!(msg.value >= amount, PaymentFailed {});
-            raw_call!(inv.vendor, amount, bytes::empty());
+            raw_call!(inv.vendor, value: amount);
         } else {
             let token = IERC20::at(inv.token);
             let success = token.transfer_from(msg.sender, inv.vendor, amount);

--- a/crates/otic/tests/fixtures/programs/finance/payment_splitter.oti
+++ b/crates/otic/tests/fixtures/programs/finance/payment_splitter.oti
@@ -120,7 +120,7 @@ contract PaymentSplitter {
         self.released[payee] = self.released[payee] + payment;
         self.total_released = self.total_released + payment;
 
-        raw_call!(payee, payment, bytes::empty());
+        raw_call!(payee, value: payment);
 
         emit PaymentReleased { to: payee, amount: payment };
 
@@ -141,7 +141,7 @@ contract PaymentSplitter {
             if payment > 0 {
                 self.released[payee] = self.released[payee] + payment;
                 self.total_released = self.total_released + payment;
-                raw_call!(payee, payment, bytes::empty());
+                raw_call!(payee, value: payment);
                 emit PaymentReleased { to: payee, amount: payment };
             }
         }
@@ -188,7 +188,7 @@ contract PaymentSplitter {
         if final_payment > 0 {
             self.released[payee] = self.released[payee] + final_payment;
             self.total_released = self.total_released + final_payment;
-            raw_call!(payee, final_payment, bytes::empty());
+            raw_call!(payee, value: final_payment);
             emit PaymentReleased { to: payee, amount: final_payment };
         }
 

--- a/crates/otic/tests/fixtures/programs/games/chess_wager.oti
+++ b/crates/otic/tests/fixtures/programs/games/chess_wager.oti
@@ -267,7 +267,7 @@ contract ChessWager {
         }
 
         self.matches[match_id] = m;
-        raw_call!(msg.sender, payout, bytes::empty());
+        raw_call!(msg.sender, value: payout);
 
         emit WinningsClaimed { match_id: match_id, player: msg.sender, amount: payout };
     }
@@ -283,7 +283,7 @@ contract ChessWager {
         self.remove_open_challenge(match_id);
 
         // Refund wager directly
-        raw_call!(m.white, m.wager, bytes::empty());
+        raw_call!(m.white, value: m.wager);
     }
 
     fn update_elo(white: Address, black: Address, result: MatchState) {
@@ -344,7 +344,7 @@ contract ChessWager {
         let amount = self.accumulated_fees;
         require!(amount > 0, NoFeesToWithdraw {});
         self.accumulated_fees = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     pub fn set_arbiter(new_arbiter: Address) {

--- a/crates/otic/tests/fixtures/programs/games/coin_flip.oti
+++ b/crates/otic/tests/fixtures/programs/games/coin_flip.oti
@@ -173,7 +173,7 @@ contract CoinFlip {
             self.bankroll = self.bankroll - payout;
             self.total_paid_out = self.total_paid_out + payout;
             self.player_total_won[flip.player] = self.player_total_won[flip.player] + payout;
-            raw_call!(flip.player, payout, bytes::empty());
+            raw_call!(flip.player, value: payout);
         }
 
         self.flips[flip_id] = flip;
@@ -220,7 +220,7 @@ contract CoinFlip {
             self.bankroll = self.bankroll - payout;
             self.total_paid_out = self.total_paid_out + payout;
             self.player_total_won[flip.player] = self.player_total_won[flip.player] + payout;
-            raw_call!(flip.player, payout, bytes::empty());
+            raw_call!(flip.player, value: payout);
         }
 
         self.flips[flip_id] = flip;
@@ -255,7 +255,7 @@ contract CoinFlip {
         require!(self.bankroll - amount >= max_liability, WithdrawalExceedsSafety {});
 
         self.bankroll = self.bankroll - amount;
-        raw_call!(msg.sender, amount, bytes::empty());
+        raw_call!(msg.sender, value: amount);
         emit BankrollWithdrawn { amount: amount };
     }
 

--- a/crates/otic/tests/fixtures/programs/games/lottery.oti
+++ b/crates/otic/tests/fixtures/programs/games/lottery.oti
@@ -126,7 +126,7 @@ contract Lottery {
         // Refund overpayment
         let excess = msg.value - cost;
         if excess > 0 {
-            raw_call!(msg.sender, excess, bytes::empty());
+            raw_call!(msg.sender, value: excess);
         }
 
         emit TicketPurchased {
@@ -160,7 +160,7 @@ contract Lottery {
         self.accumulated_fees = self.accumulated_fees + fee;
 
         // Transfer winnings
-        raw_call!(winner, payout, bytes::empty());
+        raw_call!(winner, value: payout);
 
         // Record results
         self.past_winners[self.round_id] = winner;
@@ -180,7 +180,7 @@ contract Lottery {
         let amount = self.accumulated_fees;
         require!(amount > 0, NoFeesToWithdraw {});
         self.accumulated_fees = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
         emit FeesWithdrawn { to: to, amount: amount };
     }
 

--- a/crates/otic/tests/fixtures/programs/games/nft_battle.oti
+++ b/crates/otic/tests/fixtures/programs/games/nft_battle.oti
@@ -377,7 +377,7 @@ contract NftBattle {
         let payout = self.entry_fee * 2 - (self.entry_fee / PRIZE_FEE_DIVISOR);
         if self.prize_pool >= payout {
             self.prize_pool = self.prize_pool - payout;
-            raw_call!(winner_owner, payout, bytes::empty());
+            raw_call!(winner_owner, value: payout);
         }
 
         emit BattleResolved {

--- a/crates/otic/tests/fixtures/programs/games/prediction_market.oti
+++ b/crates/otic/tests/fixtures/programs/games/prediction_market.oti
@@ -237,7 +237,7 @@ contract PredictionMarket {
         require!(payout > 0, NothingToClaim {});
         pos.claimed = true;
         self.positions[market_id][msg.sender] = pos;
-        raw_call!(msg.sender, payout, bytes::empty());
+        raw_call!(msg.sender, value: payout);
 
         emit WinningsClaimed {
             market_id: market_id,
@@ -251,7 +251,7 @@ contract PredictionMarket {
         let amount = self.protocol_balance;
         require!(amount > 0, NothingToClaim {});
         self.protocol_balance = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     pub fn set_oracle(new_oracle: Address) {

--- a/crates/otic/tests/fixtures/programs/games/raffle.oti
+++ b/crates/otic/tests/fixtures/programs/games/raffle.oti
@@ -240,7 +240,7 @@ contract Raffle {
         // Refund excess
         let excess = msg.value - cost;
         if excess > 0 {
-            raw_call!(msg.sender, excess, bytes::empty());
+            raw_call!(msg.sender, value: excess);
         }
 
         emit TicketsPurchased {
@@ -329,7 +329,7 @@ contract Raffle {
         let total_prizes = self.sum_prizes(raffle_id);
         let creator_share = raffle.total_revenue - fee - total_prizes;
         if creator_share > 0 {
-            raw_call!(raffle.creator, creator_share, bytes::empty());
+            raw_call!(raffle.creator, value: creator_share);
         }
 
         self.raffles[raffle_id] = raffle;
@@ -366,7 +366,7 @@ contract Raffle {
         self.winners[raffle_id] = winner_list;
 
         if total_claimed > 0 {
-            raw_call!(msg.sender, total_claimed, bytes::empty());
+            raw_call!(msg.sender, value: total_claimed);
         }
     }
 
@@ -383,7 +383,7 @@ contract Raffle {
         // Clear buyer's tickets to prevent double claim
         self.buyer_tickets[raffle_id][msg.sender] = Vec::new();
 
-        raw_call!(msg.sender, refund, bytes::empty());
+        raw_call!(msg.sender, value: refund);
 
         emit RefundClaimed {
             raffle_id: raffle_id,
@@ -419,7 +419,7 @@ contract Raffle {
         require!(msg.sender == self.owner, Unauthorized {});
         let amount = self.protocol_balance;
         self.protocol_balance = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     #[view]

--- a/crates/otic/tests/fixtures/programs/games/rock_paper_scissors.oti
+++ b/crates/otic/tests/fixtures/programs/games/rock_paper_scissors.oti
@@ -240,18 +240,18 @@ contract RockPaperScissors {
 
         if is_draw {
             // Return wagers
-            raw_call!(game.player1, game.wager, bytes::empty());
-            raw_call!(game.player2, game.wager, bytes::empty());
+            raw_call!(game.player1, value: game.wager);
+            raw_call!(game.player2, value: game.wager);
             self.player_draws[game.player1] = self.player_draws[game.player1] + 1;
             self.player_draws[game.player2] = self.player_draws[game.player2] + 1;
             game.winner = Address::ZERO;
         } else if p1_wins {
-            raw_call!(game.player1, total_pot, bytes::empty());
+            raw_call!(game.player1, value: total_pot);
             game.winner = game.player1;
             self.player_wins[game.player1] = self.player_wins[game.player1] + 1;
             self.player_losses[game.player2] = self.player_losses[game.player2] + 1;
         } else {
-            raw_call!(game.player2, total_pot, bytes::empty());
+            raw_call!(game.player2, value: total_pot);
             game.winner = game.player2;
             self.player_wins[game.player2] = self.player_wins[game.player2] + 1;
             self.player_losses[game.player1] = self.player_losses[game.player1] + 1;
@@ -280,27 +280,27 @@ contract RockPaperScissors {
         if game.state == GameState::Committed && block.height > game.commit_deadline {
             // Commit phase expired
             if game.player1_committed && !game.player2_committed {
-                raw_call!(game.player1, total_pot, bytes::empty());
+                raw_call!(game.player1, value: total_pot);
                 game.winner = game.player1;
             } else if !game.player1_committed && game.player2_committed {
-                raw_call!(game.player2, total_pot, bytes::empty());
+                raw_call!(game.player2, value: total_pot);
                 game.winner = game.player2;
             } else {
                 // Neither committed, refund both
-                raw_call!(game.player1, game.wager, bytes::empty());
-                raw_call!(game.player2, game.wager, bytes::empty());
+                raw_call!(game.player1, value: game.wager);
+                raw_call!(game.player2, value: game.wager);
             }
         } else if game.state == GameState::Revealed && block.height > game.reveal_deadline {
             // Reveal phase expired
             if game.player1_revealed && !game.player2_revealed {
-                raw_call!(game.player1, total_pot, bytes::empty());
+                raw_call!(game.player1, value: total_pot);
                 game.winner = game.player1;
             } else if !game.player1_revealed && game.player2_revealed {
-                raw_call!(game.player2, total_pot, bytes::empty());
+                raw_call!(game.player2, value: total_pot);
                 game.winner = game.player2;
             } else {
-                raw_call!(game.player1, game.wager, bytes::empty());
-                raw_call!(game.player2, game.wager, bytes::empty());
+                raw_call!(game.player1, value: game.wager);
+                raw_call!(game.player2, value: game.wager);
             }
         } else {
             revert!(DeadlineNotPassed {});
@@ -317,7 +317,7 @@ contract RockPaperScissors {
         require!(game.state == GameState::Waiting, InvalidState { expected: GameState::Waiting, actual: game.state });
         game.state = GameState::Cancelled;
         self.games[game_id] = game;
-        raw_call!(game.player1, game.wager, bytes::empty());
+        raw_call!(game.player1, value: game.wager);
         emit GameCancelled { game_id: game_id };
     }
 

--- a/crates/otic/tests/fixtures/programs/governance/dao.oti
+++ b/crates/otic/tests/fixtures/programs/governance/dao.oti
@@ -254,7 +254,7 @@ contract DAO {
         self.proposals[proposal_id].executed = true;
 
         // Execute the proposal action
-        raw_call!(proposal.target, proposal.value, proposal.calldata);
+        raw_call!(proposal.target, proposal.calldata, value: proposal.value);
 
         emit ProposalExecuted { id: proposal_id };
     }

--- a/crates/otic/tests/fixtures/programs/governance/governor.oti
+++ b/crates/otic/tests/fixtures/programs/governance/governor.oti
@@ -296,7 +296,7 @@ contract Governor {
         let count = self.proposal_action_count[proposal_id];
         for i in 0..count {
             let action = self.proposal_actions[proposal_id][i];
-            raw_call!(action.target, action.value, action.calldata);
+            raw_call!(action.target, action.calldata, value: action.value);
         }
 
         emit ProposalExecuted { id: proposal_id };

--- a/crates/otic/tests/fixtures/programs/governance/multisig.oti
+++ b/crates/otic/tests/fixtures/programs/governance/multisig.oti
@@ -223,7 +223,7 @@ contract Multisig {
         self.transactions[tx_id].executed = true;
         self.nonce = self.nonce + 1;
 
-        raw_call!(txn.to, txn.value, txn.data);
+        raw_call!(txn.to, txn.data, value: txn.value);
 
         emit TransactionExecuted { tx_id: tx_id };
     }

--- a/crates/otic/tests/fixtures/programs/governance/timelock.oti
+++ b/crates/otic/tests/fixtures/programs/governance/timelock.oti
@@ -253,7 +253,7 @@ contract TimelockController {
         }
 
         self.operations[id].executed = true;
-        raw_call!(op.target, op.value, op.calldata);
+        raw_call!(op.target, op.calldata, value: op.value);
 
         emit OperationExecuted { id: id };
     }
@@ -281,7 +281,7 @@ contract TimelockController {
             }
 
             self.operations[op_id].executed = true;
-            raw_call!(op.target, op.value, op.calldata);
+            raw_call!(op.target, op.calldata, value: op.value);
             emit OperationExecuted { id: op_id };
         }
 

--- a/crates/otic/tests/fixtures/programs/governance/treasury.oti
+++ b/crates/otic/tests/fixtures/programs/governance/treasury.oti
@@ -237,7 +237,7 @@ contract Treasury {
 
         // Execute transfer
         if proposal.token == Address::ZERO {
-            raw_call!(proposal.recipient, proposal.amount, bytes(""));
+            raw_call!(proposal.recipient, value: proposal.amount);
         } else {
             let erc20 = IERC20::at(proposal.token);
             erc20.transfer(proposal.recipient, proposal.amount);
@@ -313,7 +313,7 @@ contract Treasury {
             allowance.total_claimed + claim_amount;
 
         if token == Address::ZERO {
-            raw_call!(msg.sender, claim_amount, bytes(""));
+            raw_call!(msg.sender, value: claim_amount);
         } else {
             let erc20 = IERC20::at(token);
             erc20.transfer(msg.sender, claim_amount);
@@ -340,7 +340,7 @@ contract Treasury {
         require!(self.emergency_mode, NotEmergencyMode {});
 
         if token == Address::ZERO {
-            raw_call!(recipient, amount, bytes(""));
+            raw_call!(recipient, value: amount);
         } else {
             let erc20 = IERC20::at(token);
             erc20.transfer(recipient, amount);

--- a/crates/otic/tests/fixtures/programs/health/clinical_trial.oti
+++ b/crates/otic/tests/fixtures/programs/health/clinical_trial.oti
@@ -301,7 +301,7 @@ contract ClinicalTrial {
         self.trials[trial_id].spent += amount;
         self.compensation_paid[trial_id][participant] += amount;
 
-        raw_call!(participant, amount, bytes(""));
+        raw_call!(participant, value: amount);
         emit CompensationPaid { trial_id: trial_id, participant: participant, amount: amount };
     }
 

--- a/crates/otic/tests/fixtures/programs/infra/event_logger.oti
+++ b/crates/otic/tests/fixtures/programs/infra/event_logger.oti
@@ -356,7 +356,7 @@ contract EventLogger {
         require!(msg.sender == self.owner, Unauthorized {});
         let amount = self.revenue;
         self.revenue = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     #[view]

--- a/crates/otic/tests/fixtures/programs/infra/factory.oti
+++ b/crates/otic/tests/fixtures/programs/infra/factory.oti
@@ -214,8 +214,8 @@ contract ContractFactory {
         );
         let deployed_address = raw_call!(
             Address::ZERO,
-            msg.value - self.deploy_fee,
-            constructor_args
+            constructor_args,
+            value: msg.value - self.deploy_fee
         );
 
         // In practice the VM would return the new contract's address.
@@ -319,7 +319,7 @@ contract ContractFactory {
         require!(msg.sender == self.owner, Unauthorized {});
         let amount = self.revenue;
         self.revenue = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     #[view]

--- a/crates/otic/tests/fixtures/programs/infra/name_registry.oti
+++ b/crates/otic/tests/fixtures/programs/infra/name_registry.oti
@@ -151,7 +151,7 @@ contract NameRegistry {
         // Refund excess
         let excess = msg.value - total_cost;
         if excess > 0 {
-            raw_call!(msg.sender, excess, bytes::empty());
+            raw_call!(msg.sender, value: excess);
         }
 
         emit NameRegistered {
@@ -189,7 +189,7 @@ contract NameRegistry {
 
         let excess = msg.value - cost;
         if excess > 0 {
-            raw_call!(msg.sender, excess, bytes::empty());
+            raw_call!(msg.sender, value: excess);
         }
 
         emit NameRenewed { name_hash: name_hash, new_expiry: entry.expires_at };
@@ -292,7 +292,7 @@ contract NameRegistry {
         require!(msg.sender == self.owner, Unauthorized {});
         let amount = self.revenue;
         self.revenue = 0;
-        raw_call!(to, amount, bytes::empty());
+        raw_call!(to, value: amount);
     }
 
     pub fn set_fees(registration_fee: u256, renewal_fee: u256) {

--- a/crates/otic/tests/fixtures/programs/infra/proxy.oti
+++ b/crates/otic/tests/fixtures/programs/infra/proxy.oti
@@ -210,7 +210,7 @@ contract UpgradeableProxy {
             call_data_hash: data_hash,
         };
 
-        let result = raw_call!(self.implementation, 0, call_data);
+        let result = raw_call!(self.implementation, call_data);
         return result;
     }
 
@@ -220,7 +220,7 @@ contract UpgradeableProxy {
         require!(self.initialized, NotInitialized {});
         require!(!self.paused, IsPaused {});
 
-        let result = raw_call!(self.implementation, msg.value, call_data);
+        let result = raw_call!(self.implementation, call_data, value: msg.value);
         return result;
     }
 

--- a/crates/otic/tests/fixtures/programs/legal/will.oti
+++ b/crates/otic/tests/fixtures/programs/legal/will.oti
@@ -297,7 +297,7 @@ contract DigitalWill {
             let beneficiary = self.beneficiaries[will_id][alloc.beneficiary_index];
 
             if alloc.token == Address::ZERO {
-                raw_call!(beneficiary.addr, alloc.amount, bytes(""));
+                raw_call!(beneficiary.addr, value: alloc.amount);
             } else {
                 IERC20::at(alloc.token).transfer(beneficiary.addr, alloc.amount);
             }

--- a/crates/otic/tests/fixtures/programs/nft/nft_auction.oti
+++ b/crates/otic/tests/fixtures/programs/nft/nft_auction.oti
@@ -207,9 +207,9 @@ contract NFTAuction {
             let fee = (auction.highest_bid * self.fee_percent) / 10000;
             let seller_amount = auction.highest_bid - fee;
 
-            raw_call!(auction.seller, seller_amount, bytes(""));
+            raw_call!(auction.seller, value: seller_amount);
             if fee > 0 {
-                raw_call!(self.fee_recipient, fee, bytes(""));
+                raw_call!(self.fee_recipient, value: fee);
             }
 
             // Transfer NFT to winner
@@ -243,7 +243,7 @@ contract NFTAuction {
         require!(amount > 0, NoPendingReturn {});
 
         self.pending_returns[auction_id][msg.sender] = 0;
-        raw_call!(msg.sender, amount, bytes(""));
+        raw_call!(msg.sender, value: amount);
 
         emit BidRefunded { auction_id: auction_id, bidder: msg.sender, amount: amount };
     }

--- a/crates/otic/tests/fixtures/programs/nft/nft_collection.oti
+++ b/crates/otic/tests/fixtures/programs/nft/nft_collection.oti
@@ -196,7 +196,7 @@ contract NFTCollection {
         self.withdrawn = true;
 
         let balance = address(self).balance;
-        raw_call!(self.owner, balance, bytes(""));
+        raw_call!(self.owner, value: balance);
     }
 
     pub fn owner_mint(to: Address, quantity: u256) {

--- a/crates/otic/tests/fixtures/programs/nft/nft_marketplace.oti
+++ b/crates/otic/tests/fixtures/programs/nft/nft_marketplace.oti
@@ -283,7 +283,7 @@ contract NFTMarketplace {
         require!(amount > 0, NothingToWithdraw {});
 
         self.proceeds[msg.sender] = 0;
-        raw_call!(msg.sender, amount, bytes(""));
+        raw_call!(msg.sender, value: amount);
 
         emit ProceedsWithdrawn { user: msg.sender, amount: amount };
     }

--- a/crates/otic/tests/fixtures/programs/nft/nft_rental.oti
+++ b/crates/otic/tests/fixtures/programs/nft/nft_rental.oti
@@ -280,7 +280,7 @@ contract NFTRental {
         // Return collateral + any refund to renter
         let renter_return = rental.collateral + refund;
         if renter_return > 0 {
-            raw_call!(rental.renter, renter_return, bytes(""));
+            raw_call!(rental.renter, value: renter_return);
         }
 
         if refund > 0 {
@@ -315,7 +315,7 @@ contract NFTRental {
         require!(amount > 0, NothingToWithdraw {});
 
         self.earnings[msg.sender] = 0;
-        raw_call!(msg.sender, amount, bytes(""));
+        raw_call!(msg.sender, value: amount);
 
         emit EarningsWithdrawn { user: msg.sender, amount: amount };
     }
@@ -326,7 +326,7 @@ contract NFTRental {
         require!(amount > 0, NothingToWithdraw {});
 
         self.accumulated_fees = 0;
-        raw_call!(self.fee_recipient, amount, bytes(""));
+        raw_call!(self.fee_recipient, value: amount);
     }
 
     #[view]

--- a/crates/otic/tests/fixtures/programs/nft/nft_royalties.oti
+++ b/crates/otic/tests/fixtures/programs/nft/nft_royalties.oti
@@ -210,7 +210,7 @@ contract RoyaltyNFT {
         require!(amount > 0, NoPendingRoyalties {});
 
         self.pending_royalties[msg.sender] = 0;
-        raw_call!(msg.sender, amount, bytes(""));
+        raw_call!(msg.sender, value: amount);
 
         emit RoyaltyWithdrawn { recipient: msg.sender, amount: amount };
     }

--- a/crates/otic/tests/fixtures/programs/realestate/fractional_ownership.oti
+++ b/crates/otic/tests/fixtures/programs/realestate/fractional_ownership.oti
@@ -214,7 +214,7 @@ contract FractionalOwnership {
         self.claimed_dividends[property_id][msg.sender] = total_owed;
         self.dividend_pool[property_id] -= claimable;
 
-        raw_call!(msg.sender, claimable, bytes(""));
+        raw_call!(msg.sender, value: claimable);
         emit DividendClaimed { property_id: property_id, shareholder: msg.sender, amount: claimable };
     }
 
@@ -268,7 +268,7 @@ contract FractionalOwnership {
             self.shareholder_count[property_id] -= 1;
         }
 
-        raw_call!(order.seller, total_cost, bytes(""));
+        raw_call!(order.seller, value: total_cost);
 
         emit SellOrderFilled { property_id: property_id, order_id: order_id, buyer: msg.sender };
     }

--- a/crates/otic/tests/fixtures/programs/realestate/rental_agreement.oti
+++ b/crates/otic/tests/fixtures/programs/realestate/rental_agreement.oti
@@ -237,7 +237,7 @@ contract RentalAgreement {
         }
 
         // Forward rent to landlord
-        raw_call!(self.landlord, msg.value, bytes(""));
+        raw_call!(self.landlord, value: msg.value);
 
         emit RentPaid { lease_id: lease_id, amount: msg.value, for_month: next_month, late: is_late };
     }
@@ -301,7 +301,7 @@ contract RentalAgreement {
         self.deposits[lease_id].deduction_reason_hash = reason_hash;
 
         if return_amount > 0 {
-            raw_call!(lease.tenant, return_amount, bytes(""));
+            raw_call!(lease.tenant, value: return_amount);
         }
 
         emit DepositReturned {

--- a/crates/otic/tests/fixtures/programs/social/content_platform.oti
+++ b/crates/otic/tests/fixtures/programs/social/content_platform.oti
@@ -228,7 +228,7 @@ contract ContentPlatform {
         let earnings = self.creator_earnings[msg.sender];
         require!(earnings > 0, NoEarnings {});
         self.creator_earnings[msg.sender] = 0;
-        raw_call!(msg.sender, earnings, bytes(""));
+        raw_call!(msg.sender, value: earnings);
         emit EarningsWithdrawn { creator: msg.sender, amount: earnings };
     }
 

--- a/crates/otic/tests/fixtures/programs/social/tipping.oti
+++ b/crates/otic/tests/fixtures/programs/social/tipping.oti
@@ -192,7 +192,7 @@ contract TippingPlatform {
         self.check_milestones(creator);
 
         // Transfer to creator
-        raw_call!(creator, net_amount, bytes(""));
+        raw_call!(creator, value: net_amount);
 
         emit TipSent { from: msg.sender, to: creator, amount: net_amount, token: Address::ZERO };
     }
@@ -228,7 +228,7 @@ contract TippingPlatform {
         require!(msg.sender == self.owner, NotOwner {});
         let amount = self.accumulated_fees;
         self.accumulated_fees = 0;
-        raw_call!(self.owner, amount, bytes(""));
+        raw_call!(self.owner, value: amount);
         emit FeesWithdrawn { amount: amount };
     }
 

--- a/crates/otic/tests/fixtures/programs/supply/shipping.oti
+++ b/crates/otic/tests/fixtures/programs/supply/shipping.oti
@@ -276,7 +276,7 @@ contract ShippingContract {
 
         let amount = self.escrow_balances[order_id];
         self.escrow_balances[order_id] = 0;
-        raw_call!(order.carrier, amount, bytes(""));
+        raw_call!(order.carrier, value: amount);
 
         self.carrier_registry[order.carrier].completed_shipments += 1;
         emit EscrowReleased { order_id: order_id, amount: amount };
@@ -307,7 +307,7 @@ contract ShippingContract {
         self.insurance_policies[order_id].claim_amount = payout;
         self.insurance_pool -= payout;
 
-        raw_call!(self.orders[order_id].shipper, payout, bytes(""));
+        raw_call!(self.orders[order_id].shipper, value: payout);
         emit InsuranceClaimed { order_id: order_id, claim_amount: payout };
     }
 

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1403,10 +1403,32 @@ impl Vm {
                 balances: self.ctx.balances.clone(),
             }
         } else {
+            // r8 holds the call value if bit 13 of immediate is set (convention from codegen)
+            let has_value = (d.rs2_or_imm >> 13) & 1 == 1;
+            let cv = if has_value { U256::from(self.cpu.read_gp(8)) } else { U256::ZERO };
+
+            // Transfer value: debit caller, credit callee
+            let mut balances = self.ctx.balances.clone();
+            if cv > U256::ZERO {
+                let caller_addr = self.ctx.self_address;
+                let caller_bal = balances.get(&caller_addr).copied().unwrap_or(U256::ZERO);
+                if caller_bal < cv {
+                    // Insufficient balance — return failed call result
+                    return Ok(CallResult {
+                        success: false,
+                        return_data: Vec::new(),
+                        gas_used: 0,
+                    });
+                }
+                balances.insert(caller_addr, caller_bal - cv);
+                let target_bal = balances.get(&target_addr).copied().unwrap_or(U256::ZERO);
+                balances.insert(target_addr, target_bal + cv);
+            }
+
             ExecutionContext {
                 caller: self.ctx.self_address,
                 self_address: target_addr,
-                call_value: U256::ZERO,
+                call_value: cv,
                 block_number: self.ctx.block_number,
                 timestamp: self.ctx.timestamp,
                 gas_price: self.ctx.gas_price,
@@ -1415,7 +1437,7 @@ impl Vm {
                 tx_hash: self.ctx.tx_hash,
                 block_proposer: self.ctx.block_proposer,
                 block_hashes: self.ctx.block_hashes.clone(),
-                balances: self.ctx.balances.clone(),
+                balances,
             }
         };
 
@@ -1579,10 +1601,24 @@ impl Vm {
         };
         let max_forward = available_gas - (available_gas / 64);
 
+        // Read deploy value from r8 (same convention as CallExt)
+        let cv = U256::from(self.cpu.read_gp(8));
+        let mut balances = self.ctx.balances.clone();
+        if cv > U256::ZERO {
+            let caller_addr = self.ctx.self_address;
+            let caller_bal = balances.get(&caller_addr).copied().unwrap_or(U256::ZERO);
+            if caller_bal < cv {
+                return Err(Trap::MemoryFault); // insufficient balance for deploy value
+            }
+            balances.insert(caller_addr, caller_bal - cv);
+            let target_bal = balances.get(&new_addr).copied().unwrap_or(U256::ZERO);
+            balances.insert(new_addr, target_bal + cv);
+        }
+
         let child_ctx = ExecutionContext {
             caller: self.ctx.self_address,
             self_address: new_addr,
-            call_value: U256::ZERO,
+            call_value: cv,
             block_number: self.ctx.block_number,
             timestamp: self.ctx.timestamp,
             gas_price: self.ctx.gas_price,
@@ -1591,7 +1627,7 @@ impl Vm {
             tx_hash: self.ctx.tx_hash,
             block_proposer: self.ctx.block_proposer,
             block_hashes: self.ctx.block_hashes.clone(),
-            balances: self.ctx.balances.clone(),
+            balances,
         };
 
         // Run constructor if present


### PR DESCRIPTION
## Summary
- `c.method{ value: amount }()` per-call value on typed contract handles
- `raw_call!(target, args, value: amount)` value on raw calls
- `deploy!(Contract, args, value: amount)` deploy with payable constructor
- Balance transfer (debit/credit) in PVM for CallExt and Create
- `at_payable()` removed completely
- All 52 fixture files updated to new syntax
- 1196 tests pass