### PR TITLE
fix: WASM tx hash deadline encoding for production sig verification

### DIFF
--- a/crates/pyde-crypto-wasm/src/lib.rs
+++ b/crates/pyde-crypto-wasm/src/lib.rs
@@ -141,8 +141,8 @@ fn compute_tx_hash(v: &serde_json::Value) -> Result<[u8; 32], JsValue> {
     buf.extend_from_slice(&nonce.to_le_bytes());
     buf.push(0); // fee_payer tag: Sender
     buf.extend_from_slice(&hash_empty_access_list());
-    // deadline: None → 0u64
-    buf.extend_from_slice(&0u64.to_le_bytes());
+    // deadline: None → single 0 byte (matches Transaction::hash)
+    buf.push(0);
     buf.push(tx_type);
 
     Ok(poseidon2_hash(&buf).to_bytes())


### PR DESCRIPTION
## Summary
- Fix WASM `compute_tx_hash` deadline encoding: was 8 bytes (`0u64`), should be 1 byte (`push(0)`)
- This caused FALCON-512 signature verification to fail on production chain_id (non-31337)
- Devnet was unaffected because chain_id=31337 skips signature verification

Tested: transfer, deploy, and contract calls all succeed with chain_id=1 and verified FALCON signatures.