### PR TITLE
feat: persist evidence queues + benchmark fsync overhead (014c, 014f)

### DIFF
--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -11,6 +11,8 @@
 //!
 //! Key layout:
 //!   b"consensus:state"              → serialized ConsensusState
+//!   b"evidence:state"               → serialized EvidenceState (pending +
+//!                                     broadcast queues + seen dedup set)
 //!   b"p:" || slot_be8 || addr[32]   → (encoded BlockHeader, signature)
 //!   b"v:" || slot_be8 || voter_idx  → (block_hash[32], signature)
 
@@ -23,6 +25,7 @@ use std::path::Path;
 use tracing::{debug, info, warn};
 
 const STATE_KEY: &[u8] = b"consensus:state";
+const EVIDENCE_STATE_KEY: &[u8] = b"evidence:state";
 const PROPOSAL_PREFIX: &[u8] = b"p:";
 const VOTE_PREFIX: &[u8] = b"v:";
 
@@ -97,6 +100,44 @@ impl ConsensusStateStore {
             }
             Ok(None) => Ok(None),
             Err(e) => Err(format!("failed to read consensus state: {}", e)),
+        }
+    }
+
+    /// Persist the ingest queues (pending, broadcast, seen) as one
+    /// atomic blob. Rewrites the whole blob on each call — fine
+    /// because equivocations are rare and the blob is small
+    /// (~1 KB per evidence × 10 entries max, pruned per slot).
+    pub fn save_evidence_state(&self, state: &wire::EvidenceState) -> Result<(), String> {
+        let bytes = wire::encode_evidence_state(state);
+        self.db
+            .put_opt(EVIDENCE_STATE_KEY, &bytes, &self.sync_opts)
+            .map_err(|e| format!("failed to save evidence state: {}", e))?;
+        debug!(
+            pending = state.pending.len(),
+            broadcast = state.broadcast.len(),
+            seen = state.seen.len(),
+            bytes = bytes.len(),
+            "evidence state persisted"
+        );
+        Ok(())
+    }
+
+    /// Load the previously-persisted evidence state, if any.
+    pub fn load_evidence_state(&self) -> Result<Option<wire::EvidenceState>, String> {
+        match self.db.get(EVIDENCE_STATE_KEY) {
+            Ok(Some(bytes)) => {
+                let state = wire::decode_evidence_state(&bytes)
+                    .map_err(|e| format!("failed to decode evidence state: {}", e))?;
+                info!(
+                    pending = state.pending.len(),
+                    broadcast = state.broadcast.len(),
+                    seen = state.seen.len(),
+                    "evidence state restored from disk"
+                );
+                Ok(Some(state))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(format!("failed to read evidence state: {}", e)),
         }
     }
 
@@ -557,5 +598,84 @@ mod tests {
         assert!(store.load().unwrap().is_some());
         assert_eq!(store.load_all_seen_proposals().len(), 1);
         assert_eq!(store.load_all_seen_votes().len(), 1);
+    }
+
+    /// Hardening task 014f: measure fsync overhead on consensus-state
+    /// writes so we know whether per-vote `set_sync(true)` caps us
+    /// below the 12,500 TPS target at 400 ms slots.
+    ///
+    /// Gated as `#[ignore]` — it's informational + sensitive to the
+    /// host filesystem (SSD vs HDD, ext4 vs APFS vs NTFS). Run with:
+    ///
+    /// ```text
+    /// cargo test -p pyde-node --bin pyde --release -- --ignored \
+    ///     consensus_store::tests::fsync_cost_bench --nocapture
+    /// ```
+    ///
+    /// Reports per-write latency and derived max TPS. If sync mode
+    /// shows > 10× latency and drops TPS below 1000, switch to batched
+    /// writes or slot-end sync before mainnet.
+    #[test]
+    #[ignore = "benchmark — run with --ignored"]
+    fn fsync_cost_bench() {
+        use std::time::Instant;
+
+        const ITERATIONS: u32 = 500;
+
+        // Baseline: sync=false (WAL to OS page cache, no fsync).
+        let dir_async = tempdir().unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db_async = DB::open(&opts, dir_async.path().join("async")).unwrap();
+        let async_opts = WriteOptions::default();
+        let state = populated_state();
+        let bytes = wire::encode_consensus_state(&state);
+
+        let t0 = Instant::now();
+        for i in 0..ITERATIONS {
+            let mut key = b"x:".to_vec();
+            key.extend_from_slice(&i.to_le_bytes());
+            db_async.put_opt(&key, &bytes, &async_opts).unwrap();
+        }
+        let async_total = t0.elapsed();
+        let async_per = async_total.as_secs_f64() / ITERATIONS as f64 * 1_000_000.0;
+        let async_tps = 1.0 / (async_total.as_secs_f64() / ITERATIONS as f64);
+
+        // Production: sync=true (fsync on every write).
+        let dir_sync = tempdir().unwrap();
+        let db_sync = DB::open(&opts, dir_sync.path().join("sync")).unwrap();
+        let mut sync_opts = WriteOptions::default();
+        sync_opts.set_sync(true);
+
+        let t0 = Instant::now();
+        for i in 0..ITERATIONS {
+            let mut key = b"x:".to_vec();
+            key.extend_from_slice(&i.to_le_bytes());
+            db_sync.put_opt(&key, &bytes, &sync_opts).unwrap();
+        }
+        let sync_total = t0.elapsed();
+        let sync_per = sync_total.as_secs_f64() / ITERATIONS as f64 * 1_000_000.0;
+        let sync_tps = 1.0 / (sync_total.as_secs_f64() / ITERATIONS as f64);
+
+        eprintln!();
+        eprintln!("=== ConsensusStateStore fsync cost ({} writes, {}-byte payload) ===",
+            ITERATIONS, bytes.len());
+        eprintln!(
+            "async (page cache): {:>8.1} µs/write  →  {:>9.0} writes/sec",
+            async_per, async_tps
+        );
+        eprintln!(
+            "sync  (fsync)    : {:>8.1} µs/write  →  {:>9.0} writes/sec",
+            sync_per, sync_tps
+        );
+        eprintln!(
+            "overhead: {:.1}× slower",
+            sync_total.as_secs_f64() / async_total.as_secs_f64()
+        );
+        eprintln!();
+
+        // Sanity: both paths produced durable writes. We don't assert a
+        // hard TPS threshold — the number is environment-dependent. The
+        // operator reads the output and decides whether to re-tune.
     }
 }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -344,7 +344,63 @@ impl ValidatorEngine {
             self.seen_votes.insert(key, value);
         }
 
+        // Restore the ingest queues. Without this, a validator that
+        // detected equivocation and crashed before draining would lose
+        // the evidence — the seen_proposals/seen_votes indexes would
+        // still know about the conflict but the ready-to-slash queue
+        // would be empty, and if the offender never equivocated again
+        // they'd escape punishment.
+        match store.load_evidence_state() {
+            Ok(Some(ev_state)) => {
+                info!(
+                    pending = ev_state.pending.len(),
+                    broadcast = ev_state.broadcast.len(),
+                    seen = ev_state.seen.len(),
+                    "restoring evidence ingest queues from disk"
+                );
+                self.pending_evidence = ev_state.pending;
+                self.broadcast_evidence = ev_state.broadcast;
+                self.seen_evidence = ev_state.seen.into_iter().collect();
+            }
+            Ok(None) => {}
+            Err(e) => {
+                // Non-fatal: we can continue with empty queues. The
+                // dedup HashSet being empty means we might re-ingest
+                // duplicate gossip, but duplicates are caught by the
+                // on-chain slash handler (already-ejected rejection).
+                warn!(error = %e, "failed to load evidence state; starting empty");
+            }
+        }
+
         self.consensus_store = Some(store);
+    }
+
+    /// Snapshot the current evidence ingest queues into an
+    /// `EvidenceState` for persistence. Called after any mutation
+    /// that changes pending_evidence, broadcast_evidence, or
+    /// seen_evidence.
+    fn evidence_snapshot(&self) -> crate::wire::EvidenceState {
+        crate::wire::EvidenceState {
+            pending: self.pending_evidence.clone(),
+            broadcast: self.broadcast_evidence.clone(),
+            seen: self.seen_evidence.iter().copied().collect(),
+        }
+    }
+
+    /// Persist the current evidence state. No-op without a store.
+    /// Panics on failure for the same reason as `persist_consensus`:
+    /// a silent revert to in-memory-only mode loses safety
+    /// guarantees on the next crash.
+    fn persist_evidence_state(&self) {
+        if let Some(store) = &self.consensus_store {
+            if let Err(e) = store.save_evidence_state(&self.evidence_snapshot()) {
+                error!(
+                    error = %e,
+                    "FATAL: failed to persist evidence state — halting validator"
+                );
+                panic!("evidence state persist failed: {}", e);
+            }
+        }
     }
 
     /// Persist consensus state to disk. No-op when no store is attached.
@@ -1017,14 +1073,22 @@ impl ValidatorEngine {
     /// are responsible for re-queueing the evidence via `push_evidence`
     /// — otherwise it is lost along with the unbuilt proposal.
     pub fn drain_pending_evidence(&mut self) -> Vec<DoubleSignEvidence> {
-        std::mem::take(&mut self.pending_evidence)
+        let out = std::mem::take(&mut self.pending_evidence);
+        if !out.is_empty() {
+            self.persist_evidence_state();
+        }
+        out
     }
 
     /// Re-queue previously drained evidence, e.g. after a failed block
     /// build. No-op if `evidence` is empty. Preserves insertion order by
     /// appending at the tail.
     pub fn push_evidence(&mut self, evidence: Vec<DoubleSignEvidence>) {
+        if evidence.is_empty() {
+            return;
+        }
         self.pending_evidence.extend(evidence);
+        self.persist_evidence_state();
     }
 
     /// Ingest a piece of equivocation evidence — shared entry point for
@@ -1083,6 +1147,9 @@ impl ValidatorEngine {
         self.seen_evidence.insert(key);
         self.pending_evidence.push(evidence.clone());
         self.broadcast_evidence.push(evidence);
+        // Persist BEFORE returning so a crash between ingest and the
+        // next drain_* call cannot lose the evidence.
+        self.persist_evidence_state();
         true
     }
 
@@ -1091,7 +1158,11 @@ impl ValidatorEngine {
     /// or received via gossip) since the last call. The caller is
     /// responsible for publishing each entry on the consensus channel.
     pub fn drain_broadcast_evidence(&mut self) -> Vec<DoubleSignEvidence> {
-        std::mem::take(&mut self.broadcast_evidence)
+        let out = std::mem::take(&mut self.broadcast_evidence);
+        if !out.is_empty() {
+            self.persist_evidence_state();
+        }
+        out
     }
 
     /// Drain `pending_evidence` and turn each entry into a signed
@@ -1804,6 +1875,87 @@ mod tests {
         evidence.signature_1 = sig.clone();
         evidence.signature_2 = sig;
         assert!(!engine.ingest_evidence(evidence));
+    }
+
+    #[test]
+    fn evidence_queues_survive_restart() {
+        // Hardening task 014c: a validator that ingests evidence and
+        // then crashes must still have the evidence available on
+        // restart. Without this, detected-but-un-drained equivocations
+        // are silently lost if the observing validator crashes before
+        // producing its next block.
+        use pyde_crypto::falcon::falcon_keygen;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let committee_pk: Vec<u8>;
+        let signer_addr: Address;
+
+        // --- Run 1: ingest evidence, then "crash" (drop engine) ---
+        {
+            let (pk, sk) = falcon_keygen().unwrap();
+            committee_pk = pk.as_bytes().to_vec();
+            signer_addr = pyde_account::address::derive_eoa_address(&committee_pk);
+
+            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            engine.set_committee(vec![committee_pk.clone()]);
+            let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+            engine.attach_consensus_store(store);
+
+            let slot = 50u64;
+            let hash_1 = [0x01u8; 32];
+            let hash_2 = [0x02u8; 32];
+            let sign_1 = {
+                let mut m = Vec::with_capacity(40);
+                m.extend_from_slice(&slot.to_le_bytes());
+                m.extend_from_slice(&hash_1);
+                m
+            };
+            let sign_2 = {
+                let mut m = Vec::with_capacity(40);
+                m.extend_from_slice(&slot.to_le_bytes());
+                m.extend_from_slice(&hash_2);
+                m
+            };
+            let sig_1 = pyde_crypto::falcon::falcon_sign(&sk, &sign_1).unwrap().as_bytes().to_vec();
+            let sig_2 = pyde_crypto::falcon::falcon_sign(&sk, &sign_2).unwrap().as_bytes().to_vec();
+
+            let evidence = DoubleSignEvidence {
+                slot,
+                block_hash_1: hash_1,
+                signature_1: sig_1,
+                block_hash_2: hash_2,
+                signature_2: sig_2,
+                signer: signer_addr,
+                submitter: [0u8; 32],
+            };
+            assert!(engine.ingest_evidence(evidence));
+            assert_eq!(engine.pending_evidence.len(), 1);
+            assert_eq!(engine.broadcast_evidence.len(), 1);
+            // engine drops here — disk is the only source of truth now.
+        }
+
+        // --- Run 2: reopen, attach, evidence must still be there ---
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.set_committee(vec![committee_pk.clone()]);
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        engine.attach_consensus_store(store);
+
+        assert_eq!(
+            engine.pending_evidence.len(),
+            1,
+            "pending queue must survive restart"
+        );
+        assert_eq!(
+            engine.broadcast_evidence.len(),
+            1,
+            "broadcast queue must survive restart"
+        );
+        assert_eq!(engine.pending_evidence[0].slot, 50);
+        assert_eq!(engine.pending_evidence[0].signer, signer_addr);
+
+        // Dedup set is also restored — a repeat gossip would be dropped.
+        assert!(engine.seen_evidence.contains(&(50, signer_addr)));
     }
 
     // ========== End-to-end: drain evidence → Slash tx → state mutation ==========

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -786,6 +786,74 @@ pub fn decode_double_sign_evidence(data: &[u8]) -> Result<DoubleSignEvidence, &'
     })
 }
 
+// ============================================================
+// EvidenceState — ingest queues persisted as a single blob
+// ============================================================
+
+/// Full evidence state of a running `ValidatorEngine`:
+/// what's queued for block inclusion, what's queued for broadcast,
+/// and what we've already ingested. Persisted together as one
+/// atomic blob so a crash mid-ingest cannot leave the three in
+/// mutually inconsistent states.
+#[derive(Clone, Debug, Default)]
+pub struct EvidenceState {
+    pub pending: Vec<DoubleSignEvidence>,
+    pub broadcast: Vec<DoubleSignEvidence>,
+    /// (slot, signer) pairs already seen, for dedup.
+    pub seen: Vec<(u64, Address)>,
+}
+
+const EVIDENCE_STATE_VERSION: u8 = 1;
+
+pub fn encode_evidence_state(state: &EvidenceState) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(EVIDENCE_STATE_VERSION);
+    enc.u16(state.pending.len() as u16);
+    for ev in &state.pending {
+        enc.var_bytes(&encode_double_sign_evidence(ev));
+    }
+    enc.u16(state.broadcast.len() as u16);
+    for ev in &state.broadcast {
+        enc.var_bytes(&encode_double_sign_evidence(ev));
+    }
+    enc.u32(state.seen.len() as u32);
+    for (slot, addr) in &state.seen {
+        enc.u64(*slot);
+        enc.bytes32(addr);
+    }
+    enc.finish()
+}
+
+pub fn decode_evidence_state(data: &[u8]) -> Result<EvidenceState, &'static str> {
+    let mut dec = Decoder::new(data);
+    let version = dec.u8()?;
+    if version != EVIDENCE_STATE_VERSION {
+        return Err("unsupported evidence state version");
+    }
+    let pending_count = dec.u16()? as usize;
+    let mut pending = Vec::with_capacity(pending_count);
+    for _ in 0..pending_count {
+        pending.push(decode_double_sign_evidence(&dec.var_bytes()?)?);
+    }
+    let broadcast_count = dec.u16()? as usize;
+    let mut broadcast = Vec::with_capacity(broadcast_count);
+    for _ in 0..broadcast_count {
+        broadcast.push(decode_double_sign_evidence(&dec.var_bytes()?)?);
+    }
+    let seen_count = dec.u32()? as usize;
+    let mut seen = Vec::with_capacity(seen_count);
+    for _ in 0..seen_count {
+        let slot = dec.u64()?;
+        let addr = dec.bytes32()?;
+        seen.push((slot, addr));
+    }
+    Ok(EvidenceState {
+        pending,
+        broadcast,
+        seen,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1163,5 +1231,42 @@ mod tests {
     #[test]
     fn slash_evidence_empty_fails() {
         assert!(decode_slash_evidence_msg(&[]).is_err());
+    }
+
+    // ========== EvidenceState roundtrip ==========
+
+    #[test]
+    fn evidence_state_empty_roundtrip() {
+        let state = EvidenceState::default();
+        let bytes = encode_evidence_state(&state);
+        let restored = decode_evidence_state(&bytes).unwrap();
+        assert!(restored.pending.is_empty());
+        assert!(restored.broadcast.is_empty());
+        assert!(restored.seen.is_empty());
+    }
+
+    #[test]
+    fn evidence_state_populated_roundtrip() {
+        let state = EvidenceState {
+            pending: vec![dummy_evidence(10), dummy_evidence(11)],
+            broadcast: vec![dummy_evidence(12)],
+            seen: vec![(10, [0x11; 32]), (11, [0x22; 32]), (12, [0x33; 32])],
+        };
+        let bytes = encode_evidence_state(&state);
+        let restored = decode_evidence_state(&bytes).unwrap();
+        assert_eq!(restored.pending.len(), 2);
+        assert_eq!(restored.pending[0].slot, 10);
+        assert_eq!(restored.pending[1].slot, 11);
+        assert_eq!(restored.broadcast.len(), 1);
+        assert_eq!(restored.broadcast[0].slot, 12);
+        assert_eq!(restored.seen.len(), 3);
+        assert_eq!(restored.seen[1], (11, [0x22; 32]));
+    }
+
+    #[test]
+    fn evidence_state_wrong_version_fails() {
+        let mut bytes = encode_evidence_state(&EvidenceState::default());
+        bytes[0] = 0xFF;
+        assert!(decode_evidence_state(&bytes).is_err());
     }
 }


### PR DESCRIPTION
Closes Phase 1 hardening tasks **014c** and **014f**.

## 014c — Evidence queue persistence
**Before:** A validator that ingested equivocation evidence and then
crashed before draining would silently forget the evidence. The
`seen_proposals` / `seen_votes` indexes (task 002) survived restart,
but the ready-to-slash `pending_evidence` queue, the `broadcast_evidence`
staging queue, and the `seen_evidence` dedup set did not. If the
offender never equivocated again, they escaped punishment.

**After:** All three queues round-trip through `ConsensusStateStore`
as one atomic `EvidenceState` blob.

### Wire
- New `EvidenceState { pending, broadcast, seen }` struct.
- `encode_evidence_state` / `decode_evidence_state` with
  `EVIDENCE_STATE_VERSION = 1` gate.
- Single-blob layout so write-then-read is atomic.

### Store
- `save_evidence_state` / `load_evidence_state` on
  `ConsensusStateStore`. Same `sync_opts` as the existing
  `ConsensusState` persistence → fsync per write, panic-on-fail.

### Engine
- `attach_consensus_store` restores all three queues after loading
  the main `ConsensusState`.
- `ingest_evidence` persists after push (write-before-return).
- `drain_pending_evidence` + `drain_broadcast_evidence` persist on
  shrink (so a crash mid-broadcast doesn't resurrect already-sent
  items).
- `push_evidence` (re-queue path for failed block builds) persists.

### Test
`evidence_queues_survive_restart`: ingest real FALCON-signed
evidence, drop engine, reopen, verify `pending_evidence` +
`broadcast_evidence` + `seen_evidence` all reload.

## 014f — fsync cost microbench
New `#[ignore]`-gated test `fsync_cost_bench` that answers the open
question from the Phase 1 review: "does fsync-per-vote tank our
throughput?"

Local run on Apple Silicon NVMe:
```
async (page cache):   6.0 µs/write →  165,805 writes/sec
sync  (fsync)    :   25.5 µs/write →   39,234 writes/sec
overhead:            4.2× slower
```

**Conclusion:** fsync is fine. 39K writes/sec is 3× the 12,500 TPS
headline target, and actual per-validator fsync rate is ~2.5 votes/sec
at 400 ms slots — effectively free. Cloud-attached disks (EBS, GCE PD)
will be slower but still orders of magnitude above the per-validator
rate. Keep fsync-on-every-write; don't batch.

Run with:
\`\`\`
cargo test --release -p pyde-node --bin pyde \\
    consensus_store::tests::fsync_cost_bench -- --ignored --nocapture
\`\`\`

## Tests
Full workspace suite green. 1 new unit test (evidence_queues_survive_restart)
+ 3 new wire tests (EvidenceState roundtrip, empty, wrong-version)
+ 1 new ignored microbench.