### PR TITLE
feat: multi-validator MEV lifecycle + byzantine-proposer auth fix

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -554,11 +554,65 @@ pub fn try_decrypt_and_execute(
         return DecryptOutcome::TxRootMismatch;
     }
 
+    // Re-verify each EncryptedTx's FALCON signature against the sender's
+    // on-chain public key BEFORE decrypting. The sig lives in the
+    // `EncryptedTx::hash()` domain (binds sender + ciphertext_hash +
+    // nonce + gas + chain). Verifying here closes the malicious-proposer
+    // attack: a byzantine proposer could otherwise include an EncryptedTx
+    // with forged sender (bypassing mempool admission entirely), have it
+    // decrypted by the honest committee, and executed. Without this check
+    // a single byzantine proposer steals funds from any EOA.
+    //
+    // Txs whose sender has no `AuthKeys::Single` registration are rejected
+    // here: for mainnet, the only legitimate way an encrypted tx reaches
+    // a block is submit via RPC, which requires the sender to have a
+    // registered auth key (task 028). Accounts without auth_keys (system
+    // accounts, pre-auth EOAs) can't originate encrypted txs.
+    //
+    // A tx that fails verification is dropped from the execution list
+    // rather than aborting the whole block — matches the receipt-per-tx
+    // failure model used elsewhere.
+    let mut verified_enc_indices: Vec<usize> = Vec::with_capacity(decryptor.encrypted_txs.len());
+    for (i, etx) in decryptor.encrypted_txs.iter().enumerate() {
+        let sender_key = pyde_state::keys::balance_key(&etx.sender);
+        let sender_pk: Option<Vec<u8>> = state.get(&sender_key)
+            .and_then(|bytes| pyde_account::types::Account::from_bytes(&bytes))
+            .and_then(|acct| match acct.auth_keys {
+                pyde_account::types::AuthKeys::Single(pk) => Some(pk),
+                _ => None,
+            });
+        match sender_pk {
+            Some(pk) => {
+                if pyde_mempool::pool::Mempool::verify_signature_with_key(etx, &pk) {
+                    verified_enc_indices.push(i);
+                } else {
+                    warn!(
+                        slot,
+                        sender = hex::encode(etx.sender),
+                        "dropping encrypted tx with invalid FALCON signature — block may have been built by a byzantine proposer"
+                    );
+                }
+            }
+            None => {
+                warn!(
+                    slot,
+                    sender = hex::encode(etx.sender),
+                    "dropping encrypted tx from sender with no registered auth key"
+                );
+            }
+        }
+    }
+
     let decrypted_txs = match decryptor.decrypt_all() {
         Ok(t) => t,
         Err(e) => return DecryptOutcome::DecryptFailed(e),
     };
 
+    // After explicit verification above, the Transaction's signature
+    // field (which is over `EncryptedTx::hash()`, not `Transaction::hash()`)
+    // would fail a naive re-check. `dev_skip_signature: true` is safe
+    // here because each tx we execute below was already FALCON-verified
+    // in the correct hash domain.
     let block_ctx = BlockContext {
         height: slot,
         timestamp: header.timestamp,
@@ -566,10 +620,13 @@ pub fn try_decrypt_and_execute(
         block_gas_limit,
         chain_id,
         validator_address: proposer_addr,
-        dev_skip_signature: false,
+        dev_skip_signature: true,
     };
     let mut receipts = Vec::with_capacity(decrypted_txs.len());
-    for dtx in &decrypted_txs {
+    for (i, dtx) in decrypted_txs.iter().enumerate() {
+        if !verified_enc_indices.contains(&i) {
+            continue;
+        }
         match execute_transaction(dtx, &mut *state.smt_mut(), &block_ctx) {
             Ok(r) => receipts.push(r),
             Err(e) => warn!(slot, error = ?e, "decrypted tx execution failed"),
@@ -578,7 +635,7 @@ pub fn try_decrypt_and_execute(
     state.refresh_root();
 
     DecryptOutcome::Executed {
-        tx_count: decrypted_txs.len(),
+        tx_count: verified_enc_indices.len(),
         receipts,
     }
 }
@@ -914,9 +971,14 @@ mod tests {
 
     #[test]
     fn try_decrypt_and_execute_runs_on_honest_decryptor() {
-        // Positive case: honest decryptor + honest block → Executed outcome,
-        // regardless of tx-level success/failure (dummy sigs will fail at
-        // execution time, producing failed receipts, but the flow runs).
+        // Positive case: honest decryptor + honest block → Executed outcome.
+        // Note `tx_count` reports VERIFIED txs (passed FALCON check against
+        // on-chain auth key). The test's helper builds ciphertexts with
+        // dummy-byte signatures and unregistered senders, so verified
+        // count is 0 — but the Executed variant confirms the end-to-end
+        // pipeline ran without tx_root / header / decrypt failures.
+        // End-to-end with real keys is covered by the e2e suite in
+        // validator.rs tests.
         let tmp = tempfile::tempdir().unwrap();
         let mut state = StateManager::open(tmp.path(), 1024).unwrap();
         let bs = crate::block_store::BlockStore::open(tmp.path()).unwrap();
@@ -939,8 +1001,8 @@ mod tests {
         );
 
         assert!(
-            matches!(outcome, DecryptOutcome::Executed { tx_count: 2, .. }),
-            "honest decryptor must execute; got {:?}",
+            matches!(outcome, DecryptOutcome::Executed { .. }),
+            "honest decryptor must reach the Executed outcome; got {:?}",
             outcome
         );
     }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -3335,4 +3335,510 @@ mod tests {
         assert_eq!(decryptor.tx_count(), 1);
         assert_eq!(decryptor.share_count(0), 1); // our own share added
     }
+
+    // ==========================================================================
+    // Task 031 + 032: multi-node MEV lifecycle + frontrun rejection
+    // ==========================================================================
+    //
+    // These tests orchestrate three simulated validators through the full MEV
+    // pipeline: submit encrypted tx → block build → body validation → plaintext
+    // execution → threshold decryption → decrypted execution → state root
+    // convergence. Networking is stubbed (direct function calls between
+    // engines) so the tests are deterministic and fast — real libp2p transport
+    // is exercised separately by `auth_handshake.rs` + `reshare_handshake.rs`.
+
+    use crate::block_processor::{try_decrypt_and_execute, BlockProcessor, DecryptOutcome};
+    use crate::block_store::BlockStore;
+    use crate::chain::ChainState;
+    use crate::state_manager::StateManager;
+    use crate::wire;
+    use pyde_consensus::block::{Block, BlockBody};
+    use pyde_mempool::decryption::BlockDecryptor;
+    use pyde_mempool::encrypted::{encrypt_transaction, EncryptedTx};
+    use pyde_tx::parallel::ExecutionSchedule;
+    use pyde_tx::types::AccessEntry;
+    use tempfile::TempDir;
+
+    /// Per-node test rig for the MEV e2e scenarios.
+    struct E2ENode {
+        state: StateManager,
+        chain: ChainState,
+        block_store: BlockStore,
+        key_share: pyde_crypto::threshold::KeyShare,
+        _tmp: TempDir,
+    }
+
+    impl E2ENode {
+        fn new(key_share: pyde_crypto::threshold::KeyShare, chain_id: u64) -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let state = StateManager::open(tmp.path(), 1024).unwrap();
+            let block_store = BlockStore::open(tmp.path()).unwrap();
+            let chain = ChainState::genesis(state.root(), chain_id);
+            Self { state, chain, block_store, key_share, _tmp: tmp }
+        }
+    }
+
+    fn e2e_header(
+        slot: u64,
+        parent_hash: [u8; 32],
+        state_root: [u8; 32],
+        tx_root: [u8; 32],
+    ) -> BlockHeader {
+        BlockHeader {
+            slot,
+            epoch: 0,
+            parent_hash,
+            proposer: [0u8; 32],
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root,
+            state_root,
+            timestamp: slot * 400,
+        }
+    }
+
+    fn e2e_access_list() -> Vec<AccessEntry> {
+        vec![AccessEntry {
+            address: [0x01; 32],
+            reads: vec![[0x01; 32]],
+            writes: vec![],
+        }]
+    }
+
+    fn e2e_signed_encrypted(
+        tpk: &pyde_crypto::threshold::ThresholdPublicKey,
+        sender_keys: &(pyde_crypto::falcon::FalconPublicKey, pyde_crypto::falcon::FalconSecretKey),
+        recipient: Address,
+        value: u128,
+        nonce: u64,
+    ) -> EncryptedTx {
+        let (pk, sk) = sender_keys;
+        let sender = pyde_account::address::derive_eoa_address(pk.as_bytes());
+        let template = encrypt_transaction(
+            sender, nonce, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0u8; 666], &recipient, value, b"",
+            tpk,
+        ).unwrap();
+        let hash = template.hash();
+        let sig = pyde_crypto::falcon::falcon_sign(sk, &hash).unwrap().to_vec();
+        EncryptedTx {
+            sender,
+            nonce,
+            gas_limit: 100_000,
+            access_list: template.access_list.clone(),
+            deadline: None,
+            chain_id: 31337,
+            signature: sig,
+            ciphertext: template.ciphertext.clone(),
+        }
+    }
+
+    #[test]
+    fn e2e_encrypted_tx_lifecycle_three_validators() {
+        // TASK 031: submit encrypted tx → commit → decrypt → seal.
+        //
+        // Three validators with a 2-of-3 threshold. A transfer from Alice
+        // (funded at genesis) to Bob gets encrypted, committed to a block,
+        // threshold-decrypted, and applied. Final state root matches across
+        // all three validators — the strongest property we can assert
+        // about MEV-protected txs in one test.
+        use pyde_crypto::falcon::falcon_keygen;
+        use pyde_crypto::threshold::threshold_keygen;
+
+        let (tpk, key_shares) = threshold_keygen(3, 2).unwrap();
+        let alice_keys = falcon_keygen().unwrap();
+        let alice = pyde_account::address::derive_eoa_address(alice_keys.0.as_bytes());
+        let bob = pyde_account::address::derive_eoa_address(b"bob-recipient");
+
+        let mut nodes: Vec<E2ENode> = key_shares
+            .iter()
+            .take(3)
+            .map(|ks| E2ENode::new(ks.clone(), 31337))
+            .collect();
+
+        // Fund Alice with an on-chain account (balance + FALCON pubkey
+        // for signature verification during decrypted-tx execution).
+        // Bypasses real genesis config to keep the test narrow.
+        let starting_balance: u128 = 10_000_000_000_000_000_000_u128; // plenty for gas + transfer
+        let mut alice_account = pyde_account::types::Account::new_eoa(alice_keys.0.as_bytes());
+        alice_account.balance = starting_balance;
+        let account_bytes = alice_account.to_bytes();
+        for node in &mut nodes {
+            let key = pyde_state::keys::balance_key(&alice);
+            node.state.insert(key, account_bytes.clone()).unwrap();
+            node.state.refresh_root();
+            node.chain = ChainState::genesis(node.state.root(), 31337);
+        }
+        assert_eq!(nodes[0].state.root(), nodes[1].state.root());
+        assert_eq!(nodes[1].state.root(), nodes[2].state.root());
+
+        // Alice encrypts a 100-quanta transfer to Bob.
+        let enc_tx = e2e_signed_encrypted(&tpk, &alice_keys, bob, 100, 0);
+        let encrypted_body: Vec<Vec<u8>> = vec![enc_tx.to_bytes()];
+        let tx_root = pyde_consensus::block::compute_tx_root(&[], &[enc_tx.hash()]);
+
+        let starting_root = nodes[0].state.root();
+        let header = e2e_header(1, [0u8; 32], starting_root, tx_root);
+        let block = Block {
+            header: header.clone(),
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: encrypted_body.clone(),
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+
+        // Every validator processes the block. Body validation runs the
+        // tx_root check from slice 3.1; execution advances chain state.
+        // Storing the raw block lets the decrypt path fetch it later.
+        let raw = wire::encode_block(&block);
+        for node in &mut nodes {
+            BlockProcessor::validate_block_body(&block, &node.state, 31337)
+                .expect("honest block must pass body validation");
+            node.block_store.put_block(&header, &raw).unwrap();
+            BlockProcessor::process_full_block(&mut node.chain, &mut node.state, &block)
+                .expect("honest block must process");
+        }
+        for n in &nodes {
+            assert_eq!(n.chain.head_slot, 1);
+        }
+
+        // Each validator produces a decryption share. In production these
+        // ride the consensus gossip topic post-QC; we collect them directly.
+        let shares: Vec<_> = nodes
+            .iter()
+            .map(|n| pyde_crypto::threshold::generate_decryption_share(&n.key_share, &enc_tx.ciphertext))
+            .collect();
+
+        // Every validator then runs the decrypt+execute path. Uses the
+        // same `try_decrypt_and_execute` helper the production node loop
+        // calls — so the MEV invariant check (slice 3.1's second-chance
+        // tx_root verify) fires on every node.
+        for node in &mut nodes {
+            let mut decryptor = BlockDecryptor::new(vec![enc_tx.clone()], 2).unwrap();
+            decryptor.add_share(0, shares[0].clone());
+            decryptor.add_share(0, shares[1].clone());
+            assert!(decryptor.all_ready());
+            let outcome = try_decrypt_and_execute(
+                &node.block_store,
+                1,
+                &mut decryptor,
+                &mut node.state,
+                400_000_000,
+                1_000_000_000,
+                31337,
+                [0u8; 32],
+            );
+            assert!(
+                matches!(outcome, DecryptOutcome::Executed { tx_count: 1, .. }),
+                "decrypt+execute must succeed on every validator; got {:?}",
+                outcome
+            );
+        }
+
+        // All three validators converged on the same post-decryption
+        // state root, AND the root actually changed — the decrypted
+        // transfer produced a real write. Both properties together are
+        // the end-to-end MEV guarantee: every validator applied the
+        // committed ordering and ended up with the same correct state.
+        let final_root = nodes[0].state.root();
+        assert_eq!(nodes[1].state.root(), final_root);
+        assert_eq!(nodes[2].state.root(), final_root);
+        assert_ne!(final_root, starting_root);
+
+        // Bob got his transfer, Alice's balance dropped (ignoring gas).
+        let bob_key = pyde_state::keys::balance_key(&bob);
+        let bob_raw = nodes[0].state.get(&bob_key).expect("bob should exist");
+        // Account format: parse as Account if it decodes, else u128 LE.
+        let bob_balance = pyde_account::types::Account::from_bytes(&bob_raw)
+            .map(|a| a.balance)
+            .unwrap_or_else(|| {
+                let mut buf = [0u8; 16];
+                buf.copy_from_slice(&bob_raw[..16]);
+                u128::from_le_bytes(buf)
+            });
+        assert_eq!(bob_balance, 100, "bob received the 100-quanta transfer");
+    }
+
+    #[test]
+    fn e2e_frontrun_by_reorder_is_rejected() {
+        // TASK 032: any attempt to reorder encrypted_txs after QC breaks
+        // the tx_root → header hash → proposer-signature chain. Body
+        // validation rejects the tampered block before decryption.
+        use pyde_crypto::threshold::threshold_keygen;
+        let (tpk, _) = threshold_keygen(3, 2).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
+
+        let tx_a = encrypt_transaction(
+            [0xAA; 32], 0, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0xAA; 666], &[0x11; 32], 100, b"swap-a",
+            &tpk,
+        ).unwrap();
+        let tx_b = encrypt_transaction(
+            [0xBB; 32], 1, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0xBB; 666], &[0x22; 32], 200, b"swap-b",
+            &tpk,
+        ).unwrap();
+
+        // Honest tx_root commits to [A, B]; tampered body ships [B, A].
+        let honest_tx_root = pyde_consensus::block::compute_tx_root(
+            &[], &[tx_a.hash(), tx_b.hash()],
+        );
+        let header = e2e_header(1, [0u8; 32], state.root(), honest_tx_root);
+        let tampered = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![tx_b.to_bytes(), tx_a.to_bytes()],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+
+        let err = BlockProcessor::validate_block_body(&tampered, &state, 31337)
+            .expect_err("tampered block must be rejected");
+        assert!(
+            err.contains("tx_root mismatch"),
+            "expected tx_root mismatch, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn e2e_frontrun_by_injection_is_rejected() {
+        // Injection variant of 032: attacker prepends a sandwich-front tx
+        // hoping to execute before the victim. tx_root committed to just
+        // the victim, so the injected tx breaks validation.
+        use pyde_crypto::threshold::threshold_keygen;
+        let (tpk, _) = threshold_keygen(3, 2).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
+
+        let victim = encrypt_transaction(
+            [0xAA; 32], 0, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0xAA; 666], &[0x11; 32], 100, b"victim-swap",
+            &tpk,
+        ).unwrap();
+        let sandwich_front = encrypt_transaction(
+            [0xEE; 32], 0, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0xEE; 666], &[0x22; 32], 50_000, b"front",
+            &tpk,
+        ).unwrap();
+
+        let honest_tx_root = pyde_consensus::block::compute_tx_root(&[], &[victim.hash()]);
+        let header = e2e_header(1, [0u8; 32], state.root(), honest_tx_root);
+        let tampered = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![sandwich_front.to_bytes(), victim.to_bytes()],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+
+        let err = BlockProcessor::validate_block_body(&tampered, &state, 31337)
+            .expect_err("injection must be rejected");
+        assert!(err.contains("tx_root mismatch"), "got: {}", err);
+    }
+
+    #[test]
+    fn e2e_byzantine_proposer_forged_encrypted_tx_rejected_at_execute() {
+        // REGRESSION TEST for the malicious-proposer hole surfaced during
+        // slice 3.6. A byzantine proposer includes an EncryptedTx with a
+        // forged sender (bypasses mempool admission entirely). The
+        // committee decrypts it (crypto works), but execution must reject
+        // because the FALCON signature doesn't verify against Alice's
+        // on-chain auth key.
+        use pyde_crypto::falcon::falcon_keygen;
+        use pyde_crypto::threshold::threshold_keygen;
+
+        let (tpk, key_shares) = threshold_keygen(3, 2).unwrap();
+        let alice_keys = falcon_keygen().unwrap();
+        let alice = pyde_account::address::derive_eoa_address(alice_keys.0.as_bytes());
+        let attacker = pyde_account::address::derive_eoa_address(b"attacker");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let bs = BlockStore::open(tmp.path()).unwrap();
+
+        // Alice funded with proper on-chain auth key.
+        let mut alice_account = pyde_account::types::Account::new_eoa(alice_keys.0.as_bytes());
+        alice_account.balance = 10_000_000_000_000_000_000_u128;
+        state.insert(
+            pyde_state::keys::balance_key(&alice),
+            alice_account.to_bytes(),
+        ).unwrap();
+        state.refresh_root();
+
+        // Byzantine proposer forges: sender=alice, garbage sig, but the
+        // transfer ciphertext actually moves Alice's funds to attacker.
+        // (In a real attack the sig would be something plausible-looking,
+        // but a 666-byte garbage blob is indistinguishable at mempool
+        // structural check.)
+        let template = encrypt_transaction(
+            alice, 0, 100_000,
+            e2e_access_list(), None, 31337,
+            vec![0xFF; 666], &attacker, 1_000, b"",
+            &tpk,
+        ).unwrap();
+        let forged = EncryptedTx {
+            sender: alice, // plaintext — attacker claims to be alice
+            nonce: 0,
+            gas_limit: 100_000,
+            access_list: template.access_list,
+            deadline: None,
+            chain_id: 31337,
+            signature: vec![0xFF; 666], // garbage — NOT signed by alice
+            ciphertext: template.ciphertext,
+        };
+        let forged_hash = forged.hash();
+
+        // Proposer puts it in a block with the correct tx_root (they're
+        // building the block, so they can commit to whatever they're
+        // shipping — slice 3.1's ordering commitment doesn't help here,
+        // this is a different attack).
+        let tx_root = pyde_consensus::block::compute_tx_root(&[], &[forged_hash]);
+        let header = e2e_header(1, [0u8; 32], state.root(), tx_root);
+        let block = Block {
+            header: header.clone(),
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![forged.to_bytes()],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+        bs.put_block(&header, &wire::encode_block(&block)).unwrap();
+
+        // Body validation passes (tx_root matches) — this is NOT what
+        // catches the attack.
+        BlockProcessor::validate_block_body(&block, &state, 31337).unwrap();
+
+        let before_root = state.root();
+        let before_balance = 10_000_000_000_000_000_000_u128;
+
+        // Run decryption + execution. The FALCON sig won't verify against
+        // Alice's on-chain pubkey over EncryptedTx::hash(), so the tx is
+        // dropped BEFORE it can move her funds.
+        let shares: Vec<_> = key_shares
+            .iter()
+            .take(2)
+            .map(|ks| pyde_crypto::threshold::generate_decryption_share(ks, &forged.ciphertext))
+            .collect();
+        let mut decryptor = BlockDecryptor::new(vec![forged], 2).unwrap();
+        decryptor.add_share(0, shares[0].clone());
+        decryptor.add_share(0, shares[1].clone());
+        let outcome = try_decrypt_and_execute(
+            &bs, 1, &mut decryptor, &mut state,
+            400_000_000, 1_000_000_000, 31337, [0u8; 32],
+        );
+
+        // Outcome reports zero verified txs executed (the forged one
+        // was dropped).
+        match outcome {
+            DecryptOutcome::Executed { tx_count, .. } => {
+                assert_eq!(tx_count, 0, "forged tx must NOT be counted as executed");
+            }
+            other => panic!("unexpected outcome: {:?}", other),
+        }
+
+        // Alice's balance is untouched. Root may change due to SMT
+        // bookkeeping, but the balance key must still hold her original
+        // funds.
+        let alice_raw = state.get(&pyde_state::keys::balance_key(&alice)).unwrap();
+        let alice_acct = pyde_account::types::Account::from_bytes(&alice_raw).unwrap();
+        assert_eq!(
+            alice_acct.balance, before_balance,
+            "alice's funds must be untouched by the forged tx"
+        );
+        let _ = before_root;
+    }
+
+    #[test]
+    fn e2e_decrypted_ordering_matches_committed_ordering() {
+        // Completes the "committed → executed" chain: if a block commits
+        // to encrypted order [A, B], the decrypted txs must execute in
+        // THAT order, not whatever a malicious validator might prefer.
+        // A tampered decryptor (one that reorders encrypted_txs) is
+        // rejected by try_decrypt_and_execute's secondary tx_root check.
+        use pyde_crypto::falcon::falcon_keygen;
+        use pyde_crypto::threshold::threshold_keygen;
+        let (tpk, shares) = threshold_keygen(3, 2).unwrap();
+
+        // Both senders get FALCON-backed accounts so execute-time auth
+        // verification accepts the honest txs. (Proves the ordering
+        // invariant independently of the byzantine-proposer auth hole.)
+        let sender_a_keys = falcon_keygen().unwrap();
+        let sender_b_keys = falcon_keygen().unwrap();
+        let tx_a = e2e_signed_encrypted(&tpk, &sender_a_keys, [0x11; 32], 100, 0);
+        let tx_b = e2e_signed_encrypted(&tpk, &sender_b_keys, [0x22; 32], 200, 0);
+
+        let committed_root = pyde_consensus::block::compute_tx_root(
+            &[], &[tx_a.hash(), tx_b.hash()],
+        );
+        let header = e2e_header(1, [0u8; 32], [0u8; 32], committed_root);
+        let block = Block {
+            header: header.clone(),
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![tx_a.to_bytes(), tx_b.to_bytes()],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let bs = BlockStore::open(tmp.path()).unwrap();
+        bs.put_block(&header, &wire::encode_block(&block)).unwrap();
+
+        // Fund each sender account so the honest-path auth check passes.
+        // Balances are ample for the transfer + gas.
+        for keys in [&sender_a_keys, &sender_b_keys] {
+            let addr = pyde_account::address::derive_eoa_address(keys.0.as_bytes());
+            let mut acct = pyde_account::types::Account::new_eoa(keys.0.as_bytes());
+            acct.balance = 10_000_000_000_000_000_000_u128;
+            state.insert(
+                pyde_state::keys::balance_key(&addr),
+                acct.to_bytes(),
+            ).unwrap();
+        }
+        state.refresh_root();
+
+        // Honest decryptor, committed order [A, B].
+        let mut honest = BlockDecryptor::new(vec![tx_a.clone(), tx_b.clone()], 2).unwrap();
+        honest.add_share(0, pyde_crypto::threshold::generate_decryption_share(&shares[0], &tx_a.ciphertext));
+        honest.add_share(0, pyde_crypto::threshold::generate_decryption_share(&shares[1], &tx_a.ciphertext));
+        honest.add_share(1, pyde_crypto::threshold::generate_decryption_share(&shares[0], &tx_b.ciphertext));
+        honest.add_share(1, pyde_crypto::threshold::generate_decryption_share(&shares[1], &tx_b.ciphertext));
+        let honest_outcome = try_decrypt_and_execute(
+            &bs, 1, &mut honest, &mut state,
+            400_000_000, 1_000_000_000, 31337, [0u8; 32],
+        );
+        assert!(
+            matches!(honest_outcome, DecryptOutcome::Executed { tx_count: 2, .. }),
+            "honest-order decrypt must run; got {:?}",
+            honest_outcome
+        );
+
+        // Tampered decryptor flipping to [B, A] is rejected by the
+        // second-chance tx_root check in try_decrypt_and_execute.
+        let mut tampered = BlockDecryptor::new(vec![tx_b, tx_a], 2).unwrap();
+        let tampered_outcome = try_decrypt_and_execute(
+            &bs, 1, &mut tampered, &mut state,
+            400_000_000, 1_000_000_000, 31337, [0u8; 32],
+        );
+        assert!(
+            matches!(tampered_outcome, DecryptOutcome::TxRootMismatch),
+            "reordered decryptor must be rejected; got {:?}",
+            tampered_outcome
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes Phase 3 with end-to-end tests that tie together every MEV
protection layer from slices 3.1-3.5, and surfaces + closes a
load-bearing authorization bug in the decrypted-tx execution path.

## Critical fix: byzantine proposer auth bypass

\`try_decrypt_and_execute\` now verifies each EncryptedTx's FALCON
signature against the sender's on-chain auth_key **in the correct hash
domain** (\`EncryptedTx::hash()\`) BEFORE execution. Without this, a
byzantine proposer could include a forged-sender EncryptedTx that never
passed mempool admission, get it decrypted by the honest committee,
and execute it to steal the claimed sender's funds. Txs that fail
verification are dropped without touching state; \`dev_skip_signature=true\`
during execute is safe because each tx was already verified in the
correct domain.

Post-fix the tx lifecycle is bracketed by two authorization checks:
- **Submit time**: \`add_with_pubkey\` verifies \`EncryptedTx::hash()\` against the sender's on-chain \`AuthKeys::Single\` at RPC ingress (task 028).
- **Execute time**: this PR re-verifies the same sig + domain against the same auth source before applying state changes.

Bypassing either layer is detectable; a byzantine proposer can't forge a sender without compromising their FALCON key.

## Changes

**pyde-node/block_processor.rs:**
- \`try_decrypt_and_execute\` pre-verifies EncryptedTx sigs via \`Mempool::verify_signature_with_key\` against on-chain \`AuthKeys::Single\` lookup. Unverified txs dropped with warning log.
- Outcome \`tx_count\` reports verified-only count.

**pyde-node/validator.rs tests:**
- \`E2ENode\` rig + \`e2e_signed_encrypted\` helper (single-process multi-validator orchestration). Real libp2p transport is exercised separately by \`auth_handshake.rs\` + \`reshare_handshake.rs\`.

## Tests (5 new)

- \`e2e_encrypted_tx_lifecycle_three_validators\` (task 031) — three validators, 2-of-3 threshold, full submit→encrypt→commit→decrypt→seal pipeline, asserts state-root convergence + Bob's 100-quanta balance after decryption.
- \`e2e_frontrun_by_reorder_is_rejected\` (task 032) — reorder attack.
- \`e2e_frontrun_by_injection_is_rejected\` (task 032) — sandwich-front injection.
- \`e2e_decrypted_ordering_matches_committed_ordering\` — committed order must match executed order; tampered decryptor rejected by \`try_decrypt_and_execute\` secondary tx_root check.
- \`e2e_byzantine_proposer_forged_encrypted_tx_rejected_at_execute\` — **regression test** for the auth hole this PR closes. Malicious proposer forges \`sender=alice\`; execute-time verification drops the tx; Alice's balance untouched.

Full workspace: green.