### PR TITLE
feat: implement fee burning and treasury with 70/20/10 split

### DIFF
--- a/crates/account/src/address.rs
+++ b/crates/account/src/address.rs
@@ -42,6 +42,12 @@ pub fn derive_create2_address(deployer: &Address, salt: &[u8; 32], code: &[u8]) 
     poseidon2_hash(&input).to_bytes()
 }
 
+/// Well-known treasury address: Poseidon2("pyde-treasury").
+/// Accumulates 10% of all transaction fees for future prover rewards.
+pub fn treasury_address() -> Address {
+    poseidon2_hash(b"pyde-treasury").to_bytes()
+}
+
 /// Format an address as a hex string with "0x" prefix.
 pub fn format_address(addr: &Address) -> String {
     let mut s = String::with_capacity(66);

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -72,6 +72,7 @@ impl BlockProcessor {
                         fee_paid: 0,
                         fee_burned: 0,
                         fee_validator: 0,
+                        fee_treasury: 0,
                         return_data: reason.into_bytes(),
                         logs: vec![],
                         state_root: sparse_merkle_tree::H256::zero(),

--- a/crates/node/src/receipt_store.rs
+++ b/crates/node/src/receipt_store.rs
@@ -112,6 +112,7 @@ mod tests {
             fee_paid: 0,
             fee_burned: 0,
             fee_validator: 0,
+            fee_treasury: 0,
             logs: vec![],
             state_root: H256::zero(),
             return_data: vec![],
@@ -159,6 +160,7 @@ mod tests {
             fee_paid: 0,
             fee_burned: 0,
             fee_validator: 0,
+            fee_treasury: 0,
             logs: vec![
                 LogEntry { address: addr, topics: vec![], data: vec![1, 2, 3] },
                 LogEntry { address: [0xDD; 32], topics: vec![], data: vec![4, 5] },

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -850,6 +850,7 @@ fn receipt_to_json(receipt: &Receipt) -> serde_json::Value {
         "feePaid": receipt.fee_paid.to_string(),
         "feeBurned": receipt.fee_burned.to_string(),
         "feeValidator": receipt.fee_validator.to_string(),
+        "feeTreasury": receipt.fee_treasury.to_string(),
         "logs": receipt.logs.iter().map(|l| serde_json::json!({
             "address": format!("0x{}", hex::encode(l.address)),
             "topics": l.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
@@ -947,8 +948,9 @@ mod tests {
             gas_refund: 0,
             effective_gas: 21000,
             fee_paid: 1050000,
-            fee_burned: 840000,
-            fee_validator: 210000,
+            fee_burned: 735000,    // 70%
+            fee_validator: 210000, // 20%
+            fee_treasury: 105000,  // 10%
             logs: vec![],
             state_root: sparse_merkle_tree::H256::zero(),
             return_data: vec![],

--- a/crates/tx/src/execution.rs
+++ b/crates/tx/src/execution.rs
@@ -16,9 +16,10 @@ use pyde_crypto::poseidon2::poseidon2_hash;
 use sparse_merkle_tree::H256;
 
 /// Fee distribution ratios (percentages).
-/// 80% burn (deflationary + MEV prevention), 20% validator.
-pub const FEE_BURN_PCT: u64 = 80;
+/// 70% burn (deflationary), 20% validator (proposer reward), 10% treasury (future prover reward).
+pub const FEE_BURN_PCT: u64 = 70;
 pub const FEE_VALIDATOR_PCT: u64 = 20;
+pub const FEE_TREASURY_PCT: u64 = 10;
 
 /// Transaction receipt: result of executing a transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,9 +36,10 @@ pub struct Receipt {
     pub effective_gas: u64,
     /// Fee paid (effective_gas × base_fee).
     pub fee_paid: u128,
-    /// Fee distribution.
+    /// Fee distribution: 70% burned, 20% validator, 10% treasury.
     pub fee_burned: u128,
     pub fee_validator: u128,
+    pub fee_treasury: u128,
     /// Event logs emitted during execution.
     pub logs: Vec<LogEntry>,
     /// Post-execution state root (if available).
@@ -61,6 +63,7 @@ pub struct LogEntry {
 pub struct FeeDistribution {
     pub burned: u128,
     pub validator: u128,
+    pub treasury: u128,
 }
 
 /// Execution context: mutable state during transaction execution.
@@ -167,14 +170,16 @@ pub fn post_execution_refund(
     (effective_gas, actual_refund)
 }
 
-/// Distribute the fee: 80% burn, 20% validator.
+/// Distribute the fee: 70% burn, 20% validator, 10% treasury.
 pub fn distribute_fee(effective_gas: u64, base_fee: u128) -> FeeDistribution {
     let total_fee = effective_gas as u128 * base_fee;
     let burned = total_fee * FEE_BURN_PCT as u128 / 100;
-    let validator = total_fee - burned; // remainder to validator (handles rounding)
+    let validator = total_fee * FEE_VALIDATOR_PCT as u128 / 100;
+    let treasury = total_fee - burned - validator; // remainder to treasury (handles rounding)
     FeeDistribution {
         burned,
         validator,
+        treasury,
     }
 }
 
@@ -200,6 +205,7 @@ pub fn generate_receipt(
         fee_paid: effective_gas as u128 * base_fee,
         fee_burned: fee.burned,
         fee_validator: fee.validator,
+        fee_treasury: fee.treasury,
         logs,
         state_root,
         return_data,
@@ -348,12 +354,13 @@ mod tests {
     // ========== Task 0408: Fee distribution ==========
 
     #[test]
-    fn fee_distribution_80_20() {
-        let dist = distribute_fee(100_000, 1_000); // 100M total fee
+    fn fee_distribution_70_20_10() {
+        let dist = distribute_fee(100_000, 1_000);
         let total = 100_000u128 * 1_000;
-        assert_eq!(dist.burned, total * 80 / 100);
-        // Validator gets remainder (handles rounding)
-        assert_eq!(dist.burned + dist.validator, total);
+        assert_eq!(dist.burned, total * 70 / 100);
+        assert_eq!(dist.validator, total * 20 / 100);
+        // Treasury gets remainder (handles rounding)
+        assert_eq!(dist.burned + dist.validator + dist.treasury, total);
     }
 
     #[test]
@@ -361,6 +368,7 @@ mod tests {
         let dist = distribute_fee(0, 1_000);
         assert_eq!(dist.burned, 0);
         assert_eq!(dist.validator, 0);
+        assert_eq!(dist.treasury, 0);
     }
 
     // ========== Task 0410: Receipt generation ==========
@@ -395,7 +403,7 @@ mod tests {
         assert_eq!(receipt.logs.len(), 1);
         assert_eq!(receipt.logs[0].data, b"transfer");
         assert_eq!(
-            receipt.fee_burned + receipt.fee_validator,
+            receipt.fee_burned + receipt.fee_validator + receipt.fee_treasury,
             receipt.fee_paid
         );
     }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -288,13 +288,24 @@ pub fn execute_transaction(
         FeePayer::Paymaster(_) => {}
     }
 
-    // 8. Fee distribution
+    // 8. Fee distribution: 70% burned (implicit — never credited), 20% validator, 10% treasury
     let fee_dist = distribute_fee(effective_gas, block_ctx.base_fee);
 
-    // Credit validator
+    // Credit validator (20%)
     let mut validator_account = load_account(smt, &block_ctx.validator_address);
     validator_account.balance += fee_dist.validator;
     store_account(smt, &validator_account)?;
+
+    // Credit treasury (10%) — well-known address: Poseidon2("pyde-treasury")
+    if fee_dist.treasury > 0 {
+        let treasury_addr = pyde_account::address::treasury_address();
+        let mut treasury_account = load_account(smt, &treasury_addr);
+        treasury_account.balance += fee_dist.treasury;
+        store_account(smt, &treasury_account)?;
+    }
+
+    // Burn (70%): implicit — charged from sender in step 3, never credited to anyone.
+    // Total supply decreases by fee_dist.burned each transaction.
 
     // 9. Save updated accounts
     store_account(smt, &sender)?;


### PR DESCRIPTION
## Summary
- Fee distribution: 70% burned / 20% validator / 10% treasury
- Burn is implicit (charged from sender, never credited = removed from circulation)
- Treasury at well-known address accumulates 10% for future prover rewards
- Validator proposer reward (20%) credited during block processing
- RPC receipts include feeTreasury field