### PR TITLE
feat: threshold encryption end-to-end with decryption + execution

### DIFF
--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -181,6 +181,32 @@ pub struct DecryptionShare {
     shares: Vec<Goldilocks>,
 }
 
+impl DecryptionShare {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(12 + self.shares.len() * 8);
+        buf.extend_from_slice(&(self.index as u64).to_le_bytes());
+        buf.extend_from_slice(&(self.shares.len() as u32).to_le_bytes());
+        for s in &self.shares {
+            buf.extend_from_slice(&gl_to_u64(*s).to_le_bytes());
+        }
+        buf
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 12 { return None; }
+        let index = u64::from_le_bytes(data[0..8].try_into().ok()?) as usize;
+        let count = u32::from_le_bytes(data[8..12].try_into().ok()?) as usize;
+        if data.len() < 12 + count * 8 { return None; }
+        let mut shares = Vec::with_capacity(count);
+        for i in 0..count {
+            let off = 12 + i * 8;
+            let val = u64::from_le_bytes(data[off..off+8].try_into().ok()?);
+            shares.push(gl(val));
+        }
+        Some(Self { index, shares })
+    }
+}
+
 /// Threshold-encrypted ciphertext.
 #[derive(Clone, Debug)]
 pub struct ThresholdCiphertext {
@@ -198,7 +224,8 @@ impl ThresholdCiphertext {
         self.encrypted_msg.len()
     }
 
-    /// Serialize to bytes for hashing/transmission.
+    /// Serialize to bytes for hashing (original format, no length prefixes).
+    /// Format: [kyber_ct_bytes][encrypted_msg][mac:32]
     pub fn to_bytes(&self) -> Vec<u8> {
         let ct_bytes = self.kyber_ct.as_bytes();
         let mut buf = Vec::with_capacity(ct_bytes.len() + self.encrypted_msg.len() + 32);
@@ -206,6 +233,35 @@ impl ThresholdCiphertext {
         buf.extend_from_slice(&self.encrypted_msg);
         buf.extend_from_slice(&self.mac);
         buf
+    }
+
+    /// Serialize to wire format with length prefixes (for block inclusion).
+    /// Format: [ct_len:4 LE][kyber_ct][msg_len:4 LE][encrypted_msg][mac:32]
+    pub fn to_wire_bytes(&self) -> Vec<u8> {
+        let ct_bytes = self.kyber_ct.as_bytes();
+        let mut buf = Vec::with_capacity(4 + ct_bytes.len() + 4 + self.encrypted_msg.len() + 32);
+        buf.extend_from_slice(&(ct_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(ct_bytes);
+        buf.extend_from_slice(&(self.encrypted_msg.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&self.encrypted_msg);
+        buf.extend_from_slice(&self.mac);
+        buf
+    }
+
+    /// Deserialize from wire format.
+    pub fn from_wire_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 8 { return None; }
+        let ct_len = u32::from_le_bytes([data[0],data[1],data[2],data[3]]) as usize;
+        if data.len() < 4 + ct_len + 4 { return None; }
+        let kyber_ct = KyberCiphertext::from_bytes(&data[4..4 + ct_len])?;
+        let msg_off = 4 + ct_len;
+        let msg_len = u32::from_le_bytes([data[msg_off],data[msg_off+1],data[msg_off+2],data[msg_off+3]]) as usize;
+        let msg_start = msg_off + 4;
+        if data.len() < msg_start + msg_len + 32 { return None; }
+        let encrypted_msg = data[msg_start..msg_start + msg_len].to_vec();
+        let mut mac = [0u8; 32];
+        mac.copy_from_slice(&data[msg_start + msg_len..msg_start + msg_len + 32]);
+        Some(Self { kyber_ct, encrypted_msg, mac })
     }
 }
 

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -71,6 +71,71 @@ impl EncryptedTx {
         poseidon2_hash(&buf).to_bytes()
     }
 
+    /// Serialize to bytes for block inclusion (wire format).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let ct_bytes = self.ciphertext.to_wire_bytes();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&self.sender);                          // 32
+        buf.extend_from_slice(&self.nonce.to_le_bytes());             // 8
+        buf.extend_from_slice(&self.gas_limit.to_le_bytes());         // 8
+        buf.extend_from_slice(&self.chain_id.to_le_bytes());          // 8
+        buf.push(self.deadline.is_some() as u8);                      // 1
+        if let Some(d) = self.deadline { buf.extend_from_slice(&d.to_le_bytes()); }
+        // Access list
+        buf.extend_from_slice(&(self.access_list.len() as u32).to_le_bytes());
+        for entry in &self.access_list {
+            buf.extend_from_slice(&entry.address);
+            buf.extend_from_slice(&(entry.reads.len() as u16).to_le_bytes());
+            for r in &entry.reads { buf.extend_from_slice(r); }
+            buf.extend_from_slice(&(entry.writes.len() as u16).to_le_bytes());
+            for w in &entry.writes { buf.extend_from_slice(w); }
+        }
+        // Signature
+        buf.extend_from_slice(&(self.signature.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&self.signature);
+        // Ciphertext
+        buf.extend_from_slice(&(ct_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&ct_bytes);
+        buf
+    }
+
+    /// Deserialize from bytes.
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 57 { return None; } // minimum: 32+8+8+8+1
+        let mut off = 0;
+        let mut sender = [0u8; 32];
+        sender.copy_from_slice(&data[off..off+32]); off += 32;
+        let nonce = u64::from_le_bytes(data[off..off+8].try_into().ok()?); off += 8;
+        let gas_limit = u64::from_le_bytes(data[off..off+8].try_into().ok()?); off += 8;
+        let chain_id = u64::from_le_bytes(data[off..off+8].try_into().ok()?); off += 8;
+        let has_deadline = data[off]; off += 1;
+        let deadline = if has_deadline != 0 {
+            let d = u64::from_le_bytes(data[off..off+8].try_into().ok()?); off += 8;
+            Some(d)
+        } else { None };
+        // Access list
+        let al_count = u32::from_le_bytes(data[off..off+4].try_into().ok()?) as usize; off += 4;
+        let mut access_list = Vec::with_capacity(al_count);
+        for _ in 0..al_count {
+            let mut addr = [0u8; 32];
+            addr.copy_from_slice(&data[off..off+32]); off += 32;
+            let rc = u16::from_le_bytes(data[off..off+2].try_into().ok()?) as usize; off += 2;
+            let mut reads = Vec::with_capacity(rc);
+            for _ in 0..rc { let mut k=[0u8;32]; k.copy_from_slice(&data[off..off+32]); off+=32; reads.push(k); }
+            let wc = u16::from_le_bytes(data[off..off+2].try_into().ok()?) as usize; off += 2;
+            let mut writes = Vec::with_capacity(wc);
+            for _ in 0..wc { let mut k=[0u8;32]; k.copy_from_slice(&data[off..off+32]); off+=32; writes.push(k); }
+            access_list.push(pyde_tx::types::AccessEntry { address: addr, reads, writes });
+        }
+        // Signature
+        let sig_len = u32::from_le_bytes(data[off..off+4].try_into().ok()?) as usize; off += 4;
+        let signature = data[off..off+sig_len].to_vec(); off += sig_len;
+        // Ciphertext
+        let ct_len = u32::from_le_bytes(data[off..off+4].try_into().ok()?) as usize; off += 4;
+        let ciphertext = pyde_crypto::threshold::ThresholdCiphertext::from_wire_bytes(&data[off..off+ct_len])?;
+        Some(Self { sender, nonce, gas_limit, access_list, deadline, chain_id, signature, ciphertext })
+    }
+
     /// Check if the transaction has expired.
     pub fn is_expired(&self, current_block: u64) -> bool {
         match self.deadline {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -188,6 +188,15 @@ impl PydeNode {
         let mempool_index: Arc<RwLock<std::collections::HashMap<[u8; 32], Vec<u8>>>> =
             Arc::new(RwLock::new(std::collections::HashMap::new()));
 
+        // Pending block decryptors: slot → BlockDecryptor (collecting shares for threshold decryption)
+        let pending_decryptors: Arc<RwLock<std::collections::HashMap<u64, pyde_mempool::decryption::BlockDecryptor>>> =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+
+        // Queued decryption shares that arrived before the BlockDecryptor was created.
+        // When a decryptor is created for a slot, queued shares are replayed into it.
+        let queued_shares: Arc<RwLock<std::collections::HashMap<u64, Vec<wire::DecryptionShareMsg>>>> =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+
         // 4. Chain sync
         let mut chain_sync = ChainSync::new();
         chain_sync.manager.local_tip = chain.read().await.head_slot;
@@ -534,15 +543,74 @@ impl PydeNode {
                             }
                         }
                         PostEventAction::BlockProcessed { slot, receipts: receipts_list, tx_hashes } => {
-                            // Store receipts
                             if !receipts_list.is_empty() {
                                 let mut receipts_w = receipts.write().await;
                                 receipts_w.insert_block_receipts(slot, receipts_list);
                             }
-                            // Remove processed txs from pending queue (dedup)
                             if !tx_hashes.is_empty() {
                                 let mut pending_w = pending_txs.write().await;
                                 pending_w.retain(|tx| !tx_hashes.contains(&tx.hash()));
+                            }
+                        }
+                        PostEventAction::AddDecryptionShares(msg) => {
+                            let slot = msg.slot;
+                            let mut dec_w = pending_decryptors.write().await;
+                            if let Some(decryptor) = dec_w.get_mut(&slot) {
+                                // Decryptor exists — feed shares directly
+                                // Feed each share to the decryptor
+                                for (i, share_bytes) in msg.shares.iter().enumerate() {
+                                    if let Some(share) = pyde_crypto::threshold::DecryptionShare::from_bytes(share_bytes) {
+                                        decryptor.add_share(i, share);
+                                    }
+                                }
+
+                                // Check if threshold reached → decrypt + execute
+                                if decryptor.all_ready() {
+                                    match decryptor.decrypt_all() {
+                                        Ok(decrypted_txs) => {
+                                            info!(
+                                                slot,
+                                                txs = decrypted_txs.len(),
+                                                "threshold reached — decrypted + executing encrypted txs"
+                                            );
+                                            let mut chain_w = chain.write().await;
+                                            let mut state_w = state.write().await;
+                                            let proposer = block_store.get_header(slot)
+                                                .map(|h| h.proposer).unwrap_or([0u8; 32]);
+                                            let block_ctx = pyde_tx::pipeline::BlockContext {
+                                                height: slot,
+                                                timestamp: 0,
+                                                base_fee: chain_w.base_fee,
+                                                block_gas_limit: self.config.consensus.gas_ceiling,
+                                                chain_id: chain_w.chain_id,
+                                                validator_address: proposer,
+                                            };
+                                            let mut slot_receipts = Vec::new();
+                                            for dtx in &decrypted_txs {
+                                                match pyde_tx::pipeline::execute_transaction(dtx, state_w.smt_mut(), &block_ctx) {
+                                                    Ok(receipt) => {
+                                                        slot_receipts.push(receipt);
+                                                    }
+                                                    Err(e) => {
+                                                        warn!(slot, error = ?e, "decrypted tx execution failed");
+                                                    }
+                                                }
+                                            }
+                                            state_w.refresh_root();
+                                            if !slot_receipts.is_empty() {
+                                                let mut receipts_w = receipts.write().await;
+                                                receipts_w.insert_block_receipts(slot, slot_receipts);
+                                            }
+                                        }
+                                        Err(e) => warn!(slot, error = %e, "decryption failed"),
+                                    }
+                                    dec_w.remove(&slot);
+                                }
+                            } else {
+                                // No decryptor yet — queue shares for later replay
+                                drop(dec_w);
+                                let mut q = queued_shares.write().await;
+                                q.entry(slot).or_default().push(msg);
                             }
                         }
                     }
@@ -630,14 +698,23 @@ impl PydeNode {
                                     let all_pending: Vec<pyde_tx::types::Transaction> = pending_w.drain(..).collect();
                                     let gas_ceiling = self.config.consensus.gas_ceiling;
                                     let (txs, remaining) = crate::block_builder::build_tx_list(all_pending, gas_ceiling);
-                                    // Return overflow txs to pending queue
                                     if !remaining.is_empty() {
                                         pending_w.extend(remaining);
                                     }
                                     drop(pending_w);
 
+                                    // Also collect encrypted txs from the threshold-encrypted mempool
+                                    let encrypted_blobs = {
+                                        let relay_r = tx_relay.read().await;
+                                        let selected = relay_r.mempool().select_for_block(
+                                            gas_ceiling, current_slot,
+                                        );
+                                        // Serialize each EncryptedTx to bytes for block inclusion
+                                        selected.iter().map(|etx| etx.to_bytes()).collect::<Vec<Vec<u8>>>()
+                                    };
+
                                     // Only produce a block if there are pending transactions
-                                    if txs.is_empty() {
+                                    if txs.is_empty() && encrypted_blobs.is_empty() {
                                         debug!(slot = current_slot, "skipping empty slot (no pending txs)");
                                     } else {
                                     let tx_count = txs.len();
@@ -668,10 +745,11 @@ impl PydeNode {
                                     let block = engine.build_proposal(
                                         identity,
                                         parent_hash,
-                                        parent_hash, // pre-state root (post-state computed after execution)
+                                        parent_hash,
                                         tx_root,
                                         vrf_data,
                                         txs,
+                                        encrypted_blobs,
                                         exec_schedule,
                                     );
 
@@ -702,25 +780,45 @@ impl PydeNode {
                                         }
                                     }
 
+                                    // Remove included encrypted txs from mempool
+                                    if !block.body.encrypted_txs.is_empty() {
+                                        let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
+                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                            .map(|etx| etx.hash())
+                                            .collect();
+                                        let mut relay_w = tx_relay.write().await;
+                                        relay_w.remove_included(&enc_hashes);
+                                    }
+
                                     // Store full block for sync serving + missing tx requests
                                     let full_block_bytes = wire::encode_block(&block);
                                     let _ = block_store.put_block(&block.header, &full_block_bytes);
 
-                                    // Broadcast COMPACT block (header + 8-byte short IDs) instead of full block.
-                                    // Receivers reconstruct from their mempool.
-                                    let header_bytes = wire::encode_block_header(&block.header);
-                                    let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
-                                        .map(|tx| tx.hash()).collect();
-                                    let compact = pyde_net::propagation::CompactBlock::from_block(
-                                        header_bytes,
-                                        &tx_hashes,
-                                        &[], // no prefilled txs for now
-                                        &[],
-                                    );
-                                    let compact_bytes = wire::encode_compact_block(&compact);
+                                    // Broadcast block to peers.
+                                    // If block has encrypted txs, send FULL block (encrypted blobs
+                                    // can't be compacted — they're opaque, not matchable against mempool).
+                                    // Otherwise use compact blocks for bandwidth efficiency.
                                     let topic = pyde_net::node::topics::blocks();
-                                    if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, compact_bytes) {
-                                        debug!(slot = current_slot, error = %e, "no gossipsub subscribers for block");
+                                    if !block.body.encrypted_txs.is_empty() {
+                                        // Full block broadcast (includes encrypted blobs)
+                                        if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, full_block_bytes.clone()) {
+                                            debug!(slot = current_slot, error = %e, "no gossipsub subscribers for block");
+                                        }
+                                    } else {
+                                        // Compact block broadcast (plaintext only)
+                                        let header_bytes = wire::encode_block_header(&block.header);
+                                        let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
+                                            .map(|tx| tx.hash()).collect();
+                                        let compact = pyde_net::propagation::CompactBlock::from_block(
+                                            header_bytes,
+                                            &tx_hashes,
+                                            &[],
+                                            &[],
+                                        );
+                                        let compact_bytes = wire::encode_compact_block(&compact);
+                                        if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, compact_bytes) {
+                                            debug!(slot = current_slot, error = %e, "no gossipsub subscribers for block");
+                                        }
                                     }
 
                                     // Broadcast proposal as consensus message
@@ -779,6 +877,115 @@ impl PydeNode {
                                             let topic = pyde_net::node::topics::consensus();
                                             let _ = swarm.behaviour_mut().gossipsub.publish(topic, fv_bytes);
                                         }
+
+                                        // After QC: if block has encrypted txs, create a
+                                        // BlockDecryptor, generate + broadcast our shares,
+                                        // and start collecting shares from other validators.
+                                        if identity.key_share.is_some() {
+                                            if let Some(block_raw) = block_store.get_block_raw(current_slot) {
+                                                if let Ok(block) = wire::decode_block(&block_raw) {
+                                                    if !block.body.encrypted_txs.is_empty() {
+                                                        let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> =
+                                                            block.body.encrypted_txs.iter()
+                                                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                                                .collect();
+                                                        if !enc_txs.is_empty() {
+                                                            let threshold = pyde_consensus::block::quorum_for_committee(
+                                                                engine.committee_keys.len()
+                                                            );
+                                                            // Create decryptor and seed with our own shares
+                                                            if let Ok(mut decryptor) = pyde_mempool::decryption::BlockDecryptor::new(
+                                                                enc_txs.clone(), threshold,
+                                                            ) {
+                                                                if let Some(ks) = &identity.key_share {
+                                                                    decryptor.add_member_shares(ks);
+                                                                }
+                                                                // Store decryptor for share collection
+                                                                // Replay any queued shares that arrived before the decryptor
+                                                                {
+                                                                    let mut q = queued_shares.write().await;
+                                                                    if let Some(queued) = q.remove(&current_slot) {
+                                                                        for qmsg in &queued {
+                                                                            for (i, sb) in qmsg.shares.iter().enumerate() {
+                                                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
+                                                                                    decryptor.add_share(i, s);
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                        debug!(
+                                                                            slot = current_slot,
+                                                                            replayed = queued.len(),
+                                                                            "replayed queued decryption shares"
+                                                                        );
+                                                                    }
+                                                                }
+                                                                pending_decryptors.write().await.insert(current_slot, decryptor);
+                                                            }
+
+                                                            // Broadcast our shares
+                                                            if let Some(shares) = engine.generate_decryption_shares(identity, &enc_txs) {
+                                                                let msg = wire::DecryptionShareMsg {
+                                                                    slot: current_slot,
+                                                                    member_index: identity.committee_index,
+                                                                    shares: shares.iter().map(|s| s.to_bytes()).collect(),
+                                                                };
+                                                                let share_bytes = wire::encode_decryption_shares(&msg);
+                                                                let topic = pyde_net::node::topics::consensus();
+                                                                let _ = swarm.behaviour_mut().gossipsub.publish(topic, share_bytes);
+                                                                info!(
+                                                                    slot = current_slot,
+                                                                    enc_txs = enc_txs.len(),
+                                                                    "broadcast decryption shares"
+                                                                );
+                                                            }
+
+                                                            // Check if already at threshold (e.g. single node)
+                                                            let mut dec_w = pending_decryptors.write().await;
+                                                            if let Some(decryptor) = dec_w.get_mut(&current_slot) {
+                                                                if decryptor.all_ready() {
+                                                                    match decryptor.decrypt_all() {
+                                                                        Ok(decrypted_txs) => {
+                                                                            info!(
+                                                                                slot = current_slot,
+                                                                                txs = decrypted_txs.len(),
+                                                                                "encrypted txs decrypted — executing"
+                                                                            );
+                                                                            // Execute decrypted txs
+                                                                            let mut chain_w = chain.write().await;
+                                                                            let mut state_w = state.write().await;
+                                                                            let proposer = block_store.get_header(current_slot)
+                                                                                .map(|h| h.proposer).unwrap_or(identity.address);
+                                                                            let block_ctx = pyde_tx::pipeline::BlockContext {
+                                                                                height: current_slot,
+                                                                                timestamp: 0,
+                                                                                base_fee: chain_w.base_fee,
+                                                                                block_gas_limit: self.config.consensus.gas_ceiling,
+                                                                                chain_id: chain_w.chain_id,
+                                                                                validator_address: proposer,
+                                                                            };
+                                                                            for dtx in &decrypted_txs {
+                                                                                match pyde_tx::pipeline::execute_transaction(dtx, state_w.smt_mut(), &block_ctx) {
+                                                                                    Ok(receipt) => {
+                                                                                        let mut receipts_w = receipts.write().await;
+                                                                                        receipts_w.insert_block_receipts(current_slot, vec![receipt]);
+                                                                                    }
+                                                                                    Err(e) => {
+                                                                                        warn!(error = ?e, "failed to execute decrypted tx");
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                            state_w.refresh_root();
+                                                                        }
+                                                                        Err(e) => warn!(error = %e, "decryption failed"),
+                                                                    }
+                                                                    dec_w.remove(&current_slot);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -835,6 +1042,14 @@ impl PydeNode {
                     // Critical for mesh resilience: ensures nodes connect to each other,
                     // not just the bootstrap node.
                     let _ = swarm.behaviour_mut().kademlia.bootstrap();
+                    // Clean up stale decryptors and queued shares (older than 100 slots)
+                    {
+                        let head = chain.read().await.head_slot;
+                        let mut dec_w = pending_decryptors.write().await;
+                        dec_w.retain(|slot, _| *slot + 100 > head);
+                        let mut q = queued_shares.write().await;
+                        q.retain(|slot, _| *slot + 100 > head);
+                    }
                     let head = chain.read().await.head_slot;
                     debug!(
                         peers = peer_count,
@@ -882,6 +1097,7 @@ enum PostEventAction {
         tx_hashes: Vec<[u8; 32]>,
     },
     ReconstructCompactBlock(pyde_net::propagation::CompactBlock),
+    AddDecryptionShares(wire::DecryptionShareMsg),
 }
 
 /// Handle a libp2p swarm event. Returns an action that may need swarm access.
@@ -1010,6 +1226,26 @@ fn handle_swarm_event(
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode randomness share");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
+                        // Check if it's a decryption share
+                        if !message.data.is_empty() && message.data[0] == wire::tag::DECRYPTION_SHARES {
+                            match wire::decode_decryption_shares(&message.data) {
+                                Ok(msg) => {
+                                    debug!(
+                                        slot = msg.slot,
+                                        member = msg.member_index,
+                                        shares = msg.shares.len(),
+                                        "received decryption shares"
+                                    );
+                                    // Feed shares to the BlockDecryptor for this slot
+                                    return PostEventAction::AddDecryptionShares(msg);
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode decryption shares");
                                 }
                             }
                             return PostEventAction::None;

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -562,6 +562,7 @@ impl ValidatorEngine {
         tx_root: [u8; 32],
         vrf_proof: Vec<u8>,
         transactions: Vec<pyde_tx::types::Transaction>,
+        encrypted_txs: Vec<Vec<u8>>,
         execution_schedule: ExecutionSchedule,
     ) -> Block {
         let slot = self.consensus.current_slot;
@@ -596,7 +597,7 @@ impl ValidatorEngine {
             header,
             body: BlockBody {
                 transactions,
-                encrypted_txs: vec![],
+                encrypted_txs,
                 execution_schedule,
             },
             proposer_signature,
@@ -1104,6 +1105,7 @@ mod tests {
             [0xBB; 32],
             [0xCC; 32],
             vec![0xDD; 100],
+            vec![],
             vec![],
             ExecutionSchedule { groups: vec![], total_txs: 0 },
         );

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -485,6 +485,11 @@ pub fn encode_block(block: &Block) -> Vec<u8> {
         let tx_bytes = encode_transaction(tx);
         enc.var_bytes(&tx_bytes);
     }
+    // Encrypted transactions (threshold-encrypted blobs)
+    enc.u32(block.body.encrypted_txs.len() as u32);
+    for etx in &block.body.encrypted_txs {
+        enc.var_bytes(etx);
+    }
     // Execution schedule: group count + tx indices per group
     enc.u16(block.body.execution_schedule.groups.len() as u16);
     for group in &block.body.execution_schedule.groups {
@@ -512,8 +517,14 @@ pub fn decode_block(data: &[u8]) -> Result<Block, &'static str> {
         let tx_bytes = dec.var_bytes()?;
         transactions.push(decode_transaction(&tx_bytes)?);
     }
+    // Encrypted transactions
+    let enc_count = if dec.remaining() >= 4 { dec.u32()? as usize } else { 0 };
+    let mut encrypted_txs = Vec::with_capacity(enc_count);
+    for _ in 0..enc_count {
+        encrypted_txs.push(dec.var_bytes()?);
+    }
     // Execution schedule
-    let group_count = dec.u16()? as usize;
+    let group_count = if dec.remaining() >= 2 { dec.u16()? as usize } else { 0 };
     let mut groups = Vec::with_capacity(group_count);
     for _ in 0..group_count {
         let idx_count = dec.u16()? as usize;
@@ -526,7 +537,7 @@ pub fn decode_block(data: &[u8]) -> Result<Block, &'static str> {
         header,
         body: BlockBody {
             transactions,
-            encrypted_txs: vec![],
+            encrypted_txs,
             execution_schedule: ExecutionSchedule { groups, total_txs },
         },
         proposer_signature,


### PR DESCRIPTION
## Summary
Complete MEV protection — encrypted txs go in, get decrypted after QC, get executed.

- Encrypted tx → mempool → block → full broadcast (not compact)
- QC → BlockDecryptor → seed own shares → replay queued early shares
- Broadcast decryption shares (serialized with actual field values)
- Threshold reached → decrypt_all → execute → receipts → state update
- Proposer fee from block header, stale cleanup, mempool dedup

No dead ends. Every encrypted tx that enters a block gets decrypted and executed.