### PR TITLE
feat: PSS key share refresh at epoch boundary

### DIFF
--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -522,6 +522,46 @@ pub fn generate_refresh_contribution(
     RefreshContribution { from_index, deltas }
 }
 
+impl RefreshContribution {
+    /// Serialize for P2P transmission.
+    /// Format: [from_index:8 LE][n:4 LE][elements_per_val:4 LE][[delta:8 LE]*elements]*n
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let n = self.deltas.len();
+        let elems = if n > 0 { self.deltas[0].len() } else { 0 };
+        let mut buf = Vec::with_capacity(16 + n * elems * 8);
+        buf.extend_from_slice(&(self.from_index as u64).to_le_bytes());
+        buf.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.extend_from_slice(&(elems as u32).to_le_bytes());
+        for v_deltas in &self.deltas {
+            for d in v_deltas {
+                buf.extend_from_slice(&gl_to_u64(*d).to_le_bytes());
+            }
+        }
+        buf
+    }
+
+    /// Deserialize from bytes.
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 16 { return None; }
+        let from_index = u64::from_le_bytes(data[0..8].try_into().ok()?) as usize;
+        let n = u32::from_le_bytes(data[8..12].try_into().ok()?) as usize;
+        let elems = u32::from_le_bytes(data[12..16].try_into().ok()?) as usize;
+        if data.len() < 16 + n * elems * 8 { return None; }
+        let mut deltas = Vec::with_capacity(n);
+        let mut off = 16;
+        for _ in 0..n {
+            let mut v = Vec::with_capacity(elems);
+            for _ in 0..elems {
+                let val = u64::from_le_bytes(data[off..off+8].try_into().ok()?);
+                v.push(gl(val));
+                off += 8;
+            }
+            deltas.push(v);
+        }
+        Some(Self { from_index, deltas })
+    }
+}
+
 /// Apply refresh contributions to a validator's key share.
 /// Each validator sums the delta values from all contributions into their share.
 /// The underlying secret remains the same, but all shares change.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -404,7 +404,7 @@ impl PydeNode {
                             &mut tx_relay_w,
                             &mut chain_sync,
                             &mut validator_engine,
-                            &validator_identity,
+                            &mut validator_identity,
                             &block_store,
                         )
                     };
@@ -671,12 +671,20 @@ impl PydeNode {
                                             "committee rotated at epoch boundary"
                                         );
 
-                                        // Generate and broadcast our epoch randomness share
                                         if let Some(identity) = validator_identity.as_ref() {
+                                            // Generate and broadcast epoch randomness share
                                             if let Some(share) = engine.start_epoch_randomness(new_epoch + 1, identity) {
                                                 let share_bytes = wire::encode_randomness_share(new_epoch + 1, &share);
                                                 let topic = pyde_net::node::topics::consensus();
                                                 let _ = swarm.behaviour_mut().gossipsub.publish(topic, share_bytes);
+                                            }
+
+                                            // Generate and broadcast PSS refresh contribution
+                                            // (rotates threshold key shares so genesis trust dissolves)
+                                            if let Some(contrib) = engine.start_pss_refresh(new_epoch + 1, identity) {
+                                                let contrib_bytes = wire::encode_pss_refresh(new_epoch + 1, &contrib.to_bytes());
+                                                let topic = pyde_net::node::topics::consensus();
+                                                let _ = swarm.behaviour_mut().gossipsub.publish(topic, contrib_bytes);
                                             }
                                         }
                                     }
@@ -1059,6 +1067,20 @@ impl PydeNode {
                         behind = chain_sync.manager.slots_behind(),
                         "maintenance tick"
                     );
+                    // Persist refreshed key share to disk if dirty
+                    if let Some(engine) = validator_engine.as_mut() {
+                        if engine.key_share_dirty {
+                            if let Some(identity) = validator_identity.as_ref() {
+                                if let Some(ref ks) = identity.key_share {
+                                    let share_path = self.config.node.datadir.join("threshold.share");
+                                    if std::fs::write(&share_path, ks.to_bytes()).is_ok() {
+                                        engine.key_share_dirty = false;
+                                        info!("PSS: refreshed key share saved to disk");
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 _ = shutdown_rx.recv() => {
                     info!("shutdown signal received, stopping node...");
@@ -1108,7 +1130,7 @@ fn handle_swarm_event(
     tx_relay: &mut TxRelay,
     chain_sync: &mut ChainSync,
     validator_engine: &mut Option<ValidatorEngine>,
-    validator_identity: &Option<ValidatorIdentity>,
+    validator_identity: &mut Option<ValidatorIdentity>,
     block_store: &BlockStore,
 ) -> PostEventAction {
     match event {
@@ -1226,6 +1248,24 @@ fn handle_swarm_event(
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode randomness share");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
+                        // Check if it's a PSS refresh contribution
+                        if !message.data.is_empty() && message.data[0] == wire::tag::PSS_REFRESH {
+                            match wire::decode_pss_refresh(&message.data) {
+                                Ok((epoch, contrib_bytes)) => {
+                                    if let Some(contrib) = pyde_crypto::threshold::RefreshContribution::from_bytes(&contrib_bytes) {
+                                        debug!(epoch, from = contrib.from_index, "received PSS refresh contribution");
+                                        if let Some(identity) = validator_identity.as_mut() {
+                                            engine.on_pss_contribution(contrib, identity);
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode PSS contribution");
                                 }
                             }
                             return PostEventAction::None;

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -13,6 +13,9 @@ use pyde_consensus::epoch_randomness::{
     RandomnessCollector, RandomnessShare, generate_share, verify_share,
     combine_shares_dynamic,
 };
+use pyde_crypto::threshold::{
+    RefreshContribution, generate_refresh_contribution, apply_refresh, verify_refresh_contribution,
+};
 use pyde_consensus::slashing::{
     DoubleSignEvidence, SlashResult, slash_double_sign, verify_double_sign,
 };
@@ -235,6 +238,12 @@ pub struct ValidatorEngine {
     pub pending_slashes: Vec<SlashResult>,
     /// Epoch randomness collector (gathers VRF shares at epoch boundary).
     randomness_collector: Option<RandomnessCollector>,
+    /// PSS refresh contributions collected at epoch boundary.
+    pss_contributions: Vec<RefreshContribution>,
+    /// Target epoch for PSS refresh.
+    pss_target_epoch: u64,
+    /// Set to true when key share was refreshed and needs saving to disk.
+    pub key_share_dirty: bool,
 }
 
 impl ValidatorEngine {
@@ -256,6 +265,9 @@ impl ValidatorEngine {
             seen_votes: HashMap::new(),
             pending_slashes: Vec::new(),
             randomness_collector: None,
+            pss_contributions: Vec::new(),
+            pss_target_epoch: 0,
+            key_share_dirty: false,
         }
     }
 
@@ -267,6 +279,78 @@ impl ValidatorEngine {
 
     /// Start collecting epoch randomness shares for the next epoch.
     /// Called at epoch boundary. Generates and returns our own share to broadcast.
+    /// Generate a PSS refresh contribution and start collecting others'.
+    /// Returns our contribution to broadcast.
+    pub fn start_pss_refresh(
+        &mut self,
+        epoch: u64,
+        identity: &ValidatorIdentity,
+    ) -> Option<RefreshContribution> {
+        let key_share = identity.key_share.as_ref()?;
+        let n = self.committee_keys.len();
+        let threshold = quorum_for_committee(n);
+
+        // Use PRIVATE entropy: hash of secret key + epoch randomness.
+        // This ensures each validator's contribution is unpredictable to others.
+        // Public epoch_randomness alone would let attackers derive all contributions.
+        let mut private_entropy = Vec::with_capacity(64);
+        private_entropy.extend_from_slice(identity.secret_key.as_bytes());
+        private_entropy.extend_from_slice(&self.epoch_randomness);
+        let entropy = pyde_crypto::poseidon2::poseidon2_hash(&private_entropy);
+
+        let contribution = generate_refresh_contribution(
+            key_share.index,
+            n,
+            threshold,
+            epoch,
+            entropy.as_bytes(),
+        );
+
+        self.pss_contributions = vec![contribution.clone()];
+        self.pss_target_epoch = epoch;
+        info!(epoch, "started PSS key share refresh");
+        Some(contribution)
+    }
+
+    /// Add a received PSS refresh contribution. Returns the new KeyShare if threshold reached.
+    pub fn on_pss_contribution(
+        &mut self,
+        contribution: RefreshContribution,
+        identity: &mut ValidatorIdentity,
+    ) -> bool {
+        let threshold = quorum_for_committee(self.committee_keys.len());
+
+        // Verify the contribution (zero-secret reconstruction check)
+        if !verify_refresh_contribution(&contribution, threshold) {
+            warn!(from = contribution.from_index, "invalid PSS refresh contribution");
+            return false;
+        }
+
+        // Check for duplicate
+        if self.pss_contributions.iter().any(|c| c.from_index == contribution.from_index) {
+            return false;
+        }
+
+        self.pss_contributions.push(contribution);
+
+        // If threshold reached, apply all contributions to our key share
+        if self.pss_contributions.len() >= threshold {
+            if let Some(ref old_share) = identity.key_share {
+                let new_share = apply_refresh(old_share, &self.pss_contributions);
+                identity.key_share = Some(new_share);
+                self.pss_contributions.clear();
+                self.key_share_dirty = true;
+                info!(
+                    epoch = self.pss_target_epoch,
+                    contributions = threshold,
+                    "PSS key share refreshed — genesis trust dissolved"
+                );
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn start_epoch_randomness(
         &mut self,
         next_epoch: u64,

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -23,6 +23,7 @@ pub mod tag {
     pub const CONSENSUS_FINALITY_VOTE: u8 = 0x14;
     pub const COMPACT_BLOCK: u8 = 0x03;
     pub const RANDOMNESS_SHARE: u8 = 0x15;
+    pub const PSS_REFRESH: u8 = 0x16;
     pub const GET_BLOCK_TXS: u8 = 0x04;
     pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
     pub const DECRYPTION_SHARES: u8 = 0x20;
@@ -110,6 +111,27 @@ pub fn decode_randomness_share(
         vrf_output: pyde_crypto::vrf::VrfOutput::from_hash_bytes(&output_bytes),
         vrf_proof: pyde_crypto::vrf::VrfProof::from_bytes(&proof_bytes),
     }))
+}
+
+// ============================================================
+// PSS Refresh Contribution
+// ============================================================
+
+pub fn encode_pss_refresh(epoch: u64, contribution_bytes: &[u8]) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(tag::PSS_REFRESH);
+    enc.u64(epoch);
+    enc.var_bytes(contribution_bytes);
+    enc.finish()
+}
+
+pub fn decode_pss_refresh(data: &[u8]) -> Result<(u64, Vec<u8>), &'static str> {
+    let mut dec = Decoder::new(data);
+    let t = dec.u8()?;
+    if t != tag::PSS_REFRESH { return Err("not a PSS refresh"); }
+    let epoch = dec.u64()?;
+    let contribution = dec.var_bytes()?;
+    Ok((epoch, contribution))
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
Proactive Secret Sharing dissolves genesis keygen trust after epoch 1.

- Private entropy per validator (Poseidon2(sk || epoch_randomness))
- Zero-secret polynomial contributions verified before collection
- Threshold contributions → apply_refresh → new shares, same TPK
- Dirty flag + maintenance tick saves refreshed share to disk
- Old shares become useless — attacker can't accumulate across epochs