### PR TITLE
fix: snapshot reader for pyde_call, parallel scheduling

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -433,20 +433,17 @@ impl PydeApiServer for RpcServer {
         let gas_limit: u64 = call_obj.get("gas").and_then(|v| v.as_u64())
             .unwrap_or(100_000_000); // 100M default — Vec deserialization + loops need headroom
 
-        // Acquire an OWNED read lock that lives for the entire call execution.
-        // This prevents the block processor from modifying state mid-read.
-        // Previously, we dropped the lock before PVM execution and used try_read()
-        // per Sload, which could fail if the block processor held a write lock,
-        // causing stale zero values to be cached in the VM overlay.
-        let state_guard = Arc::clone(&self.state.state).read_owned().await;
-
+        // Take a read-consistent snapshot of state for the entire call.
+        // This prevents the background Merkle commit or block processor from
+        // modifying the cache mid-execution (which caused stale reads where
+        // the same key returned different values within one pyde_call).
+        let state_r = self.state.state.read().await;
         let code_key = pyde_state::keys::code_key(&to);
-        let code = state_guard.get(&code_key)
+        let code = state_r.get(&code_key)
             .ok_or_else(|| rpc_err(-32000, "no code at address".into()))?;
-
-        // Acquire second read guard for code backend BEFORE creating VM
-        // (both guards must be obtained before any non-Send value exists across await)
-        let code_guard = Arc::clone(&self.state.state).read_owned().await;
+        let storage_snapshot = state_r.snapshot_reader();
+        let code_snapshot = state_r.snapshot_reader();
+        drop(state_r); // release tokio lock — snapshot is self-contained
 
         // Run PVM directly — no validation, no nonce/balance checks
         let ctx = pyde_vm::vm::ExecutionContext {
@@ -471,15 +468,15 @@ impl PydeApiServer for RpcServer {
             return Err(rpc_err(-32000, format!("failed to load code: {:?}", e)));
         }
 
-        // Lazy storage backend (owned guard — no stale reads)
+        // Storage backend reads from frozen snapshot (no stale reads)
         vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
             let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
-            state_guard.get(&smt_key)
+            storage_snapshot(&smt_key)
         }));
         // Code backend for cross-contract calls (CallExt)
         vm.code_backend = Some(std::sync::Arc::new(move |addr: &[u8; 32]| {
             let ck = pyde_state::keys::code_key(addr);
-            code_guard.get(&ck)
+            code_snapshot(&ck)
         }));
 
         let output = vm.execute();
@@ -528,12 +525,14 @@ impl PydeApiServer for RpcServer {
             return Ok(format!("0x{:x}", 32_000 + calldata.len() as u64 * 16));
         }
 
-        let state_guard = Arc::clone(&self.state.state).read_owned().await;
+        let state_r = self.state.state.read().await;
         let code_key = pyde_state::keys::code_key(&to);
-        let code = match state_guard.get(&code_key) {
+        let code = match state_r.get(&code_key) {
             Some(c) => c,
             None => return Ok(format!("0x{:x}", 21_000)), // simple transfer
         };
+        let storage_snapshot = state_r.snapshot_reader();
+        drop(state_r);
 
         let ctx = pyde_vm::vm::ExecutionContext {
             caller: from,
@@ -553,10 +552,9 @@ impl PydeApiServer for RpcServer {
         let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(gas_limit, ctx);
         vm.calldata = calldata;
         let _ = vm.load(&code);
-        // Hold read lock for entire execution via owned guard
         vm.storage_backend = Some(std::sync::Arc::new(move |key: &ethnum::U256| {
             let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
-            state_guard.get(&smt_key)
+            storage_snapshot(&smt_key)
         }));
         let output = vm.execute();
 

--- a/crates/node/src/state_manager.rs
+++ b/crates/node/src/state_manager.rs
@@ -71,6 +71,27 @@ impl StateManager {
         }
     }
 
+    /// Take a read-consistent snapshot of the cache + SMT for static calls.
+    /// Returns a closure that reads from the frozen snapshot, immune to
+    /// concurrent cache writes from the block processor or Merkle commit.
+    pub fn snapshot_reader(&self) -> impl Fn(&Key) -> Option<Vec<u8>> + Send + Sync {
+        // Clone the entire cache — this is O(n) but pyde_call is infrequent.
+        let cache_snap: HashMap<Key, Vec<u8>> = self.cache.read()
+            .map(|c| c.clone())
+            .unwrap_or_default();
+        let smt = Arc::clone(&self.smt);
+        move |key: &Key| -> Option<Vec<u8>> {
+            if let Some(val) = cache_snap.get(key) {
+                return if val.is_empty() { None } else { Some(val.clone()) };
+            }
+            if let Ok(smt) = smt.lock() {
+                smt.get(key)
+            } else {
+                None
+            }
+        }
+    }
+
     /// Insert directly (used during genesis, bypasses deferred path).
     pub fn insert(&mut self, key: Key, value: Vec<u8>) -> Result<[u8; 32], String> {
         self.tracked_keys.insert(key);

--- a/crates/tx/src/parallel.rs
+++ b/crates/tx/src/parallel.rs
@@ -167,20 +167,31 @@ pub fn schedule(txs: &[Transaction]) -> ExecutionSchedule {
         };
     }
 
-    // Fast path: group by contract address + sender for empty access lists.
-    // Txs to the same contract or from the same sender must be sequential.
-    // This avoids O(n²) pairwise conflict checks.
-    let mut uf = UnionFind::new(n);
-    // Fast O(n) path: if all txs have access lists, use hash-based grouping.
-    // Otherwise, fall back to O(n²) pairwise conflict detection.
-    let has_access_lists = txs.iter().any(|t| !t.access_list.is_empty());
+    // If NO txs have access lists, they're all potentially conflicting
+    // → put everything in one sequential group (safe default).
+    let has_any_access_list = txs.iter().any(|t| !t.access_list.is_empty());
+    if !has_any_access_list {
+        return ExecutionSchedule {
+            groups: vec![ExecutionGroup {
+                tx_indices: (0..n).collect(),
+            }],
+            total_txs: n,
+        };
+    }
 
-    if has_access_lists {
-        for i in 0..n {
-            for j in (i + 1)..n {
-                if conflicts(&txs[i], &txs[j]) {
-                    uf.union(i, j);
-                }
+    // Pairwise conflict detection using access lists.
+    let mut uf = UnionFind::new(n);
+    for i in 0..n {
+        // Txs with empty access lists conflict with everything (unknown keys).
+        if txs[i].access_list.is_empty() {
+            for j in 0..n {
+                if i != j { uf.union(i, j); }
+            }
+            continue;
+        }
+        for j in (i + 1)..n {
+            if conflicts(&txs[i], &txs[j]) {
+                uf.union(i, j);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `StateManager::snapshot_reader()` for read-consistent static calls
- `pyde_call` and `estimateGas` now read from frozen cache snapshot, preventing stale reads from concurrent block processor/Merkle commit writes
- Fix parallel scheduler: txs with empty access lists grouped into single sequential group (was creating N independent groups)

Fixes the state visibility race where `pyde_call` returned different values for the same storage key within one execution. Also fixes pre-existing `empty_access_lists_all_in_one_group` test failure.