### PR TITLE
fix: request full block when compact block has missing txs

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -483,8 +483,15 @@ impl PydeNode {
                             let (matched, missing) = cb.reconstruct(&mempool_txs);
 
                             if !missing.is_empty() {
-                                // TODO: request missing txs from peers via GetBlockTxs
-                                warn!(slot, missing = missing.len(), "compact block has missing txs — requesting not yet implemented, skipping");
+                                // Can't fully reconstruct — request full block via sync.
+                                // Update network tip so sync manager knows to fetch this slot.
+                                debug!(
+                                    slot,
+                                    missing = missing.len(),
+                                    "compact block missing txs — triggering sync for full block"
+                                );
+                                chain_sync.manager.update_network_tip(slot);
+                                chain_sync.request_next_batch(&mut swarm);
                                 continue;
                             }
 


### PR DESCRIPTION
## Summary
Fall back to sync protocol when compact block reconstruction has missing txs.
Reuses existing GetBlocks path. No new protocol needed.
Previously blocks were silently lost — now recovered via full block download.