### PR TITLE
feat: protocol-level staking deposit and withdraw

### DIFF
--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -207,6 +207,10 @@ pub fn initialize_genesis(
 
         let key = pyde_state::keys::validator_key(&address);
         entries.push((key, val_data));
+
+        // Store address at index for enumeration
+        let idx_key = pyde_state::keys::validator_index_key(val_count);
+        entries.push((idx_key, address.to_vec()));
         val_count += 1;
     }
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -289,10 +289,15 @@ impl PydeApiServer for RpcServer {
             n
         };
 
-        let tx_type = if to == [0u8; 32] {
-            pyde_tx::types::TransactionType::Deploy
-        } else {
-            pyde_tx::types::TransactionType::Standard
+        let tx_type = match tx_obj.get("txType").and_then(|v| v.as_str()) {
+            Some("stakeDeposit") => pyde_tx::types::TransactionType::StakeDeposit,
+            Some("stakeWithdraw") => pyde_tx::types::TransactionType::StakeWithdraw,
+            Some("deploy") => pyde_tx::types::TransactionType::Deploy,
+            _ => if to == [0u8; 32] {
+                pyde_tx::types::TransactionType::Deploy
+            } else {
+                pyde_tx::types::TransactionType::Standard
+            },
         };
 
         // For deploy txs: data should already be in pipeline format:

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -52,26 +52,41 @@ pub fn verify_stake(balance: u128) -> Result<u128, String> {
 }
 
 /// Load the validator set from on-chain state.
-/// Reads validator entries stored at genesis (or updated by staking txs).
+/// Reads ALL validator entries via the index (genesis + dynamically staked).
 /// Returns a ValidatorSet that can be used for committee selection.
 pub fn load_validator_set_from_state(
     state: &crate::state_manager::StateManager,
-    genesis_config: &crate::genesis::GenesisConfig,
+    _genesis_config: &crate::genesis::GenesisConfig,
 ) -> pyde_consensus::validator::ValidatorSet {
     use pyde_consensus::validator::{Validator, ValidatorSet, ValidatorStatus};
 
     let mut set = ValidatorSet::new();
 
-    // Read each genesis validator from state
-    for val in &genesis_config.validators {
-        let address = match crate::genesis::parse_hex_address_pub(&val.address) {
-            Ok(a) => a,
-            Err(_) => continue,
+    // Read validator count from state
+    let count_key = pyde_state::keys::validator_count_key();
+    let count = state.get(&count_key)
+        .map(|b| {
+            if b.len() >= 8 {
+                u64::from_le_bytes(b[..8].try_into().unwrap_or([0; 8]))
+            } else { 0 }
+        })
+        .unwrap_or(0);
+
+    // Read each validator by index
+    for i in 0..count {
+        let idx_key = pyde_state::keys::validator_index_key(i);
+        let address = match state.get(&idx_key) {
+            Some(addr_bytes) if addr_bytes.len() == 32 => {
+                let mut addr = [0u8; 32];
+                addr.copy_from_slice(&addr_bytes);
+                addr
+            }
+            _ => continue,
         };
 
         let val_key = pyde_state::keys::validator_key(&address);
         if let Some(val_data) = state.get(&val_key) {
-            // Parse: [pk_len:4 LE][pk_bytes][stake:16 LE][status:1]
+            // Parse: [pk_len:4 LE][pk_bytes][stake:16 LE][status:1][exit_block:8 LE optional]
             if val_data.len() < 5 {
                 continue;
             }
@@ -86,6 +101,14 @@ pub fn load_validator_set_from_state(
             let status_byte = val_data[4 + pk_len + 16];
             let status = match status_byte {
                 0x00 => ValidatorStatus::Active,
+                0x01 => {
+                    // Unbonding — read exit block if available
+                    let exit_block = if val_data.len() >= 4 + pk_len + 16 + 1 + 8 {
+                        let off = 4 + pk_len + 16 + 1;
+                        u64::from_le_bytes(val_data[off..off+8].try_into().unwrap_or([0;8]))
+                    } else { 0 };
+                    ValidatorStatus::Unbonding { exit_block }
+                }
                 _ => ValidatorStatus::Exited,
             };
 

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -429,6 +429,8 @@ pub fn encode_transaction(tx: &Transaction) -> Vec<u8> {
         TransactionType::Standard => 0,
         TransactionType::Deploy => 1,
         TransactionType::Batch => 2,
+        TransactionType::StakeDeposit => 3,
+        TransactionType::StakeWithdraw => 4,
     });
     enc.finish()
 }

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -143,6 +143,16 @@ pub fn validator_count_key() -> H256 {
     H256::from(poseidon2_hash(&[discriminator::VALIDATOR_COUNT]).to_bytes())
 }
 
+/// Key for validator address at index (for enumeration).
+///
+/// `key = Poseidon2(0x11 || index_le_bytes)`
+pub fn validator_index_key(index: u64) -> H256 {
+    let mut input = Vec::with_capacity(9);
+    input.push(discriminator::VALIDATOR_COUNT);
+    input.extend_from_slice(&index.to_le_bytes());
+    H256::from(poseidon2_hash(&input).to_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -260,6 +260,93 @@ pub fn execute_transaction(
 
             (true, gas_used, 0u64, vec![], new_addr.to_vec())
         }
+        TransactionType::StakeDeposit => {
+            // Stake deposit: lock VALIDATOR_STAKE from sender, create validator entry.
+            // tx.data = FALCON-512 public key (897 bytes).
+            // 10,000 PYDE = 10_000_000_000_000 quanta (matches consensus::validator::VALIDATOR_STAKE)
+            const VALIDATOR_STAKE: u128 = 10_000_000_000_000;
+
+            if sender.balance < VALIDATOR_STAKE {
+                (false, 21_000u64, 0u64, vec![], b"insufficient balance for stake deposit".to_vec())
+            } else if tx.data.len() < 897 {
+                (false, 21_000u64, 0u64, vec![], b"tx.data must contain FALCON public key (897 bytes)".to_vec())
+            } else {
+                // Deduct stake from sender balance
+                sender.balance -= VALIDATOR_STAKE;
+
+                // Write validator entry to state: [pk_len:4 LE][pk][stake:16 LE][status:1]
+                let pk_bytes = &tx.data[..897];
+                let mut val_data = Vec::with_capacity(4 + 897 + 16 + 1);
+                val_data.extend_from_slice(&(897u32).to_le_bytes());
+                val_data.extend_from_slice(pk_bytes);
+                val_data.extend_from_slice(&VALIDATOR_STAKE.to_le_bytes());
+                val_data.push(0x00); // Active
+
+                let val_key = pyde_state::keys::validator_key(&tx.from);
+                let _ = smt.insert(val_key, val_data);
+
+                // Update validator address list (append sender address)
+                let count_key = pyde_state::keys::validator_count_key();
+                let count = smt.get(&count_key)
+                    .map(|b| {
+                        if b.len() >= 8 {
+                            u64::from_le_bytes(b[..8].try_into().unwrap_or([0;8]))
+                        } else { 0 }
+                    })
+                    .unwrap_or(0);
+                let new_count = count + 1;
+                let _ = smt.insert(count_key, new_count.to_le_bytes().to_vec());
+
+                // Store address at index for enumeration
+                let idx_key = pyde_state::keys::validator_index_key(count);
+                let _ = smt.insert(idx_key, tx.from.to_vec());
+
+                tracing::info!(
+                    validator = hex::encode(tx.from),
+                    stake = VALIDATOR_STAKE,
+                    "stake deposit: new validator registered"
+                );
+
+                (true, 50_000u64, 0u64, vec![], tx.from.to_vec())
+            }
+        }
+        TransactionType::StakeWithdraw => {
+            // Stake withdraw: set validator status to Unbonding.
+            let val_key = pyde_state::keys::validator_key(&tx.from);
+            match smt.get(&val_key) {
+                Some(mut val_data) => {
+                    if val_data.len() < 5 {
+                        (false, 21_000u64, 0u64, vec![], b"invalid validator entry".to_vec())
+                    } else {
+                        let pk_len = u32::from_le_bytes([val_data[0], val_data[1], val_data[2], val_data[3]]) as usize;
+                        let status_offset = 4 + pk_len + 16;
+                        if val_data.len() <= status_offset {
+                            (false, 21_000u64, 0u64, vec![], b"invalid validator entry".to_vec())
+                        } else if val_data[status_offset] != 0x00 {
+                            // Not Active
+                            (false, 21_000u64, 0u64, vec![], b"validator is not active".to_vec())
+                        } else {
+                            // Set status to Unbonding (0x01) + store exit block
+                            val_data[status_offset] = 0x01;
+                            // Append exit block (8 bytes LE) for unbonding period tracking
+                            val_data.extend_from_slice(&block_ctx.height.to_le_bytes());
+                            let _ = smt.insert(val_key, val_data);
+
+                            tracing::info!(
+                                validator = hex::encode(tx.from),
+                                exit_block = block_ctx.height,
+                                "stake withdraw: validator unbonding started"
+                            );
+
+                            (true, 50_000u64, 0u64, vec![], vec![])
+                        }
+                    }
+                }
+                None => {
+                    (false, 21_000u64, 0u64, vec![], b"not a registered validator".to_vec())
+                }
+            }
+        }
         _ => {
             // Simple transfer or batch (batch deferred)
             (true, 21_000u64, 0u64, vec![], vec![])

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -17,6 +17,11 @@ pub enum TransactionType {
     Deploy = 1,
     /// Batch transaction (multiple operations).
     Batch = 2,
+    /// Stake deposit: lock 10,000 PYDE and register as validator.
+    /// tx.data = FALCON-512 public key (897 bytes).
+    StakeDeposit = 3,
+    /// Stake withdraw: begin unbonding period (14 days).
+    StakeWithdraw = 4,
 }
 
 impl TransactionType {
@@ -25,6 +30,8 @@ impl TransactionType {
             0 => Some(Self::Standard),
             1 => Some(Self::Deploy),
             2 => Some(Self::Batch),
+            3 => Some(Self::StakeDeposit),
+            4 => Some(Self::StakeWithdraw),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary
- StakeDeposit (type=3): lock 10K PYDE + FALCON pubkey → register as validator
- StakeWithdraw (type=4): begin 14-day unbonding period
- Validator entries stored in state with enumerable index for epoch loading
- load_validator_set_from_state reads ALL validators (genesis + dynamically staked)
- RPC supports txType: "stakeDeposit" / "stakeWithdraw"