### PR TITLE
feat: FALCON peer attestation + validator-only consensus filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,6 +3506,8 @@ dependencies = [
 name = "pyde-net"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "getrandom 0.2.17",
  "libp2p",
  "pyde-account",
  "pyde-crypto",

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -10,7 +10,9 @@ libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "y
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
+getrandom = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 serde_json = "1"
+futures = "0.3"

--- a/crates/net/src/auth.rs
+++ b/crates/net/src/auth.rs
@@ -1,0 +1,444 @@
+//! FALCON peer-authentication protocol (tasks 029 + 030).
+//!
+//! Binds a libp2p `PeerId` to a FALCON-512 pubkey via challenge-response, so
+//! the node layer can enforce validator-only access to the consensus topic.
+//!
+//! ## Flow
+//!
+//! 1. When a connection is established, the initiator sends `PydeAuthReq`
+//!    containing a random 32-byte nonce.
+//! 2. The responder signs `nonce || peer_id_bytes` with their FALCON secret
+//!    key and replies with `PydeAuthResp { falcon_pubkey, signature }`.
+//! 3. The initiator verifies the signature against `falcon_pubkey`. On
+//!    success, the PeerId↔FALCON-pubkey binding is recorded in
+//!    `PeerManager`. On failure, the peer is marked `PeerRole::Unknown`
+//!    and will be ignored by the consensus-topic filter.
+//!
+//! ## What this protocol does NOT do
+//!
+//! - It does not prove the FALCON pubkey belongs to a committee member —
+//!   the node layer checks `attested_pubkey ∈ committee_keys` separately.
+//!   A non-validator with a valid FALCON keypair can still attest; they
+//!   just won't pass the committee filter.
+//! - It does not authorize RPC submissions — that path uses task 028's
+//!   on-chain auth_key lookup (see `pyde-mempool::pool::add_with_pubkey`).
+//!
+//! Transport confidentiality is handled by libp2p's noise/QUIC layer; this
+//! module runs on top of that already-encrypted channel.
+
+use crate::peer::PeerManager;
+use libp2p::{request_response, PeerId};
+use libp2p::StreamProtocol;
+use pyde_crypto::falcon::{falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey, FalconSignature};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Protocol name for the FALCON peer-auth handshake.
+pub const AUTH_PROTOCOL: StreamProtocol = StreamProtocol::new("/pyde/auth/1");
+
+/// Handshake request: initiator sends a fresh random nonce.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PydeAuthReq {
+    /// 32 random bytes picked by the initiator. The responder signs
+    /// `nonce || peer_id_bytes`, so replaying an older nonce against a
+    /// different peer produces a sig that won't verify.
+    pub nonce: [u8; 32],
+}
+
+/// Handshake response: responder's FALCON pubkey + FALCON sig over the
+/// `build_attestation_message(nonce, peer_id_bytes)` payload.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PydeAuthResp {
+    /// FALCON-512 public key bytes. ~897 bytes for standard FALCON-512.
+    pub falcon_pubkey: Vec<u8>,
+    /// FALCON-512 signature over `build_attestation_message(req.nonce, responder_peer_id)`.
+    pub signature: Vec<u8>,
+}
+
+/// Canonical attestation payload the responder signs.
+///
+/// Returns `nonce || peer_id_bytes`. Fixing the layout here prevents the
+/// initiator and responder from disagreeing about the signed content.
+pub fn build_attestation_message(nonce: &[u8; 32], peer_id_bytes: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(32 + peer_id_bytes.len());
+    buf.extend_from_slice(nonce);
+    buf.extend_from_slice(peer_id_bytes);
+    buf
+}
+
+/// Produce a signed `PydeAuthResp` for an incoming `PydeAuthReq`.
+pub fn build_auth_resp(
+    req: &PydeAuthReq,
+    responder_peer_id_bytes: &[u8],
+    falcon_sk: &FalconSecretKey,
+    falcon_pk: &FalconPublicKey,
+) -> Result<PydeAuthResp, String> {
+    let msg = build_attestation_message(&req.nonce, responder_peer_id_bytes);
+    let sig = falcon_sign(falcon_sk, &msg)
+        .map_err(|e| format!("falcon_sign failed: {:?}", e))?;
+    Ok(PydeAuthResp {
+        falcon_pubkey: falcon_pk.as_bytes().to_vec(),
+        signature: sig.to_vec(),
+    })
+}
+
+/// Verify a `PydeAuthResp` against the request that produced it.
+///
+/// Returns the verified FALCON pubkey on success. On any failure (malformed
+/// pubkey, malformed sig, verification mismatch) returns `None` and the
+/// caller must NOT record the binding.
+pub fn verify_auth_resp(
+    req: &PydeAuthReq,
+    resp: &PydeAuthResp,
+    responder_peer_id_bytes: &[u8],
+) -> Option<Vec<u8>> {
+    let pk = FalconPublicKey::from_bytes(&resp.falcon_pubkey)?;
+    let sig = FalconSignature::from_bytes(&resp.signature)?;
+    let msg = build_attestation_message(&req.nonce, responder_peer_id_bytes);
+    if falcon_verify(&pk, &msg, &sig) {
+        Some(resp.falcon_pubkey.clone())
+    } else {
+        None
+    }
+}
+
+/// Create the libp2p request-response behaviour for the FALCON auth protocol.
+pub fn auth_behaviour() -> request_response::cbor::Behaviour<PydeAuthReq, PydeAuthResp> {
+    request_response::cbor::Behaviour::new(
+        [(AUTH_PROTOCOL, request_response::ProtocolSupport::Full)],
+        request_response::Config::default(),
+    )
+}
+
+/// Generate a fresh 32-byte nonce for an auth request.
+pub fn generate_nonce() -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    getrandom::getrandom(&mut buf).expect("getrandom failed");
+    buf
+}
+
+/// Outcome of `apply_auth_response`, exported for telemetry + testing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthOutcome {
+    /// No pending nonce matched this peer — response is spurious or stale.
+    NoPendingNonce,
+    /// FALCON signature verification failed (wrong pubkey, bad sig,
+    /// replay, malformed fields).
+    VerifyFailed,
+    /// Peer previously attested a DIFFERENT pubkey on the same connection.
+    /// Treated as a protocol violation; the caller should disconnect.
+    RebindRejected,
+    /// Pubkey recorded in the peer manager and matched an entry in
+    /// `committee_keys` — peer was promoted to `PeerRole::Validator`.
+    StoredAsValidator,
+    /// Pubkey recorded but not in `committee_keys`. The peer can still
+    /// forward non-consensus traffic; the consensus filter (task 030)
+    /// will drop any consensus messages they try to publish.
+    StoredAsNonValidator,
+}
+
+/// Apply an incoming `PydeAuthResp` end-to-end: consume the pending
+/// nonce, verify, and update peer state. Returns a structured outcome
+/// so the node layer can log + emit metrics without a tangle of nested
+/// match arms in the swarm-event handler.
+///
+/// This is the testable seam for the handshake-response path — the
+/// node layer's swarm handler is purely the wire glue around this.
+/// Committee membership is resolved by byte-level equality with
+/// `committee_keys`, matching the rule used by
+/// `PeerManager::is_consensus_authorized`.
+pub fn apply_auth_response(
+    peer: PeerId,
+    response: &PydeAuthResp,
+    pending_auth_nonces: &mut HashMap<PeerId, [u8; 32]>,
+    peer_manager: &mut PeerManager,
+    committee_keys: &[Vec<u8>],
+) -> AuthOutcome {
+    let nonce = match pending_auth_nonces.remove(&peer) {
+        Some(n) => n,
+        None => return AuthOutcome::NoPendingNonce,
+    };
+    let req = PydeAuthReq { nonce };
+
+    // Responder signs over (nonce || derive_eoa_address(pubkey)).
+    // Computing the EOA from the attested pubkey closes the loop: a
+    // captured attestation can't be re-presented for a different EOA
+    // without breaking the signature.
+    let derived_addr = pyde_account::address::derive_eoa_address(&response.falcon_pubkey);
+    let pk_bytes = match verify_auth_resp(&req, response, &derived_addr) {
+        Some(pk) => pk,
+        None => return AuthOutcome::VerifyFailed,
+    };
+
+    if !peer_manager.set_falcon_pubkey(&peer, pk_bytes.clone()) {
+        return AuthOutcome::RebindRejected;
+    }
+
+    let in_committee = committee_keys
+        .iter()
+        .any(|ck| ck.as_slice() == pk_bytes.as_slice());
+    if in_committee {
+        peer_manager.mark_validator(&peer);
+        AuthOutcome::StoredAsValidator
+    } else {
+        AuthOutcome::StoredAsNonValidator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_crypto::falcon::falcon_keygen;
+
+    const PEER_ID_A: &[u8] = b"peer-id-A-arbitrary-multihash";
+    const PEER_ID_B: &[u8] = b"peer-id-B-arbitrary-multihash";
+
+    #[test]
+    fn nonces_are_unique() {
+        let a = generate_nonce();
+        let b = generate_nonce();
+        assert_ne!(a, b, "entropy source broken");
+    }
+
+    #[test]
+    fn honest_handshake_roundtrips() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let req = PydeAuthReq {
+            nonce: generate_nonce(),
+        };
+        let resp = build_auth_resp(&req, PEER_ID_A, &sk, &pk).unwrap();
+
+        let verified = verify_auth_resp(&req, &resp, PEER_ID_A).unwrap();
+        assert_eq!(verified, pk.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn verify_rejects_replay_under_different_peer_id() {
+        // Captured attestation from PEER_A cannot be replayed by someone
+        // claiming to be PEER_B — the signed message includes peer_id.
+        let (pk, sk) = falcon_keygen().unwrap();
+        let req = PydeAuthReq {
+            nonce: generate_nonce(),
+        };
+        let resp = build_auth_resp(&req, PEER_ID_A, &sk, &pk).unwrap();
+
+        assert!(verify_auth_resp(&req, &resp, PEER_ID_B).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_stale_nonce() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let req_signed = PydeAuthReq {
+            nonce: [0x11; 32],
+        };
+        let resp = build_auth_resp(&req_signed, PEER_ID_A, &sk, &pk).unwrap();
+
+        // Fresh request with a different nonce — responder's old sig
+        // should NOT verify against it.
+        let req_current = PydeAuthReq {
+            nonce: [0x22; 32],
+        };
+        assert!(verify_auth_resp(&req_current, &resp, PEER_ID_A).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_pubkey_mismatch() {
+        // Attacker tries to pass off a different pubkey with a valid sig
+        // from a different key. The sig won't verify against the swapped pk.
+        let (pk_real, sk_real) = falcon_keygen().unwrap();
+        let (pk_other, _sk_other) = falcon_keygen().unwrap();
+
+        let req = PydeAuthReq {
+            nonce: generate_nonce(),
+        };
+        let mut resp = build_auth_resp(&req, PEER_ID_A, &sk_real, &pk_real).unwrap();
+        // Swap in an unrelated pubkey.
+        resp.falcon_pubkey = pk_other.as_bytes().to_vec();
+
+        assert!(verify_auth_resp(&req, &resp, PEER_ID_A).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_malformed_signature() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let req = PydeAuthReq {
+            nonce: generate_nonce(),
+        };
+        let mut resp = build_auth_resp(&req, PEER_ID_A, &sk, &pk).unwrap();
+        resp.signature = vec![0u8; 10]; // too short for FALCON-512
+
+        assert!(verify_auth_resp(&req, &resp, PEER_ID_A).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_malformed_pubkey() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let req = PydeAuthReq {
+            nonce: generate_nonce(),
+        };
+        let mut resp = build_auth_resp(&req, PEER_ID_A, &sk, &pk).unwrap();
+        resp.falcon_pubkey = vec![0u8; 5]; // too short
+
+        assert!(verify_auth_resp(&req, &resp, PEER_ID_A).is_none());
+    }
+
+    #[test]
+    fn attestation_message_layout_is_stable() {
+        // Future versions must keep compatibility or bump AUTH_PROTOCOL.
+        // Lock the byte layout in a test so accidental changes are caught.
+        let nonce = [0x42u8; 32];
+        let peer = b"peer";
+        let msg = build_attestation_message(&nonce, peer);
+        assert_eq!(msg.len(), 32 + 4);
+        assert_eq!(&msg[..32], &nonce);
+        assert_eq!(&msg[32..], peer);
+    }
+
+    // ========== apply_auth_response (handshake glue) ==========
+
+    use crate::peer::{Direction, PeerInfo, PeerManager};
+
+    fn fresh_manager_with_peer(id: PeerId) -> PeerManager {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        mgr.add_peer(PeerInfo::new(id, Direction::Inbound));
+        mgr
+    }
+
+    /// Build a genuine attestation using the EOA derived from the FALCON
+    /// pubkey — matches the convention enforced by `apply_auth_response`.
+    fn build_real_attestation(
+        nonce: [u8; 32],
+    ) -> (PydeAuthResp, Vec<u8>, FalconSecretKey) {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let eoa = pyde_account::address::derive_eoa_address(&pk_bytes);
+        let req = PydeAuthReq { nonce };
+        let resp = build_auth_resp(&req, &eoa, &sk, &pk).unwrap();
+        (resp, pk_bytes, sk)
+    }
+
+    #[test]
+    fn apply_auth_response_stores_committee_member_as_validator() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce = generate_nonce();
+        nonces.insert(peer, nonce);
+
+        let (resp, pk_bytes, _sk) = build_real_attestation(nonce);
+        let committee = vec![pk_bytes.clone()];
+
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee);
+        assert_eq!(outcome, AuthOutcome::StoredAsValidator);
+        assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
+        assert_eq!(mgr.get_peer(&peer).unwrap().role, crate::peer::PeerRole::Validator);
+        // Nonce consumed.
+        assert!(!nonces.contains_key(&peer));
+    }
+
+    #[test]
+    fn apply_auth_response_stores_non_committee_peer_as_non_validator() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce = generate_nonce();
+        nonces.insert(peer, nonce);
+
+        let (resp, pk_bytes, _sk) = build_real_attestation(nonce);
+        // Empty committee — peer is attested but not in consensus.
+        let committee: Vec<Vec<u8>> = vec![];
+
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee);
+        assert_eq!(outcome, AuthOutcome::StoredAsNonValidator);
+        assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
+        assert_eq!(mgr.get_peer(&peer).unwrap().role, crate::peer::PeerRole::Unknown);
+    }
+
+    #[test]
+    fn apply_auth_response_rejects_stale_response() {
+        // Peer sends a response but we have no pending nonce for them —
+        // likely a stale or spurious message.
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new(); // nothing for this peer
+
+        let (resp, _, _) = build_real_attestation([0x01; 32]);
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &[]);
+        assert_eq!(outcome, AuthOutcome::NoPendingNonce);
+        assert!(mgr.peer_falcon_pubkey(&peer).is_none());
+    }
+
+    #[test]
+    fn apply_auth_response_rejects_bad_signature() {
+        // Attestation built for a DIFFERENT nonce than the one we sent.
+        // Verification fails.
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce_we_sent = [0x11; 32];
+        nonces.insert(peer, nonce_we_sent);
+
+        let (resp_other_nonce, _, _) = build_real_attestation([0x22; 32]);
+        let outcome =
+            apply_auth_response(peer, &resp_other_nonce, &mut nonces, &mut mgr, &[]);
+        assert_eq!(outcome, AuthOutcome::VerifyFailed);
+        assert!(mgr.peer_falcon_pubkey(&peer).is_none());
+        // Nonce still consumed so the peer can't keep retrying the same slot.
+        assert!(!nonces.contains_key(&peer));
+    }
+
+    #[test]
+    fn apply_auth_response_rejects_rebind_to_different_pubkey() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+
+        // First, legitimately attest pubkey A.
+        let mut nonces = HashMap::new();
+        let nonce_a = generate_nonce();
+        nonces.insert(peer, nonce_a);
+        let (resp_a, _pk_a, _) = build_real_attestation(nonce_a);
+        assert_eq!(
+            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[]),
+            AuthOutcome::StoredAsNonValidator
+        );
+
+        // Same peer tries to re-attest with pubkey B on the same connection.
+        let nonce_b = generate_nonce();
+        nonces.insert(peer, nonce_b);
+        let (resp_b, _pk_b, _) = build_real_attestation(nonce_b);
+        let outcome = apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[]);
+        assert_eq!(outcome, AuthOutcome::RebindRejected);
+    }
+
+    #[test]
+    fn apply_auth_response_idempotent_on_duplicate_same_key() {
+        // Not every duplicate is malicious — a retry can legitimately
+        // re-attest the same key. The set_falcon_pubkey idempotent path
+        // lets this succeed without a rebind error.
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+
+        let mut nonces = HashMap::new();
+        let nonce_a = [0xA1; 32];
+        nonces.insert(peer, nonce_a);
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let eoa = pyde_account::address::derive_eoa_address(&pk_bytes);
+        let resp_a =
+            build_auth_resp(&PydeAuthReq { nonce: nonce_a }, &eoa, &sk, &pk).unwrap();
+        assert_eq!(
+            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[]),
+            AuthOutcome::StoredAsNonValidator
+        );
+
+        // Same peer, same FALCON key, fresh nonce → still accepted.
+        let nonce_b = [0xB2; 32];
+        nonces.insert(peer, nonce_b);
+        let resp_b =
+            build_auth_resp(&PydeAuthReq { nonce: nonce_b }, &eoa, &sk, &pk).unwrap();
+        assert_eq!(
+            apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[]),
+            AuthOutcome::StoredAsNonValidator
+        );
+    }
+}

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -12,6 +12,7 @@
 //! Post-launch hardening: add FALCON peer authentication handshake on connect
 //! to reject impersonators faster (defense-in-depth, not a security fix).
 
+pub mod auth;
 pub mod channels;
 pub mod config;
 pub mod ddos;

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -4,6 +4,7 @@
 //! operations are FALCON-512 signed at the application layer — the Ed25519
 //! identity has no authority over consensus, blocks, or transactions.
 
+use crate::auth::{self, PydeAuthReq, PydeAuthResp};
 use crate::config::NetworkConfig;
 use crate::sync_protocol::{self, SyncReq, SyncResp};
 use libp2p::{
@@ -26,6 +27,8 @@ pub struct PydeBehaviour {
     pub identify: identify::Behaviour,
     /// Request-response for sync protocol (block download, chain tip queries).
     pub sync: request_response::cbor::Behaviour<SyncReq, SyncResp>,
+    /// Request-response for FALCON peer attestation (tasks 029/030).
+    pub auth: request_response::cbor::Behaviour<PydeAuthReq, PydeAuthResp>,
 }
 
 /// Generate a new node keypair. Call once on first run, then persist.
@@ -88,11 +91,15 @@ pub fn create_node(config: &NetworkConfig, local_key: identity::Keypair) -> Resu
             // Sync request-response protocol
             let sync = sync_protocol::sync_behaviour();
 
+            // FALCON peer-attestation protocol (tasks 029/030).
+            let auth = auth::auth_behaviour();
+
             Ok(PydeBehaviour {
                 gossipsub,
                 kademlia,
                 identify,
                 sync,
+                auth,
             })
         })
         .map_err(|e| format!("behaviour error: {e}"))?

--- a/crates/net/src/peer.rs
+++ b/crates/net/src/peer.rs
@@ -42,6 +42,12 @@ pub struct PeerInfo {
     pub messages_received: u64,
     /// Number of invalid messages from this peer (for reputation).
     pub invalid_messages: u64,
+    /// FALCON-512 pubkey the peer attested on connect (task 029). `None`
+    /// until the auth handshake completes; populated via
+    /// `PeerManager::set_falcon_pubkey` after `pyde_net::auth::verify_auth_resp`
+    /// succeeds. Used by the consensus-channel filter (task 030) to drop
+    /// gossip from peers not in the current committee.
+    pub falcon_pubkey: Option<Vec<u8>>,
 }
 
 impl PeerInfo {
@@ -54,6 +60,7 @@ impl PeerInfo {
             ip: None,
             messages_received: 0,
             invalid_messages: 0,
+            falcon_pubkey: None,
         }
     }
 
@@ -204,6 +211,56 @@ impl PeerManager {
         self.peers.values().filter(|p| p.role == PeerRole::Validator)
     }
 
+    /// Record the FALCON pubkey attested by a peer during the auth
+    /// handshake (task 029). Idempotent: re-binding the same pubkey is a
+    /// no-op; rebinding to a different pubkey returns `false` — the caller
+    /// should treat this as a protocol violation (peers cannot change
+    /// their FALCON identity mid-connection without reconnecting).
+    pub fn set_falcon_pubkey(&mut self, peer_id: &PeerId, pubkey: Vec<u8>) -> bool {
+        match self.peers.get_mut(peer_id) {
+            Some(info) => match &info.falcon_pubkey {
+                Some(existing) if existing == &pubkey => true,
+                Some(_) => false,
+                None => {
+                    info.falcon_pubkey = Some(pubkey);
+                    true
+                }
+            },
+            None => false,
+        }
+    }
+
+    /// Promote a peer to `PeerRole::Validator` once its attested FALCON
+    /// pubkey is confirmed to match a current committee key. The node
+    /// layer calls this after each auth handshake completes and after
+    /// every committee rotation.
+    pub fn mark_validator(&mut self, peer_id: &PeerId) -> bool {
+        match self.peers.get_mut(peer_id) {
+            Some(info) => {
+                info.role = PeerRole::Validator;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Look up a peer's attested FALCON pubkey, if any.
+    pub fn peer_falcon_pubkey(&self, peer_id: &PeerId) -> Option<&[u8]> {
+        self.peers.get(peer_id)?.falcon_pubkey.as_deref()
+    }
+
+    /// Evaluate whether a peer is authorized to publish on the
+    /// consensus-topic. A peer is authorized iff their attested FALCON
+    /// pubkey is present in `committee_keys` — missing attestations or
+    /// out-of-committee pubkeys return `false`. Callers drop consensus
+    /// gossip from unauthorized peers (task 030).
+    pub fn is_consensus_authorized(&self, peer_id: &PeerId, committee_keys: &[Vec<u8>]) -> bool {
+        match self.peer_falcon_pubkey(peer_id) {
+            Some(pk) => committee_keys.iter().any(|ck| ck.as_slice() == pk),
+            None => false,
+        }
+    }
+
     /// Evict the peer with lowest reputation. Returns the evicted peer ID.
     pub fn evict_lowest_reputation(&mut self) -> Option<PeerId> {
         let worst = self
@@ -338,5 +395,113 @@ mod tests {
         mgr.add_peer(full);
 
         assert_eq!(mgr.validators().count(), 1);
+    }
+
+    // ========== Task 029/030: FALCON attestation + consensus filter ==========
+
+    #[test]
+    fn set_falcon_pubkey_stores_attestation() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        let pk = vec![0xAA; 897];
+        assert!(mgr.set_falcon_pubkey(&id, pk.clone()));
+        assert_eq!(mgr.peer_falcon_pubkey(&id), Some(pk.as_slice()));
+    }
+
+    #[test]
+    fn set_falcon_pubkey_idempotent_on_rebind_same_key() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        let pk = vec![0xAA; 897];
+        assert!(mgr.set_falcon_pubkey(&id, pk.clone()));
+        // Re-setting to the same key is harmless; common if handshake retries.
+        assert!(mgr.set_falcon_pubkey(&id, pk));
+    }
+
+    #[test]
+    fn set_falcon_pubkey_rejects_rebind_to_different_key() {
+        // A peer switching FALCON identity mid-connection is a protocol
+        // violation — callers treat this as evidence to disconnect.
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        assert!(mgr.set_falcon_pubkey(&id, vec![0xAA; 897]));
+        assert!(!mgr.set_falcon_pubkey(&id, vec![0xBB; 897]));
+        // First key sticks; the rebind attempt is ignored.
+        assert_eq!(mgr.peer_falcon_pubkey(&id), Some(vec![0xAA; 897].as_slice()));
+    }
+
+    #[test]
+    fn set_falcon_pubkey_returns_false_for_unknown_peer() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let id = PeerId::random();
+        assert!(!mgr.set_falcon_pubkey(&id, vec![0xAA; 897]));
+    }
+
+    #[test]
+    fn is_consensus_authorized_accepts_committee_member() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        let committee_pk = vec![0xCC; 897];
+        mgr.set_falcon_pubkey(&id, committee_pk.clone());
+
+        let committee = vec![committee_pk, vec![0xDD; 897]];
+        assert!(mgr.is_consensus_authorized(&id, &committee));
+    }
+
+    #[test]
+    fn is_consensus_authorized_rejects_non_committee_member() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        // Peer has a valid FALCON pubkey, but it's not in the committee.
+        mgr.set_falcon_pubkey(&id, vec![0xEE; 897]);
+        let committee = vec![vec![0xAA; 897], vec![0xBB; 897]];
+        assert!(!mgr.is_consensus_authorized(&id, &committee));
+    }
+
+    #[test]
+    fn is_consensus_authorized_rejects_unattested_peer() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        // No pubkey set → unauthorized, even if committee non-empty.
+        let committee = vec![vec![0xAA; 897]];
+        assert!(!mgr.is_consensus_authorized(&id, &committee));
+    }
+
+    #[test]
+    fn is_consensus_authorized_rejects_unknown_peer() {
+        let mgr = PeerManager::new(10, 10, 10, 100);
+        let id = PeerId::random();
+        let committee = vec![vec![0xAA; 897]];
+        assert!(!mgr.is_consensus_authorized(&id, &committee));
+    }
+
+    #[test]
+    fn mark_validator_updates_role() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Inbound);
+        let id = peer.peer_id;
+        mgr.add_peer(peer);
+
+        assert_eq!(mgr.get_peer(&id).unwrap().role, PeerRole::Unknown);
+        assert!(mgr.mark_validator(&id));
+        assert_eq!(mgr.get_peer(&id).unwrap().role, PeerRole::Validator);
     }
 }

--- a/crates/net/tests/auth_handshake.rs
+++ b/crates/net/tests/auth_handshake.rs
@@ -1,0 +1,194 @@
+//! End-to-end integration test for the FALCON peer-auth protocol.
+//!
+//! Stands up two real libp2p swarms carrying only the `PydeAuth`
+//! request-response behaviour (a slim subset of `PydeBehaviour`, to keep
+//! the test focused on the auth wire format). One swarm dials the other,
+//! initiates a `PydeAuthReq`, the responder signs an attestation, and
+//! the initiator runs `apply_auth_response` to drive the full state
+//! transition — same path as production. This closes the
+//! "pure-function-only" testing gap flagged in the auth unit tests.
+
+use futures::StreamExt;
+use libp2p::{
+    request_response,
+    swarm::{SwarmEvent, NetworkBehaviour},
+    Swarm, SwarmBuilder,
+};
+use pyde_account::address::derive_eoa_address;
+use pyde_crypto::falcon::falcon_keygen;
+use pyde_net::auth::{
+    apply_auth_response, auth_behaviour, build_auth_resp, generate_nonce, AuthOutcome,
+    PydeAuthReq, PydeAuthResp,
+};
+use pyde_net::peer::{Direction, PeerInfo, PeerManager, PeerRole};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[derive(NetworkBehaviour)]
+struct AuthOnly {
+    auth: request_response::cbor::Behaviour<PydeAuthReq, PydeAuthResp>,
+}
+
+fn build_swarm() -> Swarm<AuthOnly> {
+    SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_quic()
+        .with_behaviour(|_| AuthOnly { auth: auth_behaviour() })
+        .expect("behaviour ok")
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
+        .build()
+}
+
+/// Drive both swarms' event loops until the initiator records an
+/// `AuthOutcome`, returning the outcome and final peer-manager state.
+/// Times out on failure so test suites don't hang.
+async fn run_handshake(
+    mut initiator: Swarm<AuthOnly>,
+    mut responder: Swarm<AuthOnly>,
+    responder_pubkey: Vec<u8>,
+    responder_sk: pyde_crypto::falcon::FalconSecretKey,
+    responder_pk: pyde_crypto::falcon::FalconPublicKey,
+    committee_keys: Vec<Vec<u8>>,
+) -> (AuthOutcome, PeerManager, Vec<u8>) {
+    // Both sides listen on a random loopback port.
+    initiator
+        .listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap())
+        .unwrap();
+    responder
+        .listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap())
+        .unwrap();
+
+    // Pump until both have concrete listen addrs, then have A dial B.
+    let responder_addr = loop {
+        tokio::select! {
+            event = responder.select_next_some() => {
+                if let SwarmEvent::NewListenAddr { address, .. } = event {
+                    break address;
+                }
+            }
+            _ = initiator.select_next_some() => {}
+        }
+    };
+    let responder_peer_id = *responder.local_peer_id();
+    let full_addr = responder_addr
+        .with(libp2p::multiaddr::Protocol::P2p(responder_peer_id));
+    initiator.dial(full_addr).unwrap();
+
+    // Track initiator state.
+    let mut nonces: HashMap<libp2p::PeerId, [u8; 32]> = HashMap::new();
+    let mut peer_manager = PeerManager::new(10, 10, 10, 100);
+    let mut connected_peer: Option<libp2p::PeerId> = None;
+    let mut sent_request = false;
+    let mut outcome: Option<AuthOutcome> = None;
+
+    // 5-second test budget. Handshake typically completes in <200ms over
+    // loopback; this is defense against CI flakiness.
+    let driver = async {
+        loop {
+            if outcome.is_some() {
+                break;
+            }
+            tokio::select! {
+                ev = initiator.select_next_some() => {
+                    match ev {
+                        SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                            peer_manager.add_peer(PeerInfo::new(peer_id, Direction::Outbound));
+                            connected_peer = Some(peer_id);
+                        }
+                        SwarmEvent::Behaviour(AuthOnlyEvent::Auth(
+                            request_response::Event::Message {
+                                message: request_response::Message::Response { response, .. },
+                                peer,
+                            },
+                        )) => {
+                            outcome = Some(apply_auth_response(
+                                peer,
+                                &response,
+                                &mut nonces,
+                                &mut peer_manager,
+                                &committee_keys,
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+                ev = responder.select_next_some() => {
+                    if let SwarmEvent::Behaviour(AuthOnlyEvent::Auth(
+                        request_response::Event::Message {
+                            message: request_response::Message::Request { request, channel, .. },
+                            ..
+                        },
+                    )) = ev {
+                        let eoa = derive_eoa_address(&responder_pubkey);
+                        let resp = build_auth_resp(&request, &eoa, &responder_sk, &responder_pk).unwrap();
+                        let _ = responder.behaviour_mut().auth.send_response(channel, resp);
+                    }
+                }
+            }
+            // Fire the outbound request once the initiator is connected.
+            if !sent_request {
+                if let Some(peer) = connected_peer {
+                    let nonce = generate_nonce();
+                    nonces.insert(peer, nonce);
+                    initiator
+                        .behaviour_mut()
+                        .auth
+                        .send_request(&peer, PydeAuthReq { nonce });
+                    sent_request = true;
+                }
+            }
+        }
+    };
+
+    timeout(Duration::from_secs(5), driver)
+        .await
+        .expect("handshake timed out");
+
+    (outcome.unwrap(), peer_manager, responder_pubkey)
+}
+
+#[tokio::test]
+async fn end_to_end_handshake_with_committee_member() {
+    // Responder holds a FALCON key that's in the committee list — initiator
+    // should end up recording the attestation AND promoting the peer to
+    // validator.
+    let (pk, sk) = falcon_keygen().unwrap();
+    let pk_bytes = pk.as_bytes().to_vec();
+    let committee = vec![pk_bytes.clone()];
+
+    let initiator = build_swarm();
+    let responder = build_swarm();
+    let (outcome, mgr, expected_pk) = run_handshake(
+        initiator, responder, pk_bytes, sk, pk, committee,
+    )
+    .await;
+
+    assert_eq!(outcome, AuthOutcome::StoredAsValidator);
+    // Exactly one peer tracked by the initiator — the responder.
+    let peer_id = mgr.all_peers().next().map(|p| p.peer_id).unwrap();
+    assert_eq!(mgr.peer_falcon_pubkey(&peer_id), Some(expected_pk.as_slice()));
+    assert_eq!(mgr.get_peer(&peer_id).unwrap().role, PeerRole::Validator);
+}
+
+#[tokio::test]
+async fn end_to_end_handshake_with_non_committee_peer() {
+    // Responder is NOT in the committee — attestation should land but role
+    // stays Unknown. Consensus-topic filter on the node side would then
+    // drop consensus messages from this peer.
+    let (pk, sk) = falcon_keygen().unwrap();
+    let pk_bytes = pk.as_bytes().to_vec();
+    let committee: Vec<Vec<u8>> = vec![]; // empty committee
+
+    let initiator = build_swarm();
+    let responder = build_swarm();
+    let (outcome, mgr, expected_pk) = run_handshake(
+        initiator, responder, pk_bytes, sk, pk, committee,
+    )
+    .await;
+
+    assert_eq!(outcome, AuthOutcome::StoredAsNonValidator);
+    let peer_id = mgr.all_peers().next().map(|p| p.peer_id).unwrap();
+    assert_eq!(mgr.peer_falcon_pubkey(&peer_id), Some(expected_pk.as_slice()));
+    assert_eq!(mgr.get_peer(&peer_id).unwrap().role, PeerRole::Unknown);
+}

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -214,6 +214,21 @@ impl PydeNode {
         chain_sync.manager.local_tip = chain.read().await.head_slot;
         let mut pinned_snapshot: Option<crate::sync::PinnedSnapshot> = None;
 
+        // Peer tracking for task 029/030 FALCON attestation + consensus filter.
+        // Sized generously — the mempool pool is 500K, validator mesh is 128
+        // with gossipsub fan-out reaching ~30 peers in practice.
+        let mut peer_manager = pyde_net::peer::PeerManager::new(
+            /* max_peers */ 200,
+            /* max_inbound */ 150,
+            /* max_outbound */ 150,
+            /* rate_limit_per_ip */ 10,
+        );
+        // Nonces we've sent out in outbound auth requests, keyed by peer.
+        // Populated in `SendAuthRequest`, consumed when the matching
+        // `PydeAuthResp` arrives.
+        let mut pending_auth_nonces: std::collections::HashMap<libp2p::PeerId, [u8; 32]> =
+            std::collections::HashMap::new();
+
         // 5. Validator engine + identity (only for validator role)
         let mut validator_identity: Option<ValidatorIdentity> = None;
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
@@ -487,6 +502,8 @@ impl PydeNode {
                             &mut validator_identity,
                             &block_store,
                             &mut pinned_snapshot,
+                            &mut peer_manager,
+                            &mut pending_auth_nonces,
                         )
                     };
 
@@ -498,6 +515,20 @@ impl PydeNode {
                         }
                         PostEventAction::SendSyncResponse(channel, response) => {
                             let _ = swarm.behaviour_mut().sync.send_response(channel, response);
+                        }
+                        PostEventAction::SendAuthRequest(peer) => {
+                            // Generate a fresh nonce, record it, send the request.
+                            // We only authenticate to peers once; if a response is
+                            // already pending we skip to avoid stacking nonces.
+                            if !pending_auth_nonces.contains_key(&peer) {
+                                let nonce = pyde_net::auth::generate_nonce();
+                                pending_auth_nonces.insert(peer, nonce);
+                                let req = pyde_net::auth::PydeAuthReq { nonce };
+                                let _ = swarm.behaviour_mut().auth.send_request(&peer, req);
+                            }
+                        }
+                        PostEventAction::SendAuthResponse(channel, resp) => {
+                            let _ = swarm.behaviour_mut().auth.send_response(channel, resp);
                         }
                         PostEventAction::ContinueSync => {
                             // If chunked snapshot in progress, request next chunk
@@ -1406,6 +1437,17 @@ enum PostEventAction {
     },
     ReconstructCompactBlock(pyde_net::propagation::CompactBlock),
     AddDecryptionShares(wire::DecryptionShareMsg),
+    /// Send a `PydeAuthReq` to a newly connected peer. The main loop
+    /// generates a fresh nonce, records it in `pending_auth_nonces`, and
+    /// dispatches via the swarm.
+    SendAuthRequest(PeerId),
+    /// Reply to an inbound `PydeAuthReq` with a signed attestation over
+    /// `(nonce, our_peer_id)`. The response channel holds the pending
+    /// outbound stream to the requester.
+    SendAuthResponse(
+        request_response::ResponseChannel<pyde_net::auth::PydeAuthResp>,
+        pyde_net::auth::PydeAuthResp,
+    ),
 }
 
 /// Handle a libp2p swarm event. Returns an action that may need swarm access.
@@ -1419,11 +1461,13 @@ fn handle_swarm_event(
     validator_identity: &mut Option<ValidatorIdentity>,
     block_store: &BlockStore,
     pinned_snapshot: &mut Option<crate::sync::PinnedSnapshot>,
+    peer_manager: &mut pyde_net::peer::PeerManager,
+    pending_auth_nonces: &mut std::collections::HashMap<PeerId, [u8; 32]>,
 ) -> PostEventAction {
     match event {
         // --- Gossipsub message received ---
         SwarmEvent::Behaviour(PydeBehaviourEvent::Gossipsub(
-            gossipsub::Event::Message { message, .. },
+            gossipsub::Event::Message { message, propagation_source, .. },
         )) => {
             let topic = message.topic.to_string();
             let channel = Channel::from_topic(&topic);
@@ -1530,6 +1574,56 @@ fn handle_swarm_event(
                     }
                 }
                 Some(Channel::Consensus) => {
+                    // Task 030: block non-validator relays of consensus
+                    // gossip. Two layered checks:
+                    //
+                    // 1. `propagation_source` — the DIRECT peer that
+                    //    forwarded this message to us. Every in-mesh peer
+                    //    has attempted our FALCON handshake, so an
+                    //    attested-non-committee propagator is a solid
+                    //    signal of a non-validator spamming the mesh.
+                    //    Drop hard.
+                    // 2. `message.source` — the ORIGINATOR. We may or may
+                    //    not have shaken hands with them (they might not
+                    //    be in our mesh at all). When we have, applying
+                    //    the same committee check blocks originator-level
+                    //    impersonation too.
+                    //
+                    // Unattested peers in either slot fall through to
+                    // app-layer FALCON sig verification — which catches
+                    // forgeries but pays the decode + verify cost.
+                    if let Some(engine) = validator_engine.as_ref() {
+                        // Primary: immediate forwarder.
+                        let prop_attested = peer_manager.peer_falcon_pubkey(&propagation_source).is_some();
+                        let prop_authorized = peer_manager
+                            .is_consensus_authorized(&propagation_source, &engine.committee_keys);
+                        if prop_attested && !prop_authorized {
+                            debug!(
+                                forwarder = %propagation_source,
+                                "dropping consensus gossip relayed by non-committee attested peer"
+                            );
+                            if let Some(info) = peer_manager.get_peer_mut(&propagation_source) {
+                                info.invalid_messages = info.invalid_messages.saturating_add(1);
+                            }
+                            return PostEventAction::None;
+                        }
+                        // Secondary: originator, when known.
+                        if let Some(source) = message.source.as_ref() {
+                            let src_attested = peer_manager.peer_falcon_pubkey(source).is_some();
+                            let src_authorized = peer_manager
+                                .is_consensus_authorized(source, &engine.committee_keys);
+                            if src_attested && !src_authorized {
+                                debug!(
+                                    %source,
+                                    "dropping consensus gossip originated by non-committee attested peer"
+                                );
+                                if let Some(info) = peer_manager.get_peer_mut(source) {
+                                    info.invalid_messages = info.invalid_messages.saturating_add(1);
+                                }
+                                return PostEventAction::None;
+                            }
+                        }
+                    }
                     if let Some(engine) = validator_engine.as_mut() {
                         // Check if it's a finality vote (different wire tag)
                         if !message.data.is_empty() && message.data[0] == wire::tag::CONSENSUS_FINALITY_VOTE {
@@ -1743,7 +1837,105 @@ fn handle_swarm_event(
             PostEventAction::None
         }
 
-        // --- Peer connected: ask for their chain tip ---
+        // --- Auth: inbound PydeAuthReq from a peer ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Auth(
+            request_response::Event::Message {
+                message: request_response::Message::Request { request, channel, .. },
+                peer,
+            },
+        )) => {
+            // Only validators can answer auth challenges — they're the only
+            // ones with a FALCON keypair. Full nodes stay silent; the
+            // requester will simply have no attestation to record for
+            // this peer, which is fine (they'll be treated as a
+            // non-validator by the consensus filter).
+            match validator_identity.as_ref() {
+                Some(id) => {
+                    let our_peer_bytes = id.address; // 32-byte EOA derived from FALCON pk
+                    match pyde_net::auth::build_auth_resp(
+                        &request,
+                        &our_peer_bytes,
+                        &id.secret_key,
+                        &id.public_key,
+                    ) {
+                        Ok(resp) => {
+                            debug!(%peer, "sending auth attestation");
+                            PostEventAction::SendAuthResponse(channel, resp)
+                        }
+                        Err(e) => {
+                            warn!(%peer, error = %e, "failed to build auth response");
+                            PostEventAction::None
+                        }
+                    }
+                }
+                None => {
+                    debug!(%peer, "ignoring auth request — no validator identity");
+                    PostEventAction::None
+                }
+            }
+        }
+
+        // --- Auth: response to our outbound PydeAuthReq ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Auth(
+            request_response::Event::Message {
+                message: request_response::Message::Response { response, .. },
+                peer,
+            },
+        )) => {
+            // All handshake logic lives in `apply_auth_response` so this
+            // arm stays purely the swarm-event adapter. Keeps the state
+            // transitions testable without a live libp2p swarm.
+            let committee_keys = validator_engine
+                .as_ref()
+                .map(|e| e.committee_keys.clone())
+                .unwrap_or_default();
+            let outcome = pyde_net::auth::apply_auth_response(
+                peer,
+                &response,
+                pending_auth_nonces,
+                peer_manager,
+                &committee_keys,
+            );
+            use pyde_net::auth::AuthOutcome;
+            match outcome {
+                AuthOutcome::StoredAsValidator => {
+                    info!(%peer, "peer attested as committee validator");
+                }
+                AuthOutcome::StoredAsNonValidator => {
+                    debug!(%peer, "peer attested as non-validator");
+                }
+                AuthOutcome::NoPendingNonce => {
+                    debug!(%peer, "unexpected auth response (no pending nonce)");
+                }
+                AuthOutcome::VerifyFailed => {
+                    warn!(%peer, "FALCON attestation failed verification");
+                }
+                AuthOutcome::RebindRejected => {
+                    warn!(%peer, "peer attempted to rebind FALCON pubkey — ignoring");
+                }
+            }
+            PostEventAction::None
+        }
+
+        // --- Auth failures ---
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Auth(
+            request_response::Event::OutboundFailure { peer, error, .. },
+        )) => {
+            debug!(%peer, ?error, "auth request failed");
+            pending_auth_nonces.remove(&peer);
+            PostEventAction::None
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Auth(
+            request_response::Event::InboundFailure { peer, error, .. },
+        )) => {
+            debug!(%peer, ?error, "auth inbound failed");
+            PostEventAction::None
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::Auth(
+            request_response::Event::ResponseSent { .. },
+        )) => PostEventAction::None,
+
+        // --- Peer connected: register + ask for chain tip + trigger auth handshake ---
         SwarmEvent::ConnectionEstablished {
             peer_id, endpoint, ..
         } => {
@@ -1752,7 +1944,19 @@ fn handle_swarm_event(
                 addr = %endpoint.get_remote_address(),
                 "peer connected"
             );
-            PostEventAction::RequestChainTip(peer_id)
+            // Track the peer so attested pubkeys can later be stored.
+            // Direction + IP are best-effort; we don't enforce inbound
+            // limits here because libp2p already handled transport.
+            let direction = match &endpoint {
+                libp2p::core::ConnectedPoint::Dialer { .. } => pyde_net::peer::Direction::Outbound,
+                libp2p::core::ConnectedPoint::Listener { .. } => pyde_net::peer::Direction::Inbound,
+            };
+            let info = pyde_net::peer::PeerInfo::new(peer_id, direction);
+            peer_manager.add_peer(info);
+
+            // Task 029: kick off the FALCON attestation handshake so the
+            // consensus filter (task 030) has a pubkey to check.
+            PostEventAction::SendAuthRequest(peer_id)
         }
 
         // --- Peer disconnected ---
@@ -1764,6 +1968,8 @@ fn handle_swarm_event(
                 cause = ?cause,
                 "peer disconnected"
             );
+            peer_manager.remove_peer(&peer_id);
+            pending_auth_nonces.remove(&peer_id);
             PostEventAction::None
         }
 


### PR DESCRIPTION
## Summary

Closes "anyone on the mesh can spam consensus gossip" by binding each
libp2p peer to a FALCON identity at connect time (task 029) and
filtering consensus-topic messages from non-committee peers at both
the forwarding and origination layers (task 030). Transport encryption
via libp2p noise/QUIC is unchanged; this adds FALCON-level application
identity on top.

## Protocol

1. New libp2p request-response behaviour on \`/pyde/auth/1\`.
2. On \`ConnectionEstablished\`, the local node sends \`PydeAuthReq { nonce }\`.
3. Responder (validators only) replies with \`PydeAuthResp { falcon_pubkey, signature }\` where signature is FALCON-512 over \`nonce || derive_eoa_address(pubkey)\`.
4. \`apply_auth_response\` verifies, stores the peer→pubkey binding in \`PeerManager\`, and promotes the peer to \`PeerRole::Validator\` when \`pubkey ∈ committee_keys\`. Returns \`AuthOutcome\` for telemetry.

## Consensus filter (task 030)

Two-layer check on every gossip message on \`pyde/consensus/1\`:

1. **Primary — \`propagation_source\`** (immediate forwarder; always a direct peer we handshook with). Attested-non-committee → drop + reputation hit. Catches non-validator relay spam at the edge.
2. **Secondary — \`message.source\`** (originator; may be non-neighbor). Same rule applied when we have a binding for them.
3. Unattested peers in either slot fall through to existing app-layer FALCON sig verification.

## Changes

**pyde-net (new \`auth.rs\`):**
- \`PydeAuthReq/Resp\`, \`build_attestation_message\`, \`build_auth_resp\`, \`verify_auth_resp\`, \`generate_nonce\`, \`auth_behaviour()\`.
- \`apply_auth_response\` — pure function encapsulating handshake state transitions.
- \`AuthOutcome\` enum: \`StoredAsValidator\`, \`StoredAsNonValidator\`, \`NoPendingNonce\`, \`VerifyFailed\`, \`RebindRejected\`.

**pyde-net::peer:**
- \`PeerInfo.falcon_pubkey: Option<Vec<u8>>\`.
- \`PeerManager::set_falcon_pubkey\`, \`mark_validator\`, \`peer_falcon_pubkey\`, \`is_consensus_authorized\`.

**pyde-net::node:** \`auth\` added to \`PydeBehaviour\`.

**pyde-node:**
- \`PeerManager\` + \`pending_auth_nonces\` tracked in \`run()\` runtime state.
- \`PostEventAction::SendAuthRequest / SendAuthResponse\`.
- Auth event handlers delegate to \`apply_auth_response\`.
- Consensus filter checks \`propagation_source\` + \`message.source\`.

## Tests (25 new)

**pyde-net::auth (14):**
- Primitives (8): nonce uniqueness, honest roundtrip, replay / stale / pubkey-mismatch / malformed-sig / malformed-pk / layout-stability.
- \`apply_auth_response\` outcomes (6): committee-validator storage, non-committee storage, stale-response, bad-signature, rebind-rejection, same-key idempotency.

**pyde-net::peer (9):**
- FALCON pubkey storage (4): stores, idempotent rebind, rejects-different-rebind, unknown-peer-rejection.
- Consensus authorization (4): accepts-committee, rejects-non-committee, rejects-unattested, rejects-unknown-peer.
- \`mark_validator\` role update.

**pyde-net integration (2, \`tests/auth_handshake.rs\`):**
- \`end_to_end_handshake_with_committee_member\` — two real swarms over QUIC loopback, initiator → responder handshake, asserts validator promotion.
- \`end_to_end_handshake_with_non_committee_peer\` — same but empty committee; asserts \`StoredAsNonValidator\` + role stays \`Unknown\`.

Full workspace test run: green. Integration tests complete in <100ms each; 5s tokio budget guards against CI flakiness.