### PR TITLE
feat: slot-prefix proposer sigs, carry hashes in DoubleSignEvidence

### DIFF
--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -13,6 +13,22 @@ use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 use pyde_crypto::poseidon2::poseidon2_hash;
 
+/// Canonical message bytes that both proposers and voters sign for a
+/// block at a given slot: `slot_le || block_hash`.
+///
+/// The slot prefix binds the signature to a specific slot, preventing
+/// cross-slot replay of the same block hash. Both proposer signatures
+/// (on block headers) and vote signatures (on `Vote` messages) use this
+/// exact layout so slashing evidence can be verified with a single
+/// routine regardless of signature origin.
+#[inline]
+pub fn proposer_sign_message(slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(8 + 32);
+    msg.extend_from_slice(&slot.to_le_bytes());
+    msg.extend_from_slice(block_hash);
+    msg
+}
+
 /// Consensus message types exchanged between validators.
 #[derive(Clone, Debug)]
 pub enum ConsensusMessage {
@@ -122,12 +138,10 @@ pub fn create_vote(
         state.highest_qc = header.qc_previous.clone();
     }
 
-    // Sign (slot || block_hash) to bind the vote to a specific slot,
-    // preventing replay of a vote from one slot to another.
+    // Sign (slot || block_hash) via the canonical proposer/vote message
+    // layout, binding the vote to a specific slot.
     let block_hash = header.hash();
-    let mut vote_msg = Vec::with_capacity(40);
-    vote_msg.extend_from_slice(&header.slot.to_le_bytes());
-    vote_msg.extend_from_slice(&block_hash);
+    let vote_msg = proposer_sign_message(header.slot, &block_hash);
     let sig = pyde_crypto::falcon::falcon_sign(voter_sk, &vote_msg)
         .map_err(|_| "vote signing failed")?;
 
@@ -156,9 +170,7 @@ pub fn verify_vote(vote: &ConsensusMessage, public_key: &[u8]) -> bool {
                 Some(pk) => pk,
                 None => return false,
             };
-            let mut vote_msg = Vec::with_capacity(40);
-            vote_msg.extend_from_slice(&slot.to_le_bytes());
-            vote_msg.extend_from_slice(block_hash);
+            let vote_msg = proposer_sign_message(*slot, block_hash);
             let sig = match FalconSignature::from_bytes(signature) {
                 Some(s) => s,
                 None => return false,

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -62,21 +62,29 @@ pub struct SlashResult {
 }
 
 /// Double-signing evidence: two different blocks signed for the same slot.
+///
+/// Carries block *hashes* rather than full `BlockHeader`s because both
+/// the proposer signature and vote signature formats bind (slot || hash)
+/// directly — verifying the evidence requires nothing more than the
+/// hashes, the two FALCON signatures, and the signer's public key. This
+/// keeps the on-chain payload (`TransactionType::Slash` data field)
+/// small and lets the tx pipeline verify the evidence without depending
+/// on `BlockHeader` internals.
 #[derive(Clone, Debug)]
 pub struct DoubleSignEvidence {
     /// The slot where double-signing occurred.
     pub slot: u64,
-    /// First block header.
-    pub block_1: BlockHeader,
-    /// FALCON signature over block_1.hash().
+    /// Hash of the first block the signer signed for this slot.
+    pub block_hash_1: [u8; 32],
+    /// FALCON signature over `proposer_sign_message(slot, block_hash_1)`.
     pub signature_1: Vec<u8>,
-    /// Second block header (must have different hash from block_1).
-    pub block_2: BlockHeader,
-    /// FALCON signature over block_2.hash().
+    /// Hash of the second block — must differ from `block_hash_1`.
+    pub block_hash_2: [u8; 32],
+    /// FALCON signature over `proposer_sign_message(slot, block_hash_2)`.
     pub signature_2: Vec<u8>,
-    /// Address of the signer.
+    /// Address of the signer being accused.
     pub signer: Address,
-    /// Address of the evidence submitter (receives finder's fee).
+    /// Address of the evidence submitter (receives the finder's fee).
     pub submitter: Address,
 }
 
@@ -105,29 +113,22 @@ impl LivenessReport {
 /// Verify double-sign evidence.
 ///
 /// Checks:
-/// 1. Both blocks are for the same slot
-/// 2. Block hashes are different
-/// 3. Both signatures are valid for the signer's public key
+/// 1. The two block hashes are different (otherwise it's not equivocation).
+/// 2. Both signatures verify over `(slot || block_hash)` against the
+///    accused signer's public key.
+///
+/// The slot binding lives inside the signed message, so a sig for slot
+/// N cannot be replayed as evidence of equivocation at slot M.
 pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> bool {
-    // Same slot
-    if evidence.block_1.slot != evidence.slot || evidence.block_2.slot != evidence.slot {
+    // Two distinct blocks (empty-or-equal hashes = not evidence).
+    if evidence.block_hash_1 == evidence.block_hash_2 {
         return false;
     }
 
-    let hash_1 = evidence.block_1.hash();
-    let hash_2 = evidence.block_2.hash();
-
-    // Different blocks
-    if hash_1 == hash_2 {
-        return false;
-    }
-
-    // Verify both signatures
     let pk = match FalconPublicKey::from_bytes(public_key) {
         Some(pk) => pk,
         None => return false,
     };
-
     let sig_1 = match FalconSignature::from_bytes(&evidence.signature_1) {
         Some(s) => s,
         None => return false,
@@ -137,7 +138,9 @@ pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> b
         None => return false,
     };
 
-    falcon_verify(&pk, &hash_1, &sig_1) && falcon_verify(&pk, &hash_2, &sig_2)
+    let msg_1 = crate::hotstuff::proposer_sign_message(evidence.slot, &evidence.block_hash_1);
+    let msg_2 = crate::hotstuff::proposer_sign_message(evidence.slot, &evidence.block_hash_2);
+    falcon_verify(&pk, &msg_1, &sig_1) && falcon_verify(&pk, &msg_2, &sig_2)
 }
 
 // ========== Slash Computation ==========
@@ -279,6 +282,17 @@ mod tests {
         }
     }
 
+    /// Helper: produce a proposer signature over the canonical
+    /// `(slot || block_hash)` message layout the production code uses.
+    fn sign_proposer(
+        sk: &pyde_crypto::falcon::FalconSecretKey,
+        slot: u64,
+        block_hash: &[u8; 32],
+    ) -> Vec<u8> {
+        let msg = crate::hotstuff::proposer_sign_message(slot, block_hash);
+        falcon_sign(sk, &msg).unwrap().as_bytes().to_vec()
+    }
+
     // ========== Task 0512: Double-sign slashes validator ==========
 
     #[test]
@@ -287,18 +301,15 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let header_1 = make_header(100, 1_000_000);
-        let header_2 = make_header(100, 2_000_000); // same slot, different timestamp → different hash
-
-        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
-        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash(); // different timestamp → different hash
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header_1,
-            signature_1: sig_1.as_bytes().to_vec(),
-            block_2: header_2,
-            signature_2: sig_2.as_bytes().to_vec(),
+            block_hash_1: hash_1,
+            signature_1: sign_proposer(&sk, 100, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
@@ -323,15 +334,15 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let header = make_header(100, 1_000_000);
-        let sig = falcon_sign(&sk, &header.hash()).unwrap();
+        let hash = make_header(100, 1_000_000).hash();
+        let sig = sign_proposer(&sk, 100, &hash);
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header.clone(),
-            signature_1: sig.as_bytes().to_vec(),
-            block_2: header, // same block!
-            signature_2: sig.as_bytes().to_vec(),
+            block_hash_1: hash,
+            signature_1: sig.clone(),
+            block_hash_2: hash, // same hash!
+            signature_2: sig,
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
@@ -346,18 +357,15 @@ mod tests {
         let (pk2, _sk2) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk1.as_bytes());
 
-        let header_1 = make_header(100, 1_000_000);
-        let header_2 = make_header(100, 2_000_000);
-
-        let sig_1 = falcon_sign(&sk1, &header_1.hash()).unwrap();
-        let sig_2 = falcon_sign(&sk1, &header_2.hash()).unwrap();
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header_1,
-            signature_1: sig_1.as_bytes().to_vec(),
-            block_2: header_2,
-            signature_2: sig_2.as_bytes().to_vec(),
+            block_hash_1: hash_1,
+            signature_1: sign_proposer(&sk1, 100, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk1, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
@@ -368,22 +376,23 @@ mod tests {
 
     #[test]
     fn wrong_slot_rejected() {
+        // Signatures are bound to (slot || hash). If the signer attested
+        // to slot 101 but the evidence claims slot 100, the FALCON
+        // verify at slot 100 fails — no cross-slot replay possible.
         let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let header_1 = make_header(100, 1_000_000);
-        let header_2 = make_header(101, 2_000_000); // different slot!
-
-        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
-        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header_1,
-            signature_1: sig_1.as_bytes().to_vec(),
-            block_2: header_2,
-            signature_2: sig_2.as_bytes().to_vec(),
+            block_hash_1: hash_1,
+            // Signed at the wrong slot (101) — verify at slot 100 rejects.
+            signature_1: sign_proposer(&sk, 101, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
@@ -458,18 +467,15 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let header_1 = make_header(100, 1_000_000);
-        let header_2 = make_header(100, 2_000_000);
-
-        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
-        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header_1,
-            signature_1: sig_1.as_bytes().to_vec(),
-            block_2: header_2,
-            signature_2: sig_2.as_bytes().to_vec(),
+            block_hash_1: hash_1,
+            signature_1: sign_proposer(&sk, 100, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"finder"),
         };
@@ -491,17 +497,15 @@ mod tests {
         set.register(addr, pk_bytes.clone(), VALIDATOR_STAKE, 0).unwrap();
         assert_eq!(set.validators[0].stake, VALIDATOR_STAKE);
 
-        let header_1 = make_header(100, 1_000_000);
-        let header_2 = make_header(100, 2_000_000);
-        let sig_1 = falcon_sign(&sk, &header_1.hash()).unwrap();
-        let sig_2 = falcon_sign(&sk, &header_2.hash()).unwrap();
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash();
 
         let evidence = DoubleSignEvidence {
             slot: 100,
-            block_1: header_1,
-            signature_1: sig_1.as_bytes().to_vec(),
-            block_2: header_2,
-            signature_2: sig_2.as_bytes().to_vec(),
+            block_hash_1: hash_1,
+            signature_1: sign_proposer(&sk, 100, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"finder"),
         };

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -1,6 +1,7 @@
 use crate::chain::ChainState;
 use crate::state_manager::StateManager;
 use pyde_consensus::block::{Block, BlockHeader};
+use pyde_consensus::hotstuff::proposer_sign_message;
 use pyde_tx::execution::Receipt;
 use pyde_tx::fee::adjust_base_fee;
 use pyde_tx::pipeline::{execute_transaction, BlockContext};
@@ -327,7 +328,10 @@ impl BlockProcessor {
         let block_hash = header.hash();
         let sig = pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature)
             .ok_or("invalid proposer signature format")?;
-        if !pyde_crypto::falcon::falcon_verify(&pk, &block_hash, &sig) {
+        // Proposers sign `slot || block_hash` (canonical layout shared
+        // with votes) to prevent cross-slot signature replay.
+        let sign_msg = proposer_sign_message(slot, &block_hash);
+        if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
             return Err("proposer signature verification failed".into());
         }
 

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -4,7 +4,7 @@ use pyde_consensus::block::{
 };
 use pyde_consensus::finality::{FinalityTracker, FinalityVote, create_finality_vote, try_form_hard_finality};
 use pyde_consensus::hotstuff::{
-    ConsensusMessage, ConsensusState, create_vote, try_form_qc, verify_vote,
+    ConsensusMessage, ConsensusState, create_vote, proposer_sign_message, try_form_qc, verify_vote,
 };
 use pyde_consensus::proposer::{compute_candidacy, ProposerCandidate};
 use pyde_crypto::vrf::VrfProof;
@@ -589,14 +589,17 @@ impl ValidatorEngine {
             None => { warn!(slot, "invalid committee public key"); return false; }
         };
 
-        // Verify proposer signature on block header
+        // Verify proposer signature on block header.
+        // Proposers sign `slot || block_hash` (same canonical layout as
+        // votes) so a sig at slot N cannot be replayed for a block at slot M.
         if !proposer_signature.is_empty() {
             let block_hash = header.hash();
             let sig = match pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature) {
                 Some(s) => s,
                 None => { warn!(slot, "invalid proposer signature format"); return false; }
             };
-            if !pyde_crypto::falcon::falcon_verify(&pk, &block_hash, &sig) {
+            let sign_msg = proposer_sign_message(slot, &block_hash);
+            if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
                 warn!(slot, "proposer signature verification failed");
                 return false;
             }
@@ -637,9 +640,9 @@ impl ValidatorEngine {
                 );
                 let evidence = DoubleSignEvidence {
                     slot,
-                    block_1: prev_header.clone(),
+                    block_hash_1: prev_header.hash(),
                     signature_1: prev_sig.clone(),
-                    block_2: header.clone(),
+                    block_hash_2: header.hash(),
                     signature_2: proposer_signature.to_vec(),
                     signer: header.proposer,
                     // submitter is filled in by whoever actually broadcasts
@@ -754,11 +757,13 @@ impl ValidatorEngine {
             timestamp: current_time_ms(),
         };
 
-        // Sign the block header hash with the proposer's FALCON key
+        // Sign the canonical (slot || block_hash) message with the
+        // proposer's FALCON key. See proposer_sign_message for the format.
         let block_hash = header.hash();
+        let sign_msg = proposer_sign_message(header.slot, &block_hash);
         let proposer_signature = match pyde_crypto::falcon::falcon_sign(
             &identity.secret_key,
-            &block_hash,
+            &sign_msg,
         ) {
             Ok(sig) => sig.to_vec(),
             Err(_) => {
@@ -1456,12 +1461,9 @@ mod tests {
     fn evidence_fixture(slot: u64, signer: Address) -> DoubleSignEvidence {
         DoubleSignEvidence {
             slot,
-            block_1: evidence_header(slot, [0x01; 32]),
+            block_hash_1: [0x01; 32],
             signature_1: vec![0xAA; 600],
-            block_2: BlockHeader {
-                tx_root: [0x02; 32],
-                ..evidence_header(slot, [0x01; 32])
-            },
+            block_hash_2: [0x02; 32],
             signature_2: vec![0xBB; 600],
             signer,
             submitter: [0u8; 32],

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -705,15 +705,29 @@ pub fn decode_consensus_state(data: &[u8]) -> Result<pyde_consensus::hotstuff::C
 
 /// Schema version tag for the Slash-tx payload. Bumping this is a
 /// protocol change: old nodes would reject new evidence and vice versa.
-const EVIDENCE_VERSION: u8 = 1;
+pub(crate) const EVIDENCE_VERSION: u8 = 1;
 
+/// Layout:
+///   u8 version = 1
+///   u64 slot
+///   [u8; 32] block_hash_1
+///   var_bytes signature_1
+///   [u8; 32] block_hash_2
+///   var_bytes signature_2
+///   [u8; 32] signer
+///   [u8; 32] submitter
+///
+/// Carrying just the hashes (not full `BlockHeader`s) is enough because
+/// each signature is verified over `proposer_sign_message(slot, hash)`
+/// — the slot binding lives inside the signed message, not the wire
+/// format, so a third-party verifier needs nothing besides the hashes.
 pub fn encode_double_sign_evidence(evidence: &DoubleSignEvidence) -> Vec<u8> {
     let mut enc = Encoder::new();
     enc.u8(EVIDENCE_VERSION);
     enc.u64(evidence.slot);
-    enc.var_bytes(&encode_block_header(&evidence.block_1));
+    enc.bytes32(&evidence.block_hash_1);
     enc.var_bytes(&evidence.signature_1);
-    enc.var_bytes(&encode_block_header(&evidence.block_2));
+    enc.bytes32(&evidence.block_hash_2);
     enc.var_bytes(&evidence.signature_2);
     enc.bytes32(&evidence.signer);
     enc.bytes32(&evidence.submitter);
@@ -727,17 +741,17 @@ pub fn decode_double_sign_evidence(data: &[u8]) -> Result<DoubleSignEvidence, &'
         return Err("unsupported double-sign evidence version");
     }
     let slot = dec.u64()?;
-    let block_1 = decode_block_header(&dec.var_bytes()?)?;
+    let block_hash_1 = dec.bytes32()?;
     let signature_1 = dec.var_bytes()?;
-    let block_2 = decode_block_header(&dec.var_bytes()?)?;
+    let block_hash_2 = dec.bytes32()?;
     let signature_2 = dec.var_bytes()?;
     let signer = dec.bytes32()?;
     let submitter = dec.bytes32()?;
     Ok(DoubleSignEvidence {
         slot,
-        block_1,
+        block_hash_1,
         signature_1,
-        block_2,
+        block_hash_2,
         signature_2,
         signer,
         submitter,
@@ -1057,17 +1071,11 @@ mod tests {
     // ========== DoubleSignEvidence roundtrip ==========
 
     fn dummy_evidence(slot: u64) -> DoubleSignEvidence {
-        // tx_root is part of BlockHeader::hash; state_root is deliberately
-        // not. So distinct tx_roots make these two blocks hash-distinct,
-        // which is the minimum requirement for valid equivocation evidence.
         DoubleSignEvidence {
             slot,
-            block_1: dummy_header(slot),
+            block_hash_1: [0x01; 32],
             signature_1: vec![0xAA; 600],
-            block_2: BlockHeader {
-                tx_root: [0xEE; 32],
-                ..dummy_header(slot)
-            },
+            block_hash_2: [0x02; 32],
             signature_2: vec![0xBB; 600],
             signer: [0x11; 32],
             submitter: [0x22; 32],
@@ -1081,15 +1089,14 @@ mod tests {
         let restored = decode_double_sign_evidence(&bytes).unwrap();
 
         assert_eq!(restored.slot, 42);
-        assert_eq!(restored.block_1.slot, 42);
-        assert_eq!(restored.block_1.tx_root, [0x22; 32]);
-        assert_eq!(restored.block_2.tx_root, [0xEE; 32]);
+        assert_eq!(restored.block_hash_1, [0x01; 32]);
+        assert_eq!(restored.block_hash_2, [0x02; 32]);
         assert_eq!(restored.signature_1, vec![0xAA; 600]);
         assert_eq!(restored.signature_2, vec![0xBB; 600]);
         assert_eq!(restored.signer, [0x11; 32]);
         assert_eq!(restored.submitter, [0x22; 32]);
-        // Sanity: the two blocks must have distinct hashes or this isn't evidence.
-        assert_ne!(restored.block_1.hash(), restored.block_2.hash());
+        // Sanity: distinct hashes or it isn't evidence of equivocation.
+        assert_ne!(restored.block_hash_1, restored.block_hash_2);
     }
 
     #[test]


### PR DESCRIPTION
Protocol groundwork for the on-chain slashing handler (next PR). Two
changes ship together because evidence verification depends on the
canonical sign-message format.

## Change 1 — slot-prefixed proposer signatures
Proposers now sign `slot_le || block_hash` (via new
`hotstuff::proposer_sign_message`), matching what votes already sign.

**Prevents cross-slot replay:** previously a proposer sig over
`block_hash` at slot N could be replayed at slot M with the same
hash. Now the slot is committed inside the signed message.

3 call sites updated: build_proposal (sign), verify_proposal_signature
and validate_network_block (verify). `create_vote` / `verify_vote`
also switched to the helper so there is one source of truth for the
(slot || hash) layout.

## Change 2 — `DoubleSignEvidence` carries hashes, not headers
`block_1/block_2: BlockHeader` → `block_hash_1/block_hash_2: [u8; 32]`.

Since the slot binding is in the signed message, the verifier only
needs `(slot, hash_1, sig_1, hash_2, sig_2, signer_pubkey)`. No
`BlockHeader` internals required. This:
- Shrinks the on-chain Slash-tx payload (~1.3 KB vs ~2 KB).
- Unblocks the next PR: the tx-pipeline handler in `pyde-tx` can
  verify evidence without depending on `pyde-consensus`
  (which would be a dep cycle).

`verify_double_sign` rewritten: hash-distinctness check + two FALCON
verifies over the canonical message.

## Change 3 — wire codec simplified
Old: `version || slot || var_bytes(header_1) || sig_1 || var_bytes(header_2) || sig_2 || signer || submitter`
New: `version || slot || hash_1 || sig_1 || hash_2 || sig_2 || signer || submitter`

## Detection site
`validator.rs` now populates `block_hash_1 = prev_header.hash()` and
`block_hash_2 = header.hash()` instead of cloning full headers.

## Tests
- Slashing tests rewritten (5 sites) — including a new
  `wrong_slot_rejected` that confirms a sig produced at slot 101
  cannot be laundered as evidence at slot 100.
- Wire evidence tests updated for the simpler layout.
- Validator fixture + 3 drain/push tests updated.
- Full workspace suite green.