### PR TITLE
feat: fsync ConsensusStateStore writes and halt on persist failure

### DIFF
--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -18,7 +18,7 @@ use crate::wire;
 use pyde_account::address::Address;
 use pyde_consensus::block::BlockHeader;
 use pyde_consensus::hotstuff::ConsensusState;
-use rocksdb::{DB, IteratorMode, Options, WriteBatch};
+use rocksdb::{DB, IteratorMode, Options, WriteBatch, WriteOptions};
 use std::path::Path;
 use tracing::{debug, info, warn};
 
@@ -37,8 +37,15 @@ pub type SeenVote = ((u64, u8), ([u8; 32], Vec<u8>));
 /// There is exactly one persisted state per node, so the store is
 /// effectively a single-key KV. RocksDB gives us atomic writes,
 /// crash recovery, and fsync guarantees at the filesystem layer.
+///
+/// All mutating writes go through `sync_opts` (`set_sync(true)`), which
+/// forces an fsync before the `put` returns. Without this, a vote
+/// "committed" to the WAL page cache could be lost in a power-loss
+/// window — the entire crash-safety guarantee of the store depends on
+/// the data actually being on disk when we return Ok.
 pub struct ConsensusStateStore {
     db: DB,
+    sync_opts: WriteOptions,
 }
 
 impl ConsensusStateStore {
@@ -49,15 +56,18 @@ impl ConsensusStateStore {
         opts.create_if_missing(true);
         let db = DB::open(&opts, &db_path)
             .map_err(|e| format!("failed to open consensus state store: {}", e))?;
-        info!(path = %db_path.display(), "consensus state store opened");
-        Ok(Self { db })
+        let mut sync_opts = WriteOptions::default();
+        sync_opts.set_sync(true);
+        info!(path = %db_path.display(), "consensus state store opened (fsync on every write)");
+        Ok(Self { db, sync_opts })
     }
 
     /// Persist the current consensus state. Overwrites any prior value.
+    /// Blocks until the write is fsync'd to disk.
     pub fn save(&self, state: &ConsensusState) -> Result<(), String> {
         let bytes = wire::encode_consensus_state(state);
         self.db
-            .put(STATE_KEY, &bytes)
+            .put_opt(STATE_KEY, &bytes, &self.sync_opts)
             .map_err(|e| format!("failed to save consensus state: {}", e))?;
         debug!(
             slot = state.current_slot,
@@ -95,6 +105,7 @@ impl ConsensusStateStore {
     // ============================================================
 
     /// Persist a seen proposal entry. Idempotent on repeat writes.
+    /// fsync'd before return (see struct docstring).
     pub fn save_seen_proposal(
         &self,
         slot: u64,
@@ -105,11 +116,12 @@ impl ConsensusStateStore {
         let key = encode_proposal_key(slot, proposer);
         let value = encode_seen_proposal(header, signature);
         self.db
-            .put(&key, &value)
+            .put_opt(&key, &value, &self.sync_opts)
             .map_err(|e| format!("failed to save seen proposal: {}", e))
     }
 
     /// Persist a seen vote entry. Idempotent on repeat writes.
+    /// fsync'd before return (see struct docstring).
     pub fn save_seen_vote(
         &self,
         slot: u64,
@@ -120,7 +132,7 @@ impl ConsensusStateStore {
         let key = encode_vote_key(slot, voter_index);
         let value = encode_seen_vote(block_hash, signature);
         self.db
-            .put(&key, &value)
+            .put_opt(&key, &value, &self.sync_opts)
             .map_err(|e| format!("failed to save seen vote: {}", e))
     }
 
@@ -212,8 +224,13 @@ impl ConsensusStateStore {
         }
 
         if count > 0 {
+            // Prune writes also fsync. Loss of a prune doesn't violate
+            // safety (stale disk entries are benign — in-memory state is
+            // source of truth for active slots), but fsync-consistent
+            // pruning keeps the disk size predictable and simplifies
+            // reasoning about what the next cold-start will reload.
             self.db
-                .write(batch)
+                .write_opt(batch, &self.sync_opts)
                 .map_err(|e| format!("failed to prune evidence: {}", e))?;
             debug!(pruned = count, prune_before, "evidence pruned");
         }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -335,16 +335,27 @@ impl ValidatorEngine {
     }
 
     /// Persist consensus state to disk. No-op when no store is attached.
+    ///
     /// Safety-critical: must be called after any mutation of
     /// `last_voted_slot`, `highest_qc`, or `current_slot`.
+    ///
+    /// **Panics on persist failure.** Continuing after a failed write would
+    /// silently degrade the validator to in-memory-only mode: the next
+    /// crash or restart would reload stale state from disk, potentially
+    /// regressing `last_voted_slot` and allowing a double-vote — a BFT
+    /// safety violation. We'd rather abort the process loudly and let
+    /// the operator restart from a clean (last known-good) disk state
+    /// after resolving the underlying I/O issue. In release builds the
+    /// workspace uses `panic = "abort"`, so this unwinds to an immediate
+    /// SIGABRT; in tests it surfaces as a test failure.
     fn persist_consensus(&self) {
         if let Some(store) = &self.consensus_store {
             if let Err(e) = store.save(&self.consensus) {
-                // A failed write is serious — next crash could regress safety.
-                // We log and continue; a follow-up write will likely succeed.
-                // Hardening: promote to fatal once we have a shutdown path that
-                // drains inflight messages before exit.
-                error!(error = %e, "failed to persist consensus state");
+                error!(
+                    error = %e,
+                    "FATAL: failed to persist consensus state — halting validator to preserve BFT safety"
+                );
+                panic!("consensus state persist failed: {}", e);
             }
         }
     }
@@ -665,9 +676,19 @@ impl ValidatorEngine {
         } else {
             // Persist BEFORE the in-memory insert so a crash between the two
             // leaves the in-memory state recoverable from disk.
+            //
+            // Panics on persist failure: losing the seen-proposal index
+            // silently disables equivocation detection for this slot,
+            // and a validator that cannot detect its own double-proposes
+            // is worse than one that halts visibly.
             if let Some(store) = &self.consensus_store {
                 if let Err(e) = store.save_seen_proposal(slot, &header.proposer, header, proposer_signature) {
-                    error!(error = %e, "failed to persist seen proposal");
+                    error!(
+                        error = %e,
+                        slot,
+                        "FATAL: failed to persist seen proposal — halting validator"
+                    );
+                    panic!("seen-proposal persist failed: {}", e);
                 }
             }
             self.seen_proposals.insert(proposal_key, (header.clone(), proposer_signature.to_vec()));
@@ -864,9 +885,17 @@ impl ValidatorEngine {
                 // can be implemented when the slashing transaction type is added.
             }
         } else {
+            // Persist BEFORE the in-memory insert. Panics on failure for
+            // the same reason as the seen-proposal site above.
             if let Some(store) = &self.consensus_store {
                 if let Err(e) = store.save_seen_vote(slot, voter_index as u8, &block_hash, &vote_sig) {
-                    error!(error = %e, "failed to persist seen vote");
+                    error!(
+                        error = %e,
+                        slot,
+                        voter_index,
+                        "FATAL: failed to persist seen vote — halting validator"
+                    );
+                    panic!("seen-vote persist failed: {}", e);
                 }
             }
             self.seen_votes.insert(vote_key, (block_hash, vote_sig));


### PR DESCRIPTION
Closes tasks **014a** and **014b** of the mainnet plan. Both tighten
the crash-safety guarantees of the consensus state subsystem
introduced in tasks 001 and 002. Shipped together because they touch
the same write path and share the same motivation: a persist that
returns `Ok` must mean the data is truly on disk and will be reloaded
on restart.

## 014a — fsync every write
`ConsensusStateStore::open` now builds a `WriteOptions` with
`set_sync(true)` and uses `put_opt` / `write_opt` for all four
mutating paths: `save`, `save_seen_proposal`, `save_seen_vote`, and
`prune_evidence_before`.

Without this, a vote "committed" to the WAL sits in the OS page cache
until the kernel flushes — a power loss in that window loses the
write and lets a restarted validator regress `last_voted_slot`. The
whole crash-safety story depends on fsync actually happening before
`save()` returns.

**Cost:** one fsync per vote. At 400 ms slots this is well within SSD
fsync budget; worth paying to make the guarantee real.

## 014b — panic on persist failure
`persist_consensus` and the two evidence-persist call sites now log
at `error!` and **panic** instead of logging and continuing.

Why: logging and continuing silently degraded the validator to
in-memory-only mode. The next restart would reload stale disk state
and could regress safety. Better to abort the process loudly; the
operator restarts from last known-good state after fixing the
underlying I/O issue.

Workspace release profile uses `panic = "abort"` → SIGABRT in
production; supervisor restarts cleanly. Tests unwind as normal.

Evidence-prune failure remains `warn!` + continue — a lost prune
can't violate safety (stale disk entries are benign; in-memory
HashMaps are the source of truth for active slots). It just means
the disk doesn't shrink until the next successful prune.

## Tests
No new tests: panic paths aren't exercisable in unit tests without
filesystem injection (read-only dirs, quota limits, etc). Existing
crash-restart tests in `validator.rs` continue to exercise the happy
path and all pass.

Full workspace suite green.