### PR TITLE
feat: mempool rate limit + FALCON pubkey binding

### DIFF
--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -20,11 +20,22 @@
 use crate::encrypted::EncryptedTx;
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Default maximum mempool capacity (number of transactions).
 /// Sized for ~100 blocks at sustained throughput (12,500 TPS × 0.4s × 100).
 pub const DEFAULT_MAX_POOL_SIZE: usize = 500_000;
+
+/// Per-sender rate limit: max submissions per `RATE_WINDOW_MS` (task 027).
+pub const DEFAULT_MAX_TX_PER_WINDOW_PER_SENDER: u32 = 10;
+
+/// Per-sender concurrent cap: max simultaneously-held txs (task 027).
+pub const DEFAULT_MAX_CONCURRENT_PER_SENDER: u32 = 100;
+
+/// Rate-window size in milliseconds. The `submit_timestamps_ms` deque of each
+/// `SenderQuota` drops entries older than this. 1000 ms pairs naturally with
+/// the "10 tx/s" mainnet target.
+pub const RATE_WINDOW_MS: u64 = 1000;
 
 /// Mempool validation error.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -45,7 +56,46 @@ pub enum MempoolError {
     MalformedEncryption,
     /// Access list is empty (required for parallel scheduling).
     MissingAccessList,
+    /// Sender submitted more than `max_tx_per_window_per_sender` txs in the
+    /// last `RATE_WINDOW_MS` — token bucket exhausted.
+    RateLimitExceeded,
+    /// Sender already has `max_concurrent_per_sender` txs simultaneously in
+    /// the pool and must wait for some to clear.
+    TooManyConcurrentFromSender,
+    /// Sender's FALCON public key could not be resolved (not in state) or
+    /// did not verify against the tx signature. Used by the verified-add
+    /// path to kill relay-inflation attacks (task 028).
+    UnknownOrUnverifiedSender,
 }
+
+/// Tracks a single sender's recent activity for rate + concurrency caps.
+#[derive(Debug, Default)]
+struct SenderQuota {
+    /// Millisecond timestamps of submissions in the last `RATE_WINDOW_MS`.
+    /// Prune-on-read: caller evicts entries older than `now - RATE_WINDOW_MS`
+    /// before consulting the length.
+    submit_timestamps_ms: VecDeque<u64>,
+    /// Count of txs this sender currently holds in the pool. Incremented on
+    /// successful add, decremented on evict / prune / remove_included.
+    in_pool_count: u32,
+}
+
+/// Clock callback for the rate limiter. Default is wall-clock
+/// `SystemTime::now()` in ms since UNIX epoch; tests inject a controllable
+/// counter. Returning ms rather than a `Duration` keeps the arithmetic in
+/// the same integer space as `RATE_WINDOW_MS` / `submit_timestamps_ms`.
+pub type ClockMs = fn() -> u64;
+
+fn wallclock_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Sender → (hash → nonce) mapping for tracking a sender's in-pool txs.
+/// Used to decrement the quota correctly on individual tx removal.
+type SenderTxIndex = HashMap<Address, HashSet<[u8; 32]>>;
 
 /// The encrypted mempool.
 #[derive(Debug)]
@@ -62,6 +112,19 @@ pub struct Mempool {
     /// have seen them, versus txs so new that missing them is not
     /// evidence of censorship.
     first_seen_slot: HashMap<[u8; 32], u64>,
+    /// Per-sender submission rate + concurrency state (task 027). Populated
+    /// on add, decremented on remove/evict/prune.
+    sender_quotas: HashMap<Address, SenderQuota>,
+    /// Sender → set of tx hashes they currently own in the pool. Kept
+    /// alongside `sender_quotas` so bulk remove paths can locate which
+    /// senders to decrement without scanning the full pool each time.
+    sender_tx_index: SenderTxIndex,
+    /// Max txs from a single sender per `RATE_WINDOW_MS`.
+    max_tx_per_window_per_sender: u32,
+    /// Max txs a single sender may simultaneously hold in the pool.
+    max_concurrent_per_sender: u32,
+    /// Time source for rate-limit bookkeeping. Overridable for tests.
+    clock_ms: ClockMs,
     /// Maximum pool size.
     max_size: usize,
     /// Current block height (for expiry checks).
@@ -77,6 +140,11 @@ impl Mempool {
             seen_hashes: HashSet::new(),
             sender_nonces: HashMap::new(),
             first_seen_slot: HashMap::new(),
+            sender_quotas: HashMap::new(),
+            sender_tx_index: HashMap::new(),
+            max_tx_per_window_per_sender: DEFAULT_MAX_TX_PER_WINDOW_PER_SENDER,
+            max_concurrent_per_sender: DEFAULT_MAX_CONCURRENT_PER_SENDER,
+            clock_ms: wallclock_ms,
             max_size: DEFAULT_MAX_POOL_SIZE,
             current_block: 0,
             block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
@@ -89,10 +157,28 @@ impl Mempool {
             seen_hashes: HashSet::with_capacity(max_size),
             sender_nonces: HashMap::new(),
             first_seen_slot: HashMap::with_capacity(max_size),
+            sender_quotas: HashMap::new(),
+            sender_tx_index: HashMap::new(),
+            max_tx_per_window_per_sender: DEFAULT_MAX_TX_PER_WINDOW_PER_SENDER,
+            max_concurrent_per_sender: DEFAULT_MAX_CONCURRENT_PER_SENDER,
+            clock_ms: wallclock_ms,
             max_size,
             current_block: 0,
             block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
         }
+    }
+
+    /// Install a custom time source. Tests use this to drive the rate-limit
+    /// window deterministically; production always uses `wallclock_ms`.
+    pub fn set_clock(&mut self, clock: ClockMs) {
+        self.clock_ms = clock;
+    }
+
+    /// Override rate-limit caps. Production uses defaults; tests use lower
+    /// values to keep runtime small.
+    pub fn set_rate_limits(&mut self, per_window: u32, concurrent: u32) {
+        self.max_tx_per_window_per_sender = per_window;
+        self.max_concurrent_per_sender = concurrent;
     }
 
     /// Update the current block height (for expiry checks).
@@ -119,70 +205,151 @@ impl Mempool {
         self.txs.is_empty()
     }
 
-    /// Add an encrypted transaction to the mempool.
+    /// Add an encrypted transaction to the mempool with structural
+    /// validation + per-sender rate limit (task 027).
     ///
-    /// Structural validation (no state access required):
-    /// 1. Signature valid (FALCON-512)
-    /// 2. Gas limit in bounds [21K, block_gas_limit]
-    /// 3. Ciphertext non-empty
-    /// 4. Access list non-empty
-    /// 5. Size within limit
-    /// 6. Not expired
-    /// 7. Not duplicate
+    /// This path does NOT cryptographically verify the FALCON signature —
+    /// it only checks the signature is structurally plausible (length).
+    /// Mainnet consumers must use `add_with_pubkey` which also enforces
+    /// task 028 (ciphertext-to-pubkey binding). `add` remains available
+    /// for devnet and for tests that don't want to construct a full key.
+    ///
+    /// Checks, in order:
+    /// 1. Per-sender rate limit (windowed)
+    /// 2. Per-sender concurrent-in-pool cap
+    /// 3. Signature structurally plausible
+    /// 4. Gas limit in bounds
+    /// 5. Ciphertext non-empty
+    /// 6. Access list non-empty
+    /// 7. Size within limit
+    /// 8. Not expired
+    /// 9. Not duplicate
     pub fn add(&mut self, tx: EncryptedTx) -> Result<(), MempoolError> {
-        // 1. Signature check
+        self.check_sender_rate(&tx.sender)?;
         self.verify_signature(&tx)?;
+        self.check_core_validity(&tx)?;
+        self.insert_tx(tx);
+        Ok(())
+    }
 
-        // 2. Gas limit bounds
+    /// Add an encrypted transaction with full FALCON signature verification
+    /// against the sender's known public key (task 028).
+    ///
+    /// Bindings closed by this path:
+    /// - Ciphertext-to-sender: the signature covers `tx.hash()` which
+    ///   includes both the sender address and the ciphertext hash, so
+    ///   relay-inflation (wrapping the same ciphertext under a different
+    ///   sender) produces a sig that will not verify.
+    /// - Sender-to-pubkey: verification runs against `sender_pubkey` looked
+    ///   up from on-chain state by the caller, so a forged pubkey would
+    ///   also fail.
+    ///
+    /// Applies the same structural + rate-limit checks as `add`.
+    pub fn add_with_pubkey(
+        &mut self,
+        tx: EncryptedTx,
+        sender_pubkey: &[u8],
+    ) -> Result<(), MempoolError> {
+        self.check_sender_rate(&tx.sender)?;
+        if !Self::verify_signature_with_key(&tx, sender_pubkey) {
+            return Err(MempoolError::UnknownOrUnverifiedSender);
+        }
+        self.check_core_validity(&tx)?;
+        self.insert_tx(tx);
+        Ok(())
+    }
+
+    fn check_sender_rate(&mut self, sender: &Address) -> Result<(), MempoolError> {
+        let now = (self.clock_ms)();
+        let window_cutoff = now.saturating_sub(RATE_WINDOW_MS);
+        let quota = self.sender_quotas.entry(*sender).or_default();
+        while let Some(&front) = quota.submit_timestamps_ms.front() {
+            if front < window_cutoff {
+                quota.submit_timestamps_ms.pop_front();
+            } else {
+                break;
+            }
+        }
+        if quota.submit_timestamps_ms.len() as u32 >= self.max_tx_per_window_per_sender {
+            return Err(MempoolError::RateLimitExceeded);
+        }
+        if quota.in_pool_count >= self.max_concurrent_per_sender {
+            return Err(MempoolError::TooManyConcurrentFromSender);
+        }
+        Ok(())
+    }
+
+    fn check_core_validity(&self, tx: &EncryptedTx) -> Result<(), MempoolError> {
         if tx.gas_limit < 21_000 {
             return Err(MempoolError::GasTooLow);
         }
         if tx.gas_limit > self.block_gas_limit {
             return Err(MempoolError::GasTooHigh);
         }
-
-        // 3. Ciphertext well-formed
         if tx.ciphertext.encrypted_len() == 0 {
             return Err(MempoolError::MalformedEncryption);
         }
-
-        // 4. Access list non-empty
         if tx.access_list.is_empty() {
             return Err(MempoolError::MissingAccessList);
         }
-
-        // 5. Size limit
         if tx.is_oversized() {
             return Err(MempoolError::Oversized);
         }
-
-        // 6. Expiry
         if tx.is_expired(self.current_block) {
             return Err(MempoolError::Expired);
         }
-
-        // 7. Duplicate
         let hash = tx.hash();
         if self.seen_hashes.contains(&hash) {
             return Err(MempoolError::Duplicate);
         }
+        Ok(())
+    }
 
-        // Evict if full: drop oldest transaction (FCFS — newest survive)
+    fn insert_tx(&mut self, tx: EncryptedTx) {
+        // Evict if full: drop oldest transaction (FCFS — newest survive).
+        // Eviction decrements the evicted sender's in_pool_count.
         if self.txs.len() >= self.max_size {
             self.evict_oldest();
         }
 
-        // Track sender nonce
-        let entry = self.sender_nonces.entry(tx.sender).or_insert(0);
+        let hash = tx.hash();
+        let sender = tx.sender;
+
+        let entry = self.sender_nonces.entry(sender).or_insert(0);
         if tx.nonce > *entry {
             *entry = tx.nonce;
         }
 
+        // Rate-limit bookkeeping: record the submit timestamp + bump the
+        // concurrent count. `check_sender_rate` already pruned stale
+        // timestamps and has ensured we're under the caps.
+        let now = (self.clock_ms)();
+        let quota = self.sender_quotas.entry(sender).or_default();
+        quota.submit_timestamps_ms.push_back(now);
+        quota.in_pool_count += 1;
+
+        self.sender_tx_index.entry(sender).or_default().insert(hash);
         self.seen_hashes.insert(hash);
         self.first_seen_slot.insert(hash, self.current_block);
         self.txs.push(tx);
+    }
 
-        Ok(())
+    /// Decrement a sender's concurrent count when a tx leaves the pool.
+    fn release_sender_slot(&mut self, sender: &Address, hash: &[u8; 32]) {
+        if let Some(set) = self.sender_tx_index.get_mut(sender) {
+            set.remove(hash);
+            if set.is_empty() {
+                self.sender_tx_index.remove(sender);
+            }
+        }
+        if let Some(q) = self.sender_quotas.get_mut(sender) {
+            q.in_pool_count = q.in_pool_count.saturating_sub(1);
+            // Keep submit_timestamps_ms — those represent rate history, not
+            // occupancy. They'll age out on their own via window pruning.
+            if q.in_pool_count == 0 && q.submit_timestamps_ms.is_empty() {
+                self.sender_quotas.remove(sender);
+            }
+        }
     }
 
     /// Evict the oldest transaction (first in the list).
@@ -192,8 +359,10 @@ impl Mempool {
         }
         let evicted = self.txs.remove(0);
         let h = evicted.hash();
+        let sender = evicted.sender;
         self.seen_hashes.remove(&h);
         self.first_seen_slot.remove(&h);
+        self.release_sender_slot(&sender, &h);
     }
 
     /// Verify the FALCON-512 signature on an encrypted transaction.
@@ -231,14 +400,22 @@ impl Mempool {
     pub fn prune_expired(&mut self) {
         let current = self.current_block;
         let before = self.txs.len();
+        let expired_senders: Vec<(Address, [u8; 32])> = self
+            .txs
+            .iter()
+            .filter(|tx| tx.is_expired(current))
+            .map(|tx| (tx.sender, tx.hash()))
+            .collect();
         self.txs.retain(|tx| !tx.is_expired(current));
 
-        // Rebuild hash set + first-seen tracking if we pruned anything
         if self.txs.len() != before {
             self.seen_hashes.clear();
             let kept: HashSet<[u8; 32]> = self.txs.iter().map(|tx| tx.hash()).collect();
             self.first_seen_slot.retain(|h, _| kept.contains(h));
             self.seen_hashes = kept;
+            for (sender, hash) in &expired_senders {
+                self.release_sender_slot(sender, hash);
+            }
         }
     }
 
@@ -275,11 +452,20 @@ impl Mempool {
     /// Remove transactions that were included in a block.
     pub fn remove_included(&mut self, hashes: &[[u8; 32]]) {
         let hash_set: HashSet<[u8; 32]> = hashes.iter().copied().collect();
+        let removed: Vec<(Address, [u8; 32])> = self
+            .txs
+            .iter()
+            .filter(|tx| hash_set.contains(&tx.hash()))
+            .map(|tx| (tx.sender, tx.hash()))
+            .collect();
         self.txs.retain(|tx| !hash_set.contains(&tx.hash()));
 
         for hash in hashes {
             self.seen_hashes.remove(hash);
             self.first_seen_slot.remove(hash);
+        }
+        for (sender, hash) in &removed {
+            self.release_sender_slot(sender, hash);
         }
     }
 
@@ -567,5 +753,250 @@ mod tests {
         let dup = tx.clone();
         let txs = vec![tx, dup];
         assert!(check_no_duplicate_txs(&txs).is_err());
+    }
+
+    // ========== Task 027: per-sender rate limit ==========
+
+    /// Build an encrypted tx from a specific sender address (not derived from
+    /// nonce, as `make_enc_tx` does). Used by rate-limit tests that need
+    /// many txs from one sender.
+    fn make_enc_tx_from(
+        pk: &threshold::ThresholdPublicKey,
+        sender: Address,
+        nonce: u64,
+    ) -> EncryptedTx {
+        let to = derive_eoa_address(b"rate-to");
+        encrypt_transaction(
+            sender, nonce, 50_000,
+            dummy_access_list(), None, 1,
+            dummy_signature(), &to, 0, b"",
+            pk,
+        ).unwrap()
+    }
+
+    /// Test clock backed by a thread-local counter. `set_test_clock_ms`
+    /// moves the needle; `test_clock_ms` is the function pointer fed to
+    /// `Mempool::set_clock`.
+    thread_local! {
+        static TEST_CLOCK: std::cell::Cell<u64> = std::cell::Cell::new(0);
+    }
+    fn test_clock_ms() -> u64 {
+        TEST_CLOCK.with(|c| c.get())
+    }
+    fn set_test_clock_ms(ms: u64) {
+        TEST_CLOCK.with(|c| c.set(ms));
+    }
+
+    #[test]
+    fn rate_limit_rejects_over_window_cap() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_clock(test_clock_ms);
+        pool.set_rate_limits(3, 100);
+        set_test_clock_ms(1_000);
+
+        let sender = derive_eoa_address(b"rate-sender");
+        for n in 0..3 {
+            pool.add(make_enc_tx_from(&pk, sender, n)).unwrap();
+        }
+
+        // Fourth submission within the same window → rate-limited.
+        let err = pool.add(make_enc_tx_from(&pk, sender, 3)).unwrap_err();
+        assert_eq!(err, MempoolError::RateLimitExceeded);
+        assert_eq!(pool.len(), 3);
+    }
+
+    #[test]
+    fn rate_limit_resets_after_window_rolls() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_clock(test_clock_ms);
+        pool.set_rate_limits(2, 100);
+
+        let sender = derive_eoa_address(b"rolling-sender");
+        set_test_clock_ms(100);
+        pool.add(make_enc_tx_from(&pk, sender, 0)).unwrap();
+        pool.add(make_enc_tx_from(&pk, sender, 1)).unwrap();
+
+        // Still within window — third is rejected.
+        set_test_clock_ms(500);
+        assert_eq!(
+            pool.add(make_enc_tx_from(&pk, sender, 2)).unwrap_err(),
+            MempoolError::RateLimitExceeded,
+        );
+
+        // Advance past window boundary (window = 1000ms, start was 100 ms).
+        // At t=1101 all original timestamps are older than now - 1000 = 101.
+        set_test_clock_ms(1_101);
+        pool.add(make_enc_tx_from(&pk, sender, 3))
+            .expect("window should have rolled");
+    }
+
+    #[test]
+    fn concurrent_cap_blocks_new_submits_until_release() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_clock(test_clock_ms);
+        // Per-window cap high so the concurrent cap is what we actually hit.
+        pool.set_rate_limits(1000, 3);
+
+        let sender = derive_eoa_address(b"concurrent-sender");
+        set_test_clock_ms(1_000);
+        let mut hashes = Vec::new();
+        for n in 0..3 {
+            let tx = make_enc_tx_from(&pk, sender, n);
+            hashes.push(tx.hash());
+            pool.add(tx).unwrap();
+        }
+
+        // 4th concurrently → blocked.
+        assert_eq!(
+            pool.add(make_enc_tx_from(&pk, sender, 3)).unwrap_err(),
+            MempoolError::TooManyConcurrentFromSender,
+        );
+
+        // Include one of the in-pool txs → slot opens up.
+        pool.remove_included(&[hashes[0]]);
+        set_test_clock_ms(2_100); // roll window so the rate counter doesn't
+                                   // independently block (submits are windowed
+                                   // but in_pool count is not).
+        pool.add(make_enc_tx_from(&pk, sender, 3))
+            .expect("slot should have been released");
+    }
+
+    #[test]
+    fn different_senders_have_independent_quotas() {
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_clock(test_clock_ms);
+        pool.set_rate_limits(2, 100);
+        set_test_clock_ms(1_000);
+
+        let alice = derive_eoa_address(b"alice");
+        let bob = derive_eoa_address(b"bob");
+
+        pool.add(make_enc_tx_from(&pk, alice, 0)).unwrap();
+        pool.add(make_enc_tx_from(&pk, alice, 1)).unwrap();
+
+        // Alice is at her rate cap, but Bob still has headroom.
+        assert_eq!(
+            pool.add(make_enc_tx_from(&pk, alice, 2)).unwrap_err(),
+            MempoolError::RateLimitExceeded,
+        );
+        pool.add(make_enc_tx_from(&pk, bob, 0))
+            .expect("bob is unaffected by alice's cap");
+        pool.add(make_enc_tx_from(&pk, bob, 1)).unwrap();
+    }
+
+    // ========== Task 028: FALCON-pubkey binding on submit ==========
+
+    /// Build an encrypted tx signed by a real FALCON keypair so the
+    /// signature verifies against the corresponding pubkey. Returns the
+    /// tx + pubkey bytes so tests can pass them to `add_with_pubkey`.
+    fn make_falcon_signed_tx(
+        threshold_pk: &threshold::ThresholdPublicKey,
+        gas: u64,
+        nonce: u64,
+    ) -> (EncryptedTx, Vec<u8>, pyde_crypto::falcon::FalconSecretKey) {
+        let (falcon_pk, falcon_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let sender = derive_eoa_address(falcon_pk.as_bytes());
+        let to = derive_eoa_address(b"falcon-to");
+
+        // First build the tx with a placeholder signature so we can compute
+        // the hash, then re-sign and rebuild (hash ignores signature field).
+        let template = encrypt_transaction(
+            sender, nonce, gas, dummy_access_list(), None, 1,
+            vec![0u8; 666], &to, 0, b"", threshold_pk,
+        ).unwrap();
+        let hash = template.hash();
+        let sig = pyde_crypto::falcon::falcon_sign(&falcon_sk, &hash)
+            .unwrap()
+            .to_vec();
+
+        let signed = EncryptedTx {
+            sender,
+            nonce,
+            gas_limit: gas,
+            access_list: template.access_list.clone(),
+            deadline: template.deadline,
+            chain_id: template.chain_id,
+            signature: sig,
+            ciphertext: template.ciphertext.clone(),
+        };
+        (signed, falcon_pk.as_bytes().to_vec(), falcon_sk)
+    }
+
+    #[test]
+    fn add_with_pubkey_accepts_matching_signature() {
+        let pk = make_pk();
+        let (tx, sender_pk_bytes, _sk) = make_falcon_signed_tx(&pk, 50_000, 0);
+        let mut pool = Mempool::new();
+        pool.add_with_pubkey(tx, &sender_pk_bytes).unwrap();
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn add_with_pubkey_rejects_wrong_pubkey() {
+        // Relay-inflation attack simulation: attacker intercepts a validly
+        // signed ciphertext and tries to insert it under their own pubkey.
+        // The FALCON verify fails → rejected.
+        let pk = make_pk();
+        let (tx, _real_pk, _real_sk) = make_falcon_signed_tx(&pk, 50_000, 0);
+
+        // Different keypair belonging to the attacker.
+        let (attacker_pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+
+        let mut pool = Mempool::new();
+        let err = pool.add_with_pubkey(tx, attacker_pk.as_bytes()).unwrap_err();
+        assert_eq!(err, MempoolError::UnknownOrUnverifiedSender);
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn add_with_pubkey_rejects_tampered_ciphertext() {
+        // If the ciphertext bytes are mutated after signing, `tx.hash()`
+        // changes and the FALCON sig over the old hash no longer verifies.
+        // Construct a valid tx, flip a byte in the ciphertext, retry.
+        let pk = make_pk();
+        let (mut tx, sender_pk_bytes, _sk) = make_falcon_signed_tx(&pk, 50_000, 0);
+
+        // Swap in a fresh ciphertext (different plaintext → different bytes)
+        // while keeping the old signature. The hash changes and sig verification
+        // against the (now wrong) hash fails.
+        let to = derive_eoa_address(b"tampered");
+        tx.ciphertext = threshold::threshold_encrypt(&pk, b"tampered payload").unwrap();
+
+        let mut pool = Mempool::new();
+        assert_eq!(
+            pool.add_with_pubkey(tx, &sender_pk_bytes).unwrap_err(),
+            MempoolError::UnknownOrUnverifiedSender,
+        );
+        let _ = to;
+    }
+
+    #[test]
+    fn add_with_pubkey_still_enforces_rate_limit() {
+        // Verified path must compose with rate limiting — an attacker with a
+        // valid key still can't spam.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_clock(test_clock_ms);
+        pool.set_rate_limits(1, 100);
+        set_test_clock_ms(1_000);
+
+        let (tx1, pk1, sk1) = make_falcon_signed_tx(&pk, 50_000, 0);
+        pool.add_with_pubkey(tx1, &pk1).unwrap();
+
+        // Second submission from the same sender; re-sign with the same sk.
+        let (mut tx2, _, _) = make_falcon_signed_tx(&pk, 50_000, 1);
+        // Align sender + resign with sk1 so the pubkey matches.
+        tx2.sender = derive_eoa_address(&pk1);
+        let new_hash = tx2.hash();
+        tx2.signature = pyde_crypto::falcon::falcon_sign(&sk1, &new_hash).unwrap().to_vec();
+
+        assert_eq!(
+            pool.add_with_pubkey(tx2, &pk1).unwrap_err(),
+            MempoolError::RateLimitExceeded,
+        );
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -791,9 +791,36 @@ impl PydeApiServer for RpcServer {
 
         let tx_hash = enc_tx.hash();
 
-        // Add to encrypted mempool
+        // Task 028: bind ciphertext to sender's on-chain FALCON pubkey.
+        // Look up the sender's account; if a Single auth_key is registered,
+        // enforce full FALCON verification (receive_tx_verified). Accounts
+        // with no registered key (fresh / faucet / system) fall back to
+        // the structural-only path so devnet bootstrap still works. Mainnet
+        // users are expected to have an auth_key set, putting them on the
+        // verified path by default.
+        let sender_pk_opt = {
+            let state_r = self.state.state.read().await;
+            let sender_key = pyde_state::keys::balance_key(&from);
+            state_r.get(&sender_key)
+                .and_then(|bytes| pyde_account::types::Account::from_bytes(&bytes))
+                .and_then(|acct| match acct.auth_keys {
+                    pyde_account::types::AuthKeys::Single(pk) => Some(pk),
+                    _ => None,
+                })
+        };
+
         let mut relay = self.state.tx_relay.write().await;
-        relay.receive_tx(enc_tx);
+        let accepted = if let Some(sender_pk) = sender_pk_opt {
+            relay.receive_tx_verified(enc_tx, &sender_pk)
+        } else {
+            relay.receive_tx(enc_tx)
+        };
+        if !accepted {
+            return Err(rpc_err(
+                -32000,
+                "tx rejected (duplicate, rate-limited, or signature failed verification)".to_string(),
+            ));
+        }
 
         info!(tx_hash = hex::encode(tx_hash), "encrypted tx accepted into mempool");
         Ok(format!("0x{}", hex::encode(tx_hash)))

--- a/crates/node/src/tx_relay.rs
+++ b/crates/node/src/tx_relay.rs
@@ -25,8 +25,10 @@ impl TxRelay {
         self.mempool.set_current_block(block);
     }
 
-    /// Attempt to add a transaction received from the network.
-    /// Returns true if accepted (new), false if rejected (duplicate, invalid, etc.).
+    /// Attempt to add a transaction received from the network using only
+    /// structural + rate-limit checks. Intended for devnet/tests.
+    /// Returns true if accepted (new), false if rejected (duplicate, invalid,
+    /// rate-limited, etc.).
     pub fn receive_tx(&mut self, tx: EncryptedTx) -> bool {
         match self.mempool.add(tx) {
             Ok(()) => {
@@ -35,6 +37,24 @@ impl TxRelay {
             }
             Err(e) => {
                 debug!(?e, "tx rejected");
+                false
+            }
+        }
+    }
+
+    /// Attempt to add a transaction using full FALCON signature verification
+    /// against the sender's known public key (task 028). Mainnet path:
+    /// callers must look up `sender_pubkey` from on-chain state before
+    /// invoking. If the sender isn't registered or the sig fails, rejected
+    /// with `UnknownOrUnverifiedSender`.
+    pub fn receive_tx_verified(&mut self, tx: EncryptedTx, sender_pubkey: &[u8]) -> bool {
+        match self.mempool.add_with_pubkey(tx, sender_pubkey) {
+            Ok(()) => {
+                debug!("tx accepted into mempool (verified)");
+                true
+            }
+            Err(e) => {
+                debug!(?e, "tx rejected (verified path)");
                 false
             }
         }


### PR DESCRIPTION
## Summary

Closes two spam vectors on the encrypted mempool:
- **Task 027** — per-sender rate limit: 10 tx/s, 100 concurrent in pool.
- **Task 028** — FALCON pubkey binding: mempool insertion runs full
  FALCON-512 verification against the sender's on-chain auth_key,
  killing relay-inflation (wrapping an intercepted ciphertext under
  a different sender).

## How it works

**Rate limit (027):**
- \`SenderQuota\` per-address: rolling window of submit timestamps (1s) + \`in_pool_count\`.
- \`add\` prunes stale timestamps, then checks \`len() < max_per_window\` and \`in_pool_count < max_concurrent\`.
- Removals (evict/prune/remove_included) decrement \`in_pool_count\`; submit history ages out on its own.
- Injectable \`ClockMs\` — production uses \`SystemTime::now()\`; tests drive the clock by hand.

**FALCON binding (028):**
- \`Mempool::add_with_pubkey(tx, sender_pubkey)\` — full FALCON verify over \`tx.hash()\` (which already covers sender + ciphertext_hash).
- Mismatched pubkey, tampered ciphertext, or forged sender all fail.
- RPC \`send_encrypted_transaction\` now looks up the sender's account, uses \`receive_tx_verified\` when \`AuthKeys::Single\` is present, falls back to structural-only for accounts with no registered key (devnet bootstrap path).

## Changes

**pyde-mempool/pool.rs:**
- New errors: \`RateLimitExceeded\`, \`TooManyConcurrentFromSender\`, \`UnknownOrUnverifiedSender\`.
- \`SenderQuota\` struct + \`sender_quotas\` / \`sender_tx_index\` fields.
- \`ClockMs\` alias + \`set_clock\` / \`set_rate_limits\`.
- \`add\` refactored into \`check_sender_rate\` → \`verify_signature\` → \`check_core_validity\` → \`insert_tx\`. New \`add_with_pubkey\` reuses the same pipeline, swapping the signature check for real crypto.
- Removal paths release sender slots via \`release_sender_slot\`.

**pyde-node/tx_relay.rs:**
- New \`receive_tx_verified(tx, sender_pubkey)\` wrapping \`add_with_pubkey\`.

**pyde-node/rpc.rs:**
- \`send_encrypted_transaction\` looks up sender's auth_keys and routes to verified/unverified path accordingly. Returns -32000 on rejection.

## Tests (8 new)

**pool::tests (rate):**
- rate_limit_rejects_over_window_cap
- rate_limit_resets_after_window_rolls
- concurrent_cap_blocks_new_submits_until_release
- different_senders_have_independent_quotas

**pool::tests (FALCON binding):**
- add_with_pubkey_accepts_matching_signature
- add_with_pubkey_rejects_wrong_pubkey
- add_with_pubkey_rejects_tampered_ciphertext
- add_with_pubkey_still_enforces_rate_limit

Full workspace test run: green.