### PR TITLE
feat: mandatory-inclusion audit for encrypted mempool

### DIFF
--- a/crates/mempool/src/inclusion.rs
+++ b/crates/mempool/src/inclusion.rs
@@ -1,0 +1,321 @@
+//! Mandatory-inclusion audit for the threshold-encrypted mempool (task 026).
+//!
+//! The invariant: a proposer cannot censor encrypted transactions they have
+//! seen. At block-build time, every encrypted_tx the proposer has held in
+//! mempool for at least `grace_slots` slots must be included in the block
+//! body — unless the block's gas budget is already exhausted.
+//!
+//! The audit runs on each validator against their own mempool view when they
+//! receive a compact block. Violations → skip vote (task 3.2 enforcement
+//! layer). Committee-aggregated views and slashing evidence are post-mainnet
+//! work — see MAINNET_PLAN.md "Deferred to post-mainnet".
+
+use crate::encrypted::EncryptedTx;
+use std::collections::HashSet;
+
+/// Result of an inclusion audit over one block proposal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InclusionAuditResult {
+    /// Hashes of encrypted_txs the validator has held longer than the grace
+    /// window that are absent from the block AND would have fit in the
+    /// remaining gas budget. A non-empty list is evidence of censorship.
+    pub missing_older_than_grace: Vec<[u8; 32]>,
+    /// Total gas committed by the encrypted_txs actually present in the
+    /// block. Reported for telemetry + future aggregate checks.
+    pub gas_used_by_encrypted: u64,
+    /// Gas headroom left after the block's encrypted set. A tx is only flagged
+    /// as "should have been included" if its `gas_limit` fits here.
+    pub gas_remaining: u64,
+}
+
+impl InclusionAuditResult {
+    /// True when the audit found no inclusion violations.
+    pub fn is_clean(&self) -> bool {
+        self.missing_older_than_grace.is_empty()
+    }
+}
+
+/// Audit a block's encrypted_tx inclusion against a validator's local view.
+///
+/// Parameters:
+/// - `mempool_view`: (tx, first_seen_slot) pairs the validator currently
+///   holds in mempool.
+/// - `block_encrypted_tx_hashes`: hashes of the encrypted_txs present in the
+///   block body (or compact-block manifest).
+/// - `block_encrypted_gas`: aggregate `gas_limit` of the block's encrypted
+///   entries — provided by the caller because only they can resolve each
+///   hash back to an EncryptedTx (the validator's local mempool may be
+///   missing some entries, which is fine for the audit).
+/// - `current_slot`: the slot of the proposal being audited.
+/// - `grace_slots`: how many slots a tx must have been in mempool before
+///   its absence counts as censorship. Mainnet default is 2 (≈800ms).
+/// - `gas_ceiling`: block gas budget.
+///
+/// Semantics:
+/// - A tx first seen this slot (or within `grace_slots - 1`) is *not*
+///   flagged when missing — the proposer may simply not have received it yet.
+/// - A tx older than grace that is missing is flagged ONLY if its gas_limit
+///   fits in the block's remaining gas budget. Otherwise the block was full
+///   and the omission is legitimate.
+/// - A tx older than grace that IS in the block is silently accepted.
+/// End-to-end audit over a block's raw encrypted_txs bytes.
+///
+/// Convenience wrapper around `audit_inclusion` for the reception path in
+/// `pyde-node`. Parses each entry of `block_encrypted_tx_bytes` into an
+/// `EncryptedTx`, builds the hash set and gas total, and forwards to the
+/// lower-level audit. Malformed entries are silently skipped — they were
+/// already rejected by the block_processor's body validation before this
+/// audit runs.
+pub fn audit_block_inclusion<'a, I>(
+    block_encrypted_tx_bytes: &[Vec<u8>],
+    mempool_view: I,
+    current_slot: u64,
+    grace_slots: u64,
+    gas_ceiling: u64,
+) -> InclusionAuditResult
+where
+    I: IntoIterator<Item = (&'a EncryptedTx, u64)>,
+{
+    let mut block_hashes: HashSet<[u8; 32]> =
+        HashSet::with_capacity(block_encrypted_tx_bytes.len());
+    let mut block_gas: u64 = 0;
+    for bytes in block_encrypted_tx_bytes {
+        if let Some(etx) = EncryptedTx::from_bytes(bytes) {
+            block_hashes.insert(etx.hash());
+            block_gas = block_gas.saturating_add(etx.gas_limit);
+        }
+    }
+    audit_inclusion(
+        mempool_view,
+        &block_hashes,
+        block_gas,
+        current_slot,
+        grace_slots,
+        gas_ceiling,
+    )
+}
+
+pub fn audit_inclusion<'a, I>(
+    mempool_view: I,
+    block_encrypted_tx_hashes: &HashSet<[u8; 32]>,
+    block_encrypted_gas: u64,
+    current_slot: u64,
+    grace_slots: u64,
+    gas_ceiling: u64,
+) -> InclusionAuditResult
+where
+    I: IntoIterator<Item = (&'a EncryptedTx, u64)>,
+{
+    let gas_remaining = gas_ceiling.saturating_sub(block_encrypted_gas);
+    let mut missing = Vec::new();
+
+    for (tx, first_seen) in mempool_view {
+        let age = current_slot.saturating_sub(first_seen);
+        if age < grace_slots {
+            // Too new — proposer may not have it yet. Not evidence of
+            // censorship.
+            continue;
+        }
+
+        let h = tx.hash();
+        if block_encrypted_tx_hashes.contains(&h) {
+            continue;
+        }
+
+        if tx.gas_limit > gas_remaining {
+            // Block was full when this tx would have needed to fit.
+            // Missing is legitimate.
+            continue;
+        }
+
+        missing.push(h);
+    }
+
+    InclusionAuditResult {
+        missing_older_than_grace: missing,
+        gas_used_by_encrypted: block_encrypted_gas,
+        gas_remaining,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encrypted::{encrypt_transaction, EncryptedTx};
+    use pyde_crypto::threshold::{threshold_keygen, ThresholdPublicKey};
+    use pyde_tx::types::AccessEntry;
+
+    const GAS_CEILING: u64 = 400_000_000;
+    const GRACE: u64 = 2;
+
+    fn access_list() -> Vec<AccessEntry> {
+        vec![AccessEntry {
+            address: [0x01; 32],
+            reads: vec![[0x01; 32]],
+            writes: vec![],
+        }]
+    }
+
+    fn make_tx(pk: &ThresholdPublicKey, seed: u8, gas: u64) -> EncryptedTx {
+        encrypt_transaction(
+            [seed; 32],
+            seed as u64,
+            gas,
+            access_list(),
+            None,
+            1,
+            vec![0xAA; 666],
+            &[seed; 32],
+            100,
+            &[seed, seed],
+            pk,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn honest_block_includes_everything_clean_audit() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let t1 = make_tx(&pk, 0xAA, 21_000);
+        let t2 = make_tx(&pk, 0xBB, 21_000);
+        let view = vec![(&t1, 5u64), (&t2, 5u64)];
+        let block_hashes: HashSet<[u8; 32]> =
+            [t1.hash(), t2.hash()].into_iter().collect();
+
+        let result = audit_inclusion(
+            view, &block_hashes, 42_000, /* slot */ 10, GRACE, GAS_CEILING,
+        );
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn censored_aged_tx_is_flagged() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let included = make_tx(&pk, 0xAA, 21_000);
+        let censored = make_tx(&pk, 0xBB, 21_000);
+        let view = vec![(&included, 5u64), (&censored, 5u64)];
+        let block_hashes: HashSet<[u8; 32]> = [included.hash()].into_iter().collect();
+
+        // current_slot=10, first_seen=5, age=5 > grace=2 → aged
+        // block_encrypted_gas=21_000 → gas_remaining=GAS_CEILING-21_000 (plenty)
+        let result = audit_inclusion(
+            view, &block_hashes, 21_000, 10, GRACE, GAS_CEILING,
+        );
+        assert!(!result.is_clean());
+        assert_eq!(result.missing_older_than_grace, vec![censored.hash()]);
+    }
+
+    #[test]
+    fn new_tx_within_grace_window_is_ignored() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let fresh = make_tx(&pk, 0xCC, 21_000);
+        // first_seen=9, current_slot=10, age=1 < grace=2 → too new
+        let view = vec![(&fresh, 9u64)];
+        let block_hashes: HashSet<[u8; 32]> = HashSet::new();
+
+        let result = audit_inclusion(view, &block_hashes, 0, 10, GRACE, GAS_CEILING);
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn full_block_legitimately_excludes_tx() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let excluded = make_tx(&pk, 0xDD, 50_000);
+        let view = vec![(&excluded, 5u64)];
+        let block_hashes: HashSet<[u8; 32]> = HashSet::new();
+
+        // Block's existing encrypted gas = ceiling - 10K → gas_remaining = 10K.
+        // excluded.gas_limit = 50K > 10K, so exclusion is legitimate.
+        let result = audit_inclusion(
+            view, &block_hashes,
+            GAS_CEILING - 10_000, 10, GRACE, GAS_CEILING,
+        );
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn empty_mempool_produces_clean_audit() {
+        let block_hashes: HashSet<[u8; 32]> = HashSet::new();
+        let view: Vec<(&EncryptedTx, u64)> = vec![];
+        let result = audit_inclusion(view, &block_hashes, 0, 10, GRACE, GAS_CEILING);
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn aged_tx_fits_when_gas_remaining_equals_gas_limit() {
+        // Boundary: tx.gas_limit == gas_remaining → still flagged as
+        // should-have-fit. Only strict > causes exemption.
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let boundary = make_tx(&pk, 0xEE, 21_000);
+        let view = vec![(&boundary, 5u64)];
+        let block_hashes: HashSet<[u8; 32]> = HashSet::new();
+
+        let result = audit_inclusion(
+            view, &block_hashes,
+            GAS_CEILING - 21_000, 10, GRACE, GAS_CEILING,
+        );
+        assert_eq!(result.missing_older_than_grace, vec![boundary.hash()]);
+    }
+
+    #[test]
+    fn multiple_aged_censored_are_all_reported() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let a = make_tx(&pk, 0x01, 21_000);
+        let b = make_tx(&pk, 0x02, 21_000);
+        let c = make_tx(&pk, 0x03, 21_000);
+        let view = vec![(&a, 4u64), (&b, 4u64), (&c, 4u64)];
+        let block_hashes: HashSet<[u8; 32]> = HashSet::new();
+
+        let result = audit_inclusion(view, &block_hashes, 0, 10, GRACE, GAS_CEILING);
+        assert_eq!(result.missing_older_than_grace.len(), 3);
+    }
+
+    // ========== audit_block_inclusion (byte-level wrapper) ==========
+
+    #[test]
+    fn audit_block_inclusion_passes_honest_block() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let a = make_tx(&pk, 0xAA, 21_000);
+        let b = make_tx(&pk, 0xBB, 21_000);
+        let view = vec![(&a, 5u64), (&b, 5u64)];
+
+        // Block body contains both txs as raw bytes — the shape node.rs
+        // passes in from block.body.encrypted_txs.
+        let block_bytes = vec![a.to_bytes(), b.to_bytes()];
+
+        let result = audit_block_inclusion(&block_bytes, view, 10, GRACE, GAS_CEILING);
+        assert!(result.is_clean());
+        assert_eq!(result.gas_used_by_encrypted, 42_000);
+    }
+
+    #[test]
+    fn audit_block_inclusion_flags_censored_aged_tx_via_bytes() {
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let included = make_tx(&pk, 0xAA, 21_000);
+        let censored = make_tx(&pk, 0xBB, 21_000);
+        let view = vec![(&included, 5u64), (&censored, 5u64)];
+
+        // Block bytes only contain `included`.
+        let block_bytes = vec![included.to_bytes()];
+
+        let result = audit_block_inclusion(&block_bytes, view, 10, GRACE, GAS_CEILING);
+        assert!(!result.is_clean());
+        assert_eq!(result.missing_older_than_grace, vec![censored.hash()]);
+    }
+
+    #[test]
+    fn audit_block_inclusion_skips_malformed_bytes() {
+        // Body validator already rejects these before the audit fires,
+        // but the helper must not panic or mis-attribute them.
+        let (pk, _) = threshold_keygen(3, 2).unwrap();
+        let tx = make_tx(&pk, 0xAA, 21_000);
+        let view = vec![(&tx, 5u64)];
+
+        // Garbage byte blob mixed with a real one.
+        let block_bytes = vec![vec![0xFF; 10], tx.to_bytes()];
+
+        let result = audit_block_inclusion(&block_bytes, view, 10, GRACE, GAS_CEILING);
+        assert!(result.is_clean());
+        assert_eq!(result.gas_used_by_encrypted, 21_000);
+    }
+}

--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod block_builder;
 pub mod decryption;
 pub mod encrypted;
+pub mod inclusion;
 pub mod ordering;
 pub mod pool;

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -56,6 +56,12 @@ pub struct Mempool {
     seen_hashes: HashSet<[u8; 32]>,
     /// Per-sender nonce tracking (sender → highest nonce seen).
     sender_nonces: HashMap<Address, u64>,
+    /// Slot at which each tx first entered this pool. Used by the
+    /// inclusion-audit path (task 026) to distinguish txs that have
+    /// been in the mempool long enough that the proposer *should*
+    /// have seen them, versus txs so new that missing them is not
+    /// evidence of censorship.
+    first_seen_slot: HashMap<[u8; 32], u64>,
     /// Maximum pool size.
     max_size: usize,
     /// Current block height (for expiry checks).
@@ -70,6 +76,7 @@ impl Mempool {
             txs: Vec::new(),
             seen_hashes: HashSet::new(),
             sender_nonces: HashMap::new(),
+            first_seen_slot: HashMap::new(),
             max_size: DEFAULT_MAX_POOL_SIZE,
             current_block: 0,
             block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
@@ -81,6 +88,7 @@ impl Mempool {
             txs: Vec::with_capacity(max_size),
             seen_hashes: HashSet::with_capacity(max_size),
             sender_nonces: HashMap::new(),
+            first_seen_slot: HashMap::with_capacity(max_size),
             max_size,
             current_block: 0,
             block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
@@ -171,6 +179,7 @@ impl Mempool {
         }
 
         self.seen_hashes.insert(hash);
+        self.first_seen_slot.insert(hash, self.current_block);
         self.txs.push(tx);
 
         Ok(())
@@ -182,7 +191,9 @@ impl Mempool {
             return;
         }
         let evicted = self.txs.remove(0);
-        self.seen_hashes.remove(&evicted.hash());
+        let h = evicted.hash();
+        self.seen_hashes.remove(&h);
+        self.first_seen_slot.remove(&h);
     }
 
     /// Verify the FALCON-512 signature on an encrypted transaction.
@@ -222,12 +233,12 @@ impl Mempool {
         let before = self.txs.len();
         self.txs.retain(|tx| !tx.is_expired(current));
 
-        // Rebuild hash set if we pruned anything
+        // Rebuild hash set + first-seen tracking if we pruned anything
         if self.txs.len() != before {
             self.seen_hashes.clear();
-            for tx in &self.txs {
-                self.seen_hashes.insert(tx.hash());
-            }
+            let kept: HashSet<[u8; 32]> = self.txs.iter().map(|tx| tx.hash()).collect();
+            self.first_seen_slot.retain(|h, _| kept.contains(h));
+            self.seen_hashes = kept;
         }
     }
 
@@ -268,7 +279,17 @@ impl Mempool {
 
         for hash in hashes {
             self.seen_hashes.remove(hash);
+            self.first_seen_slot.remove(hash);
         }
+    }
+
+    /// View of mempool entries paired with the slot they first arrived.
+    /// Used by the inclusion-audit path (task 026).
+    pub fn view_with_slots(&self) -> impl Iterator<Item = (&EncryptedTx, u64)> {
+        self.txs.iter().filter_map(move |tx| {
+            let h = tx.hash();
+            self.first_seen_slot.get(&h).map(|s| (tx, *s))
+        })
     }
 
     /// Check if a transaction hash is already in the pool.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -29,6 +29,14 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
+/// Grace window (in slots) for the task-026 mandatory-inclusion audit.
+/// An encrypted_tx must sit in local mempool for at least this many slots
+/// before its absence from a proposal counts as censorship. Mainnet ships
+/// with 2 slots (~800ms at 400ms block time) — long enough for libp2p
+/// gossip to reach the whole 128-validator committee, short enough that
+/// a censoring proposer can't hide behind latency.
+const MEV_INCLUSION_GRACE_SLOTS: u64 = 2;
+
 /// The main Pyde node. Owns all subsystems.
 pub struct PydeNode {
     config: NodeConfig,
@@ -619,6 +627,34 @@ impl PydeNode {
                                 },
                                 proposer_signature: vec![], // not in compact block, validated via proposal
                             };
+
+                            // Task 026: mandatory-inclusion audit. Compare the block's
+                            // encrypted_tx set against our local mempool view. If the
+                            // proposer skipped a tx we've held past the grace window
+                            // while gas budget remained, flag the slot so the later
+                            // select_and_vote call abstains. Enforcement is soft —
+                            // HotStuff tolerates 1/128 dissent; false positives under
+                            // network jitter only cost liveness on the affected slot.
+                            if let Some(engine) = validator_engine.as_mut() {
+                                let relay_r = tx_relay.read().await;
+                                let audit = pyde_mempool::inclusion::audit_block_inclusion(
+                                    &block.body.encrypted_txs,
+                                    relay_r.mempool().view_with_slots(),
+                                    slot,
+                                    MEV_INCLUSION_GRACE_SLOTS,
+                                    self.config.consensus.gas_ceiling,
+                                );
+                                drop(relay_r);
+                                if !audit.is_clean() {
+                                    warn!(
+                                        slot,
+                                        missing = audit.missing_older_than_grace.len(),
+                                        gas_remaining = audit.gas_remaining,
+                                        "mandatory-inclusion audit failed — skipping vote for this slot"
+                                    );
+                                    engine.flag_inclusion_violation(slot);
+                                }
+                            }
 
                             // Validate and process
                             {

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -267,6 +267,13 @@ pub struct ValidatorEngine {
     /// same slot) and gossip arrivals — each pair is broadcast at most
     /// once and stored in pending_evidence at most once.
     seen_evidence: std::collections::HashSet<(u64, Address)>,
+    /// Slots flagged by the inclusion audit (task 026). When a compact
+    /// block is received, validators compare its encrypted_txs against
+    /// their local mempool view; if a tx older than the grace window is
+    /// absent while gas budget remains, the slot is flagged and this
+    /// validator will not vote on the selected proposal for that slot.
+    /// Soft enforcement — a 1/128 false positive just costs one vote.
+    inclusion_violated_slots: std::collections::HashSet<u64>,
 }
 
 impl ValidatorEngine {
@@ -289,6 +296,7 @@ impl ValidatorEngine {
             pending_evidence: Vec::new(),
             broadcast_evidence: Vec::new(),
             seen_evidence: std::collections::HashSet::new(),
+            inclusion_violated_slots: std::collections::HashSet::new(),
             randomness_collector: None,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
@@ -778,6 +786,20 @@ impl ValidatorEngine {
         true
     }
 
+    /// Flag a slot as having failed the mandatory-inclusion audit (task 026).
+    /// Caller is the compact-block reception path in node.rs. A flagged slot
+    /// causes `select_and_vote` to skip its vote for this proposal, whatever
+    /// the VRF selection picks.
+    pub fn flag_inclusion_violation(&mut self, slot: u64) {
+        self.inclusion_violated_slots.insert(slot);
+    }
+
+    /// True when a slot was flagged via `flag_inclusion_violation`.
+    /// Exposed for tests.
+    pub fn is_inclusion_violated(&self, slot: u64) -> bool {
+        self.inclusion_violated_slots.contains(&slot)
+    }
+
     /// Select the best proposal (lowest VRF score) and vote for it.
     /// Called after the proposal collection window (100ms into the slot).
     /// Returns the vote to broadcast, or None if no proposals were buffered.
@@ -789,6 +811,19 @@ impl ValidatorEngine {
 
         // Don't double-vote
         if self.voted_slots.contains(&slot) {
+            return None;
+        }
+
+        // Task 026 — skip vote if the local inclusion audit flagged this slot.
+        // The flag is set by the compact-block reception path when encrypted
+        // txs the validator has held past the grace window are missing from
+        // the proposal while gas budget remained.
+        if self.inclusion_violated_slots.contains(&slot) {
+            warn!(slot, "skipping vote: mandatory-inclusion audit failed");
+            // Mark voted so a later arriving compact block that clears the
+            // flag doesn't cause us to belatedly cast a vote. The decision
+            // is final for this slot.
+            self.voted_slots.insert(slot);
             return None;
         }
 
@@ -1441,6 +1476,91 @@ mod tests {
 
         let vote = engine.on_proposal(&header, &identities[1]);
         assert!(vote.is_some());
+    }
+
+    // ========== Task 026: mandatory-inclusion vote-skip ==========
+
+    #[test]
+    fn select_and_vote_skips_when_inclusion_flag_set() {
+        // End-to-end enforcement test for the mandatory-inclusion path.
+        // Directly exercises the vote-skip mechanism that node.rs's compact-
+        // block handler triggers via flag_inclusion_violation.
+        let (mut engine, identities) = make_engine_with_committee(3);
+        engine.advance_slot();
+        let slot = engine.consensus.current_slot;
+
+        // Seed a buffered proposal so select_and_vote has something to act on.
+        // Without this the function returns None for an unrelated reason
+        // (nothing to vote for), which would mask whether the inclusion
+        // check actually fires.
+        let header = BlockHeader {
+            slot,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: identities[0].address,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0u8; 32],
+            state_root: [0u8; 32],
+            timestamp: 0,
+        };
+        engine.buffered_proposals.entry(slot).or_default().push(BufferedProposal {
+            header,
+            proposer_signature: vec![],
+            vrf_score: 0,
+        });
+
+        // Baseline: without the flag, select_and_vote produces a vote.
+        let baseline_engine_clone_check = {
+            // Clone-the-flag by using a fresh engine snapshot — we instead
+            // assert by the positive path in vote_on_proposal (already
+            // covered). Here, flag then assert None.
+            engine.flag_inclusion_violation(slot);
+            assert!(engine.is_inclusion_violated(slot));
+            engine.select_and_vote(&identities[1])
+        };
+        assert!(
+            baseline_engine_clone_check.is_none(),
+            "inclusion-flagged slot must not produce a vote"
+        );
+
+        // Post-skip invariant: subsequent calls still return None. The
+        // engine should treat the slot as "voted" for this round, so that
+        // a compact block that clears the flag late cannot cause a
+        // belated vote.
+        assert!(engine.voted_slots.contains(&slot));
+        assert!(engine.select_and_vote(&identities[1]).is_none());
+    }
+
+    #[test]
+    fn select_and_vote_produces_vote_without_inclusion_flag() {
+        // Positive case: no inclusion flag → normal vote path runs.
+        // Pairs with the skip test above so we know the flag is what
+        // caused the skip, not some unrelated issue.
+        let (mut engine, identities) = make_engine_with_committee(3);
+        engine.advance_slot();
+        let slot = engine.consensus.current_slot;
+
+        let header = BlockHeader {
+            slot,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: identities[0].address,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0u8; 32],
+            state_root: [0u8; 32],
+            timestamp: 0,
+        };
+        engine.buffered_proposals.entry(slot).or_default().push(BufferedProposal {
+            header,
+            proposer_signature: vec![],
+            vrf_score: 0,
+        });
+
+        assert!(!engine.is_inclusion_violated(slot));
+        let vote = engine.select_and_vote(&identities[1]);
+        assert!(vote.is_some(), "un-flagged slot should produce a vote");
     }
 
     // ========== Crash-restart safety tests ==========


### PR DESCRIPTION
> Supersedes #199 (auto-closed when base branch was deleted after #198 merged).

## Summary

Closes the proposer-censorship gap in the threshold-encrypted mempool.
Tasks 024/025 (#198) prevented post-QC reordering; this slice catches
the "proposer skips encrypted_txs from the pool entirely" attack in
the cases local-view enforcement can detect.

## How it works

- Mempool tracks `(tx_hash → first_seen_slot)` for every encrypted_tx.
- On compact-block reception, each validator audits: are there
  encrypted_txs held ≥2 slots that are absent from the block while
  gas budget remained?
- If yes → slot is flagged; `select_and_vote` abstains.
- HotStuff tolerates 1/128 dissent, so local-view false positives only
  cost liveness on the affected slot — never safety.

## Why local-view (not committee-aggregated)

Committee-aggregated signed commitments are the right long-term answer
but need gossip/schema infrastructure that doesn't need to ship
day-one. Local-view enforcement is correct under the Pyde committee
model (128-validator mesh, sub-second gossip). The hardening path is
documented in MAINNET_PLAN.md → "Deferred to post-mainnet".

## Changes

**pyde-mempool:**
- Mempool.first_seen_slot: HashMap<[u8;32], u64> — populated on add,
  cleaned on evict/prune/remove.
- Mempool::view_with_slots() iterator.
- New inclusion.rs module:
  - audit_inclusion(view, block_hashes, block_gas, slot, grace, ceiling)
  - audit_block_inclusion(block_encrypted_tx_bytes, view, ...) — byte-
    level wrapper for the node.rs reception path so the call site is
    a 1-liner + fully tested.

**pyde-node/validator.rs:**
- ValidatorEngine::flag_inclusion_violation / is_inclusion_violated.
- select_and_vote skips (and marks voted) when flagged.

**pyde-node/node.rs:**
- Audit runs on compact-block reception. Violation → flag + warn log.
- const MEV_INCLUSION_GRACE_SLOTS: u64 = 2 (~800ms at 400ms/slot).

## Tests (12 new)

**pyde-mempool::inclusion (10):**
- honest_block_includes_everything_clean_audit
- censored_aged_tx_is_flagged
- new_tx_within_grace_window_is_ignored
- full_block_legitimately_excludes_tx
- empty_mempool_produces_clean_audit
- aged_tx_fits_when_gas_remaining_equals_gas_limit
- multiple_aged_censored_are_all_reported
- audit_block_inclusion_passes_honest_block
- audit_block_inclusion_flags_censored_aged_tx_via_bytes
- audit_block_inclusion_skips_malformed_bytes

**pyde-node::validator (2):**
- select_and_vote_skips_when_inclusion_flag_set
- select_and_vote_produces_vote_without_inclusion_flag

Full workspace test run: green.