### PR TITLE
feat: multi-node consensus with VRF selection, block signing, and tx gossip

### DIFF
--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -15,8 +15,19 @@ use sparse_merkle_tree::H256;
 /// Committee size (128 validators per epoch).
 pub const COMMITTEE_SIZE: usize = 128;
 
-/// Quorum threshold (2/3 of committee = 86).
+/// Quorum threshold for production (2/3 of 128 = 86).
 pub const QUORUM_THRESHOLD: usize = 86;
+
+/// Compute quorum threshold for a given committee size: ceil(2/3 * size).
+/// For production (128 members) this returns 86.
+/// For devnet (2-4 members) this returns the correct BFT threshold.
+pub fn quorum_for_committee(committee_size: usize) -> usize {
+    if committee_size == 0 {
+        return 0;
+    }
+    // ceil(2/3 * n) = (2*n + 2) / 3
+    (2 * committee_size + 2) / 3
+}
 
 /// Blocks per epoch (~1000 blocks, ~6.6 minutes at 400ms).
 pub const EPOCH_LENGTH: u64 = 1000;
@@ -43,9 +54,14 @@ impl QuorumCert {
         self.voter_bitmap.count_ones()
     }
 
-    /// Whether this QC has enough votes (>= 86/128).
+    /// Whether this QC has enough votes (>= 86/128) for production committee.
     pub fn has_quorum(&self) -> bool {
         self.vote_count() >= QUORUM_THRESHOLD as u32
+    }
+
+    /// Whether this QC has enough votes for a given committee size.
+    pub fn has_quorum_for(&self, committee_size: usize) -> bool {
+        self.vote_count() >= quorum_for_committee(committee_size) as u32
     }
 
     /// Hash this QC: Poseidon2(slot + block_hash + voter_bitmap).
@@ -322,5 +338,33 @@ mod tests {
         assert_eq!(QUORUM_THRESHOLD, 86);
         assert_eq!(EPOCH_LENGTH, 1000);
         assert_eq!(BLOCK_TIME_MS, 400);
+    }
+
+    // ========== Dynamic quorum ==========
+
+    #[test]
+    fn quorum_for_committee_production() {
+        // 128 members → 86 (matches production constant)
+        assert_eq!(quorum_for_committee(128), 86);
+    }
+
+    #[test]
+    fn quorum_for_committee_small() {
+        assert_eq!(quorum_for_committee(0), 0);
+        assert_eq!(quorum_for_committee(1), 1); // single node: needs 1
+        assert_eq!(quorum_for_committee(2), 2); // 2 nodes: needs 2
+        assert_eq!(quorum_for_committee(3), 2); // 3 nodes: needs 2
+        assert_eq!(quorum_for_committee(4), 3); // 4 nodes: needs 3
+        assert_eq!(quorum_for_committee(5), 4); // 5 nodes: needs 4
+        assert_eq!(quorum_for_committee(10), 7);
+    }
+
+    #[test]
+    fn has_quorum_for_dynamic() {
+        let mut qc = QuorumCert::empty();
+        qc.voter_bitmap = 0b11; // 2 votes
+        assert!(qc.has_quorum_for(2));  // 2/2 = quorum
+        assert!(qc.has_quorum_for(3));  // 2/3 = quorum (threshold=2)
+        assert!(!qc.has_quorum_for(4)); // 2/4, threshold=3
     }
 }

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -8,7 +8,7 @@
 //! Pipelined: certify for slot N overlaps with propose for slot N+1.
 //! Finality: block finalized when referenced by 2 consecutive QCs.
 
-use crate::block::{BlockHeader, QuorumCert, COMMITTEE_SIZE, QUORUM_THRESHOLD};
+use crate::block::{BlockHeader, QuorumCert, COMMITTEE_SIZE, QUORUM_THRESHOLD, quorum_for_committee};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 use pyde_crypto::poseidon2::poseidon2_hash;
@@ -213,7 +213,8 @@ pub fn try_form_qc(
         }
     }
 
-    if valid_count >= QUORUM_THRESHOLD as u32 {
+    let threshold = quorum_for_committee(committee_keys.len());
+    if valid_count >= threshold as u32 {
         Some(QuorumCert {
             slot,
             block_hash,

--- a/crates/crypto/src/vrf.rs
+++ b/crates/crypto/src/vrf.rs
@@ -23,6 +23,14 @@ impl VrfOutput {
     pub fn to_hash(&self) -> Hash256 {
         self.0
     }
+
+    /// Reconstruct a VrfOutput from raw 32-byte hash.
+    pub fn from_hash_bytes(bytes: &[u8]) -> Self {
+        let mut arr = [0u8; 32];
+        let len = bytes.len().min(32);
+        arr[..len].copy_from_slice(&bytes[..len]);
+        Self(Hash256::from(arr))
+    }
 }
 
 impl VrfProof {

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -137,6 +137,80 @@ impl BlockProcessor {
         }
         Ok(())
     }
+
+    /// Extended validation for blocks received from the network.
+    /// Checks: proposer signature, proposer in committee, VRF proof, QC quorum.
+    pub fn validate_network_block(
+        header: &BlockHeader,
+        proposer_signature: &[u8],
+        committee_keys: &[Vec<u8>],
+        epoch_randomness: &[u8; 32],
+    ) -> Result<(), String> {
+        let slot = header.slot;
+
+        // Skip validation for genesis block
+        if slot == 0 {
+            return Ok(());
+        }
+
+        // 1. Proposer must be a committee member
+        let proposer_idx = committee_keys.iter().position(|k| {
+            let addr = pyde_account::address::derive_eoa_address(k);
+            addr == header.proposer
+        });
+        if proposer_idx.is_none() {
+            return Err(format!(
+                "proposer {} is not in the committee",
+                hex::encode(header.proposer)
+            ));
+        }
+        let proposer_idx = proposer_idx.unwrap();
+
+        // 2. Verify proposer signature
+        if proposer_signature.is_empty() {
+            return Err("block missing proposer signature".into());
+        }
+        let pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(&committee_keys[proposer_idx])
+            .ok_or("invalid committee public key")?;
+        let block_hash = header.hash();
+        let sig = pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature)
+            .ok_or("invalid proposer signature format")?;
+        if !pyde_crypto::falcon::falcon_verify(&pk, &block_hash, &sig) {
+            return Err("proposer signature verification failed".into());
+        }
+
+        // 3. Verify VRF proof (encoded as [output:32 || proof:N])
+        if header.vrf_proof.len() >= 33 {
+            let vrf_output_bytes = &header.vrf_proof[..32];
+            let vrf_proof_bytes = &header.vrf_proof[32..];
+
+            let pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(&committee_keys[proposer_idx])
+                .ok_or("invalid committee public key for VRF verification")?;
+            let vrf_output = pyde_crypto::vrf::VrfOutput::from_hash_bytes(vrf_output_bytes);
+            let vrf_proof = pyde_crypto::vrf::VrfProof::from_bytes(vrf_proof_bytes);
+
+            let mut vrf_input = Vec::with_capacity(40);
+            vrf_input.extend_from_slice(epoch_randomness);
+            vrf_input.extend_from_slice(&slot.to_le_bytes());
+
+            if !pyde_crypto::vrf::vrf_verify(&pk, &vrf_input, &vrf_output, &vrf_proof) {
+                return Err("invalid VRF proof in block header".into());
+            }
+        }
+
+        // 4. Previous QC should have quorum (skip for early blocks with empty QC)
+        let committee_size = committee_keys.len();
+        if header.qc_previous.slot > 0 && !header.qc_previous.has_quorum_for(committee_size) {
+            return Err(format!(
+                "previous QC at slot {} has insufficient votes ({}/{})",
+                header.qc_previous.slot,
+                header.qc_previous.vote_count(),
+                pyde_consensus::block::quorum_for_committee(committee_size),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -36,13 +36,13 @@ pub enum Command {
         #[arg(long)]
         log_json: bool,
 
-        /// Prometheus metrics port (0 = disabled).
-        #[arg(long, default_value = "9090")]
-        metrics_port: u16,
+        /// Prometheus metrics port (0 = disabled). If omitted, uses config file or 9090.
+        #[arg(long)]
+        metrics_port: Option<u16>,
 
-        /// JSON-RPC port.
-        #[arg(long, default_value = "8545")]
-        rpc_port: u16,
+        /// JSON-RPC port. If omitted, uses config file or 8545.
+        #[arg(long)]
+        rpc_port: Option<u16>,
 
         /// Enable dev mode (allows unsigned pyde_sendTransaction, auto-mine).
         #[arg(long)]
@@ -58,6 +58,29 @@ pub enum Command {
 
     /// Print default devnet genesis configuration.
     DefaultGenesis,
+
+    /// Generate a multi-validator testnet directory.
+    Testnet {
+        /// Number of validators (2-128).
+        #[arg(long, default_value = "2")]
+        validators: usize,
+
+        /// Output directory for testnet files.
+        #[arg(long, short, default_value = "./testnet")]
+        out: std::path::PathBuf,
+
+        /// Base P2P port (nodes use base, base+1, base+2, ...).
+        #[arg(long, default_value = "30303")]
+        base_port: u16,
+
+        /// Base RPC port (nodes use base, base+1, base+2, ...).
+        #[arg(long, default_value = "8545")]
+        base_rpc_port: u16,
+
+        /// Enable dev mode on all nodes.
+        #[arg(long)]
+        dev: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -152,22 +152,30 @@ pub fn initialize_genesis(
             .ok_or("genesis total supply overflow")?;
     }
 
-    // 2. Write validator stakes as balances (included in total supply)
+    // 2. Write validator stakes as balances (included in total supply).
+    // Skip validators that already appear in allocations (they're already written with auth_keys).
+    let alloc_addresses: std::collections::HashSet<String> = config.allocations.iter()
+        .map(|a| a.address.strip_prefix("0x").unwrap_or(&a.address).to_lowercase())
+        .collect();
+
     for val in &config.validators {
+        let val_addr_normalized = val.address.strip_prefix("0x").unwrap_or(&val.address).to_lowercase();
+        if alloc_addresses.contains(&val_addr_normalized) {
+            debug!(address = val.address, "validator already in allocations, skipping duplicate");
+            continue;
+        }
+
         let address = parse_hex_address(&val.address)?;
         let stake = val.stake_u128()?;
 
-        let mut account = pyde_account::types::Account {
-            address,
-            nonce: 0,
-            balance: stake,
-            code_hash: sparse_merkle_tree::H256::zero(),
-            storage_root: sparse_merkle_tree::H256::zero(),
-            account_type: pyde_account::types::AccountType::EOA,
-            auth_keys: pyde_account::types::AuthKeys::None,
-            gas_tank: 0,
-            key_nonce: 0,
-        };
+        // Parse public key to set auth_keys (validators must be able to sign)
+        let pk_hex = val.public_key.strip_prefix("0x").unwrap_or(&val.public_key);
+        let pk_bytes = hex::decode(pk_hex)
+            .map_err(|e| format!("invalid validator public key hex: {}", e))?;
+        let mut account = pyde_account::types::Account::new_eoa(&pk_bytes);
+        account.address = address;
+        account.balance = stake;
+
         let balance_key = pyde_state::keys::balance_key(&address);
         entries.push((balance_key, account.to_bytes()));
         total_supply = total_supply.checked_add(stake)
@@ -259,6 +267,254 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
     };
 
     (config, accounts)
+}
+
+/// Generate a multi-validator testnet directory.
+/// Creates: shared genesis.toml, per-node validator.key files, per-node config.toml files.
+pub fn generate_testnet(
+    out_dir: &std::path::Path,
+    num_validators: usize,
+    base_port: u16,
+    base_rpc_port: u16,
+    dev_mode: bool,
+) -> Result<(), String> {
+    use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::falcon::falcon_keygen;
+    use std::fs;
+
+    if num_validators < 2 || num_validators > 128 {
+        return Err("validators must be between 2 and 128".into());
+    }
+
+    fs::create_dir_all(out_dir)
+        .map_err(|e| format!("failed to create {}: {}", out_dir.display(), e))?;
+
+    // 10B PYDE per account
+    let funding: u128 = 10_000_000_000 * 1_000_000_000;
+
+    let mut allocations = Vec::new();
+    let mut validators = Vec::new();
+    let mut accounts = Vec::new();
+
+    // Generate FALCON keypairs for each validator
+    for _ in 0..num_validators {
+        let (pk, sk) = falcon_keygen().map_err(|e| format!("keygen failed: {}", e))?;
+        let address = derive_eoa_address(pk.as_bytes());
+
+        allocations.push(GenesisAllocation {
+            address: hex::encode(address),
+            balance: funding.to_string(),
+            public_key: Some(hex::encode(pk.as_bytes())),
+        });
+
+        validators.push(GenesisValidator {
+            address: hex::encode(address),
+            public_key: hex::encode(pk.as_bytes()),
+            stake: funding.to_string(),
+        });
+
+        accounts.push(DevnetAccount {
+            address,
+            public_key: pk,
+            secret_key: sk,
+            balance: funding,
+        });
+    }
+
+    // Also generate 5 non-validator funded accounts for testing
+    for _ in 0..5 {
+        let (pk, sk) = falcon_keygen().map_err(|e| format!("keygen failed: {}", e))?;
+        let address = derive_eoa_address(pk.as_bytes());
+        allocations.push(GenesisAllocation {
+            address: hex::encode(address),
+            balance: funding.to_string(),
+            public_key: Some(hex::encode(pk.as_bytes())),
+        });
+    }
+
+    let genesis_config = GenesisConfig {
+        chain_id: 31337,
+        timestamp: 0,
+        allocations,
+        validators,
+    };
+
+    // Write shared genesis.toml
+    let genesis_path = out_dir.join("genesis.toml");
+    fs::write(&genesis_path, genesis_config.to_toml())
+        .map_err(|e| format!("failed to write genesis.toml: {}", e))?;
+
+    // Determine first node's listen address for bootstrap
+    // (subsequent nodes bootstrap to node-0)
+    let bootstrap_addr = format!(
+        "/ip4/127.0.0.1/udp/{}/quic-v1",
+        base_port,
+    );
+
+    // Write per-node directories
+    for i in 0..num_validators {
+        let node_dir = out_dir.join(format!("node-{}", i));
+        fs::create_dir_all(&node_dir)
+            .map_err(|e| format!("failed to create {}: {}", node_dir.display(), e))?;
+
+        // Write validator.key (format: pk_len(4 LE) || pk || sk)
+        let pk_bytes = accounts[i].public_key.as_bytes();
+        let sk_bytes = accounts[i].secret_key.as_bytes();
+        let mut key_buf = Vec::with_capacity(4 + pk_bytes.len() + sk_bytes.len());
+        key_buf.extend_from_slice(&(pk_bytes.len() as u32).to_le_bytes());
+        key_buf.extend_from_slice(pk_bytes);
+        key_buf.extend_from_slice(sk_bytes);
+        fs::write(node_dir.join("validator.key"), &key_buf)
+            .map_err(|e| format!("failed to write validator.key: {}", e))?;
+
+        // Copy genesis.toml into each node's directory
+        fs::write(node_dir.join("genesis.toml"), genesis_config.to_toml())
+            .map_err(|e| format!("failed to write genesis.toml: {}", e))?;
+
+        // Write config.toml
+        let p2p_port = base_port + i as u16;
+        let rpc_port = base_rpc_port + i as u16;
+        let metrics_port = 9090 + i as u16;
+        let bootstrap = if i == 0 {
+            "[]".to_string()
+        } else {
+            // Note: peer ID is not known until node starts, so we use a placeholder.
+            // The actual connection uses `--bootstrap` CLI flag at runtime.
+            "[]".to_string()
+        };
+
+        let config_toml = format!(
+            r#"[node]
+role = "validator"
+chain_id = 31337
+datadir = "{datadir}"
+dev_mode = {dev}
+
+[network]
+port = {p2p_port}
+max_peers = 50
+max_inbound = 30
+max_outbound = 20
+rate_limit_per_ip = 5
+bootstrap_peers = {bootstrap}
+
+[consensus]
+block_time_ms = 400
+gas_target = 400000000
+gas_ceiling = 1600000000
+
+[storage]
+db_path = "state"
+cache_size = 65536
+
+[rpc]
+enabled = true
+listen = "127.0.0.1"
+port = {rpc_port}
+
+[metrics]
+enabled = true
+port = {metrics_port}
+
+[logging]
+level = "info"
+json = false
+"#,
+            datadir = node_dir.display(),
+            dev = dev_mode,
+            p2p_port = p2p_port,
+            rpc_port = rpc_port,
+            metrics_port = metrics_port,
+            bootstrap = bootstrap,
+        );
+
+        fs::write(node_dir.join("config.toml"), config_toml)
+            .map_err(|e| format!("failed to write config.toml: {}", e))?;
+    }
+
+    // Write a run.sh convenience script
+    let mut run_script = String::from("#!/bin/bash\n# Auto-generated testnet launch script\n\n");
+    run_script.push_str("set -e\n\n");
+    run_script.push_str(&format!("TESTNET_DIR=\"{}\"\n\n", out_dir.display()));
+
+    for i in 0..num_validators {
+        let p2p_port = base_port + i as u16;
+        let rpc_port = base_rpc_port + i as u16;
+        let node_dir = out_dir.join(format!("node-{}", i));
+
+        if i == 0 {
+            run_script.push_str(&format!(
+                "echo \"Starting node-0 (port {p2p_port}, RPC {rpc_port})...\"\n\
+                 pyde run --role validator --config \"{dir}/config.toml\" --datadir \"{dir}\"{dev} &\n\
+                 NODE0_PID=$!\n\
+                 sleep 2\n\n\
+                 # Get node-0's peer ID from its log output\n\
+                 echo \"Node-0 started (PID $NODE0_PID)\"\n\n",
+                p2p_port = p2p_port,
+                rpc_port = rpc_port,
+                dir = node_dir.display(),
+                dev = if dev_mode { " --dev" } else { "" },
+            ));
+        } else {
+            // Subsequent nodes bootstrap to node-0
+            // The actual multiaddr with peer ID must be provided at runtime
+            run_script.push_str(&format!(
+                "echo \"Starting node-{i} (port {p2p_port}, RPC {rpc_port})...\"\n\
+                 echo \"NOTE: Copy the bootstrap multiaddr from node-0's output and pass it:\"\n\
+                 echo \"  pyde run --role validator --config \\\"{dir}/config.toml\\\" --datadir \\\"{dir}\\\" --bootstrap \\\"<node-0-multiaddr>\\\"{dev}\"\n\n",
+                i = i,
+                p2p_port = p2p_port,
+                rpc_port = rpc_port,
+                dir = node_dir.display(),
+                dev = if dev_mode { " --dev" } else { "" },
+            ));
+        }
+    }
+
+    run_script.push_str("wait\n");
+    let script_path = out_dir.join("run.sh");
+    fs::write(&script_path, run_script)
+        .map_err(|e| format!("failed to write run.sh: {}", e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755));
+    }
+
+    // Print summary
+    println!("Testnet generated in {}", out_dir.display());
+    println!();
+    println!("Validators: {}", num_validators);
+    println!("Chain ID:   31337");
+    println!();
+    println!("Validator Addresses:");
+    for (i, acc) in accounts.iter().enumerate() {
+        println!("  ({}) {}", i, acc.address_hex());
+    }
+    println!();
+    println!("Private Keys:");
+    for (i, acc) in accounts.iter().enumerate() {
+        println!("  ({}) {}", i, acc.private_key_hex());
+    }
+    println!();
+    println!("Files:");
+    println!("  genesis.toml        — shared genesis (copy to each node's datadir)");
+    for i in 0..num_validators {
+        println!("  node-{}/config.toml  — node {} config (P2P:{}, RPC:{})",
+            i, i, base_port + i as u16, base_rpc_port + i as u16);
+        println!("  node-{}/validator.key — node {} signing key", i, i);
+    }
+    println!();
+    println!("To start:");
+    println!("  # Terminal 1 (node-0):");
+    println!("  pyde run --role validator --config {}/node-0/config.toml --datadir {}/node-0{}",
+        out_dir.display(), out_dir.display(), if dev_mode { " --dev" } else { "" });
+    println!();
+    println!("  # Terminal 2 (node-1 — copy bootstrap addr from node-0 output):");
+    println!("  pyde run --role validator --config {}/node-1/config.toml --datadir {}/node-1 --bootstrap \"<node-0-multiaddr>\"{}",
+        out_dir.display(), out_dir.display(), if dev_mode { " --dev" } else { "" });
+
+    Ok(())
 }
 
 fn parse_hex_address(hex_str: &str) -> Result<Address, String> {

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -34,6 +34,18 @@ fn main() {
             let (config, _) = genesis::devnet_genesis();
             print!("{}", config.to_toml());
         }
+        Command::Testnet {
+            validators,
+            out,
+            base_port,
+            base_rpc_port,
+            dev,
+        } => {
+            if let Err(e) = genesis::generate_testnet(&out, validators, base_port, base_rpc_port, dev) {
+                eprintln!("error: {}", e);
+                std::process::exit(1);
+            }
+        }
         Command::Run {
             role,
             config: config_path,
@@ -65,10 +77,10 @@ fn main() {
                 datadir.as_deref(),
                 Some(&log_level),
                 log_json,
-                Some(metrics_port),
+                metrics_port,
                 &bootstrap,
             );
-            config.rpc.port = rpc_port;
+            if let Some(rp) = rpc_port { config.rpc.port = rp; }
             if dev { config.node.dev_mode = true; }
 
             // Initialize logging first

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -71,8 +71,8 @@ impl PydeNode {
         let mut state = StateManager::open(datadir, self.config.storage.cache_size)?;
 
         // 3. Apply genesis if state is empty (first start)
-        if state.is_empty() {
-            let genesis_path = datadir.join("genesis.toml");
+        let genesis_path = datadir.join("genesis.toml");
+        let genesis_config = if state.is_empty() {
             let mut genesis_config = if genesis_path.exists() {
                 crate::genesis::GenesisConfig::load(&genesis_path)?
             } else {
@@ -142,12 +142,19 @@ impl PydeNode {
                 slot = genesis_block.slot(),
                 "genesis block created"
             );
+            genesis_config
         } else {
             info!(
                 state_root = hex::encode(state.root()),
                 "state loaded from disk"
             );
-        }
+            // Reload genesis config for committee formation
+            if genesis_path.exists() {
+                crate::genesis::GenesisConfig::load(&genesis_path)?
+            } else {
+                crate::genesis::GenesisConfig::default()
+            }
+        };
 
         // 3. Block store (persistent headers on disk)
         let block_store = BlockStore::open(datadir)?;
@@ -183,7 +190,7 @@ impl PydeNode {
         // 5. Validator engine + identity (only for validator role)
         let mut validator_identity: Option<ValidatorIdentity> = None;
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
-            let identity = early_validator_identity.expect("validator identity loaded earlier");
+            let mut identity = early_validator_identity.expect("validator identity loaded earlier");
             info!(
                 address = hex::encode(identity.address),
                 "validator identity loaded"
@@ -220,15 +227,38 @@ impl PydeNode {
 
             let mut engine = ValidatorEngine::new([0xAA; 32]); // devnet epoch randomness
 
-            // For devnet: this validator is the sole committee member (index 0).
-            // In production, committee is formed from on-chain validator set at epoch boundary.
-            let pk_bytes = identity.public_key.as_bytes().to_vec();
-            engine.set_committee(vec![pk_bytes]);
+            // Build committee from genesis validators (if any).
+            // If genesis has validators, use them all as the committee.
+            // Otherwise fall back to single-validator mode (just self).
+            let mut committee_keys: Vec<Vec<u8>> = Vec::new();
+            let mut my_index: u8 = 0;
+            let my_pk_hex = hex::encode(identity.public_key.as_bytes());
 
-            info!(
-                committee_size = 1,
-                "validator consensus engine initialized (devnet single-validator mode)"
-            );
+            if !genesis_config.validators.is_empty() {
+                for (i, val) in genesis_config.validators.iter().enumerate() {
+                    let pk_bytes = hex::decode(val.public_key.strip_prefix("0x").unwrap_or(&val.public_key))
+                        .map_err(|e| format!("invalid validator public key in genesis: {}", e))?;
+                    if val.public_key == my_pk_hex || val.public_key == format!("0x{}", my_pk_hex) {
+                        my_index = i as u8;
+                    }
+                    committee_keys.push(pk_bytes);
+                }
+                info!(
+                    committee_size = committee_keys.len(),
+                    my_index,
+                    "committee formed from genesis validators"
+                );
+            } else {
+                // Fallback: single-validator devnet mode
+                committee_keys.push(identity.public_key.as_bytes().to_vec());
+                info!(
+                    committee_size = 1,
+                    "validator consensus engine initialized (devnet single-validator mode)"
+                );
+            }
+
+            engine.set_committee(committee_keys);
+            identity.committee_index = my_index;
             validator_identity = Some(identity);
             Some(engine)
         } else {
@@ -283,6 +313,7 @@ impl PydeNode {
         }
 
         // 10. Start RPC server if enabled
+        let (tx_gossip_tx, mut tx_gossip_rx) = tokio::sync::mpsc::channel::<pyde_tx::types::Transaction>(1024);
         if self.config.rpc.enabled {
             let (new_heads_tx, _) = tokio::sync::broadcast::channel(256);
             let (pending_tx_tx, _) = tokio::sync::broadcast::channel(4096);
@@ -298,6 +329,7 @@ impl PydeNode {
                 pending_tx_tx,
                 logs_tx,
                 dev_mode: self.config.node.dev_mode,
+                tx_gossip_tx,
             });
             match rpc::start_rpc_server(
                 &self.config.rpc.listen,
@@ -378,6 +410,22 @@ impl PydeNode {
                             pending.push(tx);
                             debug!(tx_hash = hex::encode(tx_hash), pending = pending.len(), "tx accepted from gossip");
                         }
+                        PostEventAction::StoreReceipts(slot, receipts_list) => {
+                            let mut receipts_w = receipts.write().await;
+                            receipts_w.insert_block_receipts(slot, receipts_list);
+                        }
+                        PostEventAction::BlockProcessed { slot, receipts: receipts_list, tx_hashes } => {
+                            // Store receipts
+                            if !receipts_list.is_empty() {
+                                let mut receipts_w = receipts.write().await;
+                                receipts_w.insert_block_receipts(slot, receipts_list);
+                            }
+                            // Remove processed txs from pending queue (dedup)
+                            if !tx_hashes.is_empty() {
+                                let mut pending_w = pending_txs.write().await;
+                                pending_w.retain(|tx| !tx_hashes.contains(&tx.hash()));
+                            }
+                        }
                     }
                 }
                 _ = slot_interval.tick() => {
@@ -427,22 +475,28 @@ impl PydeNode {
                                     // Compute tx root
                                     let tx_root = pyde_consensus::block::compute_tx_root(&txs);
 
+                                    // Encode VRF data as [output:32 || proof:N] so verifiers
+                                    // can check both the score and the proof validity.
+                                    let mut vrf_data = Vec::with_capacity(32 + candidate.vrf_proof.as_bytes().len());
+                                    vrf_data.extend_from_slice(candidate.vrf_output.as_bytes());
+                                    vrf_data.extend_from_slice(candidate.vrf_proof.as_bytes());
+
                                     let block = engine.build_proposal(
                                         identity,
                                         parent_hash,
                                         parent_hash, // pre-state root (post-state computed after execution)
                                         tx_root,
-                                        candidate.vrf_proof.as_bytes().to_vec(),
+                                        vrf_data,
                                         txs,
                                         exec_schedule,
                                     );
 
-                                    // Process our own block locally
-                                    // IMPORTANT: receipts MUST be stored while state write lock is held.
-                                    // This ensures atomicity: when a client sees a receipt, the state
-                                    // changes are guaranteed to be committed. Storing receipts after
-                                    // releasing the state lock creates a race where the client sees
-                                    // the receipt but reads stale state.
+                                    // Process our own block immediately.
+                                    // VRF selection ensures only one proposal wins votes, so
+                                    // speculative execution is safe: our block either wins (QC forms)
+                                    // or nobody's block wins (timeout). In the rare case another
+                                    // proposer's block wins for the same slot, our state diverges
+                                    // but the gossip block handler rejects duplicate slots.
                                     {
                                         let mut chain_w = chain.write().await;
                                         let mut state_w = state.write().await;
@@ -451,14 +505,10 @@ impl PydeNode {
                                                 let _ = block_store.put_header(&block.header);
                                                 let _ = block_store.put_head(current_slot);
                                                 chain_sync.on_block_processed(current_slot);
-                                                // Store receipts INSIDE the state write lock
                                                 let mut receipts_w = receipts.write().await;
                                                 receipts_w.insert_block_receipts(current_slot, receipts_list.clone());
                                                 info!(
-                                                    slot = current_slot,
-                                                    txs = tc,
-                                                    gas,
-                                                    mempool_pending = tx_count,
+                                                    slot = current_slot, txs = tc, gas,
                                                     "proposed and processed block"
                                                 );
                                             }
@@ -476,7 +526,7 @@ impl PydeNode {
                                         debug!(slot = current_slot, error = %e, "no gossipsub subscribers for block");
                                     }
 
-                                    // Also broadcast proposal as consensus message
+                                    // Broadcast proposal as consensus message
                                     let proposal = pyde_consensus::hotstuff::ConsensusMessage::Proposal {
                                         header: block.header.clone(),
                                         proposer_signature: block.proposer_signature.clone(),
@@ -484,31 +534,87 @@ impl PydeNode {
                                     let proposal_bytes = wire::encode_consensus_message(&proposal);
                                     let cons_topic = pyde_net::node::topics::consensus();
                                     let _ = swarm.behaviour_mut().gossipsub.publish(cons_topic, proposal_bytes);
+
+                                    // Buffer our own proposal for VRF selection.
+                                    // Voting happens after the proposal collection window.
+                                    engine.buffer_proposal(&block.header, &block.proposer_signature);
                                 } // end if mempool_size > 0
                                 }
                             }
 
-                            // Check for timeout (no proposal received within 200ms)
-                            if engine.is_timed_out() {
-                                if let Some(identity) = validator_identity.as_ref() {
-                                    if let Some(vc_msg) = engine.on_timeout(identity) {
-                                        let vc_bytes = wire::encode_consensus_message(
-                                            &pyde_consensus::hotstuff::ConsensusMessage::Timeout {
-                                                slot: current_slot,
-                                                voter_index: identity.committee_index,
-                                                voter_address: identity.address,
-                                                highest_qc: engine.consensus.highest_qc.clone(),
-                                                signature: vec![], // signed inside on_timeout
-                                            }
-                                        );
-                                        let topic = pyde_net::node::topics::consensus();
-                                        let _ = swarm.behaviour_mut().gossipsub.publish(topic, vc_bytes);
+                            debug!(slot = current_slot, "slot tick (new)");
+                        }
+                    }
+
+                    // --- Per-tick consensus actions (run every 100ms, not just on new slots) ---
+                    if let Some(engine) = validator_engine.as_mut() {
+                        let current_slot = slot_clock.current_slot();
+                        let ms_in_slot = slot_clock.ms_into_slot();
+
+                        // Proposal selection phase: 100ms into the slot, select the
+                        // best proposal (lowest VRF score) and vote for it.
+                        if ms_in_slot >= 100 {
+                            if let Some(identity) = validator_identity.as_ref() {
+                                if let Some(vote) = engine.select_and_vote(identity) {
+                                    // Add own vote to collection
+                                    let qc_formed = if let Some(qc) = engine.on_vote(vote.clone()) {
+                                        info!(slot = current_slot, votes = qc.vote_count(), "QC formed after VRF selection");
+                                        true
+                                    } else {
+                                        false
+                                    };
+                                    // Broadcast vote
+                                    let vote_bytes = wire::encode_consensus_message(&vote);
+                                    let topic = pyde_net::node::topics::consensus();
+                                    let _ = swarm.behaviour_mut().gossipsub.publish(topic, vote_bytes);
+
+                                    // If QC formed: broadcast hard finality vote
+                                    if qc_formed {
+                                        let state_root = chain.read().await.state_root;
+                                        if let Some(fv) = engine.create_finality_vote(
+                                            current_slot,
+                                            engine.consensus.highest_qc.block_hash,
+                                            state_root,
+                                            identity,
+                                        ) {
+                                            engine.on_finality_vote(fv.clone());
+                                            let fv_bytes = wire::encode_finality_vote(&fv);
+                                            let topic = pyde_net::node::topics::consensus();
+                                            let _ = swarm.behaviour_mut().gossipsub.publish(topic, fv_bytes);
+                                        }
                                     }
                                 }
                             }
-
-                            debug!(slot = current_slot, "slot tick");
                         }
+
+                        // Check for timeout (no proposal received within 200ms)
+                        if engine.is_timed_out() {
+                            if let Some(identity) = validator_identity.as_ref() {
+                                if let Some(vc_msg) = engine.on_timeout(identity) {
+                                    let vc_bytes = wire::encode_consensus_message(
+                                        &pyde_consensus::hotstuff::ConsensusMessage::Timeout {
+                                            slot: current_slot,
+                                            voter_index: identity.committee_index,
+                                            voter_address: identity.address,
+                                            highest_qc: engine.consensus.highest_qc.clone(),
+                                            signature: vec![],
+                                        }
+                                    );
+                                    let topic = pyde_net::node::topics::consensus();
+                                    let _ = swarm.behaviour_mut().gossipsub.publish(topic, vc_bytes);
+                                }
+                            }
+                        }
+                    }
+                }
+                Some(tx) = tx_gossip_rx.recv() => {
+                    // Gossip transaction from RPC to P2P network
+                    let tx_bytes = wire::encode_transaction(&tx);
+                    let topic = pyde_net::node::topics::transactions();
+                    if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, tx_bytes) {
+                        debug!(error = %e, "failed to gossip tx (no subscribers)");
+                    } else {
+                        debug!(tx_hash = hex::encode(tx.hash()), "gossiped tx to network");
                     }
                 }
                 _ = sync_interval.tick() => {
@@ -565,6 +671,12 @@ enum PostEventAction {
     ContinueSync,
     BroadcastConsensus(Vec<u8>),
     AcceptTransaction(pyde_tx::types::Transaction),
+    StoreReceipts(u64, Vec<pyde_tx::execution::Receipt>),
+    BlockProcessed {
+        slot: u64,
+        receipts: Vec<pyde_tx::execution::Receipt>,
+        tx_hashes: Vec<[u8; 32]>,
+    },
 }
 
 /// Handle a libp2p swarm event. Returns an action that may need swarm access.
@@ -607,13 +719,36 @@ fn handle_swarm_event(
                     match wire::decode_block(&message.data) {
                         Ok(block) => {
                             let slot = block.header.slot;
+
+                            // Validate block against committee (signature, VRF, proposer, QC)
+                            if let Some(ref engine) = validator_engine {
+                                if let Err(e) = BlockProcessor::validate_network_block(
+                                    &block.header,
+                                    &block.proposer_signature,
+                                    &engine.committee_keys,
+                                    &engine.epoch_randomness,
+                                ) {
+                                    warn!(slot, error = %e, "block validation failed");
+                                    return PostEventAction::None;
+                                }
+                            }
+
                             match BlockProcessor::process_full_block(chain, state, &block) {
-                                Ok((tx_count, gas_used, _receipts)) => {
+                                Ok((tx_count, gas_used, receipts_list)) => {
                                     chain_sync.on_block_processed(slot);
                                     // Persist full block (header + body) to disk
                                     let _ = block_store.put_block(&block.header, &message.data);
                                     let _ = block_store.put_head(slot);
                                     info!(slot, tx_count, gas_used, "block received and processed");
+                                    // Collect tx hashes to deduplicate from pending queue
+                                    let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
+                                        .map(|tx| tx.hash()).collect();
+                                    // Store receipts + deduplicate txs
+                                    return PostEventAction::BlockProcessed {
+                                        slot,
+                                        receipts: receipts_list,
+                                        tx_hashes,
+                                    };
                                 }
                                 Err(e) => {
                                     debug!(slot, error = %e, "block rejected");
@@ -627,20 +762,30 @@ fn handle_swarm_event(
                 }
                 Some(Channel::Consensus) => {
                     if let Some(engine) = validator_engine.as_mut() {
+                        // Check if it's a finality vote (different wire tag)
+                        if !message.data.is_empty() && message.data[0] == wire::tag::CONSENSUS_FINALITY_VOTE {
+                            match wire::decode_finality_vote(&message.data) {
+                                Ok(fv) => {
+                                    debug!(slot = fv.slot, voter = fv.voter_index, "received finality vote");
+                                    engine.on_finality_vote(fv);
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode finality vote");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
                         match wire::decode_consensus_message(&message.data) {
                             Ok(msg) => {
                                 use pyde_consensus::hotstuff::ConsensusMessage;
                                 match msg {
-                                    ConsensusMessage::Proposal { ref header, .. } => {
+                                    ConsensusMessage::Proposal { ref header, ref proposer_signature } => {
                                         info!(slot = header.slot, "received proposal");
-                                        // Vote on the proposal if we have an identity
-                                        if let Some(identity) = validator_identity.as_ref() {
-                                            if let Some(vote) = engine.on_proposal(header, identity) {
-                                                // Broadcast vote via gossipsub
-                                                let vote_bytes = wire::encode_consensus_message(&vote);
-                                                return PostEventAction::BroadcastConsensus(vote_bytes);
-                                            }
-                                        }
+                                        // Buffer the proposal for VRF-based selection.
+                                        // Voting happens after the proposal collection window
+                                        // via select_and_vote (triggered by slot timer).
+                                        engine.buffer_proposal(header, proposer_signature);
                                     }
                                     ConsensusMessage::Vote { slot, voter_index, .. } => {
                                         debug!(slot, voter_index, "received vote");
@@ -648,11 +793,30 @@ fn handle_swarm_event(
                                             info!(slot, votes = qc.vote_count(), "QC formed");
                                         }
                                     }
-                                    ConsensusMessage::Timeout { slot, .. } => {
-                                        debug!(slot, "received timeout");
+                                    ConsensusMessage::Timeout {
+                                        slot, voter_index, voter_address, highest_qc, signature
+                                    } => {
+                                        debug!(slot, voter_index, "received timeout");
+                                        // Convert to ViewChangeMessage and process
+                                        let vc_msg = pyde_consensus::view_change::ViewChangeMessage {
+                                            slot,
+                                            highest_qc,
+                                            voter_index,
+                                            voter_address,
+                                            signature,
+                                        };
+                                        if engine.on_view_change(vc_msg) {
+                                            info!(slot, "view change QC formed — fallback proposer can proceed");
+                                        }
                                     }
-                                    ConsensusMessage::NewView { slot, .. } => {
+                                    ConsensusMessage::NewView { slot, highest_qc, voter_address, signature } => {
                                         debug!(slot, "received new view");
+                                        // NewView carries the highest QC from a validator after view change.
+                                        // Update our highest QC if theirs is higher.
+                                        if highest_qc.slot > engine.consensus.highest_qc.slot {
+                                            engine.consensus.highest_qc = highest_qc;
+                                            debug!(slot, "updated highest QC from NewView");
+                                        }
                                     }
                                 }
                             }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -36,6 +36,8 @@ pub struct RpcState {
     pub logs_tx: tokio::sync::broadcast::Sender<serde_json::Value>,
     /// Dev mode: allows unsigned pyde_sendTransaction.
     pub dev_mode: bool,
+    /// Channel to gossip submitted transactions to the P2P network.
+    pub tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_tx::types::Transaction>,
 }
 
 /// Define the Pyde JSON-RPC API.
@@ -323,11 +325,14 @@ impl PydeApiServer for RpcServer {
         // Compute tx hash (must match tx.hash() used in receipt generation)
         let tx_hash = tx.hash();
 
-        // Add to pending tx queue
+        // Add to pending tx queue and gossip to network
         let mut pending = self.state.pending_txs.write().await;
-        pending.push(tx);
+        pending.push(tx.clone());
         let queue_size = pending.len();
         drop(pending);
+
+        // Gossip to P2P network so all nodes can include it
+        let _ = self.state.tx_gossip_tx.send(tx).await;
 
         let tx_hash_hex = format!("0x{}", hex::encode(tx_hash));
         info!(
@@ -357,8 +362,11 @@ impl PydeApiServer for RpcServer {
         let tx_hash = tx.hash();
 
         let mut pending = self.state.pending_txs.write().await;
-        pending.push(tx);
+        pending.push(tx.clone());
         drop(pending);
+
+        // Gossip to P2P network
+        let _ = self.state.tx_gossip_tx.send(tx).await;
 
         Ok(format!("0x{}", hex::encode(tx_hash)))
     }

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -71,6 +71,12 @@ impl SlotClock {
     pub fn slot_duration(&self) -> Duration {
         self.slot_duration
     }
+
+    /// Milliseconds elapsed within the current slot (0..400).
+    pub fn ms_into_slot(&self) -> u64 {
+        let elapsed_ms = self.genesis_instant.elapsed().as_millis() as u64;
+        elapsed_ms % BLOCK_TIME_MS
+    }
 }
 
 fn current_time_ms() -> u64 {

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -1,13 +1,14 @@
 use pyde_account::address::Address;
 use pyde_consensus::block::{
     Block, BlockBody, BlockHeader, QuorumCert, EPOCH_LENGTH,
-    QUORUM_THRESHOLD,
 };
 use pyde_consensus::finality::{FinalityTracker, FinalityVote, create_finality_vote, try_form_hard_finality};
 use pyde_consensus::hotstuff::{
     ConsensusMessage, ConsensusState, create_vote, try_form_qc, verify_vote,
 };
 use pyde_consensus::proposer::{compute_candidacy, ProposerCandidate};
+use pyde_crypto::vrf::VrfProof;
+use pyde_consensus::block::quorum_for_committee;
 use pyde_consensus::validator::VALIDATOR_STAKE;
 use pyde_consensus::view_change::{
     TimeoutTracker, ViewChangeMessage, create_view_change, try_form_view_change_qc,
@@ -49,6 +50,13 @@ struct SlotVotes {
     votes: Vec<ConsensusMessage>,
 }
 
+/// A buffered proposal with verified VRF score.
+struct BufferedProposal {
+    header: BlockHeader,
+    proposer_signature: Vec<u8>,
+    vrf_score: u64,
+}
+
 /// The validator consensus engine.
 /// Manages the HotStuff protocol state, VRF proposer selection,
 /// voting, QC formation, and finality tracking.
@@ -69,6 +77,10 @@ pub struct ValidatorEngine {
     view_changes: HashMap<u64, Vec<ViewChangeMessage>>,
     /// Finality votes collected per slot.
     finality_votes: HashMap<u64, Vec<FinalityVote>>,
+    /// Buffered proposals per slot (collected during proposal phase, voted after selection).
+    buffered_proposals: HashMap<u64, Vec<BufferedProposal>>,
+    /// Whether we've already voted for a given slot (after proposal selection).
+    voted_slots: std::collections::HashSet<u64>,
 }
 
 impl ValidatorEngine {
@@ -84,6 +96,8 @@ impl ValidatorEngine {
             votes: HashMap::new(),
             view_changes: HashMap::new(),
             finality_votes: HashMap::new(),
+            buffered_proposals: HashMap::new(),
+            voted_slots: std::collections::HashSet::new(),
         }
     }
 
@@ -93,7 +107,9 @@ impl ValidatorEngine {
         self.committee_keys = keys;
     }
 
-    /// Check if this validator is the proposer for the current slot.
+    /// Compute VRF candidacy for the current slot.
+    /// All validators compute their candidacy and propose. The best proposal
+    /// (lowest VRF score) is selected during the proposal phase via `select_and_vote`.
     pub fn check_proposer(&self, identity: &ValidatorIdentity) -> Option<ProposerCandidate> {
         let slot = self.consensus.current_slot;
         match compute_candidacy(
@@ -112,6 +128,144 @@ impl ValidatorEngine {
                 None
             }
         }
+    }
+
+    /// Buffer a received proposal. Verifies the VRF proof against the proposer's
+    /// committee key. Invalid proofs are rejected.
+    ///
+    /// The header.vrf_proof field is encoded as [vrf_output:32 || vrf_proof:N].
+    pub fn buffer_proposal(
+        &mut self,
+        header: &BlockHeader,
+        proposer_signature: &[u8],
+    ) -> bool {
+        let slot = header.slot;
+
+        // Don't buffer if we've already voted for this slot
+        if self.voted_slots.contains(&slot) {
+            debug!(slot, "ignoring late proposal (already voted)");
+            return false;
+        }
+
+        // VRF data must be at least 32 bytes (output) + some proof bytes
+        if header.vrf_proof.len() < 33 {
+            warn!(slot, "proposal has missing or truncated VRF data");
+            return false;
+        }
+
+        // Split [output:32 || proof:N]
+        let vrf_output_bytes = &header.vrf_proof[..32];
+        let vrf_proof_bytes = &header.vrf_proof[32..];
+
+        // Find proposer's committee index by matching address
+        let proposer_idx = self.committee_keys.iter().position(|k| {
+            let addr = pyde_account::address::derive_eoa_address(k);
+            addr == header.proposer
+        });
+        let proposer_idx = match proposer_idx {
+            Some(idx) => idx,
+            None => {
+                warn!(slot, proposer = hex::encode(header.proposer), "proposal from non-committee member");
+                return false;
+            }
+        };
+
+        // Reconstruct proposer's public key
+        let pk = match pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[proposer_idx]) {
+            Some(pk) => pk,
+            None => { warn!(slot, "invalid committee public key"); return false; }
+        };
+
+        // Verify proposer signature on block header
+        if !proposer_signature.is_empty() {
+            let block_hash = header.hash();
+            let sig = match pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature) {
+                Some(s) => s,
+                None => { warn!(slot, "invalid proposer signature format"); return false; }
+            };
+            if !pyde_crypto::falcon::falcon_verify(&pk, &block_hash, &sig) {
+                warn!(slot, "proposer signature verification failed");
+                return false;
+            }
+        } else {
+            warn!(slot, "proposal missing proposer signature");
+            return false;
+        }
+        let vrf_output = pyde_crypto::vrf::VrfOutput::from_hash_bytes(vrf_output_bytes);
+        let vrf_proof = VrfProof::from_bytes(vrf_proof_bytes);
+
+        // Build VRF input: epoch_randomness || slot
+        let mut vrf_input = Vec::with_capacity(40);
+        vrf_input.extend_from_slice(&self.epoch_randomness);
+        vrf_input.extend_from_slice(&slot.to_le_bytes());
+
+        // Verify VRF proof
+        if !pyde_crypto::vrf::vrf_verify(&pk, &vrf_input, &vrf_output, &vrf_proof) {
+            warn!(slot, "invalid VRF proof from proposer");
+            return false;
+        }
+
+        // Score = first 8 bytes of VRF output (LE u64)
+        let vrf_score = {
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&vrf_output_bytes[..8]);
+            u64::from_le_bytes(buf)
+        };
+
+        // Mark proposal received for timeout tracker
+        if slot == self.timeout.slot {
+            self.timeout.receive_proposal();
+        }
+
+        let entry = self.buffered_proposals.entry(slot).or_default();
+        entry.push(BufferedProposal {
+            header: header.clone(),
+            proposer_signature: proposer_signature.to_vec(),
+            vrf_score,
+        });
+
+        debug!(slot, vrf_score, proposals = entry.len(), "proposal buffered");
+        true
+    }
+
+    /// Select the best proposal (lowest VRF score) and vote for it.
+    /// Called after the proposal collection window (100ms into the slot).
+    /// Returns the vote to broadcast, or None if no proposals were buffered.
+    pub fn select_and_vote(
+        &mut self,
+        identity: &ValidatorIdentity,
+    ) -> Option<ConsensusMessage> {
+        let slot = self.consensus.current_slot;
+
+        // Don't double-vote
+        if self.voted_slots.contains(&slot) {
+            return None;
+        }
+
+        let proposals = self.buffered_proposals.get(&slot)?;
+        if proposals.is_empty() {
+            return None;
+        }
+
+        // Pick the proposal with the lowest VRF score (clone to release borrow)
+        let best = proposals.iter().min_by_key(|p| p.vrf_score)?;
+        let best_header = best.header.clone();
+        let best_score = best.vrf_score;
+        let best_proposer = best.header.proposer;
+
+        info!(
+            slot,
+            vrf_score = best_score,
+            proposer = hex::encode(best_proposer),
+            "selected best proposal"
+        );
+
+        // Vote for the best proposal
+        let vote = self.on_proposal(&best_header, identity);
+        if vote.is_some() {
+            self.voted_slots.insert(slot);
+        }
+        vote
     }
 
     /// Build a block proposal for the current slot.
@@ -141,13 +295,26 @@ impl ValidatorEngine {
             timestamp: current_time_ms(),
         };
 
+        // Sign the block header hash with the proposer's FALCON key
+        let block_hash = header.hash();
+        let proposer_signature = match pyde_crypto::falcon::falcon_sign(
+            &identity.secret_key,
+            &block_hash,
+        ) {
+            Ok(sig) => sig.to_vec(),
+            Err(_) => {
+                warn!(slot, "failed to sign block header");
+                vec![]
+            }
+        };
+
         Block {
             header,
             body: BlockBody {
                 transactions,
                 execution_schedule,
             },
-            proposer_signature: vec![], // Signed when broadcasting
+            proposer_signature,
         }
     }
 
@@ -217,8 +384,9 @@ impl ValidatorEngine {
         });
         entry.votes.push(vote);
 
-        // Try to form QC
-        if entry.votes.len() >= QUORUM_THRESHOLD {
+        // Try to form QC (dynamic quorum based on actual committee size)
+        let threshold = quorum_for_committee(self.committee_keys.len());
+        if entry.votes.len() >= threshold {
             let qc = try_form_qc(slot, block_hash, &entry.votes, &self.committee_keys);
             if let Some(ref qc) = qc {
                 info!(slot, votes = qc.vote_count(), "QC formed");
@@ -283,8 +451,9 @@ impl ValidatorEngine {
         let entry = self.finality_votes.entry(slot).or_default();
         entry.push(vote);
 
-        // Try to form hard finality cert
-        if entry.len() >= QUORUM_THRESHOLD {
+        // Try to form hard finality cert (dynamic quorum)
+        let threshold = quorum_for_committee(self.committee_keys.len());
+        if entry.len() >= threshold {
             if let Some(cert) = try_form_hard_finality(
                 slot,
                 block_hash,
@@ -311,6 +480,8 @@ impl ValidatorEngine {
             self.votes.retain(|s, _| *s >= prune_before);
             self.view_changes.retain(|s, _| *s >= prune_before);
             self.finality_votes.retain(|s, _| *s >= prune_before);
+            self.buffered_proposals.retain(|s, _| *s >= prune_before);
+            self.voted_slots.retain(|s| *s >= prune_before);
         }
 
         debug!(slot = new_slot, "advanced to next slot");
@@ -483,12 +654,14 @@ mod tests {
     }
 
     #[test]
-    fn qc_forms_at_quorum() {
-        // Use small committee for test speed (3 validators, threshold logic uses QUORUM_THRESHOLD)
-        // Since QUORUM_THRESHOLD is 86, we can't reach it with 3 validators.
-        // Instead, verify votes accumulate correctly.
-        let (mut engine, identities) = make_engine_with_committee(3);
-        engine.advance_slot();
+    fn qc_forms_with_dynamic_quorum() {
+        // 3-member committee: quorum_for_committee(3) = 2
+        // Simulate multi-node: each validator has its own engine for voting,
+        // but votes are collected in one engine for QC formation.
+        let (_, identities) = make_engine_with_committee(3);
+        let committee_keys: Vec<Vec<u8>> = identities.iter()
+            .map(|id| id.public_key.as_bytes().to_vec())
+            .collect();
 
         let header = BlockHeader {
             slot: 1,
@@ -502,17 +675,78 @@ mod tests {
             timestamp: 0,
         };
 
-        // Each validator votes
+        // Each validator creates their vote using their own engine
+        let mut votes = Vec::new();
         for id in &identities {
-            if let Some(vote) = engine.on_proposal(&header, id) {
-                engine.on_vote(vote);
+            let mut voter_engine = ValidatorEngine::new([0xAA; 32]);
+            voter_engine.set_committee(committee_keys.clone());
+            voter_engine.advance_slot();
+            if let Some(vote) = voter_engine.on_proposal(&header, id) {
+                votes.push(vote);
+            }
+        }
+        assert_eq!(votes.len(), 3);
+
+        // Collect votes in a single engine (simulates the proposer node)
+        let mut collector = ValidatorEngine::new([0xAA; 32]);
+        collector.set_committee(committee_keys);
+        collector.advance_slot();
+
+        let mut qc_formed = false;
+        for vote in votes {
+            if let Some(qc) = collector.on_vote(vote) {
+                qc_formed = true;
+                assert!(qc.vote_count() >= 2);
             }
         }
 
-        // 3 votes collected (not enough for QC with QUORUM_THRESHOLD=86)
-        let slot_votes = engine.votes.get(&1);
-        assert!(slot_votes.is_some());
-        assert!(slot_votes.unwrap().votes.len() <= 3);
+        assert!(qc_formed, "QC should form with 3 votes in 3-member committee (quorum=2)");
+    }
+
+    #[test]
+    fn two_node_qc_requires_both_votes() {
+        // 2-member committee: quorum_for_committee(2) = 2
+        let (_, identities) = make_engine_with_committee(2);
+        let committee_keys: Vec<Vec<u8>> = identities.iter()
+            .map(|id| id.public_key.as_bytes().to_vec())
+            .collect();
+
+        let header = BlockHeader {
+            slot: 1,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: identities[0].address,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0u8; 32],
+            state_root: [0u8; 32],
+            timestamp: 0,
+        };
+
+        // Each validator votes using their own engine
+        let mut votes = Vec::new();
+        for id in &identities {
+            let mut voter_engine = ValidatorEngine::new([0xAA; 32]);
+            voter_engine.set_committee(committee_keys.clone());
+            voter_engine.advance_slot();
+            if let Some(vote) = voter_engine.on_proposal(&header, id) {
+                votes.push(vote);
+            }
+        }
+        assert_eq!(votes.len(), 2);
+
+        // Collector engine
+        let mut collector = ValidatorEngine::new([0xAA; 32]);
+        collector.set_committee(committee_keys);
+        collector.advance_slot();
+
+        // First vote — not enough
+        assert!(collector.on_vote(votes[0].clone()).is_none(), "1/2 votes should not form QC");
+
+        // Second vote — QC forms
+        let qc = collector.on_vote(votes[1].clone());
+        assert!(qc.is_some(), "2/2 votes should form QC");
+        assert_eq!(qc.unwrap().vote_count(), 2);
     }
 
     #[test]

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -20,6 +20,7 @@ pub mod tag {
     pub const CONSENSUS_VOTE: u8 = 0x11;
     pub const CONSENSUS_TIMEOUT: u8 = 0x12;
     pub const CONSENSUS_NEW_VIEW: u8 = 0x13;
+    pub const CONSENSUS_FINALITY_VOTE: u8 = 0x14;
     pub const DECRYPTION_SHARES: u8 = 0x20;
 }
 
@@ -34,6 +35,40 @@ pub struct DecryptionShareMsg {
     /// One share per encrypted tx in the block.
     /// Each share is the raw bytes of the DecryptionShare.
     pub shares: Vec<Vec<u8>>,
+}
+
+pub fn encode_finality_vote(vote: &pyde_consensus::finality::FinalityVote) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(tag::CONSENSUS_FINALITY_VOTE);
+    enc.u64(vote.slot);
+    enc.bytes32(&vote.block_hash);
+    enc.bytes32(&vote.state_root);
+    enc.u8(vote.voter_index);
+    enc.bytes32(&vote.voter_address);
+    enc.var_bytes(&vote.signature);
+    enc.finish()
+}
+
+pub fn decode_finality_vote(data: &[u8]) -> Result<pyde_consensus::finality::FinalityVote, &'static str> {
+    let mut dec = Decoder::new(data);
+    let tag_byte = dec.u8()?;
+    if tag_byte != tag::CONSENSUS_FINALITY_VOTE {
+        return Err("not a finality vote");
+    }
+    let slot = dec.u64()?;
+    let block_hash = dec.bytes32()?;
+    let state_root = dec.bytes32()?;
+    let voter_index = dec.u8()?;
+    let voter_address = dec.bytes32()?;
+    let signature = dec.var_bytes()?;
+    Ok(pyde_consensus::finality::FinalityVote {
+        slot,
+        block_hash,
+        state_root,
+        voter_index,
+        voter_address,
+        signature,
+    })
 }
 
 pub fn encode_decryption_shares(msg: &DecryptionShareMsg) -> Vec<u8> {


### PR DESCRIPTION
## Summary
- Multi-node HotStuff BFT consensus with VRF-based proposer selection (lowest score wins)
- FALCON-512 proposer block signatures with verification on receive
- Full block validation: committee membership, VRF proof, proposer signature, QC quorum
- Transaction gossip from RPC to P2P network + deduplication
- Hard finality vote exchange after QC formation
- Timeout/view-change message processing between peers
- `pyde testnet` CLI to generate multi-validator devnet configs
- Fix: genesis auth_keys overwrite bug (validators no longer clobber allocation accounts)
- Fix: CLI --rpc-port/--metrics-port no longer override config file values

Verified E2E: 2-node devnet with VRF consensus, QC formation (2/2 votes), receipts on both nodes, consistent head slot.