### PR TITLE
feat: cross-committee threshold resharing at epoch rotation

### DIFF
--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -676,6 +676,270 @@ pub fn pss_refresh(
     (new_material, new_shares)
 }
 
+// ==========================================================================
+// Cross-committee resharing (task 034)
+// ==========================================================================
+//
+// PSS (`RefreshContribution` / `apply_refresh`) refreshes shares among the
+// *same* committee. Real committee rotation requires transferring trust from
+// an OLD committee to a DIFFERENT NEW committee. The construction below is
+// classical share-transfer resharing (Desmedt/Jajodia):
+//
+// 1. Each old member `i` with share `s_i` of the secret polynomial `f` (of
+//    degree `old_t - 1`, with `f(0) = secret`) picks a fresh polynomial
+//    `g_i` of degree `new_t - 1` with `g_i(0) = s_i` and evaluates at each
+//    new member index: `sub_shares[j] = g_i(j)` for j in 1..=new_n.
+// 2. New member `j` collects `{g_i(j) : i ∈ canonical old-subset S}` from
+//    gossip. They compute `H(j) = Σ_{i ∈ S} λ_i(0) · g_i(j)`, where
+//    `λ_i(0)` is the Lagrange coefficient reconstructing `f(0)` from shares
+//    at `S`. The new share of member j is `H(j)`.
+// 3. Because `λ_i(0) · g_i(0) = λ_i(0) · s_i = λ_i(0) · f(i)`, summing over
+//    `S` gives `H(0) = Σ_{i ∈ S} λ_i(0) · f(i) = f(0) = secret`. So `H` is
+//    a valid new polynomial with the SAME secret.
+// 4. The public key is invariant across resharing — so in-flight mempool
+//    ciphertexts (encrypted under the committee's aggregate public key)
+//    stay decryptable by the new committee. No re-encryption required.
+//
+// **Determinism is load-bearing**: every new member must use the identical
+// old-subset `S`. Otherwise, new members end up on different polynomials `H`
+// and threshold decryption across the new committee breaks. The canonical
+// rule is `threshold` lowest-indexed old members whose contributions have
+// been gossiped; `canonical_resharing_subset` enforces this.
+
+/// Sub-share package from one old committee member to all new committee
+/// members. `sub_shares[j-1][e]` is `g_i(j)` — old member i's new-polynomial
+/// evaluated at new index j, for the e-th seed element.
+#[derive(Clone, Debug)]
+pub struct ResharingContribution {
+    /// 1-based index of the old committee member that produced this.
+    pub from_old_index: usize,
+    /// Length = new_n. Each inner vec has length SEED_ELEMENTS.
+    sub_shares: Vec<Vec<Goldilocks>>,
+}
+
+impl ResharingContribution {
+    /// Wire format:
+    /// [from_old_index:8 LE][new_n:4 LE][elems:4 LE][[g:8 LE]*elems]*new_n
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let n = self.sub_shares.len();
+        let elems = if n > 0 { self.sub_shares[0].len() } else { 0 };
+        let mut buf = Vec::with_capacity(16 + n * elems * 8);
+        buf.extend_from_slice(&(self.from_old_index as u64).to_le_bytes());
+        buf.extend_from_slice(&(n as u32).to_le_bytes());
+        buf.extend_from_slice(&(elems as u32).to_le_bytes());
+        for row in &self.sub_shares {
+            for g in row {
+                buf.extend_from_slice(&gl_to_u64(*g).to_le_bytes());
+            }
+        }
+        buf
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Option<Self> {
+        if data.len() < 16 { return None; }
+        let from_old_index = u64::from_le_bytes(data[0..8].try_into().ok()?) as usize;
+        let n = u32::from_le_bytes(data[8..12].try_into().ok()?) as usize;
+        let elems = u32::from_le_bytes(data[12..16].try_into().ok()?) as usize;
+        if data.len() < 16 + n * elems * 8 { return None; }
+        let mut sub_shares = Vec::with_capacity(n);
+        let mut off = 16;
+        for _ in 0..n {
+            let mut row = Vec::with_capacity(elems);
+            for _ in 0..elems {
+                let v = u64::from_le_bytes(data[off..off + 8].try_into().ok()?);
+                row.push(gl(v));
+                off += 8;
+            }
+            sub_shares.push(row);
+        }
+        Some(Self { from_old_index, sub_shares })
+    }
+
+    /// Expose `new_n` (number of new committee members this contribution targets).
+    pub fn new_n(&self) -> usize {
+        self.sub_shares.len()
+    }
+}
+
+/// Generate one old member's share-transfer contribution for the new
+/// committee. Each seed element of the old share becomes the constant term
+/// of a fresh degree-(new_threshold-1) polynomial, evaluated at new indices
+/// 1..=new_n.
+pub fn generate_resharing_contribution(
+    old_share: &KeyShare,
+    new_n: usize,
+    new_threshold: usize,
+    epoch: u64,
+    entropy: &[u8],
+) -> ResharingContribution {
+    // Domain-separate by epoch + old-index so different old members
+    // generate independent polynomials from the same public entropy.
+    let mut dom_in = Vec::with_capacity(entropy.len() + 24);
+    dom_in.extend_from_slice(entropy);
+    dom_in.extend_from_slice(b"pyde-reshare");
+    dom_in.extend_from_slice(&epoch.to_le_bytes());
+    dom_in.extend_from_slice(&(old_share.index as u64).to_le_bytes());
+    let dom_entropy = poseidon2_hash(&dom_in);
+
+    // For each seed element: polynomial with g(0) = old_share.shares[elem],
+    // evaluated at new indices 1..=new_n via shamir_split (secret = g(0)).
+    let mut per_elem: Vec<Vec<Goldilocks>> = Vec::with_capacity(SEED_ELEMENTS);
+    for elem_idx in 0..SEED_ELEMENTS {
+        let shares = shamir_split(
+            old_share.shares[elem_idx],
+            new_n,
+            new_threshold,
+            dom_entropy.as_bytes(),
+            elem_idx,
+        );
+        per_elem.push(shares.iter().map(|s| s.y).collect());
+    }
+
+    // Transpose to sub_shares[new_idx][elem_idx].
+    let sub_shares: Vec<Vec<Goldilocks>> = (0..new_n)
+        .map(|v| (0..SEED_ELEMENTS).map(|e| per_elem[e][v]).collect())
+        .collect();
+
+    ResharingContribution {
+        from_old_index: old_share.index,
+        sub_shares,
+    }
+}
+
+/// Verify a resharing contribution is internally consistent — i.e. its
+/// sub-shares truly lie on a single polynomial of degree `new_threshold - 1`
+/// per seed element. Interpolates a threshold subset, then re-evaluates at
+/// remaining new indices and compares against the provided values. A
+/// malicious old member could fabricate inconsistent points; this catches it.
+pub fn verify_resharing_contribution(
+    contribution: &ResharingContribution,
+    new_threshold: usize,
+    new_n: usize,
+) -> bool {
+    if contribution.sub_shares.len() != new_n {
+        return false;
+    }
+    if new_threshold == 0 || new_threshold > new_n {
+        return false;
+    }
+    for row in &contribution.sub_shares {
+        if row.len() != SEED_ELEMENTS {
+            return false;
+        }
+    }
+    // For each seed element, interpolate first `new_threshold` sub-shares
+    // and verify the remaining ones match via Lagrange evaluation.
+    for elem_idx in 0..SEED_ELEMENTS {
+        let interp_shares: Vec<FieldShare> = (0..new_threshold)
+            .map(|v| FieldShare {
+                x: gl((v + 1) as u64),
+                y: contribution.sub_shares[v][elem_idx],
+            })
+            .collect();
+        for check_idx in new_threshold..new_n {
+            let check_x = gl((check_idx + 1) as u64);
+            let mut y = Goldilocks::ZERO;
+            for i in 0..new_threshold {
+                let x_i = interp_shares[i].x;
+                let mut basis = Goldilocks::ONE;
+                for j in 0..new_threshold {
+                    if i != j {
+                        let x_j = interp_shares[j].x;
+                        let num = check_x - x_j;
+                        let den = x_i - x_j;
+                        basis *= num * gl_inv(den);
+                    }
+                }
+                y += interp_shares[i].y * basis;
+            }
+            if y != contribution.sub_shares[check_idx][elem_idx] {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Pick the deterministic canonical subset of old contributions every new
+/// member must use: the `old_threshold` contributions with the LOWEST
+/// `from_old_index` values. Returns `None` if fewer than `old_threshold`
+/// contributions are available. All new members converge on the same
+/// polynomial when they apply this rule.
+pub fn canonical_resharing_subset<'a>(
+    pool: &'a [ResharingContribution],
+    old_threshold: usize,
+) -> Option<Vec<&'a ResharingContribution>> {
+    if pool.len() < old_threshold {
+        return None;
+    }
+    let mut refs: Vec<&ResharingContribution> = pool.iter().collect();
+    refs.sort_by_key(|c| c.from_old_index);
+    refs.truncate(old_threshold);
+    Some(refs)
+}
+
+/// Aggregate a canonical subset of resharing contributions into a single
+/// new `KeyShare` for the given new-committee index. Lagrange coefficients
+/// are computed over the OLD indices in `canonical`, so all new members
+/// that apply this function to the same canonical subset converge on the
+/// same underlying polynomial.
+pub fn aggregate_new_share(
+    new_index: usize,
+    canonical: &[&ResharingContribution],
+) -> Option<KeyShare> {
+    if canonical.is_empty() || new_index == 0 {
+        return None;
+    }
+    let new_idx0 = new_index - 1;
+    // All contributions must target the same new_n and expose our new_idx.
+    let new_n = canonical[0].sub_shares.len();
+    if new_idx0 >= new_n {
+        return None;
+    }
+    for c in canonical.iter() {
+        if c.sub_shares.len() != new_n {
+            return None;
+        }
+        if c.sub_shares[new_idx0].len() != SEED_ELEMENTS {
+            return None;
+        }
+    }
+
+    // Lagrange coefficients at x=0 for the OLD indices.
+    let old_indices: Vec<Goldilocks> = canonical
+        .iter()
+        .map(|c| gl(c.from_old_index as u64))
+        .collect();
+    let lambdas: Vec<Goldilocks> = (0..canonical.len())
+        .map(|i| {
+            let x_i = old_indices[i];
+            let mut basis = Goldilocks::ONE;
+            for j in 0..canonical.len() {
+                if i != j {
+                    let x_j = old_indices[j];
+                    let num = Goldilocks::ZERO - x_j;
+                    let den = x_i - x_j;
+                    basis *= num * gl_inv(den);
+                }
+            }
+            basis
+        })
+        .collect();
+
+    // Combine: new_share[e] = Σ_i λ_i · g_i(new_index) for each element e.
+    let mut new_shares = vec![Goldilocks::ZERO; SEED_ELEMENTS];
+    for (i, contrib) in canonical.iter().enumerate() {
+        for elem_idx in 0..SEED_ELEMENTS {
+            new_shares[elem_idx] += lambdas[i] * contrib.sub_shares[new_idx0][elem_idx];
+        }
+    }
+
+    Some(KeyShare {
+        index: new_index,
+        shares: new_shares,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;
@@ -985,5 +1249,184 @@ mod tests {
             .collect();
         let plaintext = combine_shares(&dec_shares, 7, &ct).unwrap();
         assert_eq!(plaintext, msg);
+    }
+
+    // ======================================================================
+    // Resharing (task 034): cross-committee share transfer
+    // ======================================================================
+
+    /// Drive a full resharing from old shares at indices `old_indices` (with
+    /// threshold `old_t`) to a new committee of size `new_n` with threshold
+    /// `new_t`. Returns new KeyShares. Pure-function harness used by the
+    /// tests below.
+    fn do_resharing(
+        old_shares: &[KeyShare],
+        old_t: usize,
+        new_n: usize,
+        new_t: usize,
+        epoch: u64,
+    ) -> Vec<KeyShare> {
+        // Each old member produces one contribution. Public entropy is the
+        // epoch; domain separation by old-index happens inside the fn.
+        let entropy = epoch.to_le_bytes();
+        let pool: Vec<ResharingContribution> = old_shares
+            .iter()
+            .map(|s| generate_resharing_contribution(s, new_n, new_t, epoch, &entropy))
+            .collect();
+        let canonical = canonical_resharing_subset(&pool, old_t).unwrap();
+        (1..=new_n)
+            .map(|j| aggregate_new_share(j, &canonical).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn reshare_preserves_secret_and_decrypts_old_ciphertext() {
+        // Encrypt under the epoch-0 public key, rotate to an entirely new
+        // committee via resharing, and verify the new shares still decrypt
+        // the original ciphertext — proves the public key is invariant.
+        let (epoch_mat, old_shares) = setup_epoch(10, 7);
+        let msg = b"committee rotation preserves decryptability";
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
+
+        // New committee: 8 members, threshold 5 — different size AND
+        // different members than the original.
+        let new_shares = do_resharing(&old_shares, 7, 8, 5, 1);
+
+        // Five new members (their new threshold) suffice to decrypt.
+        let dec_shares: Vec<DecryptionShare> = new_shares[..5]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let plaintext = combine_shares(&dec_shares, 5, &ct).unwrap();
+        assert_eq!(plaintext, msg);
+    }
+
+    #[test]
+    fn reshare_any_subset_of_new_committee_suffices() {
+        // Verify that any subset of size >= new_threshold from the new
+        // committee can combine — ensures all new members sit on the same
+        // polynomial (the whole point of the canonical-subset rule).
+        let (epoch_mat, old_shares) = setup_epoch(8, 5);
+        let msg = b"interchangeable new shares";
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
+
+        let new_shares = do_resharing(&old_shares, 5, 10, 7, 2);
+
+        // Two different subsets of size 7 — both should decrypt.
+        let subset_a: Vec<DecryptionShare> = new_shares[..7]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let subset_b: Vec<DecryptionShare> = new_shares[3..10]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+
+        assert_eq!(combine_shares(&subset_a, 7, &ct).unwrap(), msg);
+        assert_eq!(combine_shares(&subset_b, 7, &ct).unwrap(), msg);
+    }
+
+    #[test]
+    fn reshare_below_old_threshold_contributions_fails() {
+        // Fewer than `old_threshold` contributions available → canonical
+        // subset selection returns None. Enforcement lives with the caller.
+        let (_, old_shares) = setup_epoch(6, 4);
+        let pool: Vec<ResharingContribution> = old_shares[..3]
+            .iter()
+            .map(|s| generate_resharing_contribution(s, 8, 5, 1, b"e"))
+            .collect();
+        assert!(canonical_resharing_subset(&pool, /* old_threshold */ 4).is_none());
+    }
+
+    #[test]
+    fn reshare_canonical_subset_is_lowest_indexed() {
+        // Determinism: regardless of iteration order, canonical subset is
+        // the threshold lowest old-indices. This guarantees convergence
+        // across new members.
+        let (_, old_shares) = setup_epoch(6, 3);
+        let pool: Vec<ResharingContribution> = old_shares
+            .iter()
+            .rev() // reversed to test sorting
+            .map(|s| generate_resharing_contribution(s, 4, 3, 1, b"e"))
+            .collect();
+        let canonical = canonical_resharing_subset(&pool, 3).unwrap();
+        let picked: Vec<usize> = canonical.iter().map(|c| c.from_old_index).collect();
+        assert_eq!(picked, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn reshare_two_new_members_converge_on_same_polynomial() {
+        // If two new members apply aggregation to the canonical subset,
+        // their resulting shares must be combinable (sit on one polynomial).
+        let (epoch_mat, old_shares) = setup_epoch(6, 4);
+        let msg = b"two members same poly";
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
+
+        let new_shares = do_resharing(&old_shares, 4, 7, 4, 1);
+
+        // Pick 4 disjoint-ish subsets, all must decrypt.
+        for start in 0..4 {
+            let subset: Vec<DecryptionShare> = new_shares[start..start + 4]
+                .iter()
+                .map(|s| generate_decryption_share(s, &ct))
+                .collect();
+            assert_eq!(
+                combine_shares(&subset, 4, &ct).unwrap(),
+                msg,
+                "subset starting at {start} failed to decrypt"
+            );
+        }
+    }
+
+    #[test]
+    fn reshare_verify_detects_inconsistent_contribution() {
+        let (_, old_shares) = setup_epoch(6, 4);
+        let mut contrib = generate_resharing_contribution(&old_shares[0], 8, 5, 1, b"e");
+        assert!(verify_resharing_contribution(&contrib, 5, 8));
+
+        // Tamper: flip a value in one of the non-interpolation rows.
+        contrib.sub_shares[6][2] = contrib.sub_shares[6][2] + gl(1);
+        assert!(!verify_resharing_contribution(&contrib, 5, 8));
+    }
+
+    #[test]
+    fn reshare_verify_rejects_wrong_dimensions() {
+        let (_, old_shares) = setup_epoch(6, 4);
+        let contrib = generate_resharing_contribution(&old_shares[0], 8, 5, 1, b"e");
+        // Pretend new_n is different from what the contribution was built for.
+        assert!(!verify_resharing_contribution(&contrib, 5, 9));
+        // Threshold > new_n should also be rejected.
+        assert!(!verify_resharing_contribution(&contrib, 9, 8));
+    }
+
+    #[test]
+    fn reshare_contribution_roundtrips_through_wire_format() {
+        let (_, old_shares) = setup_epoch(5, 3);
+        let original = generate_resharing_contribution(&old_shares[1], 6, 4, 42, b"wire");
+        let bytes = original.to_bytes();
+        let decoded = ResharingContribution::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.from_old_index, original.from_old_index);
+        assert_eq!(decoded.sub_shares.len(), original.sub_shares.len());
+        for (a, b) in decoded.sub_shares.iter().zip(original.sub_shares.iter()) {
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn reshare_chain_of_two_rotations_decrypts() {
+        // Rotate twice: old -> mid -> new. Ciphertext encrypted at epoch 0
+        // must still decrypt under epoch-2 shares.
+        let (epoch_mat, old_shares) = setup_epoch(6, 4);
+        let msg = b"two rotations";
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
+
+        let mid_shares = do_resharing(&old_shares, 4, 7, 5, 1);
+        let new_shares = do_resharing(&mid_shares, 5, 8, 6, 2);
+
+        let dec_shares: Vec<DecryptionShare> = new_shares[..6]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        assert_eq!(combine_shares(&dec_shares, 6, &ct).unwrap(), msg);
     }
 }

--- a/crates/net/tests/reshare_handshake.rs
+++ b/crates/net/tests/reshare_handshake.rs
@@ -1,0 +1,176 @@
+//! End-to-end integration test for the committee-resharing wire format.
+//!
+//! Spins up a real libp2p swarm carrying a gossipsub channel, pushes
+//! `ResharingContribution`s through it wrapped in the same CBOR/length
+//! framing the production node uses, and asserts the aggregation pipeline
+//! converges on the invariant threshold public key. Closes the "no live
+//! multi-node gossip test" caveat flagged on the task-034 PR.
+//!
+//! This is a single-process swarm — 1 gossip publisher, multiple
+//! subscribers in the same swarm — but exercises the actual libp2p stack
+//! end-to-end. Full cross-node scenarios are left to the multi-node E2E
+//! slice.
+
+use futures::StreamExt;
+use libp2p::{
+    gossipsub::{self, IdentTopic, MessageAuthenticity},
+    swarm::{NetworkBehaviour, SwarmEvent},
+    Swarm, SwarmBuilder,
+};
+use pyde_crypto::threshold::{
+    aggregate_new_share, canonical_resharing_subset, combine_shares,
+    generate_decryption_share, generate_resharing_contribution, threshold_encrypt,
+    threshold_keygen, ResharingContribution,
+};
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[derive(NetworkBehaviour)]
+struct GossipOnly {
+    gossipsub: gossipsub::Behaviour,
+}
+
+fn build_swarm() -> Swarm<GossipOnly> {
+    SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_quic()
+        .with_behaviour(|key| {
+            let cfg = gossipsub::ConfigBuilder::default()
+                .heartbeat_interval(Duration::from_millis(200))
+                .validation_mode(gossipsub::ValidationMode::Strict)
+                .build()
+                .unwrap();
+            let gossip = gossipsub::Behaviour::new(
+                MessageAuthenticity::Signed(key.clone()),
+                cfg,
+            )
+            .unwrap();
+            Ok(GossipOnly { gossipsub: gossip })
+        })
+        .unwrap()
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
+        .build()
+}
+
+#[tokio::test]
+async fn resharing_end_to_end_over_gossipsub() {
+    // Old committee: 5 members, threshold 3. Generate keys + shares.
+    const OLD_N: usize = 5;
+    const OLD_T: usize = 3;
+    const NEW_N: usize = 6;
+    const NEW_T: usize = 4;
+    const TARGET_EPOCH: u64 = 42;
+
+    let (tpk, old_shares) = threshold_keygen(OLD_N, OLD_T).unwrap();
+    let msg = b"cross-committee decrypt after rotation";
+    let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+    // Two swarms: A publishes every contribution; B subscribes + collects.
+    // Using two swarms over QUIC exercises the real transport path.
+    let mut swarm_a = build_swarm();
+    let mut swarm_b = build_swarm();
+    let topic = IdentTopic::new("pyde/reshare/test");
+    swarm_a.behaviour_mut().gossipsub.subscribe(&topic).unwrap();
+    swarm_b.behaviour_mut().gossipsub.subscribe(&topic).unwrap();
+
+    swarm_a
+        .listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap())
+        .unwrap();
+    swarm_b
+        .listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap())
+        .unwrap();
+
+    // Wait for B's listen addr, then dial from A.
+    let b_addr = loop {
+        tokio::select! {
+            ev = swarm_b.select_next_some() => {
+                if let SwarmEvent::NewListenAddr { address, .. } = ev {
+                    break address;
+                }
+            }
+            _ = swarm_a.select_next_some() => {}
+        }
+    };
+    let b_peer = *swarm_b.local_peer_id();
+    let full_addr = b_addr.with(libp2p::multiaddr::Protocol::P2p(b_peer));
+    swarm_a.dial(full_addr).unwrap();
+
+    // Pre-build all resharing contributions from every old member.
+    let contribs: Vec<ResharingContribution> = old_shares
+        .iter()
+        .map(|s| {
+            generate_resharing_contribution(s, NEW_N, NEW_T, TARGET_EPOCH, b"gossip-test")
+        })
+        .collect();
+    let mut to_publish: Vec<Vec<u8>> = contribs.iter().map(|c| c.to_bytes()).collect();
+
+    // Collect bytes received on B.
+    let mut received: Vec<ResharingContribution> = Vec::new();
+
+    let driver = async {
+        loop {
+            if received.len() == contribs.len() {
+                break;
+            }
+            tokio::select! {
+                ev = swarm_a.select_next_some() => {
+                    match ev {
+                        SwarmEvent::Behaviour(GossipOnlyEvent::Gossipsub(
+                            gossipsub::Event::Subscribed { peer_id: _, .. }
+                        )) => {
+                            // Gossipsub mesh is now ready between the two peers.
+                            // Drain the queued contributions.
+                            for bytes in to_publish.drain(..) {
+                                // Retry on publish error (topic may still be
+                                // bootstrapping heartbeats).
+                                let mut attempt = 0;
+                                while let Err(_) = swarm_a.behaviour_mut()
+                                    .gossipsub.publish(topic.clone(), bytes.clone())
+                                {
+                                    attempt += 1;
+                                    if attempt > 10 { break; }
+                                    tokio::time::sleep(Duration::from_millis(50)).await;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                ev = swarm_b.select_next_some() => {
+                    if let SwarmEvent::Behaviour(GossipOnlyEvent::Gossipsub(
+                        gossipsub::Event::Message { message, .. }
+                    )) = ev {
+                        if let Some(c) = ResharingContribution::from_bytes(&message.data) {
+                            // Dedup by from_old_index.
+                            if !received.iter().any(|x| x.from_old_index == c.from_old_index) {
+                                received.push(c);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    timeout(Duration::from_secs(10), driver)
+        .await
+        .expect("gossip round trip timed out");
+
+    assert_eq!(received.len(), OLD_N);
+
+    // On the receiving side, apply the canonical-subset rule and derive
+    // new shares for each new member, mirroring what ValidatorEngine does
+    // in production.
+    let canonical = canonical_resharing_subset(&received, OLD_T).unwrap();
+    let new_shares: Vec<_> = (1..=NEW_N)
+        .map(|j| aggregate_new_share(j, &canonical).unwrap())
+        .collect();
+
+    // Threshold (4 of 6) new members decrypt the pre-rotation ciphertext.
+    let dec: Vec<_> = new_shares[..NEW_T]
+        .iter()
+        .map(|s| generate_decryption_share(s, &ct))
+        .collect();
+    let plaintext = combine_shares(&dec, NEW_T, &ct).unwrap();
+    assert_eq!(plaintext, msg);
+}

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -633,9 +633,8 @@ mod tests {
     #[test]
     fn process_genesis_block() {
         let mut chain = ChainState::genesis([0u8; 32], 31337);
-        let dir = std::env::temp_dir().join("pyde-test-bp2-genesis");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
 
         let header = dummy_header(1);
         let (tx_count, gas_used) =
@@ -649,9 +648,8 @@ mod tests {
     #[test]
     fn reject_old_slot() {
         let mut chain = ChainState::genesis([0u8; 32], 31337);
-        let dir = std::env::temp_dir().join("pyde-test-bp2-old");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
 
         chain.advance(dummy_header(5));
 
@@ -662,9 +660,8 @@ mod tests {
     #[test]
     fn sequential_blocks() {
         let mut chain = ChainState::genesis([0u8; 32], 31337);
-        let dir = std::env::temp_dir().join("pyde-test-bp2-seq");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
 
         for slot in 1..=5 {
             BlockProcessor::process_block(&mut chain, &mut state, dummy_header(slot), &[]).unwrap();
@@ -675,9 +672,8 @@ mod tests {
 
     #[test]
     fn process_block_with_transfer() {
-        let dir = std::env::temp_dir().join("pyde-test-bp2-transfer");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
 
         // Initialize genesis with funded accounts
         let (config, _accounts) = devnet_genesis();
@@ -745,9 +741,8 @@ mod tests {
         // ordering via the QC cannot swap encrypted_tx positions afterwards.
         // Here we simulate a tampered block — header tx_root was computed
         // over [enc_a, enc_b], but the body ships [enc_b, enc_a].
-        let dir = std::env::temp_dir().join("pyde-test-bp2-reorder");
-        let _ = std::fs::remove_dir_all(&dir);
-        let state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
 
         let enc_a = build_dummy_encrypted_tx(0xAA);
         let enc_b = build_dummy_encrypted_tx(0xBB);
@@ -783,9 +778,8 @@ mod tests {
     fn validate_body_rejects_added_encrypted_tx() {
         // Proposer tries to slip an extra encrypted tx into the body
         // without updating tx_root — rejected.
-        let dir = std::env::temp_dir().join("pyde-test-bp2-add-enc");
-        let _ = std::fs::remove_dir_all(&dir);
-        let state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
 
         let honest_root = pyde_consensus::block::compute_tx_root(&[], &[]);
 
@@ -808,9 +802,8 @@ mod tests {
     #[test]
     fn validate_body_accepts_honest_block() {
         // Sanity: a well-formed block with matching tx_root passes.
-        let dir = std::env::temp_dir().join("pyde-test-bp2-honest");
-        let _ = std::fs::remove_dir_all(&dir);
-        let state = StateManager::open(&dir, 1024).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
 
         let enc = build_dummy_encrypted_tx(0xAA);
         let hash = pyde_mempool::encrypted::EncryptedTx::from_bytes(&enc).unwrap().hash();
@@ -891,10 +884,9 @@ mod tests {
         // Setup: an honest block commits to encrypted_txs [A, B]. A tampered
         // decryptor holds them as [B, A] — as would happen if an attacker
         // swapped ciphertexts between block acceptance and decrypt time.
-        let dir = std::env::temp_dir().join("pyde-test-bp2-decrypt-tamper");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
-        let bs = crate::block_store::BlockStore::open(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let bs = crate::block_store::BlockStore::open(tmp.path()).unwrap();
 
         let (_pk, _shares, enc_a, enc_b) = build_two_encrypted_txs_with_keys();
         store_block_with_encrypted_order(&bs, 1, &[&enc_a, &enc_b]);
@@ -925,10 +917,9 @@ mod tests {
         // Positive case: honest decryptor + honest block → Executed outcome,
         // regardless of tx-level success/failure (dummy sigs will fail at
         // execution time, producing failed receipts, but the flow runs).
-        let dir = std::env::temp_dir().join("pyde-test-bp2-decrypt-honest");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
-        let bs = crate::block_store::BlockStore::open(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let bs = crate::block_store::BlockStore::open(tmp.path()).unwrap();
 
         let (_pk, shares, enc_a, enc_b) = build_two_encrypted_txs_with_keys();
         store_block_with_encrypted_order(&bs, 1, &[&enc_a, &enc_b]);
@@ -956,10 +947,9 @@ mod tests {
 
     #[test]
     fn try_decrypt_and_execute_returns_header_missing_when_unknown() {
-        let dir = std::env::temp_dir().join("pyde-test-bp2-decrypt-nohdr");
-        let _ = std::fs::remove_dir_all(&dir);
-        let mut state = StateManager::open(&dir, 1024).unwrap();
-        let bs = crate::block_store::BlockStore::open(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let bs = crate::block_store::BlockStore::open(tmp.path()).unwrap();
 
         let (_pk, _shares, enc_a, enc_b) = build_two_encrypted_txs_with_keys();
         let mut decryptor = pyde_mempool::decryption::BlockDecryptor::new(

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -26,6 +26,7 @@ use tracing::{debug, info, warn};
 
 const STATE_KEY: &[u8] = b"consensus:state";
 const EVIDENCE_STATE_KEY: &[u8] = b"evidence:state";
+const RESHARE_STATE_KEY: &[u8] = b"reshare:state";
 const PROPOSAL_PREFIX: &[u8] = b"p:";
 const VOTE_PREFIX: &[u8] = b"v:";
 
@@ -139,6 +140,56 @@ impl ConsensusStateStore {
             Ok(None) => Ok(None),
             Err(e) => Err(format!("failed to read evidence state: {}", e)),
         }
+    }
+
+    /// Persist resharing runtime state (task 034 crash safety). Written
+    /// on each state transition: `prepare_for_reshare_reception`,
+    /// `start_committee_reshare`, `try_aggregate_reshare_on_slot` when it
+    /// fires. Small blob (committee keys + scalars, tens of KB), so
+    /// fsync cost per transition is bounded.
+    pub fn save_reshare_state(&self, state: &wire::ReshareState) -> Result<(), String> {
+        let bytes = wire::encode_reshare_state(state);
+        self.db
+            .put_opt(RESHARE_STATE_KEY, &bytes, &self.sync_opts)
+            .map_err(|e| format!("failed to save reshare state: {}", e))?;
+        debug!(
+            target_epoch = state.target_epoch,
+            new_index = state.new_index,
+            aggregated = state.aggregated,
+            bytes = bytes.len(),
+            "reshare state persisted"
+        );
+        Ok(())
+    }
+
+    /// Load the previously-persisted reshare state, if any.
+    pub fn load_reshare_state(&self) -> Result<Option<wire::ReshareState>, String> {
+        match self.db.get(RESHARE_STATE_KEY) {
+            Ok(Some(bytes)) => {
+                let state = wire::decode_reshare_state(&bytes)
+                    .map_err(|e| format!("failed to decode reshare state: {}", e))?;
+                info!(
+                    target_epoch = state.target_epoch,
+                    new_index = state.new_index,
+                    aggregated = state.aggregated,
+                    "reshare state restored from disk"
+                );
+                Ok(Some(state))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(format!("failed to read reshare state: {}", e)),
+        }
+    }
+
+    /// Remove any persisted reshare state. Used when an epoch's rotation
+    /// completes successfully; keeping stale state around causes confused
+    /// behavior on a subsequent restart.
+    pub fn clear_reshare_state(&self) -> Result<(), String> {
+        self.db
+            .delete_opt(RESHARE_STATE_KEY, &self.sync_opts)
+            .map_err(|e| format!("failed to clear reshare state: {}", e))?;
+        debug!("reshare state cleared");
+        Ok(())
     }
 
     // ============================================================

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -229,6 +229,13 @@ impl PydeNode {
         let mut pending_auth_nonces: std::collections::HashMap<libp2p::PeerId, [u8; 32]> =
             std::collections::HashMap::new();
 
+        // Size of the committee that was in power at the last epoch boundary.
+        // Feeds the `old_threshold` passed to `on_reshare_contribution` after
+        // `engine.set_committee` has already advanced `engine.committee_keys`
+        // to the incoming set. Initialized to 0 (no prior committee); the
+        // first epoch boundary sets it.
+        let mut last_outgoing_committee_size: usize = 0;
+
         // 5. Validator engine + identity (only for validator role)
         let mut validator_identity: Option<ValidatorIdentity> = None;
         let mut validator_engine: Option<ValidatorEngine> = if is_validator {
@@ -504,6 +511,7 @@ impl PydeNode {
                             &mut pinned_snapshot,
                             &mut peer_manager,
                             &mut pending_auth_nonces,
+                            last_outgoing_committee_size,
                         )
                     };
 
@@ -823,6 +831,36 @@ impl PydeNode {
                                 engine.advance_slot();
                             }
 
+                            // Task 034: re-broadcast our resharing contribution
+                            // while we're inside the `RESHARE_REBROADCAST_SLOTS`
+                            // window. Gossipsub's own message cache covers only
+                            // a few heartbeats; this helps validators that come
+                            // online a few slots into the target epoch catch up
+                            // without needing a dedicated sync protocol.
+                            if let Some((target_epoch, bytes)) = engine.maybe_rebroadcast_reshare() {
+                                let msg = wire::encode_resharing(target_epoch, &bytes);
+                                let topic = pyde_net::node::topics::consensus();
+                                let _ = swarm.behaviour_mut().gossipsub.publish(topic, msg);
+                                debug!(target_epoch, "re-broadcast resharing contribution");
+                            }
+
+                            // Task 034: deterministic aggregation trigger. We
+                            // deliberately DON'T aggregate on first-threshold
+                            // arrival because async gossip can deliver a
+                            // different pool subset to different new members,
+                            // causing them to derive shares on divergent
+                            // polynomials. Instead, every new member waits
+                            // `RESHARE_AGGREGATION_DELAY_SLOTS` past the
+                            // epoch boundary and aggregates from whatever is
+                            // in the pool — by then gossipsub has converged.
+                            if let Some(identity) = validator_identity.as_mut() {
+                                engine.try_aggregate_reshare_on_slot(
+                                    current_slot,
+                                    last_outgoing_committee_size,
+                                    identity,
+                                );
+                            }
+
                             // Epoch boundary: rotate committee
                             let new_epoch = current_slot / pyde_consensus::block::EPOCH_LENGTH;
                             if new_epoch > prev_epoch && new_epoch > 0 {
@@ -849,21 +887,46 @@ impl PydeNode {
                                     Ok(committee) => {
                                         let new_keys: Vec<Vec<u8>> = committee.members.iter()
                                             .map(|v| v.public_key.clone()).collect();
-                                        // Find our own index in new committee
+
+                                        // Snapshot the OLD committee BEFORE any rotation — task
+                                        // 034 resharing needs to know who's outgoing to compute
+                                        // the old_threshold we accept contributions against.
+                                        let old_committee_keys = engine.committee_keys.clone();
+                                        let was_in_old_committee =
+                                            if let Some(identity) = validator_identity.as_ref() {
+                                                old_committee_keys
+                                                    .iter()
+                                                    .any(|k| k.as_slice() == identity.public_key.as_bytes())
+                                            } else { false };
+
+                                        // Find our own index in the new committee. Zero means
+                                        // we're leaving; non-zero means we'll aggregate
+                                        // incoming resharing contributions.
+                                        let mut our_new_index: usize = 0;
                                         if let Some(identity) = validator_identity.as_mut() {
                                             let my_pk = hex::encode(identity.public_key.as_bytes());
                                             for (i, member) in committee.members.iter().enumerate() {
                                                 if hex::encode(&member.public_key) == my_pk {
                                                     identity.committee_index = i as u8;
+                                                    our_new_index = i + 1; // 1-based for KeyShare
                                                     break;
                                                 }
                                             }
                                         }
-                                        engine.set_committee(new_keys);
+                                        engine.set_committee(new_keys.clone());
                                         info!(
                                             epoch = new_epoch,
                                             committee_size = committee.size(),
                                             "committee rotated at epoch boundary"
+                                        );
+
+                                        // Prepare to aggregate resharing contributions when we're
+                                        // on the incoming committee. Safe to call even with
+                                        // our_new_index = 0 — the engine will drop contributions.
+                                        engine.prepare_for_reshare_reception(
+                                            new_epoch,
+                                            new_keys.clone(),
+                                            our_new_index,
                                         );
 
                                         if let Some(identity) = validator_identity.as_ref() {
@@ -881,7 +944,30 @@ impl PydeNode {
                                                 let topic = pyde_net::node::topics::consensus();
                                                 let _ = swarm.behaviour_mut().gossipsub.publish(topic, contrib_bytes);
                                             }
+
+                                            // Task 034: if we were in the outgoing committee and
+                                            // actually hold a key share, broadcast a resharing
+                                            // contribution so the incoming committee can derive
+                                            // its shares of the invariant threshold secret.
+                                            // Same-committee-continuation also runs through this
+                                            // path so the bookkeeping stays uniform.
+                                            if was_in_old_committee && identity.key_share.is_some() {
+                                                if let Some(contrib) = engine.start_committee_reshare(
+                                                    new_epoch, &new_keys, identity,
+                                                ) {
+                                                    let contrib_bytes = wire::encode_resharing(
+                                                        new_epoch, &contrib.to_bytes(),
+                                                    );
+                                                    let topic = pyde_net::node::topics::consensus();
+                                                    let _ = swarm.behaviour_mut().gossipsub.publish(topic, contrib_bytes);
+                                                }
+                                            }
                                         }
+
+                                        // Stash old committee size for inbound resharing
+                                        // handlers — ingestion needs old_threshold to decide
+                                        // when the canonical subset is reachable.
+                                        last_outgoing_committee_size = old_committee_keys.len();
                                     }
                                     Err(e) => {
                                         warn!(epoch = new_epoch, error = ?e, "committee selection failed, keeping current");
@@ -1463,6 +1549,7 @@ fn handle_swarm_event(
     pinned_snapshot: &mut Option<crate::sync::PinnedSnapshot>,
     peer_manager: &mut pyde_net::peer::PeerManager,
     pending_auth_nonces: &mut std::collections::HashMap<PeerId, [u8; 32]>,
+    last_outgoing_committee_size: usize,
 ) -> PostEventAction {
     match event {
         // --- Gossipsub message received ---
@@ -1700,6 +1787,47 @@ fn handle_swarm_event(
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode PSS contribution");
+                                }
+                            }
+                            return PostEventAction::None;
+                        }
+
+                        // Check if it's a committee resharing contribution (task 034)
+                        if !message.data.is_empty() && message.data[0] == wire::tag::COMMITTEE_RESHARING {
+                            match wire::decode_resharing(&message.data) {
+                                Ok((target_epoch, contrib_bytes)) => {
+                                    // Drop stale contributions targeted at epochs other
+                                    // than the one we're currently receiving for.
+                                    if target_epoch != engine.reshare_target() {
+                                        debug!(
+                                            target_epoch,
+                                            active = engine.reshare_target(),
+                                            "ignoring stale resharing contribution"
+                                        );
+                                        return PostEventAction::None;
+                                    }
+                                    match pyde_crypto::threshold::ResharingContribution::from_bytes(&contrib_bytes) {
+                                        Some(contrib) => {
+                                            debug!(
+                                                target_epoch,
+                                                from_old_index = contrib.from_old_index,
+                                                "received resharing contribution"
+                                            );
+                                            if let Some(identity) = validator_identity.as_mut() {
+                                                engine.on_reshare_contribution(
+                                                    contrib,
+                                                    last_outgoing_committee_size,
+                                                    identity,
+                                                );
+                                            }
+                                        }
+                                        None => {
+                                            debug!("malformed resharing contribution bytes");
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    debug!(error = e, "failed to decode resharing message");
                                 }
                             }
                             return PostEventAction::None;

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -620,24 +620,29 @@ mod tests {
         assert!(sync.initial_sync_done);
     }
 
-    fn make_state(name: &str) -> StateManager {
-        let dir = std::env::temp_dir().join(name);
-        let _ = std::fs::remove_dir_all(&dir);
-        StateManager::open(&dir, 1024).unwrap()
+    /// Return a `(StateManager, TempDir)` pair. Callers must hold the
+    /// `TempDir` in scope for the life of the manager; dropping it
+    /// removes the underlying directory. Using `tempfile::tempdir()`
+    /// gives unique-per-invocation paths, which sidesteps the parallel
+    /// RocksDB races that plague fixed `/tmp/pyde-*` tests.
+    fn make_state() -> (StateManager, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let sm = StateManager::open(tmp.path(), 1024).unwrap();
+        (sm, tmp)
     }
 
-    fn make_block_store(name: &str) -> BlockStore {
-        let dir = std::env::temp_dir().join(name);
-        let _ = std::fs::remove_dir_all(&dir);
-        BlockStore::open(&dir).unwrap()
+    fn make_block_store() -> (BlockStore, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let bs = BlockStore::open(tmp.path()).unwrap();
+        (bs, tmp)
     }
 
     #[test]
     fn handle_chain_tip_request() {
         let mut chain = ChainState::genesis([0u8; 32], 1);
         chain.advance(dummy_header(10));
-        let state = make_state("pyde-sync-tip-v2");
-        let bs = make_block_store("pyde-sync-tip-bs-v2");
+        let (state, _sd) = make_state();
+        let (bs, _bd) = make_block_store();
 
         let resp = ChainSync::handle_inbound_request(&SyncReq::GetChainTip, &chain, &state, &bs, &mut None::<PinnedSnapshot>);
         match resp {
@@ -652,8 +657,8 @@ mod tests {
         for slot in 1..=5 {
             chain.advance(dummy_header(slot));
         }
-        let state = make_state("pyde-sync-blocks-v2");
-        let bs = make_block_store("pyde-sync-blocks-bs-v2");
+        let (state, _sd) = make_state();
+        let (bs, _bd) = make_block_store();
 
         let resp = ChainSync::handle_inbound_request(
             &SyncReq::GetBlocks { start_slot: 1, count: 3 },
@@ -673,8 +678,8 @@ mod tests {
     #[test]
     fn handle_get_blocks_not_found() {
         let chain = ChainState::genesis([0u8; 32], 1);
-        let state = make_state("pyde-sync-notfound-v2");
-        let bs = make_block_store("pyde-sync-notfound-bs-v2");
+        let (state, _sd) = make_state();
+        let (bs, _bd) = make_block_store();
 
         let resp = ChainSync::handle_inbound_request(
             &SyncReq::GetBlocks { start_slot: 100, count: 10 },
@@ -690,13 +695,13 @@ mod tests {
     fn handle_state_snapshot_request() {
         let mut chain = ChainState::genesis([0u8; 32], 1);
         chain.advance(dummy_header(5));
-        let mut state = make_state("pyde-sync-snapshot-v2");
+        let (mut state, _sd) = make_state();
 
         // Insert some state
         let key = pyde_state::keys::balance_key(&[0x01; 32]);
         state.insert(key, 42u128.to_le_bytes().to_vec()).unwrap();
 
-        let bs = make_block_store("pyde-sync-snapshot-bs-v2");
+        let (bs, _bd) = make_block_store();
         let resp = ChainSync::handle_inbound_request(
             &SyncReq::GetStateSnapshot,
             &chain, &state, &bs, &mut None::<PinnedSnapshot>,

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -14,7 +14,9 @@ use pyde_consensus::epoch_randomness::{
     combine_shares_dynamic,
 };
 use pyde_crypto::threshold::{
-    RefreshContribution, generate_refresh_contribution, apply_refresh, verify_refresh_contribution,
+    RefreshContribution, ResharingContribution, aggregate_new_share, apply_refresh,
+    canonical_resharing_subset, generate_refresh_contribution, generate_resharing_contribution,
+    verify_refresh_contribution, verify_resharing_contribution,
 };
 use pyde_consensus::slashing::{
     DoubleSignEvidence, slash_double_sign, verify_double_sign,
@@ -250,6 +252,45 @@ pub struct ValidatorEngine {
     pss_contributions: Vec<RefreshContribution>,
     /// Target epoch for PSS refresh.
     pss_target_epoch: u64,
+    /// Cross-committee resharing contributions collected at epoch boundary
+    /// (task 034). Keyed by target epoch so late contributions from
+    /// previous epochs are ignored.
+    reshare_contributions: Vec<ResharingContribution>,
+    /// Target epoch for active resharing (the epoch whose incoming committee
+    /// the contributions are addressed to).
+    reshare_target_epoch: u64,
+    /// Committee key pubkeys of the NEW committee for the active reshare.
+    /// Used to compute new_n, new_threshold, and our own 1-based index in
+    /// the incoming committee (0 if we're not a member).
+    reshare_new_committee: Vec<Vec<u8>>,
+    /// Our 1-based index in the incoming committee for the active reshare.
+    /// Zero when we're not on the new committee (no aggregation to perform).
+    reshare_new_index: usize,
+    /// Our own resharing contribution (if we're outgoing) stashed for
+    /// periodic re-broadcast. Gossipsub's message cache only retains a few
+    /// heartbeats, so a validator that comes online a few slots after the
+    /// epoch-boundary broadcast could miss contributions. Re-broadcasting
+    /// for the first `RESHARE_REBROADCAST_SLOTS` slots of the target epoch
+    /// lets stragglers catch up without a dedicated sync protocol.
+    /// Layout: `(target_epoch, contribution_bytes)`.
+    pending_reshare_rebroadcast: Option<(u64, Vec<u8>)>,
+    /// Slot at which `start_committee_reshare` published our contribution.
+    /// `maybe_rebroadcast_reshare` uses this + `current_slot` to decide
+    /// whether we're still inside the re-broadcast window.
+    reshare_broadcast_start_slot: u64,
+    /// Slot at which the next aggregation attempt should fire. Set by
+    /// `prepare_for_reshare_reception` to
+    /// `current_slot + RESHARE_AGGREGATION_DELAY_SLOTS`. The delay gives
+    /// gossipsub enough time to deliver every old member's contribution
+    /// to every new member, so all new members see the same pool and
+    /// derive identical canonical subsets. Aggregating eagerly on first
+    /// threshold — as we did before — is unsafe under async gossip,
+    /// because different new members can hit threshold with different
+    /// pool subsets and end up on different polynomials.
+    reshare_aggregation_trigger_slot: u64,
+    /// `true` once aggregation has fired for the current target epoch.
+    /// Prevents re-aggregating when additional late contributions arrive.
+    reshare_aggregated: bool,
     /// Set to true when key share was refreshed and needs saving to disk.
     pub key_share_dirty: bool,
     /// Optional persistent store for ConsensusState. When set, the engine
@@ -300,6 +341,14 @@ impl ValidatorEngine {
             randomness_collector: None,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
+            reshare_contributions: Vec::new(),
+            reshare_target_epoch: 0,
+            reshare_new_committee: Vec::new(),
+            reshare_new_index: 0,
+            pending_reshare_rebroadcast: None,
+            reshare_broadcast_start_slot: 0,
+            reshare_aggregation_trigger_slot: 0,
+            reshare_aggregated: false,
             key_share_dirty: false,
             consensus_store: None,
         }
@@ -377,6 +426,28 @@ impl ValidatorEngine {
                 // duplicate gossip, but duplicates are caught by the
                 // on-chain slash handler (already-ejected rejection).
                 warn!(error = %e, "failed to load evidence state; starting empty");
+            }
+        }
+
+        // Reshare state restore (task 034 crash safety). Contribution pool
+        // is intentionally NOT persisted — it rebuilds from rebroadcasts
+        // during the window. All other fields ARE persisted so an in-
+        // progress rotation resumes cleanly: the same target epoch, the
+        // same new-committee index, the same aggregation trigger slot, and
+        // the same `aggregated` flag that prevents double-aggregation.
+        match store.load_reshare_state() {
+            Ok(Some(rs)) => {
+                info!(
+                    target_epoch = rs.target_epoch,
+                    new_index = rs.new_index,
+                    aggregated = rs.aggregated,
+                    "restoring reshare state from disk"
+                );
+                self.restore_reshare_state(rs);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(error = %e, "failed to load reshare state; starting empty");
             }
         }
 
@@ -515,6 +586,310 @@ impl ValidatorEngine {
             }
         }
         false
+    }
+
+    // ==================================================================
+    // Task 034 — cross-committee resharing at epoch boundary
+    // ==================================================================
+    //
+    // Flow (see `pyde_crypto::threshold` for the math):
+    //
+    // * `start_committee_reshare` is called by any OLD committee member
+    //   (those leaving or staying) when the epoch boundary announces the
+    //   new committee. Returns a contribution addressed to every new
+    //   member. The node layer broadcasts it on the consensus channel.
+    //
+    // * `prepare_for_reshare_reception` is called by any NEW committee
+    //   member when they learn the incoming committee roster. Sets
+    //   `reshare_new_index` and clears the prior bucket so stale epochs
+    //   don't leak.
+    //
+    // * `on_reshare_contribution` accepts contributions from the old
+    //   committee and, once the OLD threshold is reached, Lagrange-
+    //   interpolates the new member's share using the canonical subset
+    //   rule. Returns `true` the first time a new share is derived.
+
+    /// How long (in slots) an outgoing member keeps re-broadcasting their
+    /// resharing contribution after the initial epoch-boundary publish.
+    /// Wide enough that late-joining validators within the first few slots
+    /// of the target epoch can still catch up, narrow enough to not spam
+    /// the consensus channel. Re-broadcasts fire every
+    /// `RESHARE_REBROADCAST_INTERVAL_SLOTS` slots.
+    pub const RESHARE_REBROADCAST_SLOTS: u64 = 10;
+    pub const RESHARE_REBROADCAST_INTERVAL_SLOTS: u64 = 2;
+
+    /// Slots each new committee member waits past the epoch boundary
+    /// before aggregating received contributions. During this window
+    /// gossipsub delivers contributions to everyone, so all new members
+    /// observe the same pool and derive identical canonical subsets.
+    /// MUST be ≤ `RESHARE_REBROADCAST_SLOTS` so late joiners still get
+    /// contributions during the window.
+    pub const RESHARE_AGGREGATION_DELAY_SLOTS: u64 = 5;
+
+    /// Snapshot the resharing state for disk persistence (task 034 crash
+    /// safety). Returns `None` when nothing needs to be saved (engine is
+    /// idle between rotations). Excludes the contribution pool — on
+    /// restart within the rebroadcast window the pool rebuilds from
+    /// gossip; after the window, the node stays locked out of this
+    /// epoch's decryption and resumes normally on the next rotation.
+    pub fn reshare_state_snapshot(&self) -> Option<crate::wire::ReshareState> {
+        if self.reshare_target_epoch == 0
+            && self.pending_reshare_rebroadcast.is_none()
+        {
+            return None;
+        }
+        Some(crate::wire::ReshareState {
+            target_epoch: self.reshare_target_epoch,
+            new_index: self.reshare_new_index as u64,
+            aggregation_trigger_slot: self.reshare_aggregation_trigger_slot,
+            aggregated: self.reshare_aggregated,
+            broadcast_start_slot: self.reshare_broadcast_start_slot,
+            pending_rebroadcast: self.pending_reshare_rebroadcast.clone(),
+            new_committee_keys: self.reshare_new_committee.clone(),
+        })
+    }
+
+    /// Restore the persistent resharing fields from a disk snapshot. The
+    /// contribution pool starts empty and refills from gossip rebroadcasts.
+    pub fn restore_reshare_state(&mut self, s: crate::wire::ReshareState) {
+        self.reshare_target_epoch = s.target_epoch;
+        self.reshare_new_index = s.new_index as usize;
+        self.reshare_aggregation_trigger_slot = s.aggregation_trigger_slot;
+        self.reshare_aggregated = s.aggregated;
+        self.reshare_broadcast_start_slot = s.broadcast_start_slot;
+        self.pending_reshare_rebroadcast = s.pending_rebroadcast;
+        self.reshare_new_committee = s.new_committee_keys;
+        self.reshare_contributions.clear();
+    }
+
+    /// Generate a share-transfer contribution for the incoming committee.
+    /// Caller is an OLD committee member. Returns `None` if we don't have
+    /// a key share (e.g. not a previous committee member) or if the new
+    /// committee is empty.
+    pub fn start_committee_reshare(
+        &mut self,
+        target_epoch: u64,
+        new_committee_keys: &[Vec<u8>],
+        identity: &ValidatorIdentity,
+    ) -> Option<ResharingContribution> {
+        let key_share = identity.key_share.as_ref()?;
+        let new_n = new_committee_keys.len();
+        if new_n == 0 {
+            return None;
+        }
+        let new_threshold = quorum_for_committee(new_n);
+
+        // Private entropy: combines validator secret key with the target
+        // epoch so each old member picks an independent polynomial, even
+        // if two old members briefly share the same `from_old_index`
+        // (shouldn't happen, but defense-in-depth).
+        let mut private = Vec::with_capacity(64 + 8);
+        private.extend_from_slice(identity.secret_key.as_bytes());
+        private.extend_from_slice(&self.epoch_randomness);
+        private.extend_from_slice(&target_epoch.to_le_bytes());
+        let entropy = pyde_crypto::poseidon2::poseidon2_hash(&private);
+
+        let contribution = generate_resharing_contribution(
+            key_share,
+            new_n,
+            new_threshold,
+            target_epoch,
+            entropy.as_bytes(),
+        );
+        // Stash bytes + target epoch so `maybe_rebroadcast_reshare` can
+        // re-publish during the early target-epoch slot window.
+        self.pending_reshare_rebroadcast = Some((target_epoch, contribution.to_bytes()));
+        self.reshare_broadcast_start_slot = self.consensus.current_slot;
+        self.persist_reshare_state();
+        info!(
+            target_epoch,
+            new_n,
+            new_threshold,
+            from_old_index = contribution.from_old_index,
+            "broadcasting cross-committee resharing contribution"
+        );
+        Some(contribution)
+    }
+
+    /// Fsync the reshare snapshot to the ConsensusStateStore when one is
+    /// attached. No-op when there's no store (devnet/tests) or when
+    /// snapshot is empty. Panics on write failure — same safety-critical
+    /// contract as other consensus-state persistence.
+    fn persist_reshare_state(&self) {
+        let (Some(store), Some(snap)) = (self.consensus_store.as_ref(), self.reshare_state_snapshot()) else {
+            return;
+        };
+        if let Err(e) = store.save_reshare_state(&snap) {
+            panic!("CRITICAL: reshare state persistence failed — {}", e);
+        }
+    }
+
+    /// Called by the node-layer slot tick. Returns the stashed resharing
+    /// contribution to re-broadcast, or `None` if we're not in the window.
+    /// Re-publishes every `RESHARE_REBROADCAST_INTERVAL_SLOTS` slots for up
+    /// to `RESHARE_REBROADCAST_SLOTS` slots after the initial broadcast.
+    /// Self-clears after the window expires.
+    pub fn maybe_rebroadcast_reshare(&mut self) -> Option<(u64, Vec<u8>)> {
+        let (target_epoch, bytes) = self.pending_reshare_rebroadcast.as_ref()?;
+        let now = self.consensus.current_slot;
+        let elapsed = now.saturating_sub(self.reshare_broadcast_start_slot);
+        if elapsed > Self::RESHARE_REBROADCAST_SLOTS {
+            // Window closed — purge so we don't re-broadcast a stale epoch.
+            self.pending_reshare_rebroadcast = None;
+            return None;
+        }
+        if elapsed == 0 {
+            // Initial publish already happened this slot; don't re-broadcast
+            // immediately (gossipsub dedupes but we avoid the extra traffic).
+            return None;
+        }
+        if elapsed % Self::RESHARE_REBROADCAST_INTERVAL_SLOTS != 0 {
+            return None;
+        }
+        Some((*target_epoch, bytes.clone()))
+    }
+
+    /// Install the incoming committee roster + our 1-based index in it so
+    /// future resharing contributions can be collected. Safe to call even
+    /// if we're not in the new committee (`our_new_index` = 0) — we'll
+    /// ignore received contributions in that case.
+    ///
+    /// Sets the aggregation trigger to fire `RESHARE_AGGREGATION_DELAY_SLOTS`
+    /// slots after the current slot. Aggregation itself happens in
+    /// `try_aggregate_reshare_on_slot`, which the node slot tick drives.
+    pub fn prepare_for_reshare_reception(
+        &mut self,
+        target_epoch: u64,
+        new_committee_keys: Vec<Vec<u8>>,
+        our_new_index: usize,
+    ) {
+        self.reshare_target_epoch = target_epoch;
+        self.reshare_new_committee = new_committee_keys;
+        self.reshare_new_index = our_new_index;
+        self.reshare_contributions.clear();
+        self.reshare_aggregation_trigger_slot =
+            self.consensus.current_slot + Self::RESHARE_AGGREGATION_DELAY_SLOTS;
+        self.reshare_aggregated = false;
+        self.persist_reshare_state();
+        debug!(
+            target_epoch,
+            our_new_index,
+            trigger_slot = self.reshare_aggregation_trigger_slot,
+            "prepared resharing reception bucket"
+        );
+    }
+
+    /// Store an incoming resharing contribution in the pool. Does NOT
+    /// aggregate — that's `try_aggregate_reshare_on_slot`'s job, fired at
+    /// a deterministic trigger slot so all new members see the same
+    /// contribution pool before combining.
+    ///
+    /// Returns `true` if the contribution was newly accepted (not a
+    /// duplicate, not stale, not malformed). Return value is for
+    /// telemetry; the caller can ignore it.
+    pub fn on_reshare_contribution(
+        &mut self,
+        contribution: ResharingContribution,
+        _old_committee_size: usize,
+        _identity: &mut ValidatorIdentity,
+    ) -> bool {
+        // Silently drop: not a new committee member.
+        if self.reshare_new_index == 0 || self.reshare_new_committee.is_empty() {
+            return false;
+        }
+        if self.reshare_aggregated {
+            // Already aggregated this epoch; late arrivals are ignored.
+            return false;
+        }
+        let new_n = self.reshare_new_committee.len();
+        let new_threshold = quorum_for_committee(new_n);
+
+        // Verify structural consistency of the contribution.
+        if !verify_resharing_contribution(&contribution, new_threshold, new_n) {
+            warn!(
+                from_old_index = contribution.from_old_index,
+                "invalid resharing contribution (failed polynomial check)"
+            );
+            return false;
+        }
+
+        // Dedupe by old-index so a re-broadcast doesn't inflate our pool.
+        if self.reshare_contributions.iter().any(|c| c.from_old_index == contribution.from_old_index) {
+            return false;
+        }
+        self.reshare_contributions.push(contribution);
+        true
+    }
+
+    /// Called from the node slot tick. If the current slot is at or past
+    /// the aggregation trigger and we haven't aggregated yet, attempt to
+    /// derive our new share from the canonical subset of the contribution
+    /// pool. Returns `true` when a new `KeyShare` is derived and installed.
+    ///
+    /// Failure modes:
+    /// - Not a new committee member → returns false silently.
+    /// - Not enough contributions (< `old_threshold`) by the trigger →
+    ///   logs a warning and returns false. The engine stays "unaggregated"
+    ///   so subsequent slots will retry, which accommodates genuinely
+    ///   delayed contributions; but if too many old members went dark,
+    ///   this node is effectively locked out of threshold decryption for
+    ///   this epoch until they can resync.
+    pub fn try_aggregate_reshare_on_slot(
+        &mut self,
+        current_slot: u64,
+        old_committee_size: usize,
+        identity: &mut ValidatorIdentity,
+    ) -> bool {
+        if self.reshare_aggregated
+            || self.reshare_new_index == 0
+            || self.reshare_new_committee.is_empty()
+            || self.reshare_aggregation_trigger_slot == 0
+        {
+            return false;
+        }
+        if current_slot < self.reshare_aggregation_trigger_slot {
+            return false;
+        }
+        let old_threshold = quorum_for_committee(old_committee_size);
+        if old_threshold == 0 {
+            return false;
+        }
+        if self.reshare_contributions.len() < old_threshold {
+            warn!(
+                target_epoch = self.reshare_target_epoch,
+                received = self.reshare_contributions.len(),
+                old_threshold,
+                "resharing aggregation trigger fired but below threshold — waiting"
+            );
+            return false;
+        }
+        let canonical = match canonical_resharing_subset(&self.reshare_contributions, old_threshold) {
+            Some(c) => c,
+            None => return false,
+        };
+        let new_share = match aggregate_new_share(self.reshare_new_index, &canonical) {
+            Some(s) => s,
+            None => return false,
+        };
+
+        identity.key_share = Some(new_share);
+        self.key_share_dirty = true;
+        self.reshare_aggregated = true;
+        self.reshare_contributions.clear();
+        self.persist_reshare_state();
+        info!(
+            target_epoch = self.reshare_target_epoch,
+            new_index = self.reshare_new_index,
+            old_threshold,
+            "committee handoff complete — new key share derived from resharing"
+        );
+        true
+    }
+
+    /// Expose the target epoch of any pending resharing (for node-layer
+    /// stale-message filtering).
+    pub fn reshare_target(&self) -> u64 {
+        self.reshare_target_epoch
     }
 
     pub fn start_epoch_randomness(
@@ -1561,6 +1936,478 @@ mod tests {
         assert!(!engine.is_inclusion_violated(slot));
         let vote = engine.select_and_vote(&identities[1]);
         assert!(vote.is_some(), "un-flagged slot should produce a vote");
+    }
+
+    // ========== Task 034: cross-committee resharing ==========
+
+    use pyde_crypto::threshold::{
+        combine_shares, generate_decryption_share, threshold_encrypt, threshold_keygen,
+    };
+
+    /// Outfit a validator identity with a specific key share — lets tests
+    /// simulate membership in a particular committee without running full
+    /// DKG through ValidatorEngine.
+    fn identity_with_share(
+        index: u8,
+        key_share: pyde_crypto::threshold::KeyShare,
+    ) -> ValidatorIdentity {
+        let mut id = make_identity(index);
+        id.key_share = Some(key_share);
+        id
+    }
+
+    #[test]
+    fn reshare_full_rotation_preserves_decryption() {
+        // End-to-end: encrypt under the committee's public key, rotate to a
+        // completely fresh committee via ValidatorEngine resharing, and
+        // verify the new committee decrypts the pre-rotation ciphertext.
+        // Every new member ingests all contributions, waits past the
+        // aggregation trigger, fires aggregation from the slot tick.
+        let (tpk, old_shares) = threshold_keygen(5, 3).unwrap();
+        let msg = b"rotation survives";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+        let (mut outgoing, old_ids) = make_engine_with_committee(5);
+        let mut outgoing_ids: Vec<ValidatorIdentity> = old_ids
+            .into_iter()
+            .zip(old_shares.iter())
+            .enumerate()
+            .map(|(i, (id, ks))| {
+                let mut with_share = id;
+                with_share.key_share = Some(ks.clone());
+                with_share.committee_index = i as u8;
+                with_share
+            })
+            .collect();
+
+        let (mut incoming, new_ids) = make_engine_with_committee(6);
+        let new_committee_keys: Vec<Vec<u8>> = new_ids
+            .iter()
+            .map(|id| id.public_key.as_bytes().to_vec())
+            .collect();
+        let mut new_identities: Vec<ValidatorIdentity> = new_ids;
+
+        let contribs: Vec<ResharingContribution> = outgoing_ids
+            .iter_mut()
+            .filter_map(|id| outgoing.start_committee_reshare(1, &new_committee_keys, id))
+            .collect();
+        assert_eq!(contribs.len(), 5);
+
+        for (new_idx, identity) in new_identities.iter_mut().enumerate() {
+            incoming.prepare_for_reshare_reception(
+                /* target */ 1,
+                new_committee_keys.clone(),
+                /* our 1-based new index */ new_idx + 1,
+            );
+            // Ingest all contributions — storage only, no aggregation.
+            for c in &contribs {
+                incoming.on_reshare_contribution(c.clone(), 5, identity);
+            }
+            // Before the trigger fires, no share should be derived.
+            let trigger = incoming.reshare_aggregation_trigger_slot;
+            assert!(incoming.consensus.current_slot < trigger);
+            assert!(!incoming.try_aggregate_reshare_on_slot(
+                incoming.consensus.current_slot, 5, identity
+            ));
+            // Advance past the trigger; aggregation fires.
+            let fire_at = trigger + 1;
+            assert!(incoming.try_aggregate_reshare_on_slot(fire_at, 5, identity));
+            // Second call after aggregation: no-op.
+            assert!(!incoming.try_aggregate_reshare_on_slot(fire_at + 1, 5, identity));
+        }
+
+        let dec_shares: Vec<_> = new_identities
+            .iter()
+            .take(4)
+            .map(|id| generate_decryption_share(id.key_share.as_ref().unwrap(), &ct))
+            .collect();
+        let plaintext = combine_shares(&dec_shares, 4, &ct).unwrap();
+        assert_eq!(plaintext, msg);
+    }
+
+    #[test]
+    fn reshare_async_arrival_converges_on_same_polynomial() {
+        // CORRECTNESS REGRESSION TEST.
+        // Simulates the asymmetric-gossip scenario that motivated the
+        // deterministic-trigger design: two new members receive
+        // contributions in different orders, and one hits the old-
+        // threshold with a different subset than the other. Under the
+        // old "aggregate on first threshold reached" rule, they'd derive
+        // shares on different polynomials and threshold decryption in
+        // the new committee would silently fail. With the trigger-
+        // based rule, they wait until the pool has converged and then
+        // both pick the canonical lowest-indexed subset.
+        let (tpk, old_shares) = threshold_keygen(5, 3).unwrap();
+        let msg = b"async arrival convergence";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+        let new_committee_keys = vec![vec![0xAA; 897]; 6];
+
+        // Two new members, independent engines — model separate nodes.
+        let mut engine_a = ValidatorEngine::new([0u8; 32]);
+        engine_a.set_committee(new_committee_keys.clone());
+        let mut engine_b = ValidatorEngine::new([0u8; 32]);
+        engine_b.set_committee(new_committee_keys.clone());
+
+        engine_a.prepare_for_reshare_reception(1, new_committee_keys.clone(), 1);
+        engine_b.prepare_for_reshare_reception(1, new_committee_keys.clone(), 2);
+
+        let contribs: Vec<ResharingContribution> = old_shares
+            .iter()
+            .map(|s| generate_resharing_contribution(s, 6, 4, 1, b"conv"))
+            .collect();
+
+        let mut id_a = make_identity(0);
+        let mut id_b = make_identity(1);
+
+        // Asymmetric arrival:
+        // A receives {2, 3, 4} first (contributions 1 and 5 delayed).
+        for c in [&contribs[1], &contribs[2], &contribs[3]] {
+            engine_a.on_reshare_contribution(c.clone(), 5, &mut id_a);
+        }
+        // B receives {1, 2, 3} first.
+        for c in [&contribs[0], &contribs[1], &contribs[2]] {
+            engine_b.on_reshare_contribution(c.clone(), 5, &mut id_b);
+        }
+
+        // Under the OLD first-threshold rule this is where they'd
+        // diverge. Under the new rule, they haven't aggregated yet —
+        // the trigger hasn't fired.
+        let trigger = engine_a.reshare_aggregation_trigger_slot;
+        assert!(!engine_a.try_aggregate_reshare_on_slot(trigger - 1, 5, &mut id_a));
+        assert!(!engine_b.try_aggregate_reshare_on_slot(trigger - 1, 5, &mut id_b));
+
+        // Gossip converges: both engines now have the full set.
+        engine_a.on_reshare_contribution(contribs[0].clone(), 5, &mut id_a);
+        engine_a.on_reshare_contribution(contribs[4].clone(), 5, &mut id_a);
+        engine_b.on_reshare_contribution(contribs[3].clone(), 5, &mut id_b);
+        engine_b.on_reshare_contribution(contribs[4].clone(), 5, &mut id_b);
+
+        // Trigger fires on both.
+        assert!(engine_a.try_aggregate_reshare_on_slot(trigger, 5, &mut id_a));
+        assert!(engine_b.try_aggregate_reshare_on_slot(trigger, 5, &mut id_b));
+
+        // THE KEY CHECK: A's and B's shares must combine to decrypt.
+        // If they were on different polynomials, `combine_shares` would
+        // produce garbage.
+        let shares = vec![
+            generate_decryption_share(id_a.key_share.as_ref().unwrap(), &ct),
+            generate_decryption_share(id_b.key_share.as_ref().unwrap(), &ct),
+        ];
+        // Can't combine with only 2 of 4 required — add more honest shares.
+        let mut helpers: Vec<ValidatorEngine> = (3..=6)
+            .map(|_| {
+                let mut e = ValidatorEngine::new([0u8; 32]);
+                e.set_committee(new_committee_keys.clone());
+                e
+            })
+            .collect();
+        let mut helper_ids: Vec<ValidatorIdentity> =
+            (3..=6).map(|i| make_identity(i)).collect();
+        for (i, (engine, id)) in helpers.iter_mut().zip(helper_ids.iter_mut()).enumerate() {
+            engine.prepare_for_reshare_reception(1, new_committee_keys.clone(), i + 3);
+            for c in &contribs {
+                engine.on_reshare_contribution(c.clone(), 5, id);
+            }
+            assert!(engine.try_aggregate_reshare_on_slot(trigger, 5, id));
+        }
+        let mut all_shares = shares;
+        for id in &helper_ids[..2] {
+            all_shares.push(generate_decryption_share(id.key_share.as_ref().unwrap(), &ct));
+        }
+        let plaintext = combine_shares(&all_shares, 4, &ct).unwrap();
+        assert_eq!(
+            plaintext, msg,
+            "shares must be on same polynomial — canonical subset divergence would break this"
+        );
+    }
+
+    #[test]
+    fn reshare_aggregation_waits_for_trigger() {
+        let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let new_committee = vec![vec![0xAA; 897]; 4];
+        engine.prepare_for_reshare_reception(1, new_committee.clone(), 1);
+        let mut id = make_identity(0);
+
+        // Submit ALL 4 contributions.
+        for s in &old_shares {
+            let c = generate_resharing_contribution(s, 4, 3, 1, b"e");
+            engine.on_reshare_contribution(c, 4, &mut id);
+        }
+        // Pool is full, but trigger hasn't fired.
+        let trigger = engine.reshare_aggregation_trigger_slot;
+        assert!(trigger > 0);
+        assert!(!engine.try_aggregate_reshare_on_slot(trigger - 1, 4, &mut id));
+        assert!(id.key_share.is_none());
+
+        // At trigger: fires.
+        assert!(engine.try_aggregate_reshare_on_slot(trigger, 4, &mut id));
+        assert!(id.key_share.is_some());
+    }
+
+    #[test]
+    fn reshare_aggregation_below_threshold_retries() {
+        // If only 2 of 4 contributions arrive by trigger time, aggregation
+        // doesn't fire — and `reshare_aggregated` stays false so a
+        // subsequent slot tick with a fuller pool can succeed.
+        let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]; 4], 1);
+        let mut id = make_identity(0);
+
+        // Only 2 contributions (below old_threshold of 3).
+        for s in old_shares.iter().take(2) {
+            let c = generate_resharing_contribution(s, 4, 3, 1, b"e");
+            engine.on_reshare_contribution(c, 4, &mut id);
+        }
+        let trigger = engine.reshare_aggregation_trigger_slot;
+        assert!(!engine.try_aggregate_reshare_on_slot(trigger, 4, &mut id));
+        // Third contribution arrives late.
+        let late = generate_resharing_contribution(&old_shares[2], 4, 3, 1, b"e");
+        engine.on_reshare_contribution(late, 4, &mut id);
+        // Later slot: now we have enough → fires.
+        assert!(engine.try_aggregate_reshare_on_slot(trigger + 3, 4, &mut id));
+        assert!(id.key_share.is_some());
+    }
+
+    // ========== Task 034: reshare crash-safety ==========
+
+    #[test]
+    fn reshare_state_wire_roundtrip() {
+        let s = crate::wire::ReshareState {
+            target_epoch: 42,
+            new_index: 7,
+            aggregation_trigger_slot: 123,
+            aggregated: false,
+            broadcast_start_slot: 100,
+            pending_rebroadcast: Some((42, vec![0xAA; 16])),
+            new_committee_keys: vec![vec![0x11; 50], vec![0x22; 50], vec![0x33; 50]],
+        };
+        let bytes = crate::wire::encode_reshare_state(&s);
+        let decoded = crate::wire::decode_reshare_state(&bytes).unwrap();
+        assert_eq!(decoded, s);
+    }
+
+    #[test]
+    fn reshare_state_wire_none_rebroadcast() {
+        let s = crate::wire::ReshareState {
+            target_epoch: 0,
+            new_index: 0,
+            aggregation_trigger_slot: 0,
+            aggregated: true,
+            broadcast_start_slot: 0,
+            pending_rebroadcast: None,
+            new_committee_keys: vec![],
+        };
+        let bytes = crate::wire::encode_reshare_state(&s);
+        let decoded = crate::wire::decode_reshare_state(&bytes).unwrap();
+        assert_eq!(decoded, s);
+    }
+
+    #[test]
+    fn reshare_state_restores_across_engine_restart() {
+        // Full crash-restart roundtrip: attach a store, advance through a
+        // rotation preparation, "crash" (drop engine), reattach the store
+        // to a fresh engine, and verify the reshare state came back.
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let new_committee = vec![vec![0x11; 897], vec![0x22; 897], vec![0x33; 897], vec![0x44; 897]];
+
+        let trigger_slot;
+        {
+            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            engine.set_committee(vec![vec![0x01; 897]; 4]);
+            let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+            engine.attach_consensus_store(store);
+            engine.prepare_for_reshare_reception(7, new_committee.clone(), 2);
+            trigger_slot = engine.reshare_aggregation_trigger_slot;
+            assert!(trigger_slot > 0);
+            // engine dropped here — simulates crash.
+        }
+
+        // Reopen store, reattach.
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        engine.attach_consensus_store(store);
+
+        // Post-restore invariants.
+        assert_eq!(engine.reshare_target_epoch, 7);
+        assert_eq!(engine.reshare_new_index, 2);
+        assert_eq!(engine.reshare_aggregation_trigger_slot, trigger_slot);
+        assert_eq!(engine.reshare_new_committee, new_committee);
+        assert!(!engine.reshare_aggregated);
+        // Contribution pool is NOT persisted (rebuilds from rebroadcasts).
+        assert_eq!(engine.reshare_contributions.len(), 0);
+    }
+
+    #[test]
+    fn reshare_state_restores_aggregated_flag() {
+        // If aggregation fired before the crash, the aggregated flag must
+        // persist — otherwise the restarted node could double-aggregate
+        // when late contributions arrive and overwrite its now-correct
+        // key share with garbage derived from a different canonical set.
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+
+        {
+            let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+            let mut engine = ValidatorEngine::new([0u8; 32]);
+            let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+            engine.attach_consensus_store(store);
+            engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]; 4], 1);
+            let mut id = make_identity(0);
+            for s in &old_shares {
+                let c = generate_resharing_contribution(s, 4, 3, 1, b"e");
+                engine.on_reshare_contribution(c, 4, &mut id);
+            }
+            let trigger = engine.reshare_aggregation_trigger_slot;
+            assert!(engine.try_aggregate_reshare_on_slot(trigger, 4, &mut id));
+            assert!(engine.reshare_aggregated);
+        }
+
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        engine.attach_consensus_store(store);
+        assert!(engine.reshare_aggregated, "aggregated flag must survive restart");
+    }
+
+    #[test]
+    fn reshare_state_pending_rebroadcast_survives_restart() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let (_, old_shares) = threshold_keygen(3, 2).unwrap();
+
+        {
+            let mut engine = ValidatorEngine::new([0u8; 32]);
+            engine.set_committee(vec![vec![0x01; 897]; 3]);
+            let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+            engine.attach_consensus_store(store);
+            let id = identity_with_share(0, old_shares[0].clone());
+            engine
+                .start_committee_reshare(5, &vec![vec![0xBB; 897]; 3], &id)
+                .unwrap();
+            assert!(engine.pending_reshare_rebroadcast.is_some());
+        }
+
+        let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        engine.attach_consensus_store(store);
+        assert!(
+            engine.pending_reshare_rebroadcast.is_some(),
+            "outgoing member must continue rebroadcasting after restart"
+        );
+    }
+
+    #[test]
+    fn reshare_ignores_when_not_on_new_committee() {
+        // Departing member (not on new committee): prepare_for_reshare_reception
+        // with index 0 → contributions get silently dropped, no share derived.
+        let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]], /* our_new_index */ 0);
+        let mut leaving = identity_with_share(0, old_shares[0].clone());
+
+        let sample_contrib = generate_resharing_contribution(&old_shares[0], 4, 3, 1, b"e");
+        let derived = engine.on_reshare_contribution(sample_contrib, 4, &mut leaving);
+        assert!(!derived);
+    }
+
+    #[test]
+    fn reshare_rejects_invalid_contribution() {
+        // Tampered contribution: must fail internal consistency check and
+        // NOT be counted toward threshold.
+        let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let new_committee = vec![vec![0xAA; 897]; 4];
+        engine.prepare_for_reshare_reception(1, new_committee, 1);
+        let mut new_id = make_identity(0);
+
+        let mut bad = generate_resharing_contribution(&old_shares[0], 4, 3, 1, b"e");
+        // Flip one sub-share to break the polynomial.
+        bad.to_bytes(); // sanity
+        // Expose a mutation path: rebuild via from_bytes after a byte flip.
+        let mut bytes = bad.to_bytes();
+        // Corrupt a payload byte well past the 16-byte header.
+        let corrupt_at = bytes.len() - 4;
+        bytes[corrupt_at] ^= 0xFF;
+        let corrupted = ResharingContribution::from_bytes(&bytes).unwrap();
+        assert!(!engine.on_reshare_contribution(corrupted, 4, &mut new_id));
+    }
+
+    #[test]
+    fn reshare_deduplicates_same_old_index() {
+        // Same old member re-broadcasts (gossip retry). The pool must not
+        // double-count duplicates; subsequent calls with the same
+        // `from_old_index` return false.
+        let (_, old_shares) = threshold_keygen(4, 3).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let new_committee = vec![vec![0xAA; 897]; 4];
+        engine.prepare_for_reshare_reception(1, new_committee, 1);
+        let mut new_id = make_identity(0);
+
+        let c = generate_resharing_contribution(&old_shares[0], 4, 3, 1, b"e");
+        // First call: newly stored → returns true.
+        assert!(engine.on_reshare_contribution(c.clone(), 4, &mut new_id));
+        // Duplicate: rejected → returns false. Pool still at size 1.
+        assert!(!engine.on_reshare_contribution(c, 4, &mut new_id));
+        assert_eq!(engine.reshare_contributions.len(), 1);
+    }
+
+    #[test]
+    fn reshare_rebroadcast_fires_within_window() {
+        // Outgoing member stashes a contribution and re-broadcasts every
+        // RESHARE_REBROADCAST_INTERVAL_SLOTS slots for RESHARE_REBROADCAST_SLOTS.
+        let (_, old_shares) = threshold_keygen(3, 2).unwrap();
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        engine.set_committee(vec![vec![0xAA; 897]; 3]);
+        let mut id = identity_with_share(0, old_shares[0].clone());
+
+        // Initial broadcast at slot 0.
+        engine.start_committee_reshare(7, &vec![vec![0xBB; 897]; 3], &id).unwrap();
+
+        // Same slot: should NOT re-broadcast (already-publishing slot).
+        assert!(engine.maybe_rebroadcast_reshare().is_none());
+
+        // Slot 2 (interval hit) → re-broadcast.
+        engine.advance_slot();
+        engine.advance_slot();
+        let r = engine.maybe_rebroadcast_reshare();
+        assert!(r.is_some(), "expected rebroadcast at slot 2");
+        assert_eq!(r.unwrap().0, 7);
+
+        // Slot 3 (off-interval) → skip.
+        engine.advance_slot();
+        assert!(engine.maybe_rebroadcast_reshare().is_none());
+
+        // Slot 4 (interval hit) → re-broadcast.
+        engine.advance_slot();
+        assert!(engine.maybe_rebroadcast_reshare().is_some());
+
+        // Push past the window (RESHARE_REBROADCAST_SLOTS = 10). Clears
+        // the pending bytes so no stale epoch leaks out later.
+        for _ in 0..20 {
+            engine.advance_slot();
+        }
+        assert!(engine.maybe_rebroadcast_reshare().is_none());
+        // Second call after window: still None — the purge is sticky.
+        assert!(engine.maybe_rebroadcast_reshare().is_none());
+
+        // Suppress unused-variable warning on id in branches that don't touch it.
+        let _ = &mut id;
+    }
+
+    #[test]
+    fn reshare_rebroadcast_none_without_prior_start() {
+        // maybe_rebroadcast with no stashed contribution → always None.
+        let mut engine = ValidatorEngine::new([0u8; 32]);
+        assert!(engine.maybe_rebroadcast_reshare().is_none());
+        for _ in 0..20 {
+            engine.advance_slot();
+            assert!(engine.maybe_rebroadcast_reshare().is_none());
+        }
     }
 
     // ========== Crash-restart safety tests ==========

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -29,6 +29,10 @@ pub mod tag {
     /// validator — not just the one that directly observed the double
     /// proposal — can include the offender in a `Slash` tx.
     pub const CONSENSUS_SLASH_EVIDENCE: u8 = 0x17;
+    /// Cross-committee resharing contribution (task 034). Broadcast by
+    /// outgoing committee members to the incoming committee at epoch
+    /// boundary.
+    pub const COMMITTEE_RESHARING: u8 = 0x18;
     pub const GET_BLOCK_TXS: u8 = 0x04;
     pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
     pub const DECRYPTION_SHARES: u8 = 0x20;
@@ -137,6 +141,114 @@ pub fn decode_pss_refresh(data: &[u8]) -> Result<(u64, Vec<u8>), &'static str> {
     let epoch = dec.u64()?;
     let contribution = dec.var_bytes()?;
     Ok((epoch, contribution))
+}
+
+// ============================================================
+// Committee resharing contribution (task 034)
+// ============================================================
+
+/// Wire payload:
+/// [tag:1][target_epoch:8][contribution_bytes: var_bytes]
+/// The `contribution_bytes` blob is `ResharingContribution::to_bytes()`;
+/// `target_epoch` is the epoch the new committee takes over.
+pub fn encode_resharing(target_epoch: u64, contribution_bytes: &[u8]) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(tag::COMMITTEE_RESHARING);
+    enc.u64(target_epoch);
+    enc.var_bytes(contribution_bytes);
+    enc.finish()
+}
+
+pub fn decode_resharing(data: &[u8]) -> Result<(u64, Vec<u8>), &'static str> {
+    let mut dec = Decoder::new(data);
+    let t = dec.u8()?;
+    if t != tag::COMMITTEE_RESHARING { return Err("not a resharing"); }
+    let target_epoch = dec.u64()?;
+    let contribution = dec.var_bytes()?;
+    Ok((target_epoch, contribution))
+}
+
+// ============================================================
+// ReshareState — persistent resharing runtime (task 034 crash safety)
+// ============================================================
+
+/// Persistable resharing state for `ValidatorEngine`.
+///
+/// Excludes the in-flight contribution pool; on restart we rely on
+/// gossip rebroadcasts to refill it. That's a deliberate trade-off: the
+/// persisted blob stays small (new_committee keys + scalars only,
+/// tens of KB) so fsync latency on each state transition is bounded.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReshareState {
+    pub target_epoch: u64,
+    pub new_index: u64,
+    pub aggregation_trigger_slot: u64,
+    pub aggregated: bool,
+    pub broadcast_start_slot: u64,
+    /// Stashed contribution bytes + target epoch if we're still in the
+    /// outgoing-member rebroadcast window.
+    pub pending_rebroadcast: Option<(u64, Vec<u8>)>,
+    /// FALCON pubkeys of the incoming committee members, in index order.
+    pub new_committee_keys: Vec<Vec<u8>>,
+}
+
+/// Wire format (no tag — this is stored in RocksDB under a fixed key,
+/// not gossipsub'd):
+/// `[target_epoch:8 LE][new_index:8 LE][trigger_slot:8 LE][aggregated:1]`
+/// `[broadcast_start:8 LE][has_pending:1]`
+/// `  if has_pending: [rebroadcast_target:8 LE][bytes: var_bytes]`
+/// `[committee_len:4 LE][[key: var_bytes]*]`
+pub fn encode_reshare_state(s: &ReshareState) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u64(s.target_epoch);
+    enc.u64(s.new_index);
+    enc.u64(s.aggregation_trigger_slot);
+    enc.u8(s.aggregated as u8);
+    enc.u64(s.broadcast_start_slot);
+    match &s.pending_rebroadcast {
+        Some((epoch, bytes)) => {
+            enc.u8(1);
+            enc.u64(*epoch);
+            enc.var_bytes(bytes);
+        }
+        None => enc.u8(0),
+    }
+    enc.u32(s.new_committee_keys.len() as u32);
+    for key in &s.new_committee_keys {
+        enc.var_bytes(key);
+    }
+    enc.finish()
+}
+
+pub fn decode_reshare_state(data: &[u8]) -> Result<ReshareState, &'static str> {
+    let mut dec = Decoder::new(data);
+    let target_epoch = dec.u64()?;
+    let new_index = dec.u64()?;
+    let aggregation_trigger_slot = dec.u64()?;
+    let aggregated = dec.u8()? != 0;
+    let broadcast_start_slot = dec.u64()?;
+    let pending_flag = dec.u8()?;
+    let pending_rebroadcast = if pending_flag != 0 {
+        let epoch = dec.u64()?;
+        let bytes = dec.var_bytes()?;
+        Some((epoch, bytes))
+    } else {
+        None
+    };
+    let count = dec.u32()? as usize;
+    let mut new_committee_keys = Vec::with_capacity(count);
+    for _ in 0..count {
+        new_committee_keys.push(dec.var_bytes()?);
+    }
+    Ok(ReshareState {
+        target_epoch,
+        new_index,
+        aggregation_trigger_slot,
+        aggregated,
+        broadcast_start_slot,
+        pending_rebroadcast,
+        new_committee_keys,
+    })
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

Implements true committee rotation for the threshold-encrypted mempool
(tasks 033 + 034). At each epoch boundary, the outgoing committee
transfers control of the threshold secret to the incoming committee via
share-transfer resharing (Desmedt/Jajodia). The threshold public key
stays invariant, so in-flight ciphertexts remain decryptable without
re-encryption.

## Protocol

1. Outgoing member \`i\` with share \`s_i = f(i)\` picks polynomial \`g_i\` of degree \`new_t - 1\` with \`g_i(0) = s_i\`; broadcasts sub-shares \`g_i(j)\` for each new member \`j\`.
2. Incoming member \`j\` waits \`RESHARE_AGGREGATION_DELAY_SLOTS\` past the epoch boundary so every new member sees the same pool, then picks the **canonical subset** (threshold lowest-indexed old members) and Lagrange-combines: \`H(j) = Σ_{i ∈ canonical} λ_i(0) · g_i(j)\`.
3. Since \`H(0) = f(0) = secret\`, all new members derive shares of the same polynomial. Old committee's shares become stale.
4. Outgoing members re-broadcast every 2 slots for 10 slots. All reshare runtime state persists to \`ConsensusStateStore\` (fsync-per-transition) so an in-progress rotation resumes cleanly after a crash.

## Correctness: deterministic aggregation trigger

Async gossip can deliver contributions to different new members in different orders. Aggregating on first-threshold-reached lets member A hit threshold with pool \`{2,3,4}\` while member B hits it with \`{1,2,3}\` — canonical-subset picks different subsets → different polynomials → silent threshold-decryption failure.

**Fix**: new members don't aggregate on arrival. \`try_aggregate_reshare_on_slot\` fires at \`target_epoch_start_slot + RESHARE_AGGREGATION_DELAY_SLOTS\` (= 5). By then gossipsub has delivered everything; everyone picks identical canonical subsets.

## Crash safety

Reshare runtime state (\`target_epoch\`, \`new_index\`, trigger slot, aggregated flag, pending rebroadcast, new committee roster) fsync-persists to \`ConsensusStateStore\` on every transition. Contribution pool is intentionally NOT persisted — it rebuilds from rebroadcasts within the window. On restart, \`attach_consensus_store\` restores the static fields so an in-progress rotation resumes; the \`aggregated\` flag prevents double-aggregation when late contributions arrive.

## Deferred to post-mainnet

- **Malicious old-member attack**: \`verify_resharing_contribution\` catches polynomial inconsistency but not \`g_i(0) ≠ f(i)\`. A corrupt committee member could silently break new-committee decryption. Mitigation requires VSS / polynomial commitments. Documented in \`MAINNET_PLAN.md\` → "Deferred to post-mainnet". Phase 8+.

## Changes

**pyde-crypto::threshold (~440 LOC):** \`ResharingContribution\`, \`generate_resharing_contribution\`, \`verify_resharing_contribution\`, \`canonical_resharing_subset\`, \`aggregate_new_share\`.

**pyde-node::wire:** \`tag::COMMITTEE_RESHARING\`, \`encode_resharing\` / \`decode_resharing\`, \`ReshareState\` + encode/decode.

**pyde-node::consensus_store:** \`save_reshare_state\` / \`load_reshare_state\` / \`clear_reshare_state\`.

**pyde-node::validator:** Reshare state fields + \`start_committee_reshare\`, \`prepare_for_reshare_reception\`, \`on_reshare_contribution\`, \`try_aggregate_reshare_on_slot\`, \`maybe_rebroadcast_reshare\`, \`reshare_state_snapshot\` / \`restore_reshare_state\`, \`persist_reshare_state\`. Restore on \`attach_consensus_store\`.

**pyde-node::node:** Epoch-boundary + slot-tick wiring for reshare broadcast / rebroadcast / aggregate; inbound handler on \`tag::COMMITTEE_RESHARING\`.

**Test infrastructure:** \`block_processor\` / \`sync\` test helpers switched from fixed \`/tmp/pyde-*\` paths to \`tempfile::tempdir()\` — closes a pre-existing parallel-workspace RocksDB race.

## Tests (24 new)

**pyde-crypto::threshold (9):** reshare_preserves_secret_and_decrypts_old_ciphertext, reshare_any_subset_of_new_committee_suffices, reshare_below_old_threshold_contributions_fails, reshare_canonical_subset_is_lowest_indexed, reshare_two_new_members_converge_on_same_polynomial, reshare_verify_detects_inconsistent_contribution, reshare_verify_rejects_wrong_dimensions, reshare_contribution_roundtrips_through_wire_format, reshare_chain_of_two_rotations_decrypts.

**pyde-node::validator (14):**
- Core flow (4): reshare_full_rotation_preserves_decryption, reshare_ignores_when_not_on_new_committee, reshare_rejects_invalid_contribution, reshare_deduplicates_same_old_index.
- Rebroadcast (2): reshare_rebroadcast_fires_within_window, reshare_rebroadcast_none_without_prior_start.
- Correctness regression (1): **reshare_async_arrival_converges_on_same_polynomial** — simulates asymmetric gossip arrival; would fail under first-threshold aggregation.
- Trigger policy (2): reshare_aggregation_waits_for_trigger, reshare_aggregation_below_threshold_retries.
- Crash safety (5): reshare_state_wire_roundtrip, reshare_state_wire_none_rebroadcast, reshare_state_restores_across_engine_restart, reshare_state_restores_aggregated_flag, reshare_state_pending_rebroadcast_survives_restart.

**pyde-net integration (1, \`tests/reshare_handshake.rs\`):** resharing_end_to_end_over_gossipsub — two real QUIC swarms, gossip all contributions, canonical-subset aggregate, decrypt pre-rotation ciphertext.

Full workspace test run: green in parallel.