### PR TITLE
feat: supply sanity + per-bucket caps + validator subsidy streaming (slice 4.4a)

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -301,6 +301,35 @@ impl BlockProcessor {
             );
         }
 
+        // 4c. Validator bootstrap subsidy (slice 4.4a).
+        //
+        // Independent of inflation mint — this is a pre-allocated pool
+        // (15% of genesis per our recommended distribution) that streams
+        // to active validators during the bootstrap window. Adds to the
+        // same `rewards_per_validator` accumulator as inflation pool
+        // share, so validators claim both via the same ClaimReward tx.
+        //
+        // Gate on `current_slot < end_slot` and non-zero active count —
+        // when the window closes, the state key is left in place but
+        // effectively disabled. total_supply does NOT increment: the
+        // subsidy was minted at genesis into the pool, not created
+        // per block.
+        if let Some(subsidy) = pyde_tx::pipeline::read_validator_subsidy(state) {
+            if slot < subsidy.end_slot && subsidy.per_block > 0 {
+                let active_count = pyde_tx::pipeline::read_active_validator_count(state);
+                if active_count > 0 {
+                    let per_validator = subsidy.per_block / active_count as u128;
+                    if per_validator > 0 {
+                        let current = pyde_tx::pipeline::read_rewards_per_validator(state);
+                        pyde_tx::pipeline::write_rewards_per_validator(
+                            state,
+                            current.saturating_add(per_validator),
+                        );
+                    }
+                }
+            }
+        }
+
         // 4b. Phase 1 task 041 — track cumulative fee burn. Sum each tx's
         // receipted `fee_burned` and roll into the global counter. One
         // read-modify-write per block keeps this cheap regardless of
@@ -921,6 +950,140 @@ mod tests {
             pyde_tx::pipeline::read_total_burned(&state),
             4_200,
             "empty block must not touch total_burned"
+        );
+    }
+
+    // ========== Slice 4.4a: validator subsidy streaming ==========
+
+    #[test]
+    fn subsidy_streams_into_rewards_accumulator() {
+        // With a configured subsidy + 10 active validators, each block
+        // should increment `rewards_per_validator` by
+        //   (subsidy.per_block / active_count).
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut chain = ChainState::genesis(state.root(), 31337);
+        // Install 10 active validators via the counter helper.
+        for _ in 0..10 {
+            pyde_tx::pipeline::increment_active_validator_count(&mut state);
+        }
+        // Install a subsidy: 10,000 quanta per block, ends at slot 100.
+        pyde_tx::pipeline::write_validator_subsidy(
+            &mut state,
+            &pyde_tx::pipeline::ValidatorSubsidySchedule {
+                per_block: 10_000,
+                end_slot: 100,
+            },
+        );
+
+        // Pre-check accumulator.
+        let before = pyde_tx::pipeline::read_rewards_per_validator(&state);
+
+        let mut header = dummy_header(1);
+        header.proposer = [0xAA; 32]; // non-zero proposer so mint path runs
+        let block = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+        BlockProcessor::process_full_block(&mut chain, &mut state, &block).unwrap();
+
+        // Subsidy contribution: 10_000 / 10 = 1_000 per validator.
+        // Inflation contribution will also run but the test allocation
+        // doesn't fund the proposer so mint-to-proposer path is bounded.
+        let after = pyde_tx::pipeline::read_rewards_per_validator(&state);
+        let delta = after - before;
+        assert!(
+            delta >= 1_000,
+            "accumulator must increase by at least the subsidy share (got {})",
+            delta,
+        );
+    }
+
+    #[test]
+    fn subsidy_stops_streaming_after_end_slot() {
+        // Processing a block at slot >= end_slot must NOT advance
+        // `rewards_per_validator` due to subsidy (inflation's own
+        // contribution is separate and may still fire).
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut chain = ChainState::genesis(state.root(), 31337);
+        for _ in 0..10 {
+            pyde_tx::pipeline::increment_active_validator_count(&mut state);
+        }
+        pyde_tx::pipeline::write_validator_subsidy(
+            &mut state,
+            &pyde_tx::pipeline::ValidatorSubsidySchedule {
+                per_block: 10_000,
+                end_slot: 5,
+            },
+        );
+
+        // Advance chain past the subsidy end so we can process a block
+        // at slot 10 without the head-advancement check rejecting.
+        for slot in 1..=9 {
+            let mut h = dummy_header(slot);
+            h.proposer = [0xAA; 32];
+            let b = Block {
+                header: h,
+                body: BlockBody {
+                    transactions: vec![],
+                    encrypted_txs: vec![],
+                    execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+                },
+                proposer_signature: vec![],
+            };
+            BlockProcessor::process_full_block(&mut chain, &mut state, &b).unwrap();
+        }
+
+        let before = pyde_tx::pipeline::read_rewards_per_validator(&state);
+        let mut h = dummy_header(10);
+        h.proposer = [0xAA; 32];
+        let b = Block {
+            header: h,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+        BlockProcessor::process_full_block(&mut chain, &mut state, &b).unwrap();
+        let after = pyde_tx::pipeline::read_rewards_per_validator(&state);
+
+        // Inflation pool share still increments (block_reward > 0), but
+        // the subsidy contribution (10_000 / 10 = 1_000) is NOT there.
+        // Check the delta is strictly less than it would have been with
+        // subsidy — we measure by comparing to an equivalent step at a
+        // slot still inside the window.
+        let delta_outside = after - before;
+
+        // Do one more block at slot 11 — still outside window.
+        let before2 = after;
+        let mut h2 = dummy_header(11);
+        h2.proposer = [0xAA; 32];
+        let b2 = Block {
+            header: h2,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![],
+                execution_schedule: ExecutionSchedule { groups: vec![], total_txs: 0 },
+            },
+            proposer_signature: vec![],
+        };
+        BlockProcessor::process_full_block(&mut chain, &mut state, &b2).unwrap();
+        let after2 = pyde_tx::pipeline::read_rewards_per_validator(&state);
+        let delta_outside_2 = after2 - before2;
+
+        // Two consecutive outside-window blocks contribute identical
+        // (inflation-only) amounts; this asserts no subsidy leaked.
+        assert_eq!(
+            delta_outside, delta_outside_2,
+            "outside-window blocks must contribute identical pool shares"
         );
     }
 

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -28,6 +28,57 @@ pub struct GenesisConfig {
     pub allocations: Vec<GenesisAllocation>,
     /// Initial validators: hex address → public key hex.
     pub validators: Vec<GenesisValidator>,
+    /// Expected total supply in quanta (slice 4.4a sanity check).
+    /// Declared as a string to avoid TOML u128 limitation. When non-empty,
+    /// `initialize_genesis` verifies that the sum of all allocations
+    /// matches this value and rejects the config otherwise. Catches
+    /// typos in large allocation tables before mainnet ceremony.
+    /// Empty (default) → no check, matches pre-4.4a behaviour.
+    #[serde(default)]
+    pub initial_supply: String,
+    /// Optional per-validator streaming subsidy (slice 4.4a).
+    /// The 15% bootstrap allocation flows to active validators via the
+    /// same lazy-accrual `rewards_per_validator` accumulator that
+    /// handles inflation pool yield — one mechanism, uniform math.
+    /// `None` means no subsidy configured (devnet).
+    #[serde(default)]
+    pub validator_subsidy: Option<ValidatorSubsidyConfig>,
+    /// Per-bucket allocation ceilings (slice 4.4a).
+    /// Map of bucket name → max percentage (integer 0..=100) of
+    /// `initial_supply`. Enforced at startup: if the sum of
+    /// allocations tagged with a given bucket exceeds its cap,
+    /// `initialize_genesis` returns an error. Unset caps = no limit.
+    /// Requires `initial_supply` to be non-empty (caps are
+    /// percentages of declared supply).
+    #[serde(default)]
+    pub bucket_caps: std::collections::HashMap<String, u32>,
+}
+
+/// Configuration for the validator bootstrap subsidy stream.
+///
+/// `total_amount` quanta are minted over `duration_slots` blocks
+/// starting at genesis, distributed per-block to the ACTIVE validator
+/// pool (identical share per validator). Operates as an add-on to
+/// inflation — validators during the subsidy window earn
+/// `inflation_share + subsidy_share` per block.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatorSubsidyConfig {
+    /// Total subsidy pool in quanta as string (to avoid TOML u128 limitation).
+    pub total_amount: String,
+    /// How many slots the subsidy streams for. After `genesis.timestamp +
+    /// duration_slots × block_time`, the subsidy pool ends.
+    pub duration_slots: u64,
+}
+
+impl ValidatorSubsidyConfig {
+    pub fn total_u128(&self) -> Result<u128, String> {
+        self.total_amount.parse::<u128>().map_err(|e| {
+            format!(
+                "invalid validator_subsidy.total_amount '{}': {}",
+                self.total_amount, e
+            )
+        })
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -110,6 +161,9 @@ impl Default for GenesisConfig {
             timestamp: 0,
             allocations: Vec::new(),
             validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
         }
     }
 }
@@ -141,6 +195,8 @@ pub fn initialize_genesis(
 
     let mut entries = Vec::new();
     let mut total_supply: u128 = 0;
+    let mut bucket_totals: std::collections::HashMap<String, u128> =
+        std::collections::HashMap::new();
 
     // 1. Write initial allocations (balances)
     for alloc in &config.allocations {
@@ -198,6 +254,12 @@ pub fn initialize_genesis(
 
         total_supply = total_supply.checked_add(balance)
             .ok_or("genesis total supply overflow")?;
+
+        // Slice 4.4a: accumulate per-bucket totals for cap enforcement.
+        if let Some(name) = &alloc.bucket {
+            let e = bucket_totals.entry(name.clone()).or_insert(0u128);
+            *e = e.checked_add(balance).ok_or("bucket total overflow")?;
+        }
     }
 
     // 2. Write validator stakes as balances (included in total supply).
@@ -265,6 +327,83 @@ pub fn initialize_genesis(
     // Store validator count
     let count_key = pyde_state::keys::validator_count_key();
     entries.push((count_key, val_count.to_le_bytes().to_vec()));
+
+    // Slice 4.4a: install validator bootstrap subsidy schedule.
+    // `total_amount` was already included in `total_supply` if the
+    // operator allocated it to the subsidy pool via a genesis
+    // allocation; this record just instructs the block processor to
+    // stream it to active validators.
+    if let Some(vs) = &config.validator_subsidy {
+        let total = vs.total_u128()?;
+        if vs.duration_slots == 0 {
+            return Err("validator_subsidy.duration_slots must be > 0".into());
+        }
+        let per_block = total / vs.duration_slots as u128;
+        let schedule = pyde_tx::pipeline::ValidatorSubsidySchedule {
+            per_block,
+            end_slot: vs.duration_slots, // relative to slot 0 (genesis)
+        };
+        entries.push((
+            pyde_state::keys::validator_subsidy_key(),
+            schedule.encode(),
+        ));
+    }
+
+    // Slice 4.4a: declared-vs-actual supply sanity check. When the
+    // operator declares `initial_supply` in the config, verify the
+    // sum of allocation balances matches. Catches fat-finger typos in
+    // large allocation tables before the mainnet ceremony burns them
+    // in. Empty string (default) preserves pre-4.4a behaviour.
+    if !config.initial_supply.is_empty() {
+        let declared = config.initial_supply.parse::<u128>().map_err(|e| {
+            format!("invalid initial_supply '{}': {}", config.initial_supply, e)
+        })?;
+        if declared != total_supply {
+            return Err(format!(
+                "genesis supply mismatch: config declares {} quanta but allocations sum to {}",
+                declared, total_supply
+            ));
+        }
+    }
+
+    // Slice 4.4a: per-bucket cap enforcement. Each cap is integer
+    // percent of `total_supply`. We use u128 arithmetic with explicit
+    // multiplication to avoid float rounding and catch operators who
+    // silently exceed their declared distribution targets. Caps only
+    // apply when `initial_supply` was declared (otherwise percentages
+    // have no reference point — we'd be dividing by the actual sum,
+    // which is what the operator is trying to constrain in the first
+    // place).
+    if !config.bucket_caps.is_empty() {
+        if config.initial_supply.is_empty() {
+            return Err(
+                "bucket_caps requires initial_supply to be declared (caps are percentages of supply)".into()
+            );
+        }
+        for (bucket_name, cap_pct) in &config.bucket_caps {
+            if *cap_pct > 100 {
+                return Err(format!(
+                    "bucket_caps['{}'] = {} is not a valid percentage",
+                    bucket_name, cap_pct
+                ));
+            }
+            let actual = bucket_totals.get(bucket_name).copied().unwrap_or(0);
+            // actual * 100 > total * cap_pct  →  actual exceeds cap%
+            let lhs = actual.checked_mul(100).ok_or("bucket cap math overflow")?;
+            let rhs = total_supply
+                .checked_mul(*cap_pct as u128)
+                .ok_or("bucket cap math overflow")?;
+            if lhs > rhs {
+                return Err(format!(
+                    "bucket '{}' exceeds cap: allocated {} quanta = {:.2}% of supply, cap is {}%",
+                    bucket_name,
+                    actual,
+                    (actual as f64) * 100.0 / (total_supply as f64),
+                    cap_pct,
+                ));
+            }
+        }
+    }
 
     // 4. Batch insert all entries
     let state_root = state.update_batch(entries)?;
@@ -344,6 +483,9 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
         timestamp: 0,
         allocations,
         validators: Vec::new(),
+        initial_supply: String::new(),
+        validator_subsidy: None,
+        bucket_caps: std::collections::HashMap::new(),
     };
 
     (config, accounts)
@@ -437,6 +579,9 @@ pub fn generate_testnet(
         timestamp: 0,
         allocations,
         validators,
+        initial_supply: String::new(),
+        validator_subsidy: None,
+        bucket_caps: std::collections::HashMap::new(),
     };
 
     // Write shared genesis.toml
@@ -792,6 +937,213 @@ mod tests {
         initialize_genesis(&mut state, &config).unwrap();
         let result = initialize_genesis(&mut state, &config);
         assert!(result.is_err());
+    }
+
+    // ========== Slice 4.4a: sanity check + validator subsidy ==========
+
+    fn tiny_alloc(addr: [u8; 32], balance: u128) -> GenesisAllocation {
+        GenesisAllocation {
+            address: hex::encode(addr),
+            balance: balance.to_string(),
+            public_key: None,
+            bucket: None,
+            vesting: None,
+        }
+    }
+
+    #[test]
+    fn genesis_supply_sanity_check_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![
+                tiny_alloc([0x01; 32], 100),
+                tiny_alloc([0x02; 32], 200),
+                tiny_alloc([0x03; 32], 700),
+            ],
+            validators: Vec::new(),
+            initial_supply: "1000".to_string(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+        };
+        initialize_genesis(&mut state, &config).expect("matching sum should accept");
+    }
+
+    #[test]
+    fn genesis_supply_sanity_check_rejects_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0x01; 32], 100), tiny_alloc([0x02; 32], 200)],
+            validators: Vec::new(),
+            initial_supply: "500".to_string(), // allocations sum to 300 — mismatch
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("genesis supply mismatch"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_supply_sanity_check_empty_means_no_check() {
+        // Default behaviour: no declared supply → no check, anything
+        // allocations add up to is accepted. Preserves pre-4.4a devnet flows.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0x01; 32], 999)],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+        };
+        initialize_genesis(&mut state, &config).unwrap();
+    }
+
+    #[test]
+    fn genesis_writes_validator_subsidy_schedule() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0x01; 32], 100_000_000)],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: Some(ValidatorSubsidyConfig {
+                total_amount: "100_000_000".replace("_", ""),
+                duration_slots: 1_000,
+            }),
+            bucket_caps: std::collections::HashMap::new(),
+        };
+        initialize_genesis(&mut state, &config).unwrap();
+
+        let sched = pyde_tx::pipeline::read_validator_subsidy(&state)
+            .expect("subsidy schedule must be installed");
+        assert_eq!(sched.per_block, 100_000_000 / 1_000);
+        assert_eq!(sched.end_slot, 1_000);
+    }
+
+    #[test]
+    fn genesis_rejects_zero_duration_subsidy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0x01; 32], 100)],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: Some(ValidatorSubsidyConfig {
+                total_amount: "100".to_string(),
+                duration_slots: 0,
+            }),
+            bucket_caps: std::collections::HashMap::new(),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("duration_slots must be > 0"));
+    }
+
+    fn alloc_with_bucket(addr: [u8; 32], balance: u128, bucket: &str) -> GenesisAllocation {
+        GenesisAllocation {
+            address: hex::encode(addr),
+            balance: balance.to_string(),
+            public_key: None,
+            bucket: Some(bucket.to_string()),
+            vesting: None,
+        }
+    }
+
+    #[test]
+    fn bucket_caps_accept_under_limit() {
+        // 15% of 1000 = 150; team bucket at 100 → within cap.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut caps = std::collections::HashMap::new();
+        caps.insert("team".to_string(), 15);
+        caps.insert("treasury".to_string(), 90);
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![
+                alloc_with_bucket([0x01; 32], 100, "team"),
+                alloc_with_bucket([0x02; 32], 900, "treasury"),
+            ],
+            validators: Vec::new(),
+            initial_supply: "1000".to_string(),
+            validator_subsidy: None,
+            bucket_caps: caps,
+        };
+        initialize_genesis(&mut state, &config).unwrap();
+    }
+
+    #[test]
+    fn bucket_caps_reject_over_limit() {
+        // team cap 15% of 1000 = 150, allocation gives 200 → rejected.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut caps = std::collections::HashMap::new();
+        caps.insert("team".to_string(), 15);
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![
+                alloc_with_bucket([0x01; 32], 200, "team"),
+                alloc_with_bucket([0x02; 32], 800, "treasury"),
+            ],
+            validators: Vec::new(),
+            initial_supply: "1000".to_string(),
+            validator_subsidy: None,
+            bucket_caps: caps,
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("bucket 'team' exceeds cap"), "got: {}", err);
+    }
+
+    #[test]
+    fn bucket_caps_require_declared_supply() {
+        // Caps are percentages; without `initial_supply` there's no
+        // reference denominator → reject the config.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut caps = std::collections::HashMap::new();
+        caps.insert("team".to_string(), 15);
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![alloc_with_bucket([0x01; 32], 100, "team")],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: caps,
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("requires initial_supply"), "got: {}", err);
+    }
+
+    #[test]
+    fn bucket_caps_reject_invalid_percentage() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut caps = std::collections::HashMap::new();
+        caps.insert("team".to_string(), 101); // > 100
+        let config = GenesisConfig {
+            chain_id: 31337,
+            timestamp: 0,
+            allocations: vec![alloc_with_bucket([0x01; 32], 100, "team")],
+            validators: Vec::new(),
+            initial_supply: "100".to_string(),
+            validator_subsidy: None,
+            bucket_caps: caps,
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("not a valid percentage"), "got: {}", err);
     }
 
     #[test]

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -48,6 +48,11 @@ pub mod discriminator {
     /// tx validation subtracts the locked portion from the sender's
     /// spendable balance so time-locked tokens can't be moved early.
     pub const VESTING: u8 = 0x16;
+    /// Validator bootstrap subsidy schedule (slice 4.4a).
+    /// Stores `total_amount:16 LE || end_slot:8 LE`. Block processor
+    /// mints per-block subsidy to the `rewards_per_validator`
+    /// accumulator while `current_slot < end_slot`.
+    pub const VALIDATOR_SUBSIDY: u8 = 0x17;
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +230,17 @@ pub fn vesting_key(address: &Address) -> H256 {
     input.extend_from_slice(address);
     input.push(discriminator::VESTING);
     H256::from(poseidon2_hash(&input).to_bytes())
+}
+
+/// Validator bootstrap subsidy config key (slice 4.4a).
+///
+/// Stored value: `[total_amount:16 LE][end_slot:8 LE]`. Block processor
+/// reads this every block during reward calculation; while
+/// `current_slot < end_slot`, `total_amount / duration_slots` additional
+/// quanta are added to the `rewards_per_validator` accumulator (divided
+/// by the active validator count).
+pub fn validator_subsidy_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::VALIDATOR_SUBSIDY]).to_bytes())
 }
 
 #[cfg(test)]

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -876,6 +876,55 @@ pub fn write_vesting_schedule(
     let _ = smt.insert(pyde_state::keys::vesting_key(address), schedule.encode());
 }
 
+/// Validator bootstrap subsidy schedule (slice 4.4a).
+///
+/// `per_block` is precomputed as `total_amount / duration_slots` to avoid
+/// doing the division in the hot path every block. The block processor
+/// still gates on `end_slot` so the subsidy stream ends precisely.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidatorSubsidySchedule {
+    pub per_block: u128,
+    pub end_slot: u64,
+}
+
+impl ValidatorSubsidySchedule {
+    pub const ENCODED_LEN: usize = 16 + 8;
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::ENCODED_LEN);
+        buf.extend_from_slice(&self.per_block.to_le_bytes());
+        buf.extend_from_slice(&self.end_slot.to_le_bytes());
+        buf
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::ENCODED_LEN {
+            return None;
+        }
+        let per_block = u128::from_le_bytes(bytes[0..16].try_into().ok()?);
+        let end_slot = u64::from_le_bytes(bytes[16..24].try_into().ok()?);
+        Some(Self { per_block, end_slot })
+    }
+}
+
+/// Read the bootstrap subsidy schedule, if configured. Absent = no subsidy.
+pub fn read_validator_subsidy(
+    smt: &dyn pyde_state::smt::StateAccess,
+) -> Option<ValidatorSubsidySchedule> {
+    let bytes = smt.get(&pyde_state::keys::validator_subsidy_key())?;
+    ValidatorSubsidySchedule::decode(&bytes)
+}
+
+pub fn write_validator_subsidy(
+    smt: &mut dyn pyde_state::smt::StateAccess,
+    schedule: &ValidatorSubsidySchedule,
+) {
+    let _ = smt.insert(
+        pyde_state::keys::validator_subsidy_key(),
+        schedule.encode(),
+    );
+}
+
 /// Read active-only validator count (slice 4.2). Defaults to 0.
 pub fn read_active_validator_count(smt: &dyn pyde_state::smt::StateAccess) -> u64 {
     smt.get(&pyde_state::keys::active_validator_count_key())


### PR DESCRIPTION
## Summary

Hardening pass on slice 4.4 genesis work. Closes three of the four flagged limitations from the slice 4.4 PR:

- **Supply sanity** — genesis declares `initial_supply`; sum of allocations is cross-checked against it, mismatches abort boot.
- **Per-bucket caps** — `bucket_caps` (percent of `initial_supply`, 0–100) enforce allocation ratios per bucket. Protects against misconfigured validator/team/ecosystem splits.
- **Validator subsidy streaming** — `ValidatorSubsidySchedule { per_block, end_slot }` written at genesis. Block processor section 4c streams `per_block / active_count` into the rewards-per-validator accumulator each block until `end_slot`. Reuses the same lazy-accrual path as slice 4.1 pool rewards — no new claim logic.

## State additions

- `VALIDATOR_SUBSIDY = 0x17` discriminator + `validator_subsidy_key` helper
- `ValidatorSubsidySchedule` encode/decode + read/write helpers in `pyde-tx`

## Remaining slice 4.4 limitation

- **Airdrop Merkle claim** — deferred to slice 4.4b (~400 LOC, new `TransactionType::ClaimAirdrop` with Merkle proof verification against a genesis-stored root). Too large to fold in here cleanly.