### PR TITLE
feat: dynamic committee rotation at epoch boundaries

### DIFF
--- a/crates/consensus/src/validator.rs
+++ b/crates/consensus/src/validator.rs
@@ -201,10 +201,10 @@ impl ValidatorSet {
             .cloned()
             .collect();
 
-        if eligible.len() < COMMITTEE_SIZE {
+        if eligible.is_empty() {
             return Err(ValidatorError::NotEnoughValidators {
-                needed: COMMITTEE_SIZE,
-                available: eligible.len(),
+                needed: 1,
+                available: 0,
             });
         }
 
@@ -227,10 +227,11 @@ impl ValidatorSet {
         // Sort by score (deterministic ordering from randomness)
         scored.sort_by_key(|(score, _)| *score);
 
-        // Take first 128
+        // Take up to COMMITTEE_SIZE (or all if fewer than 128)
+        let take_count = scored.len().min(COMMITTEE_SIZE);
         let members: Vec<Validator> = scored
             .into_iter()
-            .take(COMMITTEE_SIZE)
+            .take(take_count)
             .map(|(_, v)| v)
             .collect();
 
@@ -354,13 +355,18 @@ mod tests {
     }
 
     #[test]
-    fn not_enough_validators_rejected() {
+    fn small_validator_set_selects_all() {
         let mut set = ValidatorSet::new();
-        register_n(&mut set, 100); // only 100, need 128
+        register_n(&mut set, 4); // only 4, less than 128
 
-        let err = set
-            .select_committee(0, &[0xAA; 32], vec![])
-            .unwrap_err();
+        let committee = set.select_committee(0, &[0xAA; 32], vec![]).unwrap();
+        assert_eq!(committee.size(), 4); // takes all 4
+    }
+
+    #[test]
+    fn empty_validator_set_rejected() {
+        let set = ValidatorSet::new();
+        let err = set.select_committee(0, &[0xAA; 32], vec![]).unwrap_err();
         assert!(matches!(err, ValidatorError::NotEnoughValidators { .. }));
     }
 

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -188,7 +188,33 @@ pub fn initialize_genesis(
         );
     }
 
-    // 3. Batch insert all entries
+    // 3. Write validator registry entries (for epoch committee selection).
+    // Each validator stored at validator_key(address) with serialized public key + stake.
+    // Format: [pk_len:4 LE][pk_bytes][stake:16 LE][status:1]
+    let mut val_count: u64 = 0;
+    for val in &config.validators {
+        let address = parse_hex_address(&val.address)?;
+        let pk_hex = val.public_key.strip_prefix("0x").unwrap_or(&val.public_key);
+        let pk_bytes = hex::decode(pk_hex)
+            .map_err(|e| format!("invalid validator pk for registry: {}", e))?;
+        let stake = val.stake_u128()?;
+
+        let mut val_data = Vec::with_capacity(4 + pk_bytes.len() + 16 + 1);
+        val_data.extend_from_slice(&(pk_bytes.len() as u32).to_le_bytes());
+        val_data.extend_from_slice(&pk_bytes);
+        val_data.extend_from_slice(&stake.to_le_bytes());
+        val_data.push(0x00); // 0x00 = Active status
+
+        let key = pyde_state::keys::validator_key(&address);
+        entries.push((key, val_data));
+        val_count += 1;
+    }
+
+    // Store validator count
+    let count_key = pyde_state::keys::validator_count_key();
+    entries.push((count_key, val_count.to_le_bytes().to_vec()));
+
+    // 4. Batch insert all entries
     let state_root = state.update_batch(entries)?;
 
     info!(
@@ -530,6 +556,11 @@ json = false
         out_dir.display(), out_dir.display(), if dev_mode { " --dev" } else { "" });
 
     Ok(())
+}
+
+/// Parse a hex-encoded 32-byte address.
+pub fn parse_hex_address_pub(hex_str: &str) -> Result<Address, String> {
+    parse_hex_address(hex_str)
 }
 
 fn parse_hex_address(hex_str: &str) -> Result<Address, String> {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -544,9 +544,50 @@ impl PydeNode {
 
                         // New slot — validator block production
                         if let Some(engine) = validator_engine.as_mut() {
+                            let prev_epoch = engine.consensus.current_slot / pyde_consensus::block::EPOCH_LENGTH;
                             // Sync engine slot to clock (not just +1)
                             while engine.consensus.current_slot < current_slot {
                                 engine.advance_slot();
+                            }
+
+                            // Epoch boundary: rotate committee
+                            let new_epoch = current_slot / pyde_consensus::block::EPOCH_LENGTH;
+                            if new_epoch > prev_epoch && new_epoch > 0 {
+                                let state_r = state.read().await;
+                                let val_set = crate::validator::load_validator_set_from_state(
+                                    &state_r, &genesis_config,
+                                );
+                                drop(state_r);
+
+                                match val_set.select_committee(
+                                    new_epoch,
+                                    &engine.epoch_randomness,
+                                    vec![], // no threshold PK yet
+                                ) {
+                                    Ok(committee) => {
+                                        let new_keys: Vec<Vec<u8>> = committee.members.iter()
+                                            .map(|v| v.public_key.clone()).collect();
+                                        // Find our own index in new committee
+                                        if let Some(identity) = validator_identity.as_mut() {
+                                            let my_pk = hex::encode(identity.public_key.as_bytes());
+                                            for (i, member) in committee.members.iter().enumerate() {
+                                                if hex::encode(&member.public_key) == my_pk {
+                                                    identity.committee_index = i as u8;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        engine.set_committee(new_keys);
+                                        info!(
+                                            epoch = new_epoch,
+                                            committee_size = committee.size(),
+                                            "committee rotated at epoch boundary"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        warn!(epoch = new_epoch, error = ?e, "committee selection failed, keeping current");
+                                    }
+                                }
                             }
 
                             // Skip if chain head is already at or past this slot

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -47,6 +47,57 @@ pub fn verify_stake(balance: u128) -> Result<u128, String> {
     }
 }
 
+/// Load the validator set from on-chain state.
+/// Reads validator entries stored at genesis (or updated by staking txs).
+/// Returns a ValidatorSet that can be used for committee selection.
+pub fn load_validator_set_from_state(
+    state: &crate::state_manager::StateManager,
+    genesis_config: &crate::genesis::GenesisConfig,
+) -> pyde_consensus::validator::ValidatorSet {
+    use pyde_consensus::validator::{Validator, ValidatorSet, ValidatorStatus};
+
+    let mut set = ValidatorSet::new();
+
+    // Read each genesis validator from state
+    for val in &genesis_config.validators {
+        let address = match crate::genesis::parse_hex_address_pub(&val.address) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+
+        let val_key = pyde_state::keys::validator_key(&address);
+        if let Some(val_data) = state.get(&val_key) {
+            // Parse: [pk_len:4 LE][pk_bytes][stake:16 LE][status:1]
+            if val_data.len() < 5 {
+                continue;
+            }
+            let pk_len = u32::from_le_bytes([val_data[0], val_data[1], val_data[2], val_data[3]]) as usize;
+            if val_data.len() < 4 + pk_len + 16 + 1 {
+                continue;
+            }
+            let pk_bytes = val_data[4..4 + pk_len].to_vec();
+            let mut stake_buf = [0u8; 16];
+            stake_buf.copy_from_slice(&val_data[4 + pk_len..4 + pk_len + 16]);
+            let stake = u128::from_le_bytes(stake_buf);
+            let status_byte = val_data[4 + pk_len + 16];
+            let status = match status_byte {
+                0x00 => ValidatorStatus::Active,
+                _ => ValidatorStatus::Exited,
+            };
+
+            set.validators.push(Validator {
+                address,
+                public_key: pk_bytes,
+                stake,
+                status,
+                registered_epoch: 0,
+            });
+        }
+    }
+
+    set
+}
+
 /// Collected votes for a slot, used to form QCs.
 struct SlotVotes {
     block_hash: [u8; 32],

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -23,6 +23,9 @@ pub mod discriminator {
     pub const CODE_HASH: u8 = 0x03;
     pub const STORAGE_SLOT: u8 = 0x04;
     pub const MAP_ENTRY: u8 = 0x05;
+    pub const VALIDATOR: u8 = 0x10;
+    /// Special key for the validator count (stored at validator_count_key).
+    pub const VALIDATOR_COUNT: u8 = 0x11;
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +120,27 @@ pub fn nested_map_key(contract: &Address, slot: u64, key1: &[u8], key2: &[u8]) -
     input.push(discriminator::MAP_ENTRY);
     input.extend_from_slice(key2);
     H256::from(poseidon2_hash(&input).to_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Validator registry keys
+// ---------------------------------------------------------------------------
+
+/// Derive the SMT key for a validator entry.
+///
+/// `key = Poseidon2(address || 0x10)`
+pub fn validator_key(address: &Address) -> H256 {
+    let mut input = Vec::with_capacity(33);
+    input.extend_from_slice(address);
+    input.push(discriminator::VALIDATOR);
+    H256::from(poseidon2_hash(&input).to_bytes())
+}
+
+/// Well-known key for the validator count.
+///
+/// `key = Poseidon2(0x11)`
+pub fn validator_count_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::VALIDATOR_COUNT]).to_bytes())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Committee selection works with any validator count (< 128 takes all eligible)
- Validators stored in state at genesis with public keys and stake
- At each epoch boundary (every 1000 slots), validator set is read from state
  and committee is re-selected via deterministic Poseidon2 scoring
- Validator's own committee index updates after rotation
- Foundation for future staking transactions (deposit/withdraw modify state)