### PR TITLE
chore: phase 1 closeout — peer-score evidence filter + unified slash constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ version = "0.1.0"
 dependencies = [
  "pyde-account",
  "pyde-crypto",
+ "pyde-slashing",
  "pyde-tx",
  "sparse-merkle-tree",
 ]
@@ -3537,6 +3538,7 @@ dependencies = [
  "pyde-crypto",
  "pyde-mempool",
  "pyde-net",
+ "pyde-slashing",
  "pyde-state",
  "pyde-tx",
  "pyde-vm",
@@ -3575,6 +3577,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyde-slashing"
+version = "0.1.0"
+
+[[package]]
 name = "pyde-state"
 version = "0.1.0"
 dependencies = [
@@ -3595,6 +3601,7 @@ dependencies = [
  "pyde-account",
  "pyde-aot",
  "pyde-crypto",
+ "pyde-slashing",
  "pyde-state",
  "pyde-vm",
  "sparse-merkle-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/aot",
     "crates/state",
     "crates/account",
+    "crates/slashing",
     "crates/tx",
     "crates/consensus",
     "crates/mempool",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 pyde-crypto = { path = "../crypto" }
 pyde-account = { path = "../account" }
 pyde-tx = { path = "../tx" }
+pyde-slashing = { path = "../slashing" }
 sparse-merkle-tree = "0.6"

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -18,8 +18,10 @@ use crate::validator::{Validator, ValidatorSet, ValidatorStatus, VALIDATOR_STAKE
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 
-/// Finder's fee percentage (10% of slashed amount).
-pub const FINDER_FEE_PERCENT: u128 = 10;
+/// Finder's fee percentage (10% of slashed amount). Canonical definition
+/// in `pyde-slashing`; re-exported here so existing consumers continue
+/// to work via `pyde_consensus::slashing::FINDER_FEE_PERCENT`.
+pub use pyde_slashing::FINDER_FEE_PERCENT;
 
 /// Slash percentages for liveness tiers.
 pub const LIVENESS_SLASH_MINOR: u128 = 1;   // 1% — participation < 90%

--- a/crates/consensus/src/validator.rs
+++ b/crates/consensus/src/validator.rs
@@ -9,8 +9,11 @@ use crate::block::{COMMITTEE_SIZE, EPOCH_LENGTH};
 use pyde_account::address::Address;
 use pyde_crypto::poseidon2::poseidon2_hash;
 
-/// Required stake to register as a validator (in quanta, 10^9 quanta = 1 PYDE).
-pub const VALIDATOR_STAKE: u128 = 10_000_000_000_000; // 10,000 PYDE
+/// Required stake to register as a validator. Canonical definition lives
+/// in the `pyde-slashing` leaf crate so the slash-tx handler in `pyde-tx`
+/// (which can't depend on `pyde-consensus` due to a dep cycle) reads the
+/// same value. Re-exported here for backward-compat with existing consumers.
+pub use pyde_slashing::VALIDATOR_STAKE;
 
 /// Unbonding period in blocks (~14 days at 400ms blocks).
 /// 14 days × 24 hours × 60 min × 60 sec / 0.4 sec = 3,024,000 blocks.

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,6 +18,7 @@ pyde-tx = { path = "../tx" }
 pyde-consensus = { path = "../consensus" }
 pyde-mempool = { path = "../mempool" }
 pyde-net = { path = "../net" }
+pyde-slashing = { path = "../slashing" }
 rayon = "1.10"
 libp2p = { version = "0.54", features = ["quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify", "request-response", "cbor", "serde"] }
 serde_json = "1"

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1751,6 +1751,27 @@ fn handle_swarm_event(
                         // that never directly witnessed the equivocation
                         // can include a Slash tx in its next proposal.
                         if !message.data.is_empty() && message.data[0] == wire::tag::CONSENSUS_SLASH_EVIDENCE {
+                            // Task 014d: rate-limit evidence ingest by peer score.
+                            // Evidence verification costs ~60µs of FALCON verify.
+                            // A spammer that has already produced
+                            // `EVIDENCE_SPAM_THRESHOLD` rejected messages gets
+                            // dropped without decode+verify. Honest validators
+                            // producing legitimate evidence stay well under
+                            // the threshold because `ingest_evidence` dedupes
+                            // by (slot, signer) and silently ignores repeats.
+                            const EVIDENCE_SPAM_THRESHOLD: u64 = 5;
+                            let propagator_invalid = peer_manager
+                                .get_peer(&propagation_source)
+                                .map(|p| p.invalid_messages)
+                                .unwrap_or(0);
+                            if propagator_invalid >= EVIDENCE_SPAM_THRESHOLD {
+                                debug!(
+                                    forwarder = %propagation_source,
+                                    invalid = propagator_invalid,
+                                    "dropping evidence from peer over spam threshold"
+                                );
+                                return PostEventAction::None;
+                            }
                             match wire::decode_slash_evidence_msg(&message.data) {
                                 Ok(evidence) => {
                                     let slot = evidence.slot;
@@ -1761,6 +1782,14 @@ fn handle_swarm_event(
                                             signer = hex::encode(signer),
                                             "ingested slash evidence from gossip"
                                         );
+                                    } else {
+                                        // Failed verification or dedupe — bump
+                                        // the peer's invalid counter so repeat
+                                        // offenders cross the spam threshold
+                                        // and get dropped without further verify.
+                                        if let Some(info) = peer_manager.get_peer_mut(&propagation_source) {
+                                            info.invalid_messages = info.invalid_messages.saturating_add(1);
+                                        }
                                     }
                                     // Note: no immediate re-publish here.
                                     // gossipsub already propagates the
@@ -1769,6 +1798,9 @@ fn handle_swarm_event(
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode slash evidence gossip");
+                                    if let Some(info) = peer_manager.get_peer_mut(&propagation_source) {
+                                        info.invalid_messages = info.invalid_messages.saturating_add(1);
+                                    }
                                 }
                             }
                             return PostEventAction::None;

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -2969,10 +2969,9 @@ mod tests {
         // mutations. It's what a validator would do on every block
         // proposal when its pending_evidence queue is non-empty.
         use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+        use pyde_slashing::VALIDATOR_STAKE;
         use pyde_state::smt::PydeSMT;
         use pyde_tx::pipeline::{execute_transaction, BlockContext};
-
-        const VALIDATOR_STAKE: u128 = 10_000_000_000_000;
 
         // Offender: produces the two conflicting signatures.
         let (offender_pk, offender_sk) = falcon_keygen().unwrap();

--- a/crates/slashing/Cargo.toml
+++ b/crates/slashing/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "pyde-slashing"
+version = "0.1.0"
+edition = "2021"
+description = "Shared slashing constants and evidence schema version for Pyde. Leaf crate with zero deps — intentionally kept minimal so both pyde-tx (slash-tx handler) and pyde-consensus (slash-result computation) can depend on it without creating a dep cycle."
+
+[dependencies]

--- a/crates/slashing/src/lib.rs
+++ b/crates/slashing/src/lib.rs
@@ -1,0 +1,32 @@
+//! Shared slashing constants. Single source of truth for:
+//!
+//! - `VALIDATOR_STAKE` — exact amount a validator locks on register
+//!   (also the cap on per-offense slash amount)
+//! - `FINDER_FEE_PERCENT` — percentage of burned stake that goes to the
+//!   reporter of double-sign evidence
+//! - `EVIDENCE_VERSION` — wire-format version byte on
+//!   `DoubleSignEvidence` serialization
+//!
+//! Pre-consolidation, these lived in three places:
+//! `pyde-consensus::validator`, `pyde-consensus::slashing`, and inline
+//! `const` in `pyde-tx::pipeline`. The duplication existed because
+//! `pyde-tx` can't depend on `pyde-consensus` (cycle — consensus
+//! depends on tx), so the slash-tx handler had to shadow the values.
+//! Drift across forks would have broken slash-tx execution silently.
+//! A shared leaf crate eliminates the drift risk.
+
+#![no_std]
+
+/// Validator stake denomination. 10_000 PYDE = 10^13 quanta.
+/// This value is load-bearing for slashing math — the slash handler
+/// matches against `stake.min(VALIDATOR_STAKE)` to cap punishment at
+/// one full stake even if the validator over-collateralized.
+pub const VALIDATOR_STAKE: u128 = 10_000_000_000_000;
+
+/// Finder's-fee percentage paid to the submitter of valid double-sign
+/// evidence. Expressed as integer percent (10 = 10%).
+pub const FINDER_FEE_PERCENT: u128 = 10;
+
+/// Wire-format version byte on `DoubleSignEvidence`. Bump only when
+/// the byte layout changes in a way that pre-upgrade nodes can't parse.
+pub const EVIDENCE_VERSION: u8 = 1;

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -9,6 +9,7 @@ pyde-account = { path = "../account" }
 pyde-vm = { path = "../pvm" }
 pyde-state = { path = "../state" }
 pyde-aot = { path = "../aot" }
+pyde-slashing = { path = "../slashing" }
 sparse-merkle-tree = "0.6"
 tracing = "0.1"
 hex = "0.4"

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -327,8 +327,9 @@ fn execute_transaction_inner(
         TransactionType::StakeDeposit => {
             // Stake deposit: lock VALIDATOR_STAKE from sender, create validator entry.
             // tx.data = FALCON-512 public key (897 bytes).
-            // 10,000 PYDE = 10_000_000_000_000 quanta (matches consensus::validator::VALIDATOR_STAKE)
-            const VALIDATOR_STAKE: u128 = 10_000_000_000_000;
+            // Shared constant — see `pyde-slashing` crate for the authoritative
+            // value and why it's in a leaf crate.
+            use pyde_slashing::VALIDATOR_STAKE;
 
             if sender.balance < VALIDATOR_STAKE {
                 (
@@ -731,13 +732,14 @@ fn execute_in_pvm(
 // Slash transaction handler
 // ============================================================
 //
-// Canonical constants — kept in lockstep with consensus::slashing.
-// pyde-tx cannot depend on pyde-consensus (consensus already depends
-// on tx), so the values are duplicated here. Any change must land on
-// both sides simultaneously.
-const SLASH_VALIDATOR_STAKE: u128 = 10_000_000_000_000;
-const SLASH_FINDER_FEE_PERCENT: u128 = 10;
-const SLASH_EVIDENCE_VERSION: u8 = 1;
+// Canonical constants live in `pyde-slashing`. Both `pyde-tx` and
+// `pyde-consensus` depend on it directly — this eliminates the earlier
+// drift risk where the shadow copies could fork.
+use pyde_slashing::{
+    EVIDENCE_VERSION as SLASH_EVIDENCE_VERSION,
+    FINDER_FEE_PERCENT as SLASH_FINDER_FEE_PERCENT,
+    VALIDATOR_STAKE as SLASH_VALIDATOR_STAKE,
+};
 
 /// Parsed contents of a `TransactionType::Slash` payload.
 struct SlashEvidence {


### PR DESCRIPTION
## Summary

Closes Phase 1 hardening leftovers 014d + 014g. 014e is reviewed and
explicitly deferred as post-mainnet operational polish — see
\`MAINNET_PLAN.md\` "Deferred" section for rationale.

## Changes

**Task 014g — unified slash constants (\`pyde-slashing\` leaf crate):**
- New zero-dep \`pyde-slashing\` crate exporting \`VALIDATOR_STAKE\`, \`FINDER_FEE_PERCENT\`, \`EVIDENCE_VERSION\`.
- \`pyde-tx/pipeline.rs\` drops its shadow \`SLASH_*\` constants + inline \`const VALIDATOR_STAKE\` — imports from \`pyde-slashing\`.
- \`pyde-consensus::validator\` + \`pyde-consensus::slashing\` re-export the shared constants (backward-compat).
- \`pyde-node/validator.rs\` test drops inline \`const VALIDATOR_STAKE\`.
- Kills the drift risk that motivated the task.

**Task 014d — peer-score rate limit on evidence ingest:**
- Consensus gossip handler for \`CONSENSUS_SLASH_EVIDENCE\` checks \`propagation_source\`'s \`invalid_messages\` counter against \`EVIDENCE_SPAM_THRESHOLD = 5\` before decoding + verifying.
- Invalid decode OR failed \`ingest_evidence\` bumps the counter on the propagator. Repeat offenders cross the threshold and get dropped without paying the ~60µs FALCON verify cost.
- Pairs with task 029 attestation filter; honest validators dedupe their own evidence via \`(slot, signer)\` so they stay well under the threshold.

**Task 014e — DEFERRED (post-mainnet):**
- Current \`panic!\` on persist failure is safety-optimal. Continuing after failed safety-critical disk write risks a BFT double-vote on restart. A graceful variant requires per-site persist-before-mutate refactoring for marginal benefit (cleaner logs + pending broadcast drainage). Documented in MAINNET_PLAN "Deferred to post-mainnet" section.

## Tests

No new tests: 014g is pure refactor (existing suite covers correctness), 014d is a defensive filter (existing gossip+evidence tests validate the happy path).

Full workspace test run: green.