### PR TITLE
feat: queue DoubleSignEvidence for slashing, add wire codec and drain API

### DIFF
--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -17,7 +17,7 @@ use pyde_crypto::threshold::{
     RefreshContribution, generate_refresh_contribution, apply_refresh, verify_refresh_contribution,
 };
 use pyde_consensus::slashing::{
-    DoubleSignEvidence, SlashResult, slash_double_sign, verify_double_sign,
+    DoubleSignEvidence, slash_double_sign, verify_double_sign,
 };
 use pyde_consensus::validator::VALIDATOR_STAKE;
 use pyde_consensus::view_change::{
@@ -237,8 +237,13 @@ pub struct ValidatorEngine {
     /// Seen votes per slot: (slot, voter_index) → (block_hash, signature).
     /// Used to detect double-voting (equivocation).
     seen_votes: HashMap<(u64, u8), ([u8; 32], Vec<u8>)>,
-    /// Collected slashing evidence to broadcast.
-    pub pending_slashes: Vec<SlashResult>,
+    /// Collected double-sign evidence awaiting inclusion in a Slash tx.
+    /// Drained by `drain_pending_evidence` when the block builder wants
+    /// to construct slashing transactions. We hold the raw evidence here
+    /// rather than the computed SlashResult because the slashing handler
+    /// on the receiving node will re-verify signatures from state —
+    /// SlashResult is just a local convenience.
+    pub pending_evidence: Vec<DoubleSignEvidence>,
     /// Epoch randomness collector (gathers VRF shares at epoch boundary).
     randomness_collector: Option<RandomnessCollector>,
     /// PSS refresh contributions collected at epoch boundary.
@@ -270,7 +275,7 @@ impl ValidatorEngine {
             voted_slots: std::collections::HashSet::new(),
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
-            pending_slashes: Vec::new(),
+            pending_evidence: Vec::new(),
             randomness_collector: None,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
@@ -637,16 +642,21 @@ impl ValidatorEngine {
                     block_2: header.clone(),
                     signature_2: proposer_signature.to_vec(),
                     signer: header.proposer,
-                    submitter: [0u8; 32], // self — filled by caller
+                    // submitter is filled in by whoever actually broadcasts
+                    // the Slash tx — typically the next block proposer.
+                    submitter: [0u8; 32],
                 };
-                if let Some(result) = slash_double_sign(&evidence, &self.committee_keys[proposer_idx]) {
+                // Cross-check both signatures verify against the accused
+                // proposer's committee key. slash_double_sign returns None
+                // if either sig is invalid; in that case we drop the
+                // evidence rather than queue garbage.
+                if slash_double_sign(&evidence, &self.committee_keys[proposer_idx]).is_some() {
                     info!(
                         slot,
-                        offender = hex::encode(result.offender),
-                        burned = result.amount_burned,
-                        "slash evidence created for double-propose"
+                        offender = hex::encode(evidence.signer),
+                        "double-propose evidence queued for slashing"
                     );
-                    self.pending_slashes.push(result);
+                    self.pending_evidence.push(evidence);
                 }
             }
         } else {
@@ -950,6 +960,25 @@ impl ValidatorEngine {
                 self.finality.record_hard_finality(cert);
             }
         }
+    }
+
+    /// Take ownership of all queued double-sign evidence, clearing the
+    /// internal queue. Called by the block builder when constructing a
+    /// proposal so each piece of evidence can be wrapped into a
+    /// `TransactionType::Slash` and submitted on-chain.
+    ///
+    /// If the caller fails to produce the block (e.g. view change), they
+    /// are responsible for re-queueing the evidence via `push_evidence`
+    /// — otherwise it is lost along with the unbuilt proposal.
+    pub fn drain_pending_evidence(&mut self) -> Vec<DoubleSignEvidence> {
+        std::mem::take(&mut self.pending_evidence)
+    }
+
+    /// Re-queue previously drained evidence, e.g. after a failed block
+    /// build. No-op if `evidence` is empty. Preserves insertion order by
+    /// appending at the tail.
+    pub fn push_evidence(&mut self, evidence: Vec<DoubleSignEvidence>) {
+        self.pending_evidence.extend(evidence);
     }
 
     /// Advance to the next slot. Returns the new slot number.
@@ -1420,6 +1449,69 @@ mod tests {
         let on_disk_votes = store.load_all_seen_votes();
         assert!(on_disk_props.iter().all(|((s, _), _)| *s >= 5));
         assert!(on_disk_votes.iter().all(|((s, _), _)| *s >= 5));
+    }
+
+    // ========== Pending evidence drain/push ==========
+
+    fn evidence_fixture(slot: u64, signer: Address) -> DoubleSignEvidence {
+        DoubleSignEvidence {
+            slot,
+            block_1: evidence_header(slot, [0x01; 32]),
+            signature_1: vec![0xAA; 600],
+            block_2: BlockHeader {
+                tx_root: [0x02; 32],
+                ..evidence_header(slot, [0x01; 32])
+            },
+            signature_2: vec![0xBB; 600],
+            signer,
+            submitter: [0u8; 32],
+        }
+    }
+
+    #[test]
+    fn drain_pending_evidence_empties_queue() {
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.pending_evidence.push(evidence_fixture(1, [0xAB; 32]));
+        engine.pending_evidence.push(evidence_fixture(2, [0xCD; 32]));
+
+        let drained = engine.drain_pending_evidence();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].slot, 1);
+        assert_eq!(drained[1].slot, 2);
+        assert!(engine.pending_evidence.is_empty());
+
+        // Second drain returns empty — ownership was already transferred.
+        assert!(engine.drain_pending_evidence().is_empty());
+    }
+
+    #[test]
+    fn push_evidence_restores_queue() {
+        // Simulates the failed-block-build recovery path: drain, fail to
+        // build, push back, drain again.
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.pending_evidence.push(evidence_fixture(7, [0x99; 32]));
+
+        let drained = engine.drain_pending_evidence();
+        assert_eq!(drained.len(), 1);
+        assert!(engine.pending_evidence.is_empty());
+
+        engine.push_evidence(drained);
+        assert_eq!(engine.pending_evidence.len(), 1);
+        assert_eq!(engine.pending_evidence[0].slot, 7);
+    }
+
+    #[test]
+    fn push_evidence_appends_preserving_order() {
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.pending_evidence.push(evidence_fixture(1, [0x01; 32]));
+
+        engine.push_evidence(vec![
+            evidence_fixture(2, [0x02; 32]),
+            evidence_fixture(3, [0x03; 32]),
+        ]);
+
+        let slots: Vec<u64> = engine.pending_evidence.iter().map(|e| e.slot).collect();
+        assert_eq!(slots, vec![1, 2, 3]);
     }
 
     #[test]

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -9,6 +9,7 @@
 use pyde_account::address::Address;
 use pyde_consensus::block::{Block, BlockBody, BlockHeader, QuorumCert};
 use pyde_consensus::hotstuff::ConsensusMessage;
+use pyde_consensus::slashing::DoubleSignEvidence;
 use pyde_tx::parallel::ExecutionSchedule;
 use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
 
@@ -698,6 +699,51 @@ pub fn decode_consensus_state(data: &[u8]) -> Result<pyde_consensus::hotstuff::C
     })
 }
 
+// ============================================================
+// DoubleSignEvidence (payload for TransactionType::Slash)
+// ============================================================
+
+/// Schema version tag for the Slash-tx payload. Bumping this is a
+/// protocol change: old nodes would reject new evidence and vice versa.
+const EVIDENCE_VERSION: u8 = 1;
+
+pub fn encode_double_sign_evidence(evidence: &DoubleSignEvidence) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(EVIDENCE_VERSION);
+    enc.u64(evidence.slot);
+    enc.var_bytes(&encode_block_header(&evidence.block_1));
+    enc.var_bytes(&evidence.signature_1);
+    enc.var_bytes(&encode_block_header(&evidence.block_2));
+    enc.var_bytes(&evidence.signature_2);
+    enc.bytes32(&evidence.signer);
+    enc.bytes32(&evidence.submitter);
+    enc.finish()
+}
+
+pub fn decode_double_sign_evidence(data: &[u8]) -> Result<DoubleSignEvidence, &'static str> {
+    let mut dec = Decoder::new(data);
+    let version = dec.u8()?;
+    if version != EVIDENCE_VERSION {
+        return Err("unsupported double-sign evidence version");
+    }
+    let slot = dec.u64()?;
+    let block_1 = decode_block_header(&dec.var_bytes()?)?;
+    let signature_1 = dec.var_bytes()?;
+    let block_2 = decode_block_header(&dec.var_bytes()?)?;
+    let signature_2 = dec.var_bytes()?;
+    let signer = dec.bytes32()?;
+    let submitter = dec.bytes32()?;
+    Ok(DoubleSignEvidence {
+        slot,
+        block_1,
+        signature_1,
+        block_2,
+        signature_2,
+        signer,
+        submitter,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1006,5 +1052,59 @@ mod tests {
     fn consensus_state_truncated_fails() {
         assert!(decode_consensus_state(&[]).is_err());
         assert!(decode_consensus_state(&[1]).is_err());
+    }
+
+    // ========== DoubleSignEvidence roundtrip ==========
+
+    fn dummy_evidence(slot: u64) -> DoubleSignEvidence {
+        // tx_root is part of BlockHeader::hash; state_root is deliberately
+        // not. So distinct tx_roots make these two blocks hash-distinct,
+        // which is the minimum requirement for valid equivocation evidence.
+        DoubleSignEvidence {
+            slot,
+            block_1: dummy_header(slot),
+            signature_1: vec![0xAA; 600],
+            block_2: BlockHeader {
+                tx_root: [0xEE; 32],
+                ..dummy_header(slot)
+            },
+            signature_2: vec![0xBB; 600],
+            signer: [0x11; 32],
+            submitter: [0x22; 32],
+        }
+    }
+
+    #[test]
+    fn double_sign_evidence_roundtrip() {
+        let evidence = dummy_evidence(42);
+        let bytes = encode_double_sign_evidence(&evidence);
+        let restored = decode_double_sign_evidence(&bytes).unwrap();
+
+        assert_eq!(restored.slot, 42);
+        assert_eq!(restored.block_1.slot, 42);
+        assert_eq!(restored.block_1.tx_root, [0x22; 32]);
+        assert_eq!(restored.block_2.tx_root, [0xEE; 32]);
+        assert_eq!(restored.signature_1, vec![0xAA; 600]);
+        assert_eq!(restored.signature_2, vec![0xBB; 600]);
+        assert_eq!(restored.signer, [0x11; 32]);
+        assert_eq!(restored.submitter, [0x22; 32]);
+        // Sanity: the two blocks must have distinct hashes or this isn't evidence.
+        assert_ne!(restored.block_1.hash(), restored.block_2.hash());
+    }
+
+    #[test]
+    fn double_sign_evidence_wrong_version_fails() {
+        let mut bytes = encode_double_sign_evidence(&dummy_evidence(1));
+        bytes[0] = 0xFF;
+        assert!(decode_double_sign_evidence(&bytes).is_err());
+    }
+
+    #[test]
+    fn double_sign_evidence_truncated_fails() {
+        assert!(decode_double_sign_evidence(&[]).is_err());
+        assert!(decode_double_sign_evidence(&[EVIDENCE_VERSION]).is_err());
+        // Truncate mid-encoding
+        let bytes = encode_double_sign_evidence(&dummy_evidence(5));
+        assert!(decode_double_sign_evidence(&bytes[..bytes.len() - 10]).is_err());
     }
 }


### PR DESCRIPTION
Slice A of the slashing pipeline (plan task 005). Purely engine-side
groundwork — no on-chain effects yet. A follow-up PR will plug this
into the tx pipeline (`TransactionType::Slash` handler) and the block
builder.

## Representation change
`pending_slashes: Vec<SlashResult>` → `pending_evidence: Vec<DoubleSignEvidence>`.

The slashing transaction carries raw evidence on the wire; the
receiving node re-verifies it from its own view of state. Storing
the locally-computed `SlashResult` as the queue item was the wrong
representation — it couldn't be transmitted and couldn't be
re-verified by peers. `DoubleSignEvidence` is the actual payload of
the eventual `Slash` tx.

At the detection site we still call `slash_double_sign` as a validity
check (returns `None` if either signature doesn't verify against the
accused proposer's committee key). On success we queue the raw
evidence rather than the derived result.

## New API surface
- `wire::encode_double_sign_evidence` / `decode_double_sign_evidence`
  (version byte = 1; reuses the existing block-header codec;
  length-prefixes FALCON signatures).
- `ValidatorEngine::drain_pending_evidence() -> Vec<DoubleSignEvidence>`
  — transfers ownership, leaves the queue empty.
- `ValidatorEngine::push_evidence(Vec<DoubleSignEvidence>)` — restores
  a drained batch, e.g. on a failed block build.

## Tests
- wire (3): roundtrip, wrong-version rejected, truncated rejected.
- validator (3): drain empties the queue, push re-queues, multi-item
  push preserves order.

Full workspace suite green.

## Deferred to slice B
- `TransactionType::Slash` handler in `tx/src/pipeline.rs`: decode →
  verify signatures → look up offender in state → debit stake → pay
  finder's fee → burn remainder → mark offender Ejected.
- Block-builder integration: drain evidence during proposal
  construction, emit Slash txs.
- End-to-end test: two conflicting proposals → detection →
  `pending_evidence` populated → drain → included in Slash tx →
  offender stake debited. (Needs FALCON + VRF scaffolding that slice
  B builds anyway.)