### PR TITLE
feat: persist equivocation evidence across validator restarts

### DIFF
--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -1,19 +1,36 @@
-//! Persistent storage for HotStuff consensus state.
+//! Persistent storage for HotStuff consensus state + equivocation evidence.
 //!
-//! Safety property: on validator restart, we must never regress
-//! `last_voted_slot` or `highest_qc`. A double-vote after a crash
+//! Safety property 1 (consensus state): on validator restart, we must never
+//! regress `last_voted_slot` or `highest_qc`. A double-vote after a crash
 //! would be a BFT safety violation.
 //!
+//! Safety property 2 (seen proposals/votes): equivocation detection requires
+//! remembering every distinct (slot, proposer) proposal and (slot, voter)
+//! vote that crossed this node. Losing that index across a crash means a
+//! Byzantine validator can equivocate either side of the crash undetected.
+//!
 //! Key layout:
-//!   b"consensus:state" → serialized ConsensusState (see wire::encode_consensus_state)
+//!   b"consensus:state"              → serialized ConsensusState
+//!   b"p:" || slot_be8 || addr[32]   → (encoded BlockHeader, signature)
+//!   b"v:" || slot_be8 || voter_idx  → (block_hash[32], signature)
 
 use crate::wire;
+use pyde_account::address::Address;
+use pyde_consensus::block::BlockHeader;
 use pyde_consensus::hotstuff::ConsensusState;
-use rocksdb::{DB, Options};
+use rocksdb::{DB, IteratorMode, Options, WriteBatch};
 use std::path::Path;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 const STATE_KEY: &[u8] = b"consensus:state";
+const PROPOSAL_PREFIX: &[u8] = b"p:";
+const VOTE_PREFIX: &[u8] = b"v:";
+
+/// A proposal seen from a proposer at a given slot (for double-propose detection).
+pub type SeenProposal = ((u64, Address), (BlockHeader, Vec<u8>));
+
+/// A vote seen from a voter at a given slot (for double-vote detection).
+pub type SeenVote = ((u64, u8), ([u8; 32], Vec<u8>));
 
 /// RocksDB-backed store for a validator's `ConsensusState`.
 ///
@@ -72,6 +89,240 @@ impl ConsensusStateStore {
             Err(e) => Err(format!("failed to read consensus state: {}", e)),
         }
     }
+
+    // ============================================================
+    // Seen proposals / votes (equivocation evidence index)
+    // ============================================================
+
+    /// Persist a seen proposal entry. Idempotent on repeat writes.
+    pub fn save_seen_proposal(
+        &self,
+        slot: u64,
+        proposer: &Address,
+        header: &BlockHeader,
+        signature: &[u8],
+    ) -> Result<(), String> {
+        let key = encode_proposal_key(slot, proposer);
+        let value = encode_seen_proposal(header, signature);
+        self.db
+            .put(&key, &value)
+            .map_err(|e| format!("failed to save seen proposal: {}", e))
+    }
+
+    /// Persist a seen vote entry. Idempotent on repeat writes.
+    pub fn save_seen_vote(
+        &self,
+        slot: u64,
+        voter_index: u8,
+        block_hash: &[u8; 32],
+        signature: &[u8],
+    ) -> Result<(), String> {
+        let key = encode_vote_key(slot, voter_index);
+        let value = encode_seen_vote(block_hash, signature);
+        self.db
+            .put(&key, &value)
+            .map_err(|e| format!("failed to save seen vote: {}", e))
+    }
+
+    /// Load all persisted seen proposals. Corrupt entries are skipped + logged.
+    pub fn load_all_seen_proposals(&self) -> Vec<SeenProposal> {
+        let mut out = Vec::new();
+        for item in self.db.prefix_iterator(PROPOSAL_PREFIX) {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(e) => {
+                    warn!(error = %e, "iterator error on seen proposals");
+                    continue;
+                }
+            };
+            if !k.starts_with(PROPOSAL_PREFIX) {
+                break;
+            }
+            let (slot, addr) = match decode_proposal_key(&k) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    warn!(error = e, "skipping corrupt proposal key");
+                    continue;
+                }
+            };
+            match decode_seen_proposal(&v) {
+                Ok((header, sig)) => out.push(((slot, addr), (header, sig))),
+                Err(e) => warn!(slot, error = e, "skipping corrupt proposal value"),
+            }
+        }
+        out
+    }
+
+    /// Load all persisted seen votes. Corrupt entries are skipped + logged.
+    pub fn load_all_seen_votes(&self) -> Vec<SeenVote> {
+        let mut out = Vec::new();
+        for item in self.db.prefix_iterator(VOTE_PREFIX) {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(e) => {
+                    warn!(error = %e, "iterator error on seen votes");
+                    continue;
+                }
+            };
+            if !k.starts_with(VOTE_PREFIX) {
+                break;
+            }
+            let (slot, voter_index) = match decode_vote_key(&k) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    warn!(error = e, "skipping corrupt vote key");
+                    continue;
+                }
+            };
+            match decode_seen_vote(&v) {
+                Ok((block_hash, sig)) => out.push(((slot, voter_index), (block_hash, sig))),
+                Err(e) => warn!(slot, error = e, "skipping corrupt vote value"),
+            }
+        }
+        out
+    }
+
+    /// Delete all seen-proposal and seen-vote entries with slot < prune_before.
+    /// Mirrors the in-memory pruning in `ValidatorEngine::advance_slot`.
+    pub fn prune_evidence_before(&self, prune_before: u64) -> Result<usize, String> {
+        let mut batch = WriteBatch::default();
+        let mut count = 0usize;
+
+        for prefix in [PROPOSAL_PREFIX, VOTE_PREFIX] {
+            for item in self.db.iterator(IteratorMode::From(prefix, rocksdb::Direction::Forward)) {
+                let (k, _v) = match item {
+                    Ok(kv) => kv,
+                    Err(_) => continue,
+                };
+                if !k.starts_with(prefix) {
+                    break;
+                }
+                let slot_bytes: &[u8] = match k.get(prefix.len()..prefix.len() + 8) {
+                    Some(b) => b,
+                    None => continue,
+                };
+                let mut buf = [0u8; 8];
+                buf.copy_from_slice(slot_bytes);
+                let slot = u64::from_be_bytes(buf);
+                if slot < prune_before {
+                    batch.delete(&k);
+                    count += 1;
+                }
+            }
+        }
+
+        if count > 0 {
+            self.db
+                .write(batch)
+                .map_err(|e| format!("failed to prune evidence: {}", e))?;
+            debug!(pruned = count, prune_before, "evidence pruned");
+        }
+        Ok(count)
+    }
+}
+
+// ============================================================
+// Key + value encoding helpers
+// ============================================================
+
+fn encode_proposal_key(slot: u64, proposer: &Address) -> Vec<u8> {
+    let mut k = Vec::with_capacity(PROPOSAL_PREFIX.len() + 8 + 32);
+    k.extend_from_slice(PROPOSAL_PREFIX);
+    k.extend_from_slice(&slot.to_be_bytes());
+    k.extend_from_slice(proposer);
+    k
+}
+
+fn decode_proposal_key(key: &[u8]) -> Result<(u64, Address), &'static str> {
+    if key.len() != PROPOSAL_PREFIX.len() + 8 + 32 {
+        return Err("unexpected proposal key length");
+    }
+    if !key.starts_with(PROPOSAL_PREFIX) {
+        return Err("missing proposal prefix");
+    }
+    let mut slot_buf = [0u8; 8];
+    slot_buf.copy_from_slice(&key[PROPOSAL_PREFIX.len()..PROPOSAL_PREFIX.len() + 8]);
+    let slot = u64::from_be_bytes(slot_buf);
+    let mut addr = [0u8; 32];
+    addr.copy_from_slice(&key[PROPOSAL_PREFIX.len() + 8..]);
+    Ok((slot, addr))
+}
+
+fn encode_vote_key(slot: u64, voter_index: u8) -> Vec<u8> {
+    let mut k = Vec::with_capacity(VOTE_PREFIX.len() + 8 + 1);
+    k.extend_from_slice(VOTE_PREFIX);
+    k.extend_from_slice(&slot.to_be_bytes());
+    k.push(voter_index);
+    k
+}
+
+fn decode_vote_key(key: &[u8]) -> Result<(u64, u8), &'static str> {
+    if key.len() != VOTE_PREFIX.len() + 8 + 1 {
+        return Err("unexpected vote key length");
+    }
+    if !key.starts_with(VOTE_PREFIX) {
+        return Err("missing vote prefix");
+    }
+    let mut slot_buf = [0u8; 8];
+    slot_buf.copy_from_slice(&key[VOTE_PREFIX.len()..VOTE_PREFIX.len() + 8]);
+    let slot = u64::from_be_bytes(slot_buf);
+    let voter_index = key[VOTE_PREFIX.len() + 8];
+    Ok((slot, voter_index))
+}
+
+fn encode_seen_proposal(header: &BlockHeader, signature: &[u8]) -> Vec<u8> {
+    let header_bytes = wire::encode_block_header(header);
+    let mut out = Vec::with_capacity(8 + header_bytes.len() + signature.len());
+    out.extend_from_slice(&(header_bytes.len() as u32).to_le_bytes());
+    out.extend_from_slice(&header_bytes);
+    out.extend_from_slice(&(signature.len() as u32).to_le_bytes());
+    out.extend_from_slice(signature);
+    out
+}
+
+fn decode_seen_proposal(bytes: &[u8]) -> Result<(BlockHeader, Vec<u8>), &'static str> {
+    if bytes.len() < 4 {
+        return Err("seen proposal value too short");
+    }
+    let mut len_buf = [0u8; 4];
+    len_buf.copy_from_slice(&bytes[..4]);
+    let header_len = u32::from_le_bytes(len_buf) as usize;
+    if bytes.len() < 4 + header_len + 4 {
+        return Err("seen proposal header truncated");
+    }
+    let header = wire::decode_block_header(&bytes[4..4 + header_len])?;
+    let sig_start = 4 + header_len;
+    len_buf.copy_from_slice(&bytes[sig_start..sig_start + 4]);
+    let sig_len = u32::from_le_bytes(len_buf) as usize;
+    if bytes.len() < sig_start + 4 + sig_len {
+        return Err("seen proposal signature truncated");
+    }
+    let sig = bytes[sig_start + 4..sig_start + 4 + sig_len].to_vec();
+    Ok((header, sig))
+}
+
+fn encode_seen_vote(block_hash: &[u8; 32], signature: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(32 + 4 + signature.len());
+    out.extend_from_slice(block_hash);
+    out.extend_from_slice(&(signature.len() as u32).to_le_bytes());
+    out.extend_from_slice(signature);
+    out
+}
+
+fn decode_seen_vote(bytes: &[u8]) -> Result<([u8; 32], Vec<u8>), &'static str> {
+    if bytes.len() < 32 + 4 {
+        return Err("seen vote value too short");
+    }
+    let mut block_hash = [0u8; 32];
+    block_hash.copy_from_slice(&bytes[..32]);
+    let mut len_buf = [0u8; 4];
+    len_buf.copy_from_slice(&bytes[32..36]);
+    let sig_len = u32::from_le_bytes(len_buf) as usize;
+    if bytes.len() < 36 + sig_len {
+        return Err("seen vote signature truncated");
+    }
+    let sig = bytes[36..36 + sig_len].to_vec();
+    Ok((block_hash, sig))
 }
 
 #[cfg(test)]
@@ -156,5 +407,138 @@ mod tests {
         assert_eq!(loaded.current_slot, 100);
         assert_eq!(loaded.last_voted_slot, 100);
         assert_eq!(loaded.highest_qc.slot, 99);
+    }
+
+    // ========== Seen proposals / votes ==========
+
+    fn dummy_header(slot: u64) -> BlockHeader {
+        BlockHeader {
+            slot,
+            epoch: slot / 1000,
+            parent_hash: [0x11; 32],
+            proposer: [0xAA; 32],
+            vrf_proof: vec![0xCC; 100],
+            qc_previous: QuorumCert {
+                slot: slot.saturating_sub(1),
+                block_hash: [0xBB; 32],
+                voter_bitmap: 0,
+                signatures: vec![],
+            },
+            tx_root: [0x22; 32],
+            state_root: [0x33; 32],
+            timestamp: slot * 400,
+        }
+    }
+
+    #[test]
+    fn seen_proposal_roundtrip() {
+        let dir = tempdir().unwrap();
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+
+        let proposer = [0xAA; 32];
+        let header = dummy_header(10);
+        let sig = vec![0xEE; 600];
+
+        store.save_seen_proposal(10, &proposer, &header, &sig).unwrap();
+
+        let all = store.load_all_seen_proposals();
+        assert_eq!(all.len(), 1);
+        let ((slot, addr), (loaded_header, loaded_sig)) = &all[0];
+        assert_eq!(*slot, 10);
+        assert_eq!(*addr, proposer);
+        assert_eq!(loaded_header.slot, 10);
+        assert_eq!(loaded_header.timestamp, 4000);
+        assert_eq!(*loaded_sig, sig);
+    }
+
+    #[test]
+    fn seen_vote_roundtrip() {
+        let dir = tempdir().unwrap();
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+
+        let block_hash = [0x77; 32];
+        let sig = vec![0xFF; 600];
+        store.save_seen_vote(42, 7, &block_hash, &sig).unwrap();
+
+        let all = store.load_all_seen_votes();
+        assert_eq!(all.len(), 1);
+        let ((slot, voter_idx), (loaded_hash, loaded_sig)) = &all[0];
+        assert_eq!(*slot, 42);
+        assert_eq!(*voter_idx, 7);
+        assert_eq!(*loaded_hash, block_hash);
+        assert_eq!(*loaded_sig, sig);
+    }
+
+    #[test]
+    fn multiple_proposals_same_slot_different_proposers() {
+        let dir = tempdir().unwrap();
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+
+        let a = [0xAA; 32];
+        let b = [0xBB; 32];
+        store.save_seen_proposal(5, &a, &dummy_header(5), &vec![0x11; 10]).unwrap();
+        store.save_seen_proposal(5, &b, &dummy_header(5), &vec![0x22; 10]).unwrap();
+
+        let all = store.load_all_seen_proposals();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn prune_removes_old_entries_only() {
+        let dir = tempdir().unwrap();
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+
+        for slot in 1..=15u64 {
+            store.save_seen_proposal(slot, &[0xAA; 32], &dummy_header(slot), &vec![0x11; 10]).unwrap();
+            store.save_seen_vote(slot, 0, &[0x77; 32], &vec![0x22; 10]).unwrap();
+        }
+
+        assert_eq!(store.load_all_seen_proposals().len(), 15);
+        assert_eq!(store.load_all_seen_votes().len(), 15);
+
+        // Keep last 10 slots: slots < 6 should be pruned.
+        let pruned = store.prune_evidence_before(6).unwrap();
+        assert_eq!(pruned, 10); // 5 proposals + 5 votes
+
+        let props = store.load_all_seen_proposals();
+        let votes = store.load_all_seen_votes();
+        assert_eq!(props.len(), 10);
+        assert_eq!(votes.len(), 10);
+        assert!(props.iter().all(|((slot, _), _)| *slot >= 6));
+        assert!(votes.iter().all(|((slot, _), _)| *slot >= 6));
+    }
+
+    #[test]
+    fn evidence_survives_reopen() {
+        let dir = tempdir().unwrap();
+        let proposer = [0xAA; 32];
+        let header = dummy_header(7);
+        let sig = vec![0xEE; 600];
+
+        {
+            let store = ConsensusStateStore::open(dir.path()).unwrap();
+            store.save_seen_proposal(7, &proposer, &header, &sig).unwrap();
+            store.save_seen_vote(7, 3, &[0x99; 32], &vec![0xFF; 600]).unwrap();
+        }
+
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+        assert_eq!(store.load_all_seen_proposals().len(), 1);
+        assert_eq!(store.load_all_seen_votes().len(), 1);
+    }
+
+    #[test]
+    fn consensus_state_and_evidence_coexist() {
+        // Belt-and-braces: saving state + evidence in the same DB must not
+        // stomp each other (shared RocksDB with distinct key prefixes).
+        let dir = tempdir().unwrap();
+        let store = ConsensusStateStore::open(dir.path()).unwrap();
+
+        store.save(&populated_state()).unwrap();
+        store.save_seen_proposal(50, &[0xAA; 32], &dummy_header(50), &vec![0x11; 10]).unwrap();
+        store.save_seen_vote(50, 1, &[0x99; 32], &vec![0x22; 10]).unwrap();
+
+        assert!(store.load().unwrap().is_some());
+        assert_eq!(store.load_all_seen_proposals().len(), 1);
+        assert_eq!(store.load_all_seen_votes().len(), 1);
     }
 }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -307,6 +307,25 @@ impl ValidatorEngine {
                 return;
             }
         }
+
+        // Restore equivocation evidence index. Missing or corrupt entries are
+        // skipped by the store loader; we take whatever comes back.
+        let proposals = store.load_all_seen_proposals();
+        let votes = store.load_all_seen_votes();
+        if !proposals.is_empty() || !votes.is_empty() {
+            info!(
+                proposals = proposals.len(),
+                votes = votes.len(),
+                "restoring equivocation evidence from disk"
+            );
+        }
+        for (key, value) in proposals {
+            self.seen_proposals.insert(key, value);
+        }
+        for (key, value) in votes {
+            self.seen_votes.insert(key, value);
+        }
+
         self.consensus_store = Some(store);
     }
 
@@ -631,6 +650,13 @@ impl ValidatorEngine {
                 }
             }
         } else {
+            // Persist BEFORE the in-memory insert so a crash between the two
+            // leaves the in-memory state recoverable from disk.
+            if let Some(store) = &self.consensus_store {
+                if let Err(e) = store.save_seen_proposal(slot, &header.proposer, header, proposer_signature) {
+                    error!(error = %e, "failed to persist seen proposal");
+                }
+            }
             self.seen_proposals.insert(proposal_key, (header.clone(), proposer_signature.to_vec()));
         }
 
@@ -823,6 +849,11 @@ impl ValidatorEngine {
                 // can be implemented when the slashing transaction type is added.
             }
         } else {
+            if let Some(store) = &self.consensus_store {
+                if let Err(e) = store.save_seen_vote(slot, voter_index as u8, &block_hash, &vote_sig) {
+                    error!(error = %e, "failed to persist seen vote");
+                }
+            }
             self.seen_votes.insert(vote_key, (block_hash, vote_sig));
         }
 
@@ -940,6 +971,13 @@ impl ValidatorEngine {
             self.voted_slots.retain(|s| *s >= prune_before);
             self.seen_proposals.retain(|(s, _), _| *s >= prune_before);
             self.seen_votes.retain(|(s, _), _| *s >= prune_before);
+            // Mirror the same pruning on disk so the evidence index does not
+            // grow unbounded. Best-effort: a failure here just delays cleanup.
+            if let Some(store) = &self.consensus_store {
+                if let Err(e) = store.prune_evidence_before(prune_before) {
+                    warn!(error = %e, "failed to prune evidence on disk");
+                }
+            }
         }
 
         debug!(slot = new_slot, "advanced to next slot");
@@ -1272,6 +1310,116 @@ mod tests {
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
         assert_eq!(engine.consensus.current_slot, 7);
+    }
+
+    // ========== Equivocation evidence crash-restart tests ==========
+
+    fn evidence_header(slot: u64, state_root: [u8; 32]) -> BlockHeader {
+        BlockHeader {
+            slot,
+            epoch: slot / 1000,
+            parent_hash: [0x11; 32],
+            proposer: [0xAA; 32],
+            vrf_proof: vec![0xCC; 100],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0x22; 32],
+            state_root,
+            timestamp: slot * 400,
+        }
+    }
+
+    #[test]
+    fn seen_proposals_restored_on_attach() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let proposer: Address = [0xAB; 32];
+        let header = evidence_header(5, [0x33; 32]);
+        let sig = vec![0xEE; 600];
+
+        // Write evidence via an isolated store (simulating pre-crash state).
+        {
+            let store = ConsensusStateStore::open(dir.path()).unwrap();
+            store.save_seen_proposal(5, &proposer, &header, &sig).unwrap();
+        }
+
+        // Fresh engine attaches the same store and must restore the index.
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        engine.attach_consensus_store(store);
+
+        let entry = engine
+            .seen_proposals
+            .get(&(5u64, proposer))
+            .expect("proposal must be reloaded");
+        assert_eq!(entry.0.slot, 5);
+        assert_eq!(entry.0.state_root, [0x33; 32]);
+        assert_eq!(entry.1, sig);
+    }
+
+    #[test]
+    fn seen_votes_restored_on_attach() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let block_hash = [0x99; 32];
+        let sig = vec![0xFF; 600];
+
+        {
+            let store = ConsensusStateStore::open(dir.path()).unwrap();
+            store.save_seen_vote(12, 4, &block_hash, &sig).unwrap();
+        }
+
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        engine.attach_consensus_store(store);
+
+        let entry = engine
+            .seen_votes
+            .get(&(12u64, 4u8))
+            .expect("vote must be reloaded");
+        assert_eq!(entry.0, block_hash);
+        assert_eq!(entry.1, sig);
+    }
+
+    #[test]
+    fn advance_slot_prunes_evidence_on_disk() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+
+        // Seed 15 slots of evidence via the store directly.
+        {
+            let store = ConsensusStateStore::open(dir.path()).unwrap();
+            for slot in 1..=15u64 {
+                store
+                    .save_seen_proposal(slot, &[0xAA; 32], &evidence_header(slot, [0x33; 32]), &vec![0x11; 10])
+                    .unwrap();
+                store.save_seen_vote(slot, 0, &[0x99; 32], &vec![0x22; 10]).unwrap();
+            }
+        }
+
+        // Attach, jump forward to slot 15, advancing triggers prune.
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        engine.attach_consensus_store(Arc::clone(&store));
+        // Sanity: reload pulled them all in.
+        assert_eq!(engine.seen_proposals.len(), 15);
+        assert_eq!(engine.seen_votes.len(), 15);
+
+        // Jump to slot 15 (prune removes slot < new_slot - 10 = 5).
+        engine.consensus.current_slot = 14;
+        engine.advance_slot(); // new_slot = 15, prune_before = 5
+
+        // Memory pruned in lockstep.
+        assert!(engine.seen_proposals.iter().all(|((s, _), _)| *s >= 5));
+        assert!(engine.seen_votes.iter().all(|((s, _), _)| *s >= 5));
+
+        // Disk pruned too.
+        let on_disk_props = store.load_all_seen_proposals();
+        let on_disk_votes = store.load_all_seen_votes();
+        assert!(on_disk_props.iter().all(|((s, _), _)| *s >= 5));
+        assert!(on_disk_votes.iter().all(|((s, _), _)| *s >= 5));
     }
 
     #[test]


### PR DESCRIPTION
Implements task 002 from the mainnet readiness plan: the seen-proposal
and seen-vote indexes that drive equivocation detection now survive
validator crashes. Previously they lived only in-memory, meaning a
Byzantine validator could send conflicting proposals/votes across a
restart boundary and never be caught by the observing validator.

## Changes

### `consensus_store`
- New keys: `b"p:" || slot_be8 || addr` → seen proposal;
  `b"v:" || slot_be8 || voter_idx` → seen vote.
- New methods: `save_seen_proposal`, `save_seen_vote`,
  `load_all_seen_proposals`, `load_all_seen_votes`,
  `prune_evidence_before`.
- Big-endian slot in the key so lexicographic iteration is slot-ordered.

### `validator`
- `attach_consensus_store` now reloads both seen_proposals and
  seen_votes HashMaps from disk alongside `ConsensusState`.
- `on_proposal` / `on_vote` persist new entries BEFORE the in-memory
  insert (same write-before-act ordering as task 001).
- `advance_slot` prunes on-disk evidence in lockstep with memory
  (keep last 10 slots).

## Tests
- 6 new `consensus_store` tests: roundtrip, multi-entry-per-slot,
  prefix iteration, prune-only-old, reopen, coexistence with state.
- 3 new `validator` tests: attach restores seen_proposals and
  seen_votes from disk; `advance_slot` prunes on disk + in memory.

## Safety note
Persist happens before the HashMap insert, so a crash in between leaves
the HashMap recoverable from disk on restart. A failed persist is
logged at `error!` and execution continues — same treatment as task 001.