### PR TITLE
feat: add TransactionType::Slash variant and fix wire decode gap

### DIFF
--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -447,13 +447,7 @@ pub fn encode_transaction(tx: &Transaction) -> Vec<u8> {
     if let Some(d) = tx.deadline { enc.u64(d); }
     enc.u64(tx.chain_id);
     // tx_type
-    enc.u8(match tx.tx_type {
-        TransactionType::Standard => 0,
-        TransactionType::Deploy => 1,
-        TransactionType::Batch => 2,
-        TransactionType::StakeDeposit => 3,
-        TransactionType::StakeWithdraw => 4,
-    });
+    enc.u8(tx.tx_type as u8);
     enc.finish()
 }
 
@@ -477,12 +471,7 @@ pub fn decode_transaction(data: &[u8]) -> Result<Transaction, &'static str> {
     for _ in 0..access_count { access_list.push(decode_access_entry(&mut dec)?); }
     let deadline = if dec.u8()? == 1 { Some(dec.u64()?) } else { None };
     let chain_id = dec.u64()?;
-    let tx_type = match dec.u8()? {
-        0 => TransactionType::Standard,
-        1 => TransactionType::Deploy,
-        2 => TransactionType::Batch,
-        _ => return Err("invalid tx_type tag"),
-    };
+    let tx_type = TransactionType::from_u8(dec.u8()?).ok_or("invalid tx_type tag")?;
     Ok(Transaction {
         from, to, value, data: data_field, gas_limit, nonce, signature,
         fee_payer, access_list, deadline, chain_id, tx_type,
@@ -800,6 +789,27 @@ mod tests {
         assert_eq!(restored.deadline, Some(1000));
         assert_eq!(restored.chain_id, 1);
         assert!(matches!(restored.tx_type, TransactionType::Batch));
+    }
+
+    #[test]
+    fn tx_type_roundtrip_all_variants() {
+        // The prior decode hand-coded only Standard/Deploy/Batch and rejected
+        // StakeDeposit/StakeWithdraw; this guards against that class of regression.
+        let variants = [
+            TransactionType::Standard,
+            TransactionType::Deploy,
+            TransactionType::Batch,
+            TransactionType::StakeDeposit,
+            TransactionType::StakeWithdraw,
+            TransactionType::Slash,
+        ];
+        for ty in variants {
+            let mut tx = dummy_tx();
+            tx.tx_type = ty;
+            let bytes = encode_transaction(&tx);
+            let restored = decode_transaction(&bytes).unwrap();
+            assert_eq!(restored.tx_type, ty, "tx_type roundtrip failed for {:?}", ty);
+        }
     }
 
     // ========== Block roundtrip ==========

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -22,6 +22,12 @@ pub enum TransactionType {
     StakeDeposit = 3,
     /// Stake withdraw: begin unbonding period (14 days).
     StakeWithdraw = 4,
+    /// Slashing evidence submission. `tx.data` = serialized
+    /// `pyde_consensus::slashing::DoubleSignEvidence`. When executed,
+    /// the pipeline verifies the evidence, debits the offender's stake,
+    /// burns the slashed amount, and pays the finder's fee to
+    /// `tx.from`. Gate is permissionless so any node can submit.
+    Slash = 5,
 }
 
 impl TransactionType {
@@ -32,6 +38,7 @@ impl TransactionType {
             2 => Some(Self::Batch),
             3 => Some(Self::StakeDeposit),
             4 => Some(Self::StakeWithdraw),
+            5 => Some(Self::Slash),
             _ => None,
         }
     }
@@ -440,6 +447,40 @@ mod tests {
         let bytes = tx.to_bytes();
         let restored = Transaction::from_bytes(&bytes).unwrap();
         assert_eq!(tx, restored);
+    }
+
+    #[test]
+    fn tx_type_u8_roundtrip_covers_all_variants() {
+        // Every declared variant must roundtrip. If a new variant is added
+        // without updating from_u8, this test catches it.
+        let all = [
+            TransactionType::Standard,
+            TransactionType::Deploy,
+            TransactionType::Batch,
+            TransactionType::StakeDeposit,
+            TransactionType::StakeWithdraw,
+            TransactionType::Slash,
+        ];
+        for ty in all {
+            let tag = ty as u8;
+            assert_eq!(TransactionType::from_u8(tag), Some(ty), "roundtrip failed for {:?}", ty);
+        }
+        // Unknown tags are rejected.
+        assert_eq!(TransactionType::from_u8(255), None);
+    }
+
+    #[test]
+    fn serialize_slash_tx() {
+        // Evidence payload shape is defined in task 005; task 004 just
+        // ensures the type tag survives wire encoding with arbitrary
+        // opaque bytes in tx.data.
+        let mut tx = make_test_tx();
+        tx.tx_type = TransactionType::Slash;
+        tx.data = vec![0xAB; 1200]; // placeholder evidence blob
+        let bytes = tx.to_bytes();
+        let restored = Transaction::from_bytes(&bytes).unwrap();
+        assert_eq!(tx, restored);
+        assert_eq!(restored.tx_type, TransactionType::Slash);
     }
 
     // ========== Task 0383: Hash is deterministic ==========


### PR DESCRIPTION
Implements task 004 from the mainnet readiness plan. Adds a new
`TransactionType::Slash = 5` variant so a follow-up task can define
the slashing-transaction handler that actually debits offender stake
and pays the finder's fee — currently consensus detects equivocation
and pushes to `pending_slashes`, but nothing drains that Vec.

## Scope

### Added
- `TransactionType::Slash` enum variant.
- `TransactionType::from_u8` returns `Some(Slash)` for tag 5.

### Incidentally fixed
`crates/node/src/wire.rs` decode previously hand-coded only
`Standard` / `Deploy` / `Batch`, so `StakeDeposit` (tag 3) and
`StakeWithdraw` (tag 4) transactions would error as
`"invalid tx_type tag"` on the wire even though the type was declared.
Replaced the hand-coded match with:
- encode: `tx.tx_type as u8` (leverages `#[repr(u8)]`)
- decode: `TransactionType::from_u8(...)`

so all declared variants roundtrip and future additions don't reopen
the gap.

## Tests
- `types::tx_type_u8_roundtrip_covers_all_variants`
- `types::serialize_slash_tx`
- `wire::tx_type_roundtrip_all_variants` (regression guard)

Full workspace green.

## Deferred to the follow-up (plan task 005)
- Actual `DoubleSignEvidence` serialization format for `tx.data`.
- Validation pipeline (verify signatures, check offender in committee).
- State mutation (debit stake, burn, pay finder's fee).
- Block-processor wiring to drain `pending_slashes` into slash-txs.