### PR TITLE
feat: Docker devnet with 4 validators + Prometheus + Grafana

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git/
+node_modules/
+pyde-book/
+crates/pyde-rust-sdk/LIVE_TEST_PLAN.md
+crates/pyde-dev/CHEATCODES_ROADMAP.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Stage 1: Build the pyde-node binary
+FROM rust:1.89-bookworm AS builder
+
+# Install build dependencies (libclang for bindgen/RocksDB, cmake for aws-lc)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang libclang-dev cmake pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+
+# Build release binary
+RUN cargo build --release -p pyde-node && \
+    cp target/release/pyde /usr/local/bin/pyde
+
+# Stage 2: Slim runtime image
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/pyde /usr/local/bin/pyde
+
+# Copy Docker runtime files
+COPY docker/entrypoint.sh /docker/entrypoint.sh
+COPY docker/prometheus.yml /docker/prometheus.yml
+COPY docker/grafana/ /docker/grafana/
+RUN chmod +x /docker/entrypoint.sh
+
+# Default data directory
+RUN mkdir -p /data /testnet
+ENV PYDE_DATADIR=/data
+
+EXPOSE 30303/udp 8545 9090
+
+ENTRYPOINT ["pyde"]
+CMD ["run", "--role", "validator", "--datadir", "/data", "--log-level", "info"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,134 @@
+# Pyde Devnet: 4 validators + Prometheus + Grafana
+# Usage:
+#   docker build -t pyde-node:latest .
+#   docker compose up -d
+#
+# RPC endpoints:
+#   Node-0: http://localhost:8545
+#   Node-1: http://localhost:8546
+#   Node-2: http://localhost:8547
+#   Node-3: http://localhost:8548
+#
+# Monitoring:
+#   Prometheus: http://localhost:9999
+#   Grafana:    http://localhost:3000 (admin/admin)
+
+services:
+  node-0:
+    image: pyde-node:latest
+    entrypoint: ["/bin/bash", "/docker/entrypoint.sh"]
+    environment:
+      - NODE_INDEX=0
+      - VALIDATORS=4
+      - DEV_MODE=true
+    volumes:
+      - testnet-data:/testnet
+      - node0-data:/data
+    ports:
+      - "8545:8545"
+      - "9090:9090"
+    networks:
+      pyde-net:
+        ipv4_address: 172.20.0.10
+
+  node-1:
+    image: pyde-node:latest
+    entrypoint: ["/bin/bash", "/docker/entrypoint.sh"]
+    environment:
+      - NODE_INDEX=1
+      - DEV_MODE=true
+    volumes:
+      - testnet-data:/testnet
+      - node1-data:/data
+    ports:
+      - "8546:8546"
+      - "9091:9091"
+    depends_on:
+      - node-0
+    networks:
+      pyde-net:
+        ipv4_address: 172.20.0.11
+
+  node-2:
+    image: pyde-node:latest
+    entrypoint: ["/bin/bash", "/docker/entrypoint.sh"]
+    environment:
+      - NODE_INDEX=2
+      - DEV_MODE=true
+    volumes:
+      - testnet-data:/testnet
+      - node2-data:/data
+    ports:
+      - "8547:8547"
+      - "9092:9092"
+    depends_on:
+      - node-0
+    networks:
+      pyde-net:
+        ipv4_address: 172.20.0.12
+
+  node-3:
+    image: pyde-node:latest
+    entrypoint: ["/bin/bash", "/docker/entrypoint.sh"]
+    environment:
+      - NODE_INDEX=3
+      - DEV_MODE=true
+    volumes:
+      - testnet-data:/testnet
+      - node3-data:/data
+    ports:
+      - "8548:8548"
+      - "9093:9093"
+    depends_on:
+      - node-0
+    networks:
+      pyde-net:
+        ipv4_address: 172.20.0.13
+
+  prometheus:
+    image: prom/prometheus:latest
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        cat > /tmp/prometheus.yml << 'CONF'
+        global:
+          scrape_interval: 5s
+        scrape_configs:
+          - job_name: pyde-validators
+            static_configs:
+              - targets: ['node-0:9090','node-1:9091','node-2:9092','node-3:9093']
+        CONF
+        /bin/prometheus --config.file=/tmp/prometheus.yml --storage.tsdb.path=/prometheus
+    ports:
+      - "9999:9090"
+    depends_on:
+      - node-0
+    networks:
+      pyde-net:
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      pyde-net:
+
+volumes:
+  testnet-data:
+  node0-data:
+  node1-data:
+  node2-data:
+  node3-data:
+
+networks:
+  pyde-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+DATADIR="${PYDE_DATADIR:-/data}"
+NODE_INDEX="${NODE_INDEX:-0}"
+VALIDATORS="${VALIDATORS:-4}"
+BASE_PORT="${BASE_PORT:-30303}"
+BASE_RPC="${BASE_RPC:-8545}"
+DEV_MODE="${DEV_MODE:-true}"
+
+CONFIG="$DATADIR/config.toml"
+
+if [ "$NODE_INDEX" = "0" ] && [ ! -f "$CONFIG" ]; then
+    echo "Node-0: Generating testnet with $VALIDATORS validators..."
+    pyde testnet \
+        --validators "$VALIDATORS" \
+        --out /testnet \
+        --base-port "$BASE_PORT" \
+        --base-rpc-port "$BASE_RPC" \
+        ${DEV_MODE:+--dev}
+
+    # Fix configs for Docker networking:
+    # 1. Replace 127.0.0.1 bootstrap IPs with Docker container IPs (172.20.0.1X)
+    # 2. Change RPC listen from 127.0.0.1 to 0.0.0.0 (accessible from host)
+    for i in $(seq 0 $((VALIDATORS - 1))); do
+        NODE_DIR="/testnet/node-${i}"
+        if [ -f "$NODE_DIR/config.toml" ]; then
+            # Replace bootstrap IPs: 127.0.0.1 → 172.20.0.1X
+            for j in $(seq 0 $((VALIDATORS - 1))); do
+                DOCKER_IP="172.20.0.1${j}"
+                PORT=$((BASE_PORT + j))
+                sed -i "s|/ip4/127.0.0.1/udp/${PORT}/|/ip4/${DOCKER_IP}/udp/${PORT}/|g" "$NODE_DIR/config.toml"
+            done
+            # RPC: bind to all interfaces
+            sed -i 's|listen = "127.0.0.1"|listen = "0.0.0.0"|' "$NODE_DIR/config.toml"
+        fi
+    done
+
+    cp /testnet/node-0/* "$DATADIR/"
+    echo "Node-0: Testnet generated."
+fi
+
+# Wait for config (other nodes wait for node-0)
+if [ "$NODE_INDEX" != "0" ]; then
+    NODE_DIR="/testnet/node-${NODE_INDEX}"
+    echo "Node-$NODE_INDEX: Waiting for testnet config..."
+    for i in $(seq 1 30); do
+        if [ -f "$NODE_DIR/config.toml" ]; then
+            cp "$NODE_DIR"/* "$DATADIR/"
+            echo "Node-$NODE_INDEX: Config loaded."
+            break
+        fi
+        sleep 1
+    done
+    if [ ! -f "$DATADIR/config.toml" ]; then
+        echo "Node-$NODE_INDEX: ERROR — config not found after 30s"
+        exit 1
+    fi
+fi
+
+# Override datadir in config
+sed -i "s|datadir = .*|datadir = \"$DATADIR\"|" "$DATADIR/config.toml"
+
+# Build args
+ARGS="run --role validator --config $DATADIR/config.toml --datadir $DATADIR"
+if [ "$DEV_MODE" = "true" ]; then
+    ARGS="$ARGS --dev"
+fi
+
+echo "Node-$NODE_INDEX: Starting pyde..."
+exec pyde $ARGS

--- a/docker/grafana/dashboards/devnet.json
+++ b/docker/grafana/dashboards/devnet.json
@@ -1,0 +1,89 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Chain Head (slot)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "max(pyde_chain_head_slot)", "legendFormat": "head" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Blocks Produced",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "sum(pyde_blocks_processed_total)", "legendFormat": "total" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Transactions Processed",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "sum(pyde_transactions_processed_total)", "legendFormat": "total" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Connected Peers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [{ "expr": "avg(pyde_peers_connected)", "legendFormat": "avg" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Block Production Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [{ "expr": "rate(pyde_blocks_processed_total[1m])", "legendFormat": "{{instance}} blocks/min" }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "title": "TPS (Transactions Per Second)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [{ "expr": "rate(pyde_transactions_processed_total[1m]) * 60", "legendFormat": "{{instance}} TPS" }],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "title": "Gas Used Per Block",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [{ "expr": "pyde_block_gas_used", "legendFormat": "{{instance}}" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Block Processing Time (ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [{ "expr": "pyde_block_processing_ms", "legendFormat": "{{instance}}" }],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "title": "Peers Per Node",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [{ "expr": "pyde_peers_connected", "legendFormat": "{{instance}}" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    },
+    {
+      "title": "Mempool Size",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [{ "expr": "pyde_mempool_size", "legendFormat": "{{instance}}" }],
+      "fieldConfig": { "defaults": { "unit": "none" } }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["pyde", "devnet"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Pyde Devnet",
+  "uid": "pyde-devnet",
+  "version": 1
+}

--- a/docker/grafana/provisioning/dashboards/default.yml
+++ b/docker/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Pyde Devnet'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'pyde-validators'
+    static_configs:
+      - targets:
+          - 'node-0:9090'
+          - 'node-1:9091'
+          - 'node-2:9092'
+          - 'node-3:9093'
+        labels:
+          network: 'devnet'


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (Rust 1.89 compile → slim Debian runtime)
- docker-compose: 4 validators + Prometheus + Grafana in one command
- Auto-generates testnet config on first startup
- Docker networking with fixed IPs, all services interconnected
- Grafana dashboard: chain head, blocks, TPS, gas, peers, mempool
- Prometheus scraping all 4 validators at 5s intervals

Usage:
```
docker build -t pyde-node:latest .
docker compose up -d
```

RPC: localhost:8545-8548 | Grafana: localhost:3000 | Prometheus: localhost:9999

Verified E2E: 4-node consensus with QC, tx processed, all nodes synced at same slot.