### PR TITLE
feat: gossip equivocation evidence across consensus channel

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -508,6 +508,18 @@ impl PydeNode {
                                 warn!(error = %e, "failed to broadcast consensus message");
                             }
                         }
+                        PostEventAction::BroadcastConsensusMany(messages) => {
+                            let topic = pyde_net::node::topics::consensus();
+                            for data in messages {
+                                if let Err(e) = swarm
+                                    .behaviour_mut()
+                                    .gossipsub
+                                    .publish(topic.clone(), data)
+                                {
+                                    warn!(error = %e, "failed to broadcast consensus message");
+                                }
+                            }
+                        }
                         PostEventAction::AcceptTransaction(tx) => {
                             let tx_hash = tx.hash();
                             // Index for compact block reconstruction
@@ -1038,6 +1050,18 @@ impl PydeNode {
                                     // Buffer our own proposal for VRF selection.
                                     // Voting happens after the proposal collection window.
                                     engine.buffer_proposal(&block.header, &block.proposer_signature);
+
+                                    // If buffering triggered local detection of an
+                                    // equivocation, relay the evidence on the consensus
+                                    // channel so peers can slash even if they never
+                                    // directly witnessed the double-propose.
+                                    for ev in engine.drain_broadcast_evidence() {
+                                        let bytes = wire::encode_slash_evidence_msg(&ev);
+                                        let topic = pyde_net::node::topics::consensus();
+                                        if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, bytes) {
+                                            warn!(error = ?e, "failed to publish slash evidence");
+                                        }
+                                    }
                                 } // end if mempool_size > 0
                                 }
                             }
@@ -1308,6 +1332,11 @@ enum PostEventAction {
     SendSyncResponse(request_response::ResponseChannel<SyncResp>, SyncResp),
     ContinueSync,
     BroadcastConsensus(Vec<u8>),
+    /// Batch-publish multiple consensus messages in one post-event
+    /// action. Used for slashing evidence: a single received proposal
+    /// can cause the engine to queue several messages at once (e.g. if
+    /// gossip and local detection arrive in the same tick).
+    BroadcastConsensusMany(Vec<Vec<u8>>),
     AcceptTransaction(pyde_tx::types::Transaction),
     StoreReceipts(u64, Vec<pyde_tx::execution::Receipt>),
     AddPeerToKademlia(PeerId, Vec<libp2p::Multiaddr>),
@@ -1477,6 +1506,34 @@ fn handle_swarm_event(
                             return PostEventAction::None;
                         }
 
+                        // Check if it's a slashing-evidence gossip message.
+                        // Validators relay these so that even a validator
+                        // that never directly witnessed the equivocation
+                        // can include a Slash tx in its next proposal.
+                        if !message.data.is_empty() && message.data[0] == wire::tag::CONSENSUS_SLASH_EVIDENCE {
+                            match wire::decode_slash_evidence_msg(&message.data) {
+                                Ok(evidence) => {
+                                    let slot = evidence.slot;
+                                    let signer = evidence.signer;
+                                    if engine.ingest_evidence(evidence) {
+                                        info!(
+                                            slot,
+                                            signer = hex::encode(signer),
+                                            "ingested slash evidence from gossip"
+                                        );
+                                    }
+                                    // Note: no immediate re-publish here.
+                                    // gossipsub already propagates the
+                                    // message across the mesh; re-emitting
+                                    // would cause an amplification storm.
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode slash evidence gossip");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
                         // Check if it's a PSS refresh contribution
                         if !message.data.is_empty() && message.data[0] == wire::tag::PSS_REFRESH {
                             match wire::decode_pss_refresh(&message.data) {
@@ -1525,6 +1582,20 @@ fn handle_swarm_event(
                                         // Voting happens after the proposal collection window
                                         // via select_and_vote (triggered by slot timer).
                                         engine.buffer_proposal(header, proposer_signature);
+                                        // Same detection-then-relay pattern as when we
+                                        // produce our own proposal: buffering a received
+                                        // proposal can reveal it conflicts with one we
+                                        // already saw from the same proposer. Hand the
+                                        // encoded envelopes back to the outer loop to
+                                        // publish — swarm isn't accessible from here.
+                                        let new_evidence: Vec<Vec<u8>> = engine
+                                            .drain_broadcast_evidence()
+                                            .iter()
+                                            .map(wire::encode_slash_evidence_msg)
+                                            .collect();
+                                        if !new_evidence.is_empty() {
+                                            return PostEventAction::BroadcastConsensusMany(new_evidence);
+                                        }
                                     }
                                     ConsensusMessage::Vote { slot, voter_index, .. } => {
                                         debug!(slot, voter_index, "received vote");

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -256,6 +256,17 @@ pub struct ValidatorEngine {
     /// writes to disk on every safety-critical mutation and reloads on startup.
     /// Crash-safe property: never regress last_voted_slot or highest_qc.
     consensus_store: Option<Arc<ConsensusStateStore>>,
+    /// Evidence staged for P2P broadcast. Populated by local detection
+    /// (and by ingest_evidence on first-seen gossip items); drained by
+    /// the node loop after each proposal it processes, so new
+    /// equivocations reach every validator even if only one directly
+    /// witnessed them.
+    broadcast_evidence: Vec<DoubleSignEvidence>,
+    /// (slot, signer) pairs we've already ingested. Dedups both local
+    /// re-detection (same validator conflicting across >2 blocks at the
+    /// same slot) and gossip arrivals — each pair is broadcast at most
+    /// once and stored in pending_evidence at most once.
+    seen_evidence: std::collections::HashSet<(u64, Address)>,
 }
 
 impl ValidatorEngine {
@@ -276,6 +287,8 @@ impl ValidatorEngine {
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
             pending_evidence: Vec::new(),
+            broadcast_evidence: Vec::new(),
+            seen_evidence: std::collections::HashSet::new(),
             randomness_collector: None,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
@@ -660,17 +673,16 @@ impl ValidatorEngine {
                     // the Slash tx — typically the next block proposer.
                     submitter: [0u8; 32],
                 };
-                // Cross-check both signatures verify against the accused
-                // proposer's committee key. slash_double_sign returns None
-                // if either sig is invalid; in that case we drop the
-                // evidence rather than queue garbage.
-                if slash_double_sign(&evidence, &self.committee_keys[proposer_idx]).is_some() {
+                // Route through ingest_evidence: validates both sigs,
+                // dedupes on (slot, signer), and also stages the entry
+                // for P2P broadcast so other validators can slash even
+                // if they never directly observed the equivocation.
+                if self.ingest_evidence(evidence) {
                     info!(
                         slot,
-                        offender = hex::encode(evidence.signer),
+                        offender = hex::encode(header.proposer),
                         "double-propose evidence queued for slashing"
                     );
-                    self.pending_evidence.push(evidence);
                 }
             }
         } else {
@@ -1013,6 +1025,73 @@ impl ValidatorEngine {
     /// appending at the tail.
     pub fn push_evidence(&mut self, evidence: Vec<DoubleSignEvidence>) {
         self.pending_evidence.extend(evidence);
+    }
+
+    /// Ingest a piece of equivocation evidence — shared entry point for
+    /// both local detection and gossip reception. The flow is:
+    ///
+    /// 1. Deduplicate on `(slot, signer)`. A validator that has already
+    ///    queued evidence against the same offender at the same slot
+    ///    ignores repeats.
+    /// 2. Verify that `signer` is a current committee member. Evidence
+    ///    naming a non-validator is meaningless and wastes block space.
+    /// 3. Verify both FALCON signatures against the signer's committee
+    ///    key (delegated to `slash_double_sign`, which re-runs the
+    ///    canonical verification used by the on-chain handler).
+    /// 4. If all three pass, push to `pending_evidence` (for block
+    ///    inclusion) and `broadcast_evidence` (for P2P relay).
+    ///
+    /// Returns `true` if the evidence was newly accepted; `false` means
+    /// it was a duplicate or failed verification. Callers relying on
+    /// the return value: gossip path should only relay on `true` to
+    /// avoid amplification storms.
+    pub fn ingest_evidence(&mut self, evidence: DoubleSignEvidence) -> bool {
+        let key = (evidence.slot, evidence.signer);
+        if self.seen_evidence.contains(&key) {
+            return false;
+        }
+
+        // Resolve the accused signer to their committee index. A signer
+        // not in the active committee cannot be slashed — drop.
+        let signer_pk = self.committee_keys.iter().find(|pk| {
+            pyde_account::address::derive_eoa_address(pk) == evidence.signer
+        });
+        let pk_bytes = match signer_pk {
+            Some(pk) => pk.clone(),
+            None => {
+                debug!(
+                    slot = evidence.slot,
+                    signer = hex::encode(evidence.signer),
+                    "rejecting evidence: signer not in committee"
+                );
+                return false;
+            }
+        };
+
+        // slash_double_sign returns None if the sig/format verification
+        // fails. We discard the SlashResult — only verification matters;
+        // the on-chain handler re-computes it from state.
+        if slash_double_sign(&evidence, &pk_bytes).is_none() {
+            debug!(
+                slot = evidence.slot,
+                signer = hex::encode(evidence.signer),
+                "rejecting evidence: signature verification failed"
+            );
+            return false;
+        }
+
+        self.seen_evidence.insert(key);
+        self.pending_evidence.push(evidence.clone());
+        self.broadcast_evidence.push(evidence);
+        true
+    }
+
+    /// Drain the broadcast staging queue. Returns every piece of
+    /// evidence that has been newly ingested (either locally detected
+    /// or received via gossip) since the last call. The caller is
+    /// responsible for publishing each entry on the consensus channel.
+    pub fn drain_broadcast_evidence(&mut self) -> Vec<DoubleSignEvidence> {
+        std::mem::take(&mut self.broadcast_evidence)
     }
 
     /// Drain `pending_evidence` and turn each entry into a signed
@@ -1607,6 +1686,124 @@ mod tests {
 
         let slots: Vec<u64> = engine.pending_evidence.iter().map(|e| e.slot).collect();
         assert_eq!(slots, vec![1, 2, 3]);
+    }
+
+    // ========== Evidence gossip ingest + dedup ==========
+
+    /// Build valid evidence signed by a real FALCON key. Registers
+    /// `pk` as committee index 0 so ingest_evidence passes the
+    /// signer-in-committee check.
+    fn valid_evidence_and_engine()
+        -> (ValidatorEngine, pyde_crypto::falcon::FalconSecretKey, DoubleSignEvidence, Address)
+    {
+        use pyde_crypto::falcon::falcon_keygen;
+
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
+
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.set_committee(vec![pk_bytes]);
+
+        let slot = 42u64;
+        let hash_1 = [0x01u8; 32];
+        let hash_2 = [0x02u8; 32];
+        let sign_1 = {
+            let mut m = Vec::with_capacity(40);
+            m.extend_from_slice(&slot.to_le_bytes());
+            m.extend_from_slice(&hash_1);
+            m
+        };
+        let sign_2 = {
+            let mut m = Vec::with_capacity(40);
+            m.extend_from_slice(&slot.to_le_bytes());
+            m.extend_from_slice(&hash_2);
+            m
+        };
+        let sig_1 = pyde_crypto::falcon::falcon_sign(&sk, &sign_1).unwrap().as_bytes().to_vec();
+        let sig_2 = pyde_crypto::falcon::falcon_sign(&sk, &sign_2).unwrap().as_bytes().to_vec();
+
+        let evidence = DoubleSignEvidence {
+            slot,
+            block_hash_1: hash_1,
+            signature_1: sig_1,
+            block_hash_2: hash_2,
+            signature_2: sig_2,
+            signer,
+            submitter: [0u8; 32],
+        };
+        (engine, sk, evidence, signer)
+    }
+
+    #[test]
+    fn ingest_evidence_accepts_valid_and_stages_for_broadcast() {
+        let (mut engine, _sk, evidence, signer) = valid_evidence_and_engine();
+        assert!(engine.ingest_evidence(evidence.clone()));
+
+        // Pending queue populated (block builder will drain it).
+        assert_eq!(engine.pending_evidence.len(), 1);
+        assert_eq!(engine.pending_evidence[0].signer, signer);
+
+        // Broadcast queue populated (node loop will drain it).
+        let broadcast = engine.drain_broadcast_evidence();
+        assert_eq!(broadcast.len(), 1);
+        assert_eq!(broadcast[0].signer, signer);
+
+        // Second drain is empty — ownership transferred.
+        assert!(engine.drain_broadcast_evidence().is_empty());
+    }
+
+    #[test]
+    fn ingest_evidence_dedups_on_slot_signer_pair() {
+        let (mut engine, _sk, evidence, _signer) = valid_evidence_and_engine();
+        assert!(engine.ingest_evidence(evidence.clone()));
+        // Second call with the same (slot, signer) is dropped — returns
+        // false, doesn't re-push to either queue.
+        assert!(!engine.ingest_evidence(evidence.clone()));
+        assert_eq!(engine.pending_evidence.len(), 1);
+
+        let broadcast = engine.drain_broadcast_evidence();
+        assert_eq!(broadcast.len(), 1, "duplicates must not double-broadcast");
+    }
+
+    #[test]
+    fn ingest_evidence_rejects_non_committee_signer() {
+        let (mut engine, _sk, mut evidence, _signer) = valid_evidence_and_engine();
+        // Replace the signer with an address that isn't in committee_keys.
+        evidence.signer = [0xEE; 32];
+        assert!(!engine.ingest_evidence(evidence));
+        assert!(engine.pending_evidence.is_empty());
+        assert!(engine.drain_broadcast_evidence().is_empty());
+    }
+
+    #[test]
+    fn ingest_evidence_rejects_forged_signatures() {
+        let (mut engine, _sk, mut evidence, _signer) = valid_evidence_and_engine();
+        // Replace sig_2 with random bytes — FALCON verify will fail.
+        evidence.signature_2 = vec![0xFFu8; evidence.signature_2.len()];
+        assert!(!engine.ingest_evidence(evidence));
+        assert!(engine.pending_evidence.is_empty());
+    }
+
+    #[test]
+    fn ingest_evidence_rejects_same_hash() {
+        // `block_hash_1 == block_hash_2` isn't equivocation; verify_double_sign
+        // returns false, so ingest_evidence should drop it.
+        let (mut engine, sk, mut evidence, _signer) = valid_evidence_and_engine();
+        // Sign the SAME hash twice so both signatures are individually valid.
+        let h = [0x77u8; 32];
+        let sign_msg = {
+            let mut m = Vec::with_capacity(40);
+            m.extend_from_slice(&evidence.slot.to_le_bytes());
+            m.extend_from_slice(&h);
+            m
+        };
+        let sig = pyde_crypto::falcon::falcon_sign(&sk, &sign_msg).unwrap().as_bytes().to_vec();
+        evidence.block_hash_1 = h;
+        evidence.block_hash_2 = h;
+        evidence.signature_1 = sig.clone();
+        evidence.signature_2 = sig;
+        assert!(!engine.ingest_evidence(evidence));
     }
 
     // ========== End-to-end: drain evidence → Slash tx → state mutation ==========

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -25,6 +25,10 @@ pub mod tag {
     pub const COMPACT_BLOCK: u8 = 0x03;
     pub const RANDOMNESS_SHARE: u8 = 0x15;
     pub const PSS_REFRESH: u8 = 0x16;
+    /// Equivocation evidence broadcast on the consensus channel so any
+    /// validator — not just the one that directly observed the double
+    /// proposal — can include the offender in a `Slash` tx.
+    pub const CONSENSUS_SLASH_EVIDENCE: u8 = 0x17;
     pub const GET_BLOCK_TXS: u8 = 0x04;
     pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
     pub const DECRYPTION_SHARES: u8 = 0x20;
@@ -734,6 +738,30 @@ pub fn encode_double_sign_evidence(evidence: &DoubleSignEvidence) -> Vec<u8> {
     enc.finish()
 }
 
+/// Wrap encoded evidence in a gossip envelope: `tag || evidence_bytes`.
+/// The tag lets the consensus channel handler dispatch this message
+/// alongside proposals, votes, timeouts, etc. without collision.
+pub fn encode_slash_evidence_msg(evidence: &DoubleSignEvidence) -> Vec<u8> {
+    let payload = encode_double_sign_evidence(evidence);
+    let mut out = Vec::with_capacity(1 + payload.len());
+    out.push(tag::CONSENSUS_SLASH_EVIDENCE);
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Unwrap a gossip envelope produced by `encode_slash_evidence_msg`.
+/// Returns the decoded `DoubleSignEvidence`, or an error if the tag is
+/// wrong or the payload is malformed.
+pub fn decode_slash_evidence_msg(data: &[u8]) -> Result<DoubleSignEvidence, &'static str> {
+    if data.is_empty() {
+        return Err("empty slash-evidence gossip message");
+    }
+    if data[0] != tag::CONSENSUS_SLASH_EVIDENCE {
+        return Err("not a slash-evidence gossip message");
+    }
+    decode_double_sign_evidence(&data[1..])
+}
+
 pub fn decode_double_sign_evidence(data: &[u8]) -> Result<DoubleSignEvidence, &'static str> {
     let mut dec = Decoder::new(data);
     let version = dec.u8()?;
@@ -1113,5 +1141,27 @@ mod tests {
         // Truncate mid-encoding
         let bytes = encode_double_sign_evidence(&dummy_evidence(5));
         assert!(decode_double_sign_evidence(&bytes[..bytes.len() - 10]).is_err());
+    }
+
+    #[test]
+    fn slash_evidence_gossip_envelope_roundtrip() {
+        let evidence = dummy_evidence(99);
+        let bytes = encode_slash_evidence_msg(&evidence);
+        assert_eq!(bytes[0], tag::CONSENSUS_SLASH_EVIDENCE);
+        let restored = decode_slash_evidence_msg(&bytes).unwrap();
+        assert_eq!(restored.slot, 99);
+        assert_eq!(restored.block_hash_1, evidence.block_hash_1);
+    }
+
+    #[test]
+    fn slash_evidence_wrong_tag_fails() {
+        let mut bytes = encode_slash_evidence_msg(&dummy_evidence(1));
+        bytes[0] = tag::CONSENSUS_VOTE; // wrong tag
+        assert!(decode_slash_evidence_msg(&bytes).is_err());
+    }
+
+    #[test]
+    fn slash_evidence_empty_fails() {
+        assert!(decode_slash_evidence_msg(&[]).is_err());
     }
 }


### PR DESCRIPTION
Implements plan task **007**. This is the last item in Phase 1.

## Problem
The slashing pipeline we built in tasks 001–005 has a coverage gap:
only the validator that *directly witnessed* a double-propose could
queue the evidence. If that validator never became the next
proposer (committee rotation, VRF selection missing them, crash),
the evidence was never turned into an on-chain Slash tx and the
offender went unpunished.

## Fix
Validators now relay equivocation evidence on the consensus channel.
When any node detects an equivocation, the whole committee learns
about it; whoever the VRF picks as the next proposer can include
the Slash tx.

## Wire format
- New tag `CONSENSUS_SLASH_EVIDENCE = 0x17`.
- `encode_slash_evidence_msg` wraps the existing evidence codec in
  a tagged envelope so the dispatcher can distinguish it from
  proposals, votes, timeouts, etc.
- `decode_slash_evidence_msg` rejects mismatched or truncated
  envelopes.

## Engine ingest + dedup
`ingest_evidence(evidence)` on `ValidatorEngine` is the single
entry point for **both** local detection and gossip reception:
1. Dedups on `(slot, signer)` via a `seen_evidence` `HashSet`.
2. Verifies `signer` is in the current committee.
3. Re-runs FALCON sig verification via `slash_double_sign`.
4. On first-valid acceptance, pushes to `pending_evidence` (for
   block inclusion) and `broadcast_evidence` (for P2P relay).
5. Returns `bool` — gossip callers use this to avoid re-amplifying
   duplicates.

The local detection site in `buffer_proposal` now routes through
`ingest_evidence`, so validation + dedup logic is shared.

`drain_broadcast_evidence()` transfers ownership of the staging
queue to the caller.

## Gossip wire-up in node.rs
- New `PostEventAction::BroadcastConsensusMany(Vec<Vec<u8>>)` for
  batching multiple messages out of a single event handler.
- Local self-proposal path: inline publish via
  `swarm.gossipsub.publish`.
- Gossip-receive proposal path: returns the batch via the new
  post-event variant (swarm isn't in scope there).
- Receive handler for tag 0x17: decode envelope → call
  `ingest_evidence` → rely on gossipsub's own mesh propagation (no
  re-publish, to avoid amplification storms).

## Tests
- **3 new wire tests:** envelope roundtrip, wrong tag rejected,
  empty rejected.
- **5 new validator tests:** ingest accepts valid + stages for
  broadcast, dedups on `(slot, signer)`, rejects non-committee
  signer, rejects forged sigs, rejects same-hash "evidence".

Full workspace suite green.

## Phase 1 complete
With this PR merged, every plan item in Phase 1 of
\`MAINNET_PLAN.md\` is done:
- 001–003 ConsensusState + evidence persistence + reload
- 004–006 Slash tx type, handler, block-builder integration
- 007 Evidence gossip ← this PR
- 008 PVM jump/call bounds
- 009 Witness post_state_root
- 010–014 Safety + consistency cleanups
- 014a/b fsync + halt-on-persist