### PR TITLE
fix: SDK-critical RPC fixes, reentrancy guard, WS broadcasts

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -331,10 +331,13 @@ impl PydeNode {
 
         // 10. Start RPC server if enabled
         let (tx_gossip_tx, mut tx_gossip_rx) = tokio::sync::mpsc::channel::<pyde_tx::types::Transaction>(1024);
+        // WebSocket subscription broadcast channels (created even if RPC disabled — cheap no-op)
+        let (new_heads_tx, _) = tokio::sync::broadcast::channel::<serde_json::Value>(256);
+        let (pending_tx_tx, _) = tokio::sync::broadcast::channel::<String>(4096);
+        let (logs_tx, _) = tokio::sync::broadcast::channel::<serde_json::Value>(1024);
+        let ws_heads = new_heads_tx.clone();
+        let ws_logs = logs_tx.clone();
         if self.config.rpc.enabled {
-            let (new_heads_tx, _) = tokio::sync::broadcast::channel(256);
-            let (pending_tx_tx, _) = tokio::sync::broadcast::channel(4096);
-            let (logs_tx, _) = tokio::sync::broadcast::channel(1024);
             let rpc_state = Arc::new(RpcState {
                 chain: chain.clone(),
                 state: state.clone(),
@@ -870,6 +873,22 @@ impl PydeNode {
                                                 chain_sync.on_block_processed(current_slot);
                                                 let mut receipts_w = receipts.write().await;
                                                 receipts_w.insert_block_receipts(current_slot, receipts_list.clone());
+                                                // Broadcast to WS subscribers
+                                                let _ = ws_heads.send(serde_json::json!({
+                                                    "slot": format!("0x{:x}", current_slot),
+                                                    "timestamp": format!("0x{:x}", block.header.timestamp),
+                                                    "proposer": format!("0x{}", hex::encode(block.header.proposer)),
+                                                    "txCount": format!("0x{:x}", tc),
+                                                }));
+                                                for r in receipts_list.iter() {
+                                                    for log in &r.logs {
+                                                        let _ = ws_logs.send(serde_json::json!({
+                                                            "address": format!("0x{}", hex::encode(log.address)),
+                                                            "topics": log.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
+                                                            "data": format!("0x{}", hex::encode(&log.data)),
+                                                        }));
+                                                    }
+                                                }
                                                 info!(
                                                     slot = current_slot, txs = tc, gas,
                                                     "proposed and processed block"

--- a/crates/node/src/receipt_store.rs
+++ b/crates/node/src/receipt_store.rs
@@ -56,22 +56,25 @@ impl ReceiptStore {
         address_filter: Option<&[u8; 32]>,
     ) -> Vec<(u64, &LogEntry)> {
         let mut results = Vec::new();
-        for slot in from_slot..=to_slot {
-            if let Some(tx_hashes) = self.slot_txs.get(&slot) {
-                for hash in tx_hashes {
-                    if let Some(receipt) = self.receipts.get(hash) {
-                        for log in &receipt.logs {
-                            if let Some(addr) = address_filter {
-                                if &log.address != addr {
-                                    continue;
-                                }
+        // Iterate over stored slots only (not the full range which could be u64::MAX)
+        for (&slot, tx_hashes) in &self.slot_txs {
+            if slot < from_slot || slot > to_slot {
+                continue;
+            }
+            for hash in tx_hashes {
+                if let Some(receipt) = self.receipts.get(hash) {
+                    for log in &receipt.logs {
+                        if let Some(addr) = address_filter {
+                            if &log.address != addr {
+                                continue;
                             }
-                            results.push((slot, log));
                         }
+                        results.push((slot, log));
                     }
                 }
             }
         }
+        results.sort_by_key(|(slot, _)| *slot);
         results
     }
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -503,8 +503,8 @@ impl PydeApiServer for RpcServer {
                 let blob = vm.memory.load_bytes(r1 as usize, r2 as usize);
                 Ok(format!("0x{}", hex::encode(blob)))
             } else {
-                // GP return: r1 as integer
-                Ok(format!("0x{:x}", r1))
+                // GP return: r1 as u64 — encode as 8 bytes LE hex (consistent with ABI)
+                Ok(format!("0x{}", hex::encode(r1.to_le_bytes())))
             }
         } else {
             Err(rpc_err(-32000, format!("execution failed: {:?}", output.outcome)))
@@ -560,28 +560,10 @@ impl PydeApiServer for RpcServer {
         }));
         let output = vm.execute();
 
-        // Return actual function output (not gas_used).
-        // Uses same r1/r2 convention as do_ext_call and pipeline return_data capture.
-        let return_data = if output.outcome == pyde_vm::vm::Outcome::Success {
-            let r2 = vm.cpu.read_gp(2);
-            if r2 > 0 {
-                // Blob/wide return: r1 = pointer, r2 = length
-                let ptr = vm.cpu.read_gp(1) as usize;
-                let len = (r2 as usize).min(pyde_vm::memory::MEMORY_SIZE);
-                if ptr + len <= pyde_vm::memory::MEMORY_SIZE {
-                    vm.memory.load_bytes(ptr, len)
-                } else {
-                    vm.cpu.read_gp(1).to_le_bytes().to_vec()
-                }
-            } else {
-                // GP return: r1 = value (8 bytes LE)
-                vm.cpu.read_gp(1).to_le_bytes().to_vec()
-            }
-        } else {
-            vec![]
-        };
-
-        Ok(format!("0x{}", hex::encode(&return_data)))
+        // Return gas used (with 20% safety margin for real execution overhead)
+        let gas_used = vm.gas_used_total;
+        let estimate = if gas_used == 0 { 21_000 } else { gas_used + gas_used / 5 };
+        Ok(format!("0x{:x}", estimate))
     }
 
     async fn get_transaction_receipt(&self, tx_hash: String) -> Result<serde_json::Value, ErrorObjectOwned> {
@@ -590,7 +572,7 @@ impl PydeApiServer for RpcServer {
 
         match store.get(&hash) {
             Some(receipt) => Ok(receipt_to_json(receipt)),
-            None => Err(rpc_err(-32602, "receipt not found".to_string())),
+            None => Ok(serde_json::Value::Null),
         }
     }
 

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -429,9 +429,8 @@ impl CodeGen {
                 self.emit_calldata_decode(func);
                 self.emit_function_guards(func);
                 self.emit_jump_placeholder(Opcode::Call, 0, 0, *func_label);
-                if func.is_pub && !func.is_view && !func.is_constructor && !func.is_reentrant {
-                    self.emit_reentrancy_cleanup();
-                }
+                // Reentrancy cleanup moved to function body (before Ret) for reliability.
+                // The dispatch wrapper no longer handles cleanup.
                 self.emit_op(Opcode::Halt, 0, 0, 0);
             }
         }
@@ -820,6 +819,7 @@ impl CodeGen {
 
         // Reentrancy guard: check lock, set lock
         if func.is_pub && !func.is_view && !func.is_constructor && !func.is_reentrant {
+            self.needs_guard_cleanup = true;
             // Widen reentrancy slot to wide scratch
             self.emit_op(Opcode::Addi, 15, 0, REENTRANCY_SLOT);
             self.emit_op(Opcode::Widen, WIDE_SCRATCH, 15, 0); // w7 = slot key
@@ -861,7 +861,10 @@ impl CodeGen {
     /// `is_entry`: if true, emit Halt at end (constructor/standalone); if false, emit Ret.
     fn gen_function(&mut self, func: &IrFunction, is_entry: bool) {
         self.regs.reset();
-        self.needs_guard_cleanup = false;
+        // Set guard cleanup flag based on function properties (same condition as guard emission).
+        // This ensures cleanup is emitted before Ret in the function body.
+        self.needs_guard_cleanup = self.emit_guards
+            && func.is_pub && !func.is_view && !func.is_constructor && !func.is_reentrant;
         self.current_return_ty = func.return_ty.clone();
 
         // Remap IR labels to unique codegen labels to prevent cross-function collisions.
@@ -1523,6 +1526,12 @@ impl CodeGen {
                 } else {
                     // Void return: clear r2 to prevent false blob detection
                     self.emit_op(Opcode::Addi, 2, 0, 0);
+                }
+                // Reentrancy guard cleanup: clear lock before returning.
+                // Emitted inside the function body (before Ret) rather than in the
+                // dispatch wrapper (after Call returns) for reliable state persistence.
+                if self.needs_guard_cleanup && !is_entry {
+                    self.emit_reentrancy_cleanup();
                 }
                 if is_entry {
                     self.emit_op(Opcode::Halt, 0, 0, 0);

--- a/crates/pyde-crypto-wasm/src/lib.rs
+++ b/crates/pyde-crypto-wasm/src/lib.rs
@@ -178,7 +178,9 @@ fn serialize_tx(v: &serde_json::Value, signature: &[u8]) -> Result<Vec<u8>, JsVa
     buf.extend_from_slice(signature);                          // ~666
     buf.push(1); // fee_payer bytes len
     buf.push(0); // FeePayer::Sender tag
-    buf.extend_from_slice(&0u32.to_le_bytes());               // access_list len = 0
+    // access_list: byte length of serialized data (4 bytes for the empty count prefix)
+    buf.extend_from_slice(&4u32.to_le_bytes());               // access_list byte len = 4
+    buf.extend_from_slice(&0u32.to_le_bytes());               // entry count = 0
     buf.push(0); // no deadline
     buf.extend_from_slice(&chain_id.to_le_bytes());           // 8
     buf.push(tx_type);                                         // 1

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -1180,11 +1180,6 @@ mod tests {
         let b30 = call(&smt, cd("get_balance", &[30]));
         let b1 = call(&smt, cd("get_balance", &[1]));
 
-        eprintln!("bal(10)={b10} (want 40700)");
-        eprintln!("bal(20)={b20} (want 41700)");
-        eprintln!("bal(30)={b30} (want 24500)");
-        eprintln!("bal(1)={b1} (want 2100)");
-
         assert_eq!(b10, 40700, "bal(10) = 38000 + 2700");
         assert_eq!(b20, 41700, "bal(20) = 39000 + 2700");
         assert_eq!(b30, 24500, "bal(30) = 21800 + 2700");


### PR DESCRIPTION
## Summary
- Fix WASM tx serialization (access list byte length was 0, needs 4-byte count prefix)
- Fix RPC `getTransactionReceipt` to return null instead of error when not found
- Fix RPC `call` GP return format (8-byte LE hex instead of odd-length hex)
- Fix RPC `estimateGas` to return actual gas used, not function return data
- Fix RPC `getLogs` to iterate stored slots instead of 0..u64::MAX (was hanging node)
- Fix otic reentrancy guard: emit cleanup inside function body before Ret
- Wire WS broadcast channels for onBlock/onLogs subscriptions
- Remove debug eprintln from pipeline test

Validated with 109-test TS SDK live test suite covering all LIVE_TEST_PLAN groups.