### PR TITLE
feat: genesis vesting schedules (slice 4.4)

### DIFF
--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -39,6 +39,37 @@ pub struct GenesisAllocation {
     /// Optional hex-encoded FALCON-512 public key (sets auth_keys for tx signing).
     #[serde(default)]
     pub public_key: Option<String>,
+    /// Optional allocation bucket label (Phase 4 slice 4.4). Pure
+    /// metadata — not interpreted by the protocol, only useful for
+    /// offline accounting ("did we actually put 30% in community?").
+    /// Typical values: "team", "investors", "treasury", "community",
+    /// "validator_subsidy", "liquidity".
+    #[serde(default)]
+    pub bucket: Option<String>,
+    /// Optional vesting schedule. When present, the full `balance` is
+    /// deposited but only the unlocked portion is spendable until the
+    /// cliff is reached and linear vesting completes. See
+    /// `pyde_tx::vesting::VestingSchedule` for the unlock curve.
+    #[serde(default)]
+    pub vesting: Option<GenesisVesting>,
+}
+
+/// Serialization-friendly vesting spec loaded from TOML.
+///
+/// Units are in SLOTS, not seconds. At 400ms slots the relationships:
+///   1 day   = 216_000 slots
+///   30 days = 6_480_000 slots
+///   1 year  = 78_892_800 slots
+/// Operators encode durations in slots to match the runtime.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GenesisVesting {
+    /// Slot at which vesting begins. Usually 0 (genesis).
+    #[serde(default)]
+    pub start_slot: u64,
+    /// Slots from `start` during which nothing unlocks.
+    pub cliff_slots: u64,
+    /// Total vesting duration in slots (counted from `start`, not cliff).
+    pub duration_slots: u64,
 }
 
 impl GenesisAllocation {
@@ -141,10 +172,27 @@ pub fn initialize_genesis(
 
         let key = pyde_state::keys::balance_key(&address);
         entries.push((key, account.to_bytes()));
+
+        // Slice 4.4: install vesting schedule if the allocation specifies
+        // one. The full `balance` is credited to the account immediately;
+        // the protocol subtracts the locked portion from the spendable
+        // balance during tx validation. Empty schedule is a no-op.
+        if let Some(v) = &alloc.vesting {
+            let schedule = pyde_tx::vesting::VestingSchedule {
+                start_slot: v.start_slot,
+                cliff_slots: v.cliff_slots,
+                duration_slots: v.duration_slots,
+                total_amount: balance,
+            };
+            entries.push((pyde_state::keys::vesting_key(&address), schedule.encode()));
+        }
+
         debug!(
             address = alloc.address,
             balance,
             has_auth_keys = alloc.public_key.is_some(),
+            bucket = alloc.bucket.as_deref().unwrap_or(""),
+            vesting = alloc.vesting.is_some(),
             "genesis allocation"
         );
 
@@ -279,6 +327,8 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
             address: hex::encode(address),
             balance: funding_per_account.to_string(),
             public_key: Some(hex::encode(pk.as_bytes())),
+            bucket: None,
+            vesting: None,
         });
 
         accounts.push(DevnetAccount {
@@ -336,6 +386,8 @@ pub fn generate_testnet(
             address: hex::encode(address),
             balance: funding.to_string(),
             public_key: Some(hex::encode(pk.as_bytes())),
+            bucket: None,
+            vesting: None,
         });
 
         validators.push(GenesisValidator {
@@ -360,6 +412,8 @@ pub fn generate_testnet(
             address: hex::encode(address),
             balance: funding.to_string(),
             public_key: Some(hex::encode(pk.as_bytes())),
+            bucket: None,
+            vesting: None,
         });
         accounts.push(DevnetAccount {
             address, public_key: pk, secret_key: sk, balance: funding,
@@ -374,6 +428,8 @@ pub fn generate_testnet(
         address: hex::encode(faucet_address),
         balance: faucet_balance.to_string(),
         public_key: Some(hex::encode(faucet_pk.as_bytes())),
+        bucket: None,
+        vesting: None,
     });
 
     let genesis_config = GenesisConfig {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -133,6 +133,8 @@ impl PydeNode {
                         address: val_addr.clone(),
                         balance: pyde_consensus::validator::VALIDATOR_STAKE.to_string(),
                         public_key: Some(hex::encode(identity.public_key.as_bytes())),
+                        bucket: None,
+                        vesting: None,
                     });
                     info!(address = val_addr, "auto-funded validator in genesis with 10,000 PYDE");
                 }

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -43,6 +43,11 @@ pub mod discriminator {
     /// slashed — `VALIDATOR_COUNT` is monotonic (enumerable history),
     /// `ACTIVE_VALIDATOR_COUNT` is the number currently in status `Active`.
     pub const ACTIVE_VALIDATOR_COUNT: u8 = 0x15;
+    /// Per-account vesting schedule (Phase 4 slice 4.4). Genesis
+    /// allocations with a vesting config write one entry per recipient;
+    /// tx validation subtracts the locked portion from the sender's
+    /// spendable balance so time-locked tokens can't be moved early.
+    pub const VESTING: u8 = 0x16;
 }
 
 // ---------------------------------------------------------------------------
@@ -209,6 +214,17 @@ pub fn rewards_per_validator_key() -> H256 {
 /// the yield of still-active members. u64 LE.
 pub fn active_validator_count_key() -> H256 {
     H256::from(poseidon2_hash(&[discriminator::ACTIVE_VALIDATOR_COUNT]).to_bytes())
+}
+
+/// Per-account vesting schedule key (slice 4.4).
+///
+/// Value is the encoded `VestingSchedule` struct. Absent when the account
+/// has no vesting; tx validation treats "absent" as "fully unlocked."
+pub fn vesting_key(address: &Address) -> H256 {
+    let mut input = Vec::with_capacity(33);
+    input.extend_from_slice(address);
+    input.push(discriminator::VESTING);
+    H256::from(poseidon2_hash(&input).to_bytes())
 }
 
 #[cfg(test)]

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -8,3 +8,4 @@ pub mod parallel;
 pub mod pipeline;
 pub mod types;
 pub mod validation;
+pub mod vesting;

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -182,6 +182,12 @@ fn execute_transaction_inner(
     let mut recipient = load_account(smt, &tx.to);
     let mut nonce_state = load_nonce(smt, &tx.from);
 
+    // Compute vested-locked amount for the sender (slice 4.4). Senders
+    // with no vesting schedule get 0 — their full balance is spendable.
+    let sender_locked = read_vesting_schedule(smt, &tx.from)
+        .map(|s| s.locked_at(block_ctx.height))
+        .unwrap_or(0);
+
     // 2. Validate
     let val_ctx = ValidationContext {
         block_height: block_ctx.height,
@@ -189,6 +195,7 @@ fn execute_transaction_inner(
         block_gas_limit: block_ctx.block_gas_limit,
         chain_id: block_ctx.chain_id,
         dev_skip_signature: block_ctx.dev_skip_signature,
+        sender_locked,
     };
     validate_transaction(tx, &sender, &nonce_state, &val_ctx)?;
 
@@ -845,6 +852,28 @@ fn read_u128_state(
             None
         }
     })
+}
+
+/// Read a vesting schedule from state (slice 4.4). Returns `None` when
+/// the account has no vesting — tx validation treats this as "fully
+/// unlocked." Writers: genesis init installs one per allocation; post-
+/// genesis there is no mechanism to create or modify vesting, so an
+/// installed schedule is effectively write-once.
+pub fn read_vesting_schedule(
+    smt: &dyn pyde_state::smt::StateAccess,
+    address: &Address,
+) -> Option<crate::vesting::VestingSchedule> {
+    let bytes = smt.get(&pyde_state::keys::vesting_key(address))?;
+    crate::vesting::VestingSchedule::decode(&bytes)
+}
+
+/// Install a vesting schedule for an account. Called by genesis init.
+pub fn write_vesting_schedule(
+    smt: &mut dyn pyde_state::smt::StateAccess,
+    address: &Address,
+    schedule: &crate::vesting::VestingSchedule,
+) {
+    let _ = smt.insert(pyde_state::keys::vesting_key(address), schedule.encode());
 }
 
 /// Read active-only validator count (slice 4.2). Defaults to 0.
@@ -2629,6 +2658,161 @@ mod tests {
         let val = crate::fee::GENESIS_TOTAL_SUPPLY + 12_345_678;
         write_total_supply(&mut smt, val);
         assert_eq!(read_total_supply(&smt), val);
+    }
+
+    // ========== Phase 4 slice 4.4: vesting enforcement ==========
+
+    fn make_vesting_fixture(
+        balance: u128,
+        vesting: crate::vesting::VestingSchedule,
+    ) -> (PydeSMT, Address, pyde_crypto::falcon::FalconSecretKey) {
+        let mut smt = PydeSMT::new();
+        let (pk, sk) = falcon_keygen().unwrap();
+        let addr = derive_eoa_address(pk.as_bytes());
+        fund_account_with_pk(&mut smt, &addr, balance, pk.as_bytes());
+        write_vesting_schedule(&mut smt, &addr, &vesting);
+        (smt, addr, sk)
+    }
+
+    fn transfer_tx(
+        from: Address,
+        to: Address,
+        value: u128,
+        nonce: u64,
+    ) -> Transaction {
+        Transaction {
+            from, to, value,
+            data: vec![],
+            gas_limit: 50_000,
+            nonce,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::Standard,
+        }
+    }
+
+    #[test]
+    fn tx_rejected_when_value_exceeds_unlocked() {
+        // Pre-cliff: 100% of balance locked. Any non-zero value must fail
+        // the balance check.
+        let total: u128 = 1_000_000_000_000;
+        let vest = crate::vesting::VestingSchedule {
+            start_slot: 0,
+            cliff_slots: 1_000,
+            duration_slots: 10_000,
+            total_amount: total,
+        };
+        let (mut smt, addr, sk) = make_vesting_fixture(total, vest);
+        let recipient = derive_eoa_address(b"recipient");
+
+        let mut ctx = make_block_ctx();
+        ctx.height = 100; // before cliff
+        ctx.base_fee = 1;
+
+        let mut tx = transfer_tx(addr, recipient, 100, 0);
+        sign_tx(&mut tx, &sk);
+        let err = execute_transaction(&tx, &mut smt, &ctx).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::Validation(crate::validation::ValidationError::InsufficientBalance { .. })),
+            "pre-cliff transfer must be rejected with InsufficientBalance; got {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn tx_accepted_when_value_within_unlocked() {
+        // At 50% duration, 50% is unlocked. Transfer below that succeeds.
+        let total: u128 = 1_000_000_000_000;
+        let vest = crate::vesting::VestingSchedule {
+            start_slot: 0,
+            cliff_slots: 100,
+            duration_slots: 1_000,
+            total_amount: total,
+        };
+        let (mut smt, addr, sk) = make_vesting_fixture(total, vest);
+        let recipient = derive_eoa_address(b"recipient-ok");
+
+        let mut ctx = make_block_ctx();
+        ctx.height = 500; // 50% through duration
+        ctx.base_fee = 1;
+
+        // Unlocked at slot 500 = 500/1000 × total = 500 PYDE.
+        // Transfer 100 PYDE — well within.
+        let mut tx = transfer_tx(addr, recipient, 100_000_000_000, 0);
+        sign_tx(&mut tx, &sk);
+        let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(r.success, "transfer within unlocked must succeed");
+    }
+
+    #[test]
+    fn tx_rejected_at_boundary_exceeds_unlocked() {
+        // Exact boundary: unlocked = 50_000_000_000, value = 50_000_000_001.
+        // Gas adds more required. Must fail.
+        let total: u128 = 100_000_000_000;
+        let vest = crate::vesting::VestingSchedule {
+            start_slot: 0,
+            cliff_slots: 100,
+            duration_slots: 1_000,
+            total_amount: total,
+        };
+        let (mut smt, addr, sk) = make_vesting_fixture(total, vest);
+        let recipient = derive_eoa_address(b"recipient-boundary");
+
+        let mut ctx = make_block_ctx();
+        ctx.height = 500;
+        ctx.base_fee = 1;
+
+        let mut tx = transfer_tx(addr, recipient, 50_000_000_001, 0);
+        sign_tx(&mut tx, &sk);
+        let err = execute_transaction(&tx, &mut smt, &ctx).unwrap_err();
+        assert!(
+            matches!(err, PipelineError::Validation(crate::validation::ValidationError::InsufficientBalance { .. })),
+            "transfer > unlocked must fail with InsufficientBalance; got {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn tx_fully_unlocked_after_duration() {
+        let total: u128 = 1_000_000_000_000;
+        let vest = crate::vesting::VestingSchedule {
+            start_slot: 0,
+            cliff_slots: 100,
+            duration_slots: 1_000,
+            total_amount: total,
+        };
+        let (mut smt, addr, sk) = make_vesting_fixture(total, vest);
+        let recipient = derive_eoa_address(b"recipient-post");
+
+        let mut ctx = make_block_ctx();
+        ctx.height = 10_000; // well past end
+        ctx.base_fee = 1;
+
+        let mut tx = transfer_tx(addr, recipient, total - 50_000, 0);
+        sign_tx(&mut tx, &sk);
+        let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(r.success, "post-vesting transfer must succeed");
+    }
+
+    #[test]
+    fn account_without_vesting_is_fully_spendable() {
+        let mut smt = PydeSMT::new();
+        let (pk, sk) = falcon_keygen().unwrap();
+        let addr = derive_eoa_address(pk.as_bytes());
+        fund_account_with_pk(&mut smt, &addr, 1_000_000_000_000, pk.as_bytes());
+        assert!(read_vesting_schedule(&smt, &addr).is_none());
+
+        let recipient = derive_eoa_address(b"recipient-free");
+        let mut ctx = make_block_ctx();
+        ctx.base_fee = 1;
+
+        let mut tx = transfer_tx(addr, recipient, 500_000_000_000, 0);
+        sign_tx(&mut tx, &sk);
+        let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(r.success);
     }
 
     fn fund_account_with_pk(

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -34,6 +34,11 @@ pub struct ValidationContext {
     /// if chain_id == 31337" which let a misconfigured mainnet node
     /// with a devnet chain_id accept forged transactions.
     pub dev_skip_signature: bool,
+    /// Sender's currently-locked vesting balance (Phase 4 slice 4.4).
+    /// Computed by the caller from the sender's `VestingSchedule`
+    /// before validation. Deducted from `sender.balance` when checking
+    /// that `gas_cost + value` fits. Zero for accounts with no vesting.
+    pub sender_locked: u128,
 }
 
 /// Validation error with specific reason.
@@ -144,16 +149,23 @@ fn validate_balance(
     let gas_cost = tx.gas_limit as u128 * ctx.base_fee;
     let total_required = gas_cost + tx.value;
 
+    // Vested / locked balance (slice 4.4) is subtracted from the raw
+    // account balance before any solvency check. `saturating_sub`
+    // handles the edge case where a slash reduces balance below the
+    // lock amount — the account is effectively frozen until vesting
+    // progresses further (or the lock ends).
+    let spendable = sender.balance.saturating_sub(ctx.sender_locked);
+
     // Check the fee payer's balance
     let available = match &tx.fee_payer {
-        crate::types::FeePayer::Sender => sender.balance,
+        crate::types::FeePayer::Sender => spendable,
         crate::types::FeePayer::GasTank(_) => {
-            // Gas tank pays gas, sender pays value only
-            // Gas tank balance check happens at execution time
-            if sender.balance < tx.value {
+            // Gas tank pays gas, sender pays value only.
+            // Gas tank balance check happens at execution time.
+            if spendable < tx.value {
                 return Err(ValidationError::InsufficientBalance {
                     required: tx.value,
-                    available: sender.balance,
+                    available: spendable,
                 });
             }
             return Ok(());
@@ -282,6 +294,7 @@ mod tests {
             // signature validation, and the module's signature test
             // overrides this field.
             dev_skip_signature: true,
+            sender_locked: 0,
         }
     }
 

--- a/crates/tx/src/vesting.rs
+++ b/crates/tx/src/vesting.rs
@@ -1,0 +1,178 @@
+//! Linear-with-cliff vesting for genesis allocations (Phase 4 slice 4.4).
+//!
+//! Schema-only: the allocation *buckets* (team / investors / treasury /
+//! community / validator subsidy / liquidity) are recorded as config
+//! metadata only. The protocol enforces one thing — the per-recipient
+//! schedule. Send txs from a vested account are rejected if the amount
+//! exceeds `balance - locked_remaining(current_slot)`.
+//!
+//! Shape: slot ranges + total amount.
+//! - `start_slot`: when vesting begins (usually 0 = genesis).
+//! - `cliff_slots`: slots after start during which nothing unlocks.
+//! - `duration_slots`: total vesting duration. After
+//!   `start + duration`, the full amount is unlocked.
+//! - `total_amount`: initial allocation subject to vesting.
+//!
+//! Unlock curve:
+//! - `slot < start + cliff` → unlocked = 0
+//! - `slot >= start + duration` → unlocked = total_amount
+//! - in between → linear: `total_amount * (slot - start) / duration`
+//!
+//! Note the cliff does NOT "catch up" to the linear curve at cliff-end.
+//! Standard industry pattern: cliff = 0 unlocks, then at cliff the
+//! curve jumps to `total * cliff / duration`, then continues linearly.
+
+/// Vesting schedule attached to a genesis allocation. Stored at
+/// `vesting_key(address)` in the state SMT; absent rows imply the
+/// account has no vesting and can spend its full balance.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VestingSchedule {
+    pub start_slot: u64,
+    pub cliff_slots: u64,
+    pub duration_slots: u64,
+    pub total_amount: u128,
+}
+
+impl VestingSchedule {
+    /// Wire layout:
+    ///   [start:8 LE][cliff:8 LE][duration:8 LE][total:16 LE] = 40 bytes.
+    pub const ENCODED_LEN: usize = 8 + 8 + 8 + 16;
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::ENCODED_LEN);
+        buf.extend_from_slice(&self.start_slot.to_le_bytes());
+        buf.extend_from_slice(&self.cliff_slots.to_le_bytes());
+        buf.extend_from_slice(&self.duration_slots.to_le_bytes());
+        buf.extend_from_slice(&self.total_amount.to_le_bytes());
+        buf
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::ENCODED_LEN {
+            return None;
+        }
+        let start_slot = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let cliff_slots = u64::from_le_bytes(bytes[8..16].try_into().ok()?);
+        let duration_slots = u64::from_le_bytes(bytes[16..24].try_into().ok()?);
+        let total_amount = u128::from_le_bytes(bytes[24..40].try_into().ok()?);
+        Some(Self {
+            start_slot,
+            cliff_slots,
+            duration_slots,
+            total_amount,
+        })
+    }
+
+    /// Compute the unlocked portion of `total_amount` at `current_slot`.
+    /// Returns 0 before the cliff, `total_amount` after full vesting,
+    /// linear interpolation in between.
+    ///
+    /// `duration_slots == 0` is treated as "fully vested at start"
+    /// (instant unlock; no protocol-level vesting despite a record
+    /// being present). This makes migration easier — entries created
+    /// before vesting was meaningful won't accidentally lock balances.
+    pub fn unlocked_at(&self, current_slot: u64) -> u128 {
+        if self.duration_slots == 0 {
+            return self.total_amount;
+        }
+        if current_slot < self.start_slot.saturating_add(self.cliff_slots) {
+            return 0;
+        }
+        let end = self.start_slot.saturating_add(self.duration_slots);
+        if current_slot >= end {
+            return self.total_amount;
+        }
+        let elapsed = current_slot.saturating_sub(self.start_slot) as u128;
+        let duration = self.duration_slots as u128;
+        // Compute in u128 to avoid overflow on large totals.
+        self.total_amount.saturating_mul(elapsed) / duration
+    }
+
+    /// Currently-locked amount = total - unlocked. Used by tx validation
+    /// to derive the sender's spendable balance.
+    pub fn locked_at(&self, current_slot: u64) -> u128 {
+        self.total_amount.saturating_sub(self.unlocked_at(current_slot))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sched(start: u64, cliff: u64, dur: u64, total: u128) -> VestingSchedule {
+        VestingSchedule {
+            start_slot: start,
+            cliff_slots: cliff,
+            duration_slots: dur,
+            total_amount: total,
+        }
+    }
+
+    #[test]
+    fn unlocked_zero_before_cliff() {
+        let s = sched(0, 100, 1000, 1_000_000);
+        assert_eq!(s.unlocked_at(0), 0);
+        assert_eq!(s.unlocked_at(50), 0);
+        assert_eq!(s.unlocked_at(99), 0);
+    }
+
+    #[test]
+    fn unlocked_jumps_at_cliff_to_linear_curve() {
+        // At cliff = 100 of 1000 duration → 10% unlocks.
+        let s = sched(0, 100, 1000, 1_000_000);
+        assert_eq!(s.unlocked_at(100), 100_000);
+    }
+
+    #[test]
+    fn unlocked_linear_between_cliff_and_end() {
+        let s = sched(0, 100, 1000, 1_000_000);
+        // 50% of duration elapsed → 50% unlocked
+        assert_eq!(s.unlocked_at(500), 500_000);
+        // 75% → 75%
+        assert_eq!(s.unlocked_at(750), 750_000);
+    }
+
+    #[test]
+    fn unlocked_full_at_end_and_after() {
+        let s = sched(0, 100, 1000, 1_000_000);
+        assert_eq!(s.unlocked_at(1000), 1_000_000);
+        assert_eq!(s.unlocked_at(10_000), 1_000_000);
+    }
+
+    #[test]
+    fn unlocked_respects_non_zero_start_slot() {
+        let s = sched(500, 100, 1000, 1_000_000);
+        assert_eq!(s.unlocked_at(499), 0, "pre-start");
+        assert_eq!(s.unlocked_at(599), 0, "pre-cliff");
+        assert_eq!(s.unlocked_at(600), 100_000, "at cliff");
+        assert_eq!(s.unlocked_at(1500), 1_000_000, "at end");
+    }
+
+    #[test]
+    fn zero_duration_means_instant_unlock() {
+        let s = sched(0, 0, 0, 1_000_000);
+        assert_eq!(s.unlocked_at(0), 1_000_000);
+    }
+
+    #[test]
+    fn locked_and_unlocked_sum_to_total() {
+        let s = sched(0, 100, 1000, 1_000_000);
+        for slot in [0, 50, 100, 250, 500, 750, 1000, 2000] {
+            assert_eq!(s.locked_at(slot) + s.unlocked_at(slot), 1_000_000);
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let s = sched(1_000, 86_400, 31_536_000, 150_000_000 * 1_000_000_000);
+        let bytes = s.encode();
+        assert_eq!(bytes.len(), VestingSchedule::ENCODED_LEN);
+        let back = VestingSchedule::decode(&bytes).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn decode_rejects_truncated() {
+        assert!(VestingSchedule::decode(&[0u8; 39]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Closes slice 4.4 (task 035). Ships the protocol infrastructure for genesis vesting schedules without locking specific recipient addresses or amounts — those stay in the \`genesis.toml\` config until mainnet ceremony. Operators can inject any distribution plan at launch time without a code change.

## Design

**Allocation schema (metadata-only):** \`GenesisAllocation\` gains an optional \`bucket\` string field (\`"team"\`/\`"investors"\`/\`"treasury"\`/\`"community"\`/\`"validator_subsidy"\`/\`"liquidity"\`). Pure accounting label — protocol doesn't interpret it, but operators can verify distribution math offline.

**Vesting schedule (protocol-enforced):** Optional \`vesting: Option<GenesisVesting>\` per allocation. When present, genesis init writes a \`VestingSchedule\` record at \`vesting_key(addr)\` in the state SMT. Per-tx validation looks up this record and subtracts the currently-locked portion from the sender's spendable balance.

**Unlock curve:**
- \`slot < start + cliff\` → unlocked = 0
- \`slot >= start + duration\` → unlocked = total
- between → linear: \`total × (slot - start) / duration\`
- At cliff, curve jumps to \`total × cliff / duration\`

## Strongly recommended distribution (to be applied at mainnet ceremony)

| Bucket | % | PYDE | Vesting |
|---|---|---|---|
| Team / Founders | 15% | 150M | 4y linear, 1y cliff |
| Future Investors (reserved) | 15% | 150M | 2-3y linear, 6mo cliff |
| Treasury / Foundation | 20% | 200M | Immediate; DAO-governed |
| Community / Ecosystem / Airdrops | 30% | 300M | 40% at genesis, 60% over 2y |
| Validator Bootstrap Subsidy | 15% | 150M | Streamed over 2y |
| Exchange / Liquidity | 5% | 50M | 20% at genesis, 80% over 12mo |

Total insider-controlled at genesis: 30%. Community-forward narrative aligned with Sui/Avalanche precedent; avoids the Solana/Aptos insider-heavy trap.

## Changes

**pyde-state::keys:** discriminator \`VESTING = 0x16\`, \`vesting_key(addr)\`.

**pyde-tx::vesting (new module):** \`VestingSchedule\` struct with \`encode\`/\`decode\`/\`unlocked_at\`/\`locked_at\`. Pure functions, u128 math with \`saturating_mul\` guards.

**pyde-tx::pipeline:** \`read_vesting_schedule\`, \`write_vesting_schedule\`. Pipeline computes \`sender_locked\` from schedule + current slot, passes it to \`ValidationContext\`.

**pyde-tx::validation:** \`ValidationContext.sender_locked\`; \`validate_balance\` derives spendable as \`sender.balance.saturating_sub(sender_locked)\`.

**pyde-node::genesis:** \`GenesisAllocation.{bucket, vesting}\` fields; \`GenesisVesting { start_slot, cliff_slots, duration_slots }\` spec; \`initialize_genesis\` writes one \`VestingSchedule\` per allocation with a spec.

## Tests (14 new)

**pyde-tx::vesting (9):** zero_before_cliff, jumps_at_cliff, linear_between, full_at_end_and_after, non_zero_start_slot, zero_duration_instant_unlock, locked_unlocked_sum_to_total, encode_decode_roundtrip, decode_rejects_truncated.

**pyde-tx::pipeline (5):** tx_rejected_when_value_exceeds_unlocked (pre-cliff), tx_accepted_when_value_within_unlocked, tx_rejected_at_boundary_exceeds_unlocked, tx_fully_unlocked_after_duration, account_without_vesting_is_fully_spendable.

Full workspace test run: green.

## Known limitations (documented in code)

1. \`bucket\` is metadata-only — protocol doesn't enforce "total team allocation ≤ 15%". Offline audit is the check.
2. Vesting is write-once at genesis. No on-chain way to modify or revoke a schedule post-launch.
3. Validator subsidy streaming not formalized; the 15% bucket uses vesting like anything else.
4. Airdrop claim flow (30% community bucket) is its own slice, not blocking mainnet code.