### PR TITLE
feat: wire epoch randomness via threshold VRF share exchange

### DIFF
--- a/crates/consensus/src/epoch_randomness.rs
+++ b/crates/consensus/src/epoch_randomness.rs
@@ -27,8 +27,14 @@ use crate::block::COMMITTEE_SIZE;
 /// Domain separator for epoch randomness VRF input.
 const DOMAIN: &[u8] = b"pyde-epoch-randomness-v1";
 
-/// Minimum shares required (2/3 + 1 of committee).
+/// Minimum shares required for production (2/3 + 1 of 128).
 pub const RANDOMNESS_THRESHOLD: usize = 85;
+
+/// Compute dynamic randomness threshold for a given committee size.
+/// Uses ceil(2/3 * size), same as consensus quorum.
+pub fn randomness_threshold_for(committee_size: usize) -> usize {
+    crate::block::quorum_for_committee(committee_size)
+}
 
 /// A randomness share from one committee member.
 #[derive(Clone, Debug)]
@@ -101,8 +107,26 @@ pub fn verify_share(
 /// the result is order-independent (prevents last-revealer bias).
 ///
 /// Returns None if fewer than RANDOMNESS_THRESHOLD shares provided.
+/// Combine shares with dynamic threshold based on committee size.
+pub fn combine_shares_dynamic(
+    shares: &[RandomnessShare],
+    epoch: u64,
+    committee_size: usize,
+) -> Option<EpochRandomness> {
+    let threshold = randomness_threshold_for(committee_size);
+    combine_shares_with_threshold(shares, epoch, threshold)
+}
+
 pub fn combine_shares(shares: &[RandomnessShare], epoch: u64) -> Option<EpochRandomness> {
-    if shares.len() < RANDOMNESS_THRESHOLD {
+    combine_shares_with_threshold(shares, epoch, RANDOMNESS_THRESHOLD)
+}
+
+fn combine_shares_with_threshold(
+    shares: &[RandomnessShare],
+    epoch: u64,
+    threshold: usize,
+) -> Option<EpochRandomness> {
+    if shares.len() < threshold {
         return None;
     }
 
@@ -114,7 +138,7 @@ pub fn combine_shares(shares: &[RandomnessShare], epoch: u64) -> Option<EpochRan
             unique_shares.push(share);
         }
     }
-    if unique_shares.len() < RANDOMNESS_THRESHOLD {
+    if unique_shares.len() < threshold {
         return None;
     }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -583,6 +583,15 @@ impl PydeNode {
                                             committee_size = committee.size(),
                                             "committee rotated at epoch boundary"
                                         );
+
+                                        // Generate and broadcast our epoch randomness share
+                                        if let Some(identity) = validator_identity.as_ref() {
+                                            if let Some(share) = engine.start_epoch_randomness(new_epoch + 1, identity) {
+                                                let share_bytes = wire::encode_randomness_share(new_epoch + 1, &share);
+                                                let topic = pyde_net::node::topics::consensus();
+                                                let _ = swarm.behaviour_mut().gossipsub.publish(topic, share_bytes);
+                                            }
+                                        }
                                     }
                                     Err(e) => {
                                         warn!(epoch = new_epoch, error = ?e, "committee selection failed, keeping current");
@@ -962,6 +971,26 @@ fn handle_swarm_event(
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode finality vote");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
+                        // Check if it's an epoch randomness share
+                        if !message.data.is_empty() && message.data[0] == wire::tag::RANDOMNESS_SHARE {
+                            match wire::decode_randomness_share(&message.data) {
+                                Ok((epoch, share)) => {
+                                    debug!(epoch, validator = share.validator_index, "received randomness share");
+                                    if let Some(new_randomness) = engine.on_randomness_share(share) {
+                                        info!(
+                                            epoch,
+                                            randomness = hex::encode(new_randomness),
+                                            "epoch randomness updated"
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode randomness share");
                                 }
                             }
                             return PostEventAction::None;

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -9,6 +9,10 @@ use pyde_consensus::hotstuff::{
 use pyde_consensus::proposer::{compute_candidacy, ProposerCandidate};
 use pyde_crypto::vrf::VrfProof;
 use pyde_consensus::block::quorum_for_committee;
+use pyde_consensus::epoch_randomness::{
+    RandomnessCollector, RandomnessShare, generate_share, verify_share,
+    combine_shares_dynamic,
+};
 use pyde_consensus::slashing::{
     DoubleSignEvidence, SlashResult, slash_double_sign, verify_double_sign,
 };
@@ -143,6 +147,8 @@ pub struct ValidatorEngine {
     seen_votes: HashMap<(u64, u8), ([u8; 32], Vec<u8>)>,
     /// Collected slashing evidence to broadcast.
     pub pending_slashes: Vec<SlashResult>,
+    /// Epoch randomness collector (gathers VRF shares at epoch boundary).
+    randomness_collector: Option<RandomnessCollector>,
 }
 
 impl ValidatorEngine {
@@ -163,6 +169,7 @@ impl ValidatorEngine {
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
             pending_slashes: Vec::new(),
+            randomness_collector: None,
         }
     }
 
@@ -170,6 +177,71 @@ impl ValidatorEngine {
     pub fn set_committee(&mut self, keys: Vec<Vec<u8>>) {
         info!(members = keys.len(), "committee keys loaded");
         self.committee_keys = keys;
+    }
+
+    /// Start collecting epoch randomness shares for the next epoch.
+    /// Called at epoch boundary. Generates and returns our own share to broadcast.
+    pub fn start_epoch_randomness(
+        &mut self,
+        next_epoch: u64,
+        identity: &ValidatorIdentity,
+    ) -> Option<RandomnessShare> {
+        let share = generate_share(
+            &identity.public_key,
+            &identity.secret_key,
+            next_epoch,
+            identity.committee_index,
+            identity.address,
+        ).ok()?;
+
+        let mut collector = RandomnessCollector::new(next_epoch);
+        collector.add_share(share.clone());
+        self.randomness_collector = Some(collector);
+
+        info!(epoch = next_epoch, "started epoch randomness collection");
+        Some(share)
+    }
+
+    /// Add a received randomness share from another committee member.
+    /// Returns the new epoch randomness if threshold reached.
+    pub fn on_randomness_share(
+        &mut self,
+        share: RandomnessShare,
+    ) -> Option<[u8; 32]> {
+        let collector = self.randomness_collector.as_mut()?;
+
+        // Verify share against committee key
+        let idx = share.validator_index as usize;
+        if idx >= self.committee_keys.len() {
+            return None;
+        }
+        let pk = match pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[idx]) {
+            Some(pk) => pk,
+            None => return None,
+        };
+        if !verify_share(&share, &pk, collector.epoch) {
+            warn!(epoch = collector.epoch, validator = idx, "invalid randomness share");
+            return None;
+        }
+
+        collector.add_share(share);
+
+        // Check with dynamic threshold based on committee size
+        let threshold = quorum_for_committee(self.committee_keys.len());
+        if collector.share_count() >= threshold {
+            if let Some(result) = collector.finalize() {
+                info!(
+                    epoch = result.epoch,
+                    shares = result.share_count,
+                    "epoch randomness combined"
+                );
+                self.epoch_randomness = result.randomness;
+                self.randomness_collector = None;
+                return Some(result.randomness);
+            }
+        }
+
+        None
     }
 
     /// Compute VRF candidacy for the current slot.

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -22,6 +22,7 @@ pub mod tag {
     pub const CONSENSUS_NEW_VIEW: u8 = 0x13;
     pub const CONSENSUS_FINALITY_VOTE: u8 = 0x14;
     pub const COMPACT_BLOCK: u8 = 0x03;
+    pub const RANDOMNESS_SHARE: u8 = 0x15;
     pub const GET_BLOCK_TXS: u8 = 0x04;
     pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
     pub const DECRYPTION_SHARES: u8 = 0x20;
@@ -72,6 +73,43 @@ pub fn decode_finality_vote(data: &[u8]) -> Result<pyde_consensus::finality::Fin
         voter_address,
         signature,
     })
+}
+
+// ============================================================
+// Epoch Randomness Share
+// ============================================================
+
+pub fn encode_randomness_share(
+    epoch: u64,
+    share: &pyde_consensus::epoch_randomness::RandomnessShare,
+) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(tag::RANDOMNESS_SHARE);
+    enc.u64(epoch);
+    enc.u8(share.validator_index);
+    enc.bytes32(&share.address);
+    enc.var_bytes(share.vrf_output.as_bytes());
+    enc.var_bytes(share.vrf_proof.as_bytes());
+    enc.finish()
+}
+
+pub fn decode_randomness_share(
+    data: &[u8],
+) -> Result<(u64, pyde_consensus::epoch_randomness::RandomnessShare), &'static str> {
+    let mut dec = Decoder::new(data);
+    let t = dec.u8()?;
+    if t != tag::RANDOMNESS_SHARE { return Err("not a randomness share"); }
+    let epoch = dec.u64()?;
+    let validator_index = dec.u8()?;
+    let address = dec.bytes32()?;
+    let output_bytes = dec.var_bytes()?;
+    let proof_bytes = dec.var_bytes()?;
+    Ok((epoch, pyde_consensus::epoch_randomness::RandomnessShare {
+        validator_index,
+        address,
+        vrf_output: pyde_crypto::vrf::VrfOutput::from_hash_bytes(&output_bytes),
+        vrf_proof: pyde_crypto::vrf::VrfProof::from_bytes(&proof_bytes),
+    }))
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Each committee member generates a VRF randomness share at epoch boundary
- Shares broadcast on consensus topic, verified against committee keys
- Dynamic threshold (ceil(2/3 * N)) for devnet/testnet compatibility
- Shares combined via sorted Poseidon2 hash (order-independent, unbiasable)
- Replaces fixed [0xAA; 32] with real threshold VRF randomness
- Security: unpredictable to <2/3 coalition, unbiasable by last revealer