### PR TITLE
feat: full mesh topology, Kademlia peer discovery, and leader failure recovery

### DIFF
--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -344,12 +344,14 @@ pub fn generate_testnet(
     fs::write(&genesis_path, genesis_config.to_toml())
         .map_err(|e| format!("failed to write genesis.toml: {}", e))?;
 
-    // Determine first node's listen address for bootstrap
-    // (subsequent nodes bootstrap to node-0)
-    let bootstrap_addr = format!(
-        "/ip4/127.0.0.1/udp/{}/quic-v1",
-        base_port,
-    );
+    // Pre-generate node identity keys (Ed25519 for libp2p) so we know peer IDs
+    // and can write full bootstrap multiaddrs in each config.
+    let mut node_keypairs: Vec<(libp2p::identity::Keypair, libp2p::PeerId)> = Vec::new();
+    for _ in 0..num_validators {
+        let kp = pyde_net::node::generate_keypair();
+        let peer_id = libp2p::PeerId::from(kp.public());
+        node_keypairs.push((kp, peer_id));
+    }
 
     // Write per-node directories
     for i in 0..num_validators {
@@ -367,21 +369,34 @@ pub fn generate_testnet(
         fs::write(node_dir.join("validator.key"), &key_buf)
             .map_err(|e| format!("failed to write validator.key: {}", e))?;
 
+        // Write node.key (pre-generated so we know the peer ID for bootstrap addrs)
+        let node_key_bytes = pyde_net::node::keypair_to_bytes(&node_keypairs[i].0)
+            .map_err(|e| format!("failed to serialize node key: {}", e))?;
+        fs::write(node_dir.join("node.key"), &node_key_bytes)
+            .map_err(|e| format!("failed to write node.key: {}", e))?;
+
         // Copy genesis.toml into each node's directory
         fs::write(node_dir.join("genesis.toml"), genesis_config.to_toml())
             .map_err(|e| format!("failed to write genesis.toml: {}", e))?;
+
+        // Build bootstrap list: ALL other nodes (full mesh)
+        let mut bootstrap_addrs: Vec<String> = Vec::new();
+        for j in 0..num_validators {
+            if j != i {
+                let other_port = base_port + j as u16;
+                let other_peer_id = &node_keypairs[j].1;
+                bootstrap_addrs.push(format!(
+                    "\"/ip4/127.0.0.1/udp/{}/quic-v1/p2p/{}\"",
+                    other_port, other_peer_id
+                ));
+            }
+        }
+        let bootstrap = format!("[{}]", bootstrap_addrs.join(", "));
 
         // Write config.toml
         let p2p_port = base_port + i as u16;
         let rpc_port = base_rpc_port + i as u16;
         let metrics_port = 9090 + i as u16;
-        let bootstrap = if i == 0 {
-            "[]".to_string()
-        } else {
-            // Note: peer ID is not known until node starts, so we use a placeholder.
-            // The actual connection uses `--bootstrap` CLI flag at runtime.
-            "[]".to_string()
-        };
 
         let config_toml = format!(
             r#"[node]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -13,6 +13,7 @@ use crate::validator::{ValidatorEngine, ValidatorIdentity, verify_stake};
 use crate::wire;
 use libp2p::futures::StreamExt;
 use libp2p::gossipsub;
+use libp2p::identify;
 use libp2p::request_response;
 use libp2p::swarm::SwarmEvent;
 use libp2p::PeerId;
@@ -410,6 +411,21 @@ impl PydeNode {
                             pending.push(tx);
                             debug!(tx_hash = hex::encode(tx_hash), pending = pending.len(), "tx accepted from gossip");
                         }
+                        PostEventAction::AddPeerToKademlia(peer_id, addrs) => {
+                            for addr in &addrs {
+                                swarm.behaviour_mut().kademlia.add_address(&peer_id, addr.clone());
+                            }
+                            // Proactively dial peers we learn about through Identify.
+                            // This builds a mesh so nodes survive bootstrap node failure.
+                            if !swarm.is_connected(&peer_id) {
+                                for addr in addrs {
+                                    if let Err(e) = swarm.dial(addr) {
+                                        debug!(error = %e, "failed to dial discovered peer");
+                                    }
+                                }
+                            }
+                            let _ = swarm.behaviour_mut().kademlia.bootstrap();
+                        }
                         PostEventAction::StoreReceipts(slot, receipts_list) => {
                             let mut receipts_w = receipts.write().await;
                             receipts_w.insert_block_receipts(slot, receipts_list);
@@ -632,6 +648,10 @@ impl PydeNode {
                     crate::metrics::record_mempool(mempool_size);
                     let peer_count = swarm.connected_peers().count();
                     crate::metrics::record_peers(peer_count);
+                    // Periodically trigger Kademlia bootstrap to discover + connect to new peers.
+                    // Critical for mesh resilience: ensures nodes connect to each other,
+                    // not just the bootstrap node.
+                    let _ = swarm.behaviour_mut().kademlia.bootstrap();
                     let head = chain.read().await.head_slot;
                     debug!(
                         peers = peer_count,
@@ -672,6 +692,7 @@ enum PostEventAction {
     BroadcastConsensus(Vec<u8>),
     AcceptTransaction(pyde_tx::types::Transaction),
     StoreReceipts(u64, Vec<pyde_tx::execution::Receipt>),
+    AddPeerToKademlia(PeerId, Vec<libp2p::Multiaddr>),
     BlockProcessed {
         slot: u64,
         receipts: Vec<pyde_tx::execution::Receipt>,
@@ -899,6 +920,31 @@ fn handle_swarm_event(
         SwarmEvent::NewListenAddr { address, .. } => {
             info!(%address, "listening on");
             PostEventAction::None
+        }
+
+        // --- Identify: peer shared their listen addresses ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Identify(
+            identify::Event::Received { peer_id, info, .. },
+        )) => {
+            debug!(%peer_id, addrs = info.listen_addrs.len(), "identify received");
+            if !info.listen_addrs.is_empty() {
+                PostEventAction::AddPeerToKademlia(peer_id, info.listen_addrs)
+            } else {
+                PostEventAction::None
+            }
+        }
+
+        // --- Kademlia: routing table updated (discovered a new peer) ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Kademlia(
+            libp2p::kad::Event::RoutingUpdated { peer, addresses, .. },
+        )) => {
+            let addrs: Vec<libp2p::Multiaddr> = addresses.into_vec();
+            if !addrs.is_empty() {
+                debug!(%peer, addrs = addrs.len(), "kademlia discovered peer");
+                PostEventAction::AddPeerToKademlia(peer, addrs)
+            } else {
+                PostEventAction::None
+            }
         }
 
         // All other events


### PR DESCRIPTION
## Summary
- Testnet generator pre-generates node identity keys for full mesh bootstrap (every node connects to every other)
- Identify event handling adds discovered peer addresses to Kademlia DHT
- Kademlia RoutingUpdated events proactively dial discovered peers
- Periodic Kademlia bootstrap in maintenance timer for ongoing mesh healing

Verified E2E:
- 4-node consensus: QC formed with 3-4 votes (quorum=3 for committee of 4)
- TX gossip: tx submitted to non-proposer reaches proposer and gets included
- Leader failure: kill node-0, remaining 3 nodes continue consensus (QC with 3/3 votes)
- All surviving nodes at same head slot