### PR TITLE
feat: airdrop Merkle claim + sweep (slice 4.4b)

### DIFF
--- a/crates/account/src/address.rs
+++ b/crates/account/src/address.rs
@@ -48,6 +48,14 @@ pub fn treasury_address() -> Address {
     poseidon2_hash(b"pyde-treasury").to_bytes()
 }
 
+/// Well-known airdrop pool address: Poseidon2("pyde-airdrop-pool").
+/// Genesis pre-mints the total claimable amount to this address;
+/// `ClaimAirdrop` debits the pool and credits the claimer.
+/// `SweepAirdrop` transfers any post-deadline residue to the treasury.
+pub fn airdrop_pool_address() -> Address {
+    poseidon2_hash(b"pyde-airdrop-pool").to_bytes()
+}
+
 /// Format an address as a hex string with "0x" prefix.
 pub fn format_address(addr: &Address) -> String {
     let mut s = String::with_capacity(66);

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -52,6 +52,74 @@ pub struct GenesisConfig {
     /// percentages of declared supply).
     #[serde(default)]
     pub bucket_caps: std::collections::HashMap<String, u32>,
+    /// Optional airdrop commitment (slice 4.4b). When present, genesis
+    /// pre-mints the airdrop pool to `airdrop_pool_address()` and stores
+    /// the Merkle root + deadline + expected-sum so `ClaimAirdrop` txs
+    /// can verify proofs against the commitment.
+    #[serde(default)]
+    pub airdrop: Option<AirdropConfig>,
+}
+
+/// Genesis airdrop commitment (slice 4.4b).
+///
+/// The operator ships the Merkle root of the `(address, amount)` set
+/// they're airdropping. At genesis:
+///
+/// 1. `pool_total_amount` quanta are minted to `airdrop_pool_address()`
+///    (counts toward `initial_supply` like any other allocation).
+/// 2. `root` and `deadline_slot` are stored so `ClaimAirdrop` handlers
+///    can verify proofs and reject late claims.
+/// 3. `expected_claim_sum` is enforced to be ≤ `pool_total_amount` so
+///    underfunding is caught at boot, not at claim time.
+///
+/// Unclaimed residue after `deadline_slot` can be moved to the treasury
+/// via a permissionless `SweepAirdrop` tx.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AirdropConfig {
+    /// Hex-encoded 32-byte Merkle root.
+    pub root: String,
+    /// Slot after which `ClaimAirdrop` is rejected.
+    pub deadline_slot: u64,
+    /// Total quanta pre-minted to the airdrop pool as a string.
+    pub pool_total_amount: String,
+    /// Operator-declared sum of all claimable leaves as a string.
+    /// Enforced: `expected_claim_sum <= pool_total_amount`. Must be set
+    /// so that underfunding the pool fails genesis, not later claims.
+    pub expected_claim_sum: String,
+}
+
+impl AirdropConfig {
+    pub fn root_bytes(&self) -> Result<[u8; 32], String> {
+        let hex = self.root.strip_prefix("0x").unwrap_or(&self.root);
+        let bytes = hex::decode(hex).map_err(|e| format!("invalid airdrop root hex: {}", e))?;
+        if bytes.len() != 32 {
+            return Err(format!(
+                "airdrop root must be 32 bytes, got {}",
+                bytes.len()
+            ));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+
+    pub fn pool_total_u128(&self) -> Result<u128, String> {
+        self.pool_total_amount.parse::<u128>().map_err(|e| {
+            format!(
+                "invalid airdrop.pool_total_amount '{}': {}",
+                self.pool_total_amount, e
+            )
+        })
+    }
+
+    pub fn expected_sum_u128(&self) -> Result<u128, String> {
+        self.expected_claim_sum.parse::<u128>().map_err(|e| {
+            format!(
+                "invalid airdrop.expected_claim_sum '{}': {}",
+                self.expected_claim_sum, e
+            )
+        })
+    }
 }
 
 /// Configuration for the validator bootstrap subsidy stream.
@@ -164,6 +232,7 @@ impl Default for GenesisConfig {
             initial_supply: String::new(),
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         }
     }
 }
@@ -328,6 +397,62 @@ pub fn initialize_genesis(
     let count_key = pyde_state::keys::validator_count_key();
     entries.push((count_key, val_count.to_le_bytes().to_vec()));
 
+    // Slice 4.4b: pre-mint airdrop pool + install commitment.
+    //
+    // Pool is credited to the well-known `airdrop_pool_address()` so
+    // `ClaimAirdrop` handlers debit it by exact leaf amount. The pool
+    // amount is added to `total_supply` the same way any other
+    // allocation is — so the 4.4a supply sanity check still holds.
+    if let Some(air) = &config.airdrop {
+        let root = air.root_bytes()?;
+        let pool_total = air.pool_total_u128()?;
+        let expected_sum = air.expected_sum_u128()?;
+
+        if expected_sum > pool_total {
+            return Err(format!(
+                "airdrop underfunded: expected_claim_sum={} quanta but pool_total_amount={}",
+                expected_sum, pool_total
+            ));
+        }
+
+        let pool_addr = pyde_account::address::airdrop_pool_address();
+        let pool_account = pyde_account::types::Account {
+            address: pool_addr,
+            nonce: 0,
+            balance: pool_total,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        entries.push((
+            pyde_state::keys::balance_key(&pool_addr),
+            pool_account.to_bytes(),
+        ));
+
+        entries.push((pyde_state::keys::airdrop_root_key(), root.to_vec()));
+        entries.push((
+            pyde_state::keys::airdrop_deadline_key(),
+            air.deadline_slot.to_le_bytes().to_vec(),
+        ));
+        entries.push((
+            pyde_state::keys::airdrop_expected_sum_key(),
+            expected_sum.to_le_bytes().to_vec(),
+        ));
+
+        total_supply = total_supply
+            .checked_add(pool_total)
+            .ok_or("genesis total supply overflow")?;
+
+        // Count the airdrop pool as its own bucket for per-bucket cap
+        // enforcement. Operators who want to cap airdrop size pass
+        // `bucket_caps["airdrop"] = N`.
+        let e = bucket_totals.entry("airdrop".to_string()).or_insert(0u128);
+        *e = e.checked_add(pool_total).ok_or("airdrop bucket overflow")?;
+    }
+
     // Slice 4.4a: install validator bootstrap subsidy schedule.
     // `total_amount` was already included in `total_supply` if the
     // operator allocated it to the subsidy pool via a genesis
@@ -486,6 +611,7 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
         initial_supply: String::new(),
         validator_subsidy: None,
         bucket_caps: std::collections::HashMap::new(),
+        airdrop: None,
     };
 
     (config, accounts)
@@ -582,6 +708,7 @@ pub fn generate_testnet(
         initial_supply: String::new(),
         validator_subsidy: None,
         bucket_caps: std::collections::HashMap::new(),
+        airdrop: None,
     };
 
     // Write shared genesis.toml
@@ -967,6 +1094,7 @@ mod tests {
             initial_supply: "1000".to_string(),
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         };
         initialize_genesis(&mut state, &config).expect("matching sum should accept");
     }
@@ -983,6 +1111,7 @@ mod tests {
             initial_supply: "500".to_string(), // allocations sum to 300 — mismatch
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("genesis supply mismatch"), "got: {}", err);
@@ -1002,6 +1131,7 @@ mod tests {
             initial_supply: String::new(),
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
     }
@@ -1021,6 +1151,7 @@ mod tests {
                 duration_slots: 1_000,
             }),
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
 
@@ -1045,6 +1176,7 @@ mod tests {
                 duration_slots: 0,
             }),
             bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("duration_slots must be > 0"));
@@ -1079,6 +1211,7 @@ mod tests {
             initial_supply: "1000".to_string(),
             validator_subsidy: None,
             bucket_caps: caps,
+            airdrop: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
     }
@@ -1101,6 +1234,7 @@ mod tests {
             initial_supply: "1000".to_string(),
             validator_subsidy: None,
             bucket_caps: caps,
+            airdrop: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("bucket 'team' exceeds cap"), "got: {}", err);
@@ -1122,6 +1256,7 @@ mod tests {
             initial_supply: String::new(),
             validator_subsidy: None,
             bucket_caps: caps,
+            airdrop: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("requires initial_supply"), "got: {}", err);
@@ -1141,6 +1276,7 @@ mod tests {
             initial_supply: "100".to_string(),
             validator_subsidy: None,
             bucket_caps: caps,
+            airdrop: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("not a valid percentage"), "got: {}", err);
@@ -1163,5 +1299,146 @@ mod tests {
     #[test]
     fn parse_hex_address_wrong_length() {
         assert!(parse_hex_address("deadbeef").is_err());
+    }
+
+    // ========== Slice 4.4b: airdrop commitment ==========
+
+    fn airdrop_cfg(root: [u8; 32], pool: u128, expected: u128, deadline: u64) -> AirdropConfig {
+        AirdropConfig {
+            root: hex::encode(root),
+            deadline_slot: deadline,
+            pool_total_amount: pool.to_string(),
+            expected_claim_sum: expected.to_string(),
+        }
+    }
+
+    #[test]
+    fn genesis_writes_airdrop_root_and_funds_pool() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (root, _) = pyde_tx::airdrop::build_tree(&[([0x11; 32], 500u128), ([0x22; 32], 500u128)]);
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0xAA; 32], 200)],
+            validators: Vec::new(),
+            initial_supply: "1200".to_string(), // 200 alloc + 1000 pool
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: Some(airdrop_cfg(root, 1000, 1000, 10_000)),
+        };
+        initialize_genesis(&mut state, &config).expect("airdrop genesis should accept");
+
+        // Root stored
+        let root_bytes = state.get(&pyde_state::keys::airdrop_root_key()).unwrap();
+        assert_eq!(root_bytes.len(), 32);
+        assert_eq!(&root_bytes[..], &root[..]);
+        // Deadline stored
+        let deadline_bytes = state.get(&pyde_state::keys::airdrop_deadline_key()).unwrap();
+        let deadline = u64::from_le_bytes(deadline_bytes[..8].try_into().unwrap());
+        assert_eq!(deadline, 10_000);
+        // Pool funded to exactly pool_total_amount
+        let pool_addr = pyde_account::address::airdrop_pool_address();
+        let bytes = state.get(&pyde_state::keys::balance_key(&pool_addr)).unwrap();
+        let account = pyde_account::types::Account::from_bytes(&bytes).unwrap();
+        assert_eq!(account.balance, 1000);
+    }
+
+    #[test]
+    fn genesis_rejects_underfunded_airdrop_pool() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (root, _) = pyde_tx::airdrop::build_tree(&[([0x11; 32], 2000u128)]);
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: "1000".to_string(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            // expected_claim_sum (2000) > pool_total (1000) → underfunded
+            airdrop: Some(airdrop_cfg(root, 1000, 2000, 10_000)),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("airdrop underfunded"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_airdrop_pool_counts_toward_supply() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (root, _) = pyde_tx::airdrop::build_tree(&[([0x11; 32], 500u128)]);
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0xAA; 32], 300)],
+            validators: Vec::new(),
+            // Declared supply 700 = 300 alloc + 400 pool. If the pool
+            // weren't counted toward total_supply, the sanity check
+            // would see 300 ≠ 700 and reject. Successful acceptance
+            // proves pool balance flows into the total.
+            initial_supply: "700".to_string(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: Some(airdrop_cfg(root, 400, 400, 10_000)),
+        };
+        // 300 + 400 = 700, matches declared → accepts.
+        initialize_genesis(&mut state, &config).expect("declared supply includes pool");
+    }
+
+    #[test]
+    fn genesis_rejects_invalid_airdrop_root_hex() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let mut config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: "100".to_string(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: Some(AirdropConfig {
+                root: "not-hex".to_string(),
+                deadline_slot: 100,
+                pool_total_amount: "100".to_string(),
+                expected_claim_sum: "100".to_string(),
+            }),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("invalid airdrop root hex"), "got: {}", err);
+
+        // Wrong length (16 bytes instead of 32)
+        config.airdrop.as_mut().unwrap().root = hex::encode([0xAB; 16]);
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("airdrop root must be 32 bytes"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_airdrop_honors_bucket_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (root, _) = pyde_tx::airdrop::build_tree(&[([0x11; 32], 300u128)]);
+
+        let mut caps = std::collections::HashMap::new();
+        caps.insert("airdrop".to_string(), 20u32); // cap 20% of 1000 = 200
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![tiny_alloc([0xAA; 32], 700)],
+            validators: Vec::new(),
+            initial_supply: "1000".to_string(),
+            validator_subsidy: None,
+            bucket_caps: caps,
+            // Pool is 300 quanta = 30% of 1000 → exceeds 20% cap.
+            airdrop: Some(airdrop_cfg(root, 300, 300, 10_000)),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("bucket 'airdrop' exceeds cap"), "got: {}", err);
     }
 }

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -53,6 +53,20 @@ pub mod discriminator {
     /// mints per-block subsidy to the `rewards_per_validator`
     /// accumulator while `current_slot < end_slot`.
     pub const VALIDATOR_SUBSIDY: u8 = 0x17;
+    /// Airdrop Merkle root (slice 4.4b). 32-byte commitment to
+    /// `{(address, amount)}` tuples. `ClaimAirdrop` transactions verify
+    /// a proof against this root before debiting the pool.
+    pub const AIRDROP_ROOT: u8 = 0x18;
+    /// Airdrop claim deadline (slice 4.4b). Slot after which
+    /// `ClaimAirdrop` is rejected. u64 LE.
+    pub const AIRDROP_DEADLINE: u8 = 0x19;
+    /// Per-leaf-index claimed marker (slice 4.4b). 1-byte presence
+    /// flag keyed by the leaf's u64 index — prevents double-claim.
+    pub const AIRDROP_CLAIMED: u8 = 0x1A;
+    /// Declared sum of all claimable leaf amounts (slice 4.4b).
+    /// Enforced at genesis: `airdrop_pool.balance >= AIRDROP_EXPECTED_SUM`.
+    /// u128 LE.
+    pub const AIRDROP_EXPECTED_SUM: u8 = 0x1B;
 }
 
 // ---------------------------------------------------------------------------
@@ -241,6 +255,38 @@ pub fn vesting_key(address: &Address) -> H256 {
 /// by the active validator count).
 pub fn validator_subsidy_key() -> H256 {
     H256::from(poseidon2_hash(&[discriminator::VALIDATOR_SUBSIDY]).to_bytes())
+}
+
+/// Airdrop Merkle root key (slice 4.4b). Value is the 32-byte root.
+/// Written at genesis, immutable thereafter.
+pub fn airdrop_root_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::AIRDROP_ROOT]).to_bytes())
+}
+
+/// Airdrop claim deadline key (slice 4.4b). Value is u64 LE (slot).
+pub fn airdrop_deadline_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::AIRDROP_DEADLINE]).to_bytes())
+}
+
+/// Airdrop declared-sum key (slice 4.4b). Value is u128 LE — the
+/// operator-declared total of all claimable leaves. Checked against
+/// pool balance at genesis so underfunding is caught at boot, not
+/// at claim time.
+pub fn airdrop_expected_sum_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::AIRDROP_EXPECTED_SUM]).to_bytes())
+}
+
+/// Per-leaf claimed-marker key (slice 4.4b). Presence of the key
+/// (any value) means the leaf has been claimed. Keyed by leaf index
+/// so a single address can appear in the tree multiple times under
+/// distinct indices if the operator wants to tranche out claims.
+///
+/// `key = Poseidon2(0x1A || leaf_index_le_8)`
+pub fn airdrop_claimed_key(leaf_index: u64) -> H256 {
+    let mut input = Vec::with_capacity(9);
+    input.push(discriminator::AIRDROP_CLAIMED);
+    input.extend_from_slice(&leaf_index.to_le_bytes());
+    H256::from(poseidon2_hash(&input).to_bytes())
 }
 
 #[cfg(test)]

--- a/crates/tx/src/airdrop.rs
+++ b/crates/tx/src/airdrop.rs
@@ -1,0 +1,323 @@
+//! Airdrop Merkle proof verification (slice 4.4b).
+//!
+//! Tree layout:
+//! - Leaf:     `Poseidon2(0x00 || leaf_index_le_8 || address_32 || amount_le_16)`
+//! - Internal: `poseidon2_pair(left, right)`
+//!
+//! The leading `0x00` byte in leaves domain-separates them from internal
+//! nodes (which come out of `poseidon2_pair`, not `poseidon2_hash`, and
+//! therefore have no freely-chosen preimage). This blocks the classic
+//! sorted-pair second-preimage attack where an internal hash could be
+//! presented as a leaf.
+//!
+//! Proof format carried in `ClaimAirdrop` `tx.data`:
+//!
+//! ```text
+//! [leaf_index:8 LE][amount:16 LE][proof_len:1][sibling_0:32]...[sibling_{N-1}:32]
+//! ```
+//!
+//! Direction at each level is taken from the index bits: bit `i` of
+//! `leaf_index` = 0 → sibling sits to the right of the current hash at
+//! level `i`; bit = 1 → sibling sits to the left.
+
+use pyde_account::address::Address;
+use pyde_crypto::poseidon2::{poseidon2_hash, poseidon2_pair};
+
+/// 32-byte Merkle hash.
+pub type MerkleHash = [u8; 32];
+
+/// Domain-separation tag for leaves.
+const LEAF_TAG: u8 = 0x00;
+
+/// Maximum proof length carried in a single tx. 1-byte length field
+/// caps depth at 255 — a tree that deep would hold `2^255` leaves, so
+/// this ceiling is purely a serialization cap, not a protocol limit.
+pub const MAX_PROOF_LEN: usize = 255;
+
+/// Minimum encoded payload size: `index (8) + amount (16) + proof_len (1)`.
+pub const MIN_CLAIM_DATA_LEN: usize = 25;
+
+/// Decoded `ClaimAirdrop` payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClaimPayload {
+    pub leaf_index: u64,
+    pub amount: u128,
+    pub proof: Vec<MerkleHash>,
+}
+
+impl ClaimPayload {
+    /// Decode a `tx.data` payload into a structured claim. Returns `None`
+    /// for any malformed or truncated input — the pipeline treats this as
+    /// a rejected tx.
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < MIN_CLAIM_DATA_LEN {
+            return None;
+        }
+        let leaf_index = u64::from_le_bytes(bytes[0..8].try_into().ok()?);
+        let amount = u128::from_le_bytes(bytes[8..24].try_into().ok()?);
+        let proof_len = bytes[24] as usize;
+        let expected = MIN_CLAIM_DATA_LEN + proof_len * 32;
+        if bytes.len() != expected {
+            return None;
+        }
+        let mut proof = Vec::with_capacity(proof_len);
+        for i in 0..proof_len {
+            let off = MIN_CLAIM_DATA_LEN + i * 32;
+            let mut sibling = [0u8; 32];
+            sibling.copy_from_slice(&bytes[off..off + 32]);
+            proof.push(sibling);
+        }
+        Some(Self {
+            leaf_index,
+            amount,
+            proof,
+        })
+    }
+
+    /// Serialize for tests and off-chain tooling. Inverse of `decode`.
+    pub fn encode(&self) -> Vec<u8> {
+        assert!(self.proof.len() <= MAX_PROOF_LEN, "proof too long");
+        let mut out = Vec::with_capacity(MIN_CLAIM_DATA_LEN + self.proof.len() * 32);
+        out.extend_from_slice(&self.leaf_index.to_le_bytes());
+        out.extend_from_slice(&self.amount.to_le_bytes());
+        out.push(self.proof.len() as u8);
+        for sibling in &self.proof {
+            out.extend_from_slice(sibling);
+        }
+        out
+    }
+}
+
+/// Compute the leaf hash for `(index, address, amount)`.
+pub fn leaf_hash(index: u64, address: &Address, amount: u128) -> MerkleHash {
+    let mut input = Vec::with_capacity(1 + 8 + 32 + 16);
+    input.push(LEAF_TAG);
+    input.extend_from_slice(&index.to_le_bytes());
+    input.extend_from_slice(address);
+    input.extend_from_slice(&amount.to_le_bytes());
+    poseidon2_hash(&input).to_bytes()
+}
+
+/// Walk the proof from the leaf to compute a root. Returns the computed
+/// 32-byte root — callers compare against the stored `airdrop_root`.
+///
+/// Order at each level is derived from the corresponding bit of
+/// `leaf_index`. This ensures the proof commits to the leaf's position,
+/// not just its content — without it, an attacker could swap two leaves'
+/// proofs and claim either.
+pub fn compute_root(
+    leaf_index: u64,
+    address: &Address,
+    amount: u128,
+    proof: &[MerkleHash],
+) -> MerkleHash {
+    let mut node = leaf_hash(leaf_index, address, amount);
+    let mut index = leaf_index;
+    for sibling in proof {
+        let (left, right) = if index & 1 == 0 {
+            (node, *sibling)
+        } else {
+            (*sibling, node)
+        };
+        node = poseidon2_pair(
+            pyde_crypto::hash::Hash256::from(left),
+            pyde_crypto::hash::Hash256::from(right),
+        )
+        .to_bytes();
+        index >>= 1;
+    }
+    node
+}
+
+/// Verify that `(index, address, amount, proof)` is consistent with `root`.
+pub fn verify_proof(
+    leaf_index: u64,
+    address: &Address,
+    amount: u128,
+    proof: &[MerkleHash],
+    root: &MerkleHash,
+) -> bool {
+    &compute_root(leaf_index, address, amount, proof) == root
+}
+
+// ---------------------------------------------------------------------------
+// Off-chain builder (test helper; operators run a separate tool in prod).
+// ---------------------------------------------------------------------------
+
+/// Build a full Merkle tree from a vector of `(address, amount)` pairs.
+/// Leaves are indexed in the order provided. Returns `(root, proofs)`
+/// where `proofs[i]` is the proof for leaf `i`.
+///
+/// Reference implementation — genesis tests, devnet tooling, and any
+/// downstream CLI can share the same leaf/node formulation so the
+/// off-chain tree matches what `verify_proof` expects on-chain.
+pub fn build_tree(leaves: &[(Address, u128)]) -> (MerkleHash, Vec<Vec<MerkleHash>>) {
+    assert!(!leaves.is_empty(), "cannot build a tree with zero leaves");
+
+    // Pad leaf count to next power of two with all-zero hashes so every
+    // internal level is full. Zero padding is safe because the off-chain
+    // builder determines leaf index and no attacker can submit a claim
+    // against a padded slot — its preimage has no valid (address,amount).
+    let mut level: Vec<MerkleHash> = leaves
+        .iter()
+        .enumerate()
+        .map(|(i, (addr, amt))| leaf_hash(i as u64, addr, *amt))
+        .collect();
+
+    let depth = if level.len() <= 1 {
+        0
+    } else {
+        (level.len() - 1).ilog2() as usize + 1
+    };
+    let padded_width = 1usize << depth;
+    while level.len() < padded_width {
+        level.push([0u8; 32]);
+    }
+
+    let mut siblings_per_leaf: Vec<Vec<MerkleHash>> = vec![Vec::with_capacity(depth); leaves.len()];
+
+    for _d in 0..depth {
+        for leaf_i in 0..leaves.len() {
+            let pos_at_level = leaf_i >> _d;
+            let sibling_pos = pos_at_level ^ 1;
+            siblings_per_leaf[leaf_i].push(level[sibling_pos]);
+        }
+
+        let mut next = Vec::with_capacity(level.len() / 2);
+        for pair in level.chunks(2) {
+            let parent = poseidon2_pair(
+                pyde_crypto::hash::Hash256::from(pair[0]),
+                pyde_crypto::hash::Hash256::from(pair[1]),
+            )
+            .to_bytes();
+            next.push(parent);
+        }
+        level = next;
+    }
+
+    (level[0], siblings_per_leaf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(seed: u64) -> Address {
+        let mut a = [0u8; 32];
+        a[..8].copy_from_slice(&seed.to_le_bytes());
+        a
+    }
+
+    #[test]
+    fn leaf_hash_deterministic() {
+        let a = addr(1);
+        assert_eq!(leaf_hash(0, &a, 100), leaf_hash(0, &a, 100));
+    }
+
+    #[test]
+    fn leaf_hash_differs_on_index_address_amount() {
+        let a = addr(1);
+        let b = addr(2);
+        assert_ne!(leaf_hash(0, &a, 100), leaf_hash(1, &a, 100));
+        assert_ne!(leaf_hash(0, &a, 100), leaf_hash(0, &b, 100));
+        assert_ne!(leaf_hash(0, &a, 100), leaf_hash(0, &a, 101));
+    }
+
+    #[test]
+    fn single_leaf_tree() {
+        let leaves = vec![(addr(1), 100u128)];
+        let (root, proofs) = build_tree(&leaves);
+        // Single-leaf tree: depth is 0, root == leaf hash, proof is empty.
+        assert_eq!(proofs[0].len(), 0);
+        assert_eq!(root, leaf_hash(0, &addr(1), 100));
+        assert!(verify_proof(0, &addr(1), 100, &proofs[0], &root));
+    }
+
+    #[test]
+    fn two_leaf_tree_proof_verifies() {
+        let leaves = vec![(addr(1), 100u128), (addr(2), 200u128)];
+        let (root, proofs) = build_tree(&leaves);
+        assert!(verify_proof(0, &addr(1), 100, &proofs[0], &root));
+        assert!(verify_proof(1, &addr(2), 200, &proofs[1], &root));
+    }
+
+    #[test]
+    fn eight_leaf_tree_all_proofs_verify() {
+        let leaves: Vec<_> = (0..8).map(|i| (addr(i), (i as u128) * 100)).collect();
+        let (root, proofs) = build_tree(&leaves);
+        for (i, (a, amt)) in leaves.iter().enumerate() {
+            assert!(
+                verify_proof(i as u64, a, *amt, &proofs[i], &root),
+                "proof {i} failed"
+            );
+        }
+    }
+
+    #[test]
+    fn proof_rejects_wrong_address() {
+        let leaves = vec![(addr(1), 100u128), (addr(2), 200u128)];
+        let (root, proofs) = build_tree(&leaves);
+        assert!(!verify_proof(0, &addr(99), 100, &proofs[0], &root));
+    }
+
+    #[test]
+    fn proof_rejects_wrong_amount() {
+        let leaves = vec![(addr(1), 100u128), (addr(2), 200u128)];
+        let (root, proofs) = build_tree(&leaves);
+        assert!(!verify_proof(0, &addr(1), 999, &proofs[0], &root));
+    }
+
+    #[test]
+    fn proof_rejects_wrong_index() {
+        let leaves = vec![(addr(1), 100u128), (addr(2), 200u128)];
+        let (root, proofs) = build_tree(&leaves);
+        // Using leaf 1's proof but claiming it's for leaf 0.
+        assert!(!verify_proof(0, &addr(2), 200, &proofs[1], &root));
+    }
+
+    #[test]
+    fn proof_rejects_mutated_sibling() {
+        let leaves = vec![(addr(1), 100u128), (addr(2), 200u128)];
+        let (root, mut proofs) = build_tree(&leaves);
+        proofs[0][0][0] ^= 0xFF;
+        assert!(!verify_proof(0, &addr(1), 100, &proofs[0], &root));
+    }
+
+    #[test]
+    fn claim_payload_roundtrip() {
+        let payload = ClaimPayload {
+            leaf_index: 42,
+            amount: 1_000_000,
+            proof: vec![[0xAB; 32], [0xCD; 32], [0xEF; 32]],
+        };
+        let bytes = payload.encode();
+        let decoded = ClaimPayload::decode(&bytes).unwrap();
+        assert_eq!(payload, decoded);
+    }
+
+    #[test]
+    fn claim_payload_rejects_truncated() {
+        assert_eq!(ClaimPayload::decode(&[]), None);
+        assert_eq!(ClaimPayload::decode(&[0u8; 20]), None);
+    }
+
+    #[test]
+    fn claim_payload_rejects_length_mismatch() {
+        let mut payload = ClaimPayload {
+            leaf_index: 0,
+            amount: 0,
+            proof: vec![[0xAB; 32]],
+        };
+        let bytes = payload.encode();
+        // Claim proof_len=1 but only supply empty siblings.
+        let mut truncated = bytes.clone();
+        truncated.truncate(MIN_CLAIM_DATA_LEN);
+        assert_eq!(ClaimPayload::decode(&truncated), None);
+
+        // Claim proof_len=0 but append extra bytes.
+        payload.proof.clear();
+        let mut extended = payload.encode();
+        extended.extend_from_slice(&[0u8; 32]);
+        assert_eq!(ClaimPayload::decode(&extended), None);
+    }
+}

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -1,6 +1,7 @@
 //! Pyde Transaction Processing: transaction types, serialization, and hashing.
 
 pub mod access_infer;
+pub mod airdrop;
 pub mod execution;
 pub mod fee;
 pub mod gas_tank;

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -482,6 +482,12 @@ fn execute_transaction_inner(
             }
         }
         TransactionType::Slash => execute_slash(tx, smt, &mut sender.balance),
+        TransactionType::ClaimAirdrop => {
+            execute_claim_airdrop(tx, smt, block_ctx, &mut sender.balance)
+        }
+        TransactionType::SweepAirdrop => {
+            execute_sweep_airdrop(smt, block_ctx)
+        }
         TransactionType::ClaimReward => {
             // Pull the sender's accrued pool share. Valid only for
             // Active (0x00) and Unbonding (0x01) entries — Exited
@@ -925,6 +931,72 @@ pub fn write_validator_subsidy(
     );
 }
 
+/// Read the airdrop Merkle root, if configured.
+pub fn read_airdrop_root(
+    smt: &dyn pyde_state::smt::StateAccess,
+) -> Option<[u8; 32]> {
+    let bytes = smt.get(&pyde_state::keys::airdrop_root_key())?;
+    if bytes.len() == 32 {
+        let mut root = [0u8; 32];
+        root.copy_from_slice(&bytes);
+        Some(root)
+    } else {
+        None
+    }
+}
+
+pub fn write_airdrop_root(smt: &mut dyn pyde_state::smt::StateAccess, root: &[u8; 32]) {
+    let _ = smt.insert(pyde_state::keys::airdrop_root_key(), root.to_vec());
+}
+
+/// Read the airdrop claim deadline (slot). Absent = no deadline configured.
+pub fn read_airdrop_deadline(smt: &dyn pyde_state::smt::StateAccess) -> Option<u64> {
+    let bytes = smt.get(&pyde_state::keys::airdrop_deadline_key())?;
+    if bytes.len() >= 8 {
+        Some(u64::from_le_bytes(bytes[..8].try_into().ok()?))
+    } else {
+        None
+    }
+}
+
+pub fn write_airdrop_deadline(smt: &mut dyn pyde_state::smt::StateAccess, slot: u64) {
+    let _ = smt.insert(
+        pyde_state::keys::airdrop_deadline_key(),
+        slot.to_le_bytes().to_vec(),
+    );
+}
+
+/// Read the operator-declared expected airdrop claim sum.
+pub fn read_airdrop_expected_sum(smt: &dyn pyde_state::smt::StateAccess) -> Option<u128> {
+    let bytes = smt.get(&pyde_state::keys::airdrop_expected_sum_key())?;
+    if bytes.len() >= 16 {
+        Some(u128::from_le_bytes(bytes[..16].try_into().ok()?))
+    } else {
+        None
+    }
+}
+
+pub fn write_airdrop_expected_sum(smt: &mut dyn pyde_state::smt::StateAccess, amount: u128) {
+    let _ = smt.insert(
+        pyde_state::keys::airdrop_expected_sum_key(),
+        amount.to_le_bytes().to_vec(),
+    );
+}
+
+/// Check whether a leaf index has already been claimed.
+pub fn is_airdrop_claimed(smt: &dyn pyde_state::smt::StateAccess, leaf_index: u64) -> bool {
+    smt.get(&pyde_state::keys::airdrop_claimed_key(leaf_index))
+        .is_some()
+}
+
+/// Mark a leaf index as claimed. Idempotent — value is a single marker byte.
+pub fn mark_airdrop_claimed(smt: &mut dyn pyde_state::smt::StateAccess, leaf_index: u64) {
+    let _ = smt.insert(
+        pyde_state::keys::airdrop_claimed_key(leaf_index),
+        vec![0x01],
+    );
+}
+
 /// Read active-only validator count (slice 4.2). Defaults to 0.
 pub fn read_active_validator_count(smt: &dyn pyde_state::smt::StateAccess) -> u64 {
     smt.get(&pyde_state::keys::active_validator_count_key())
@@ -1213,6 +1285,183 @@ fn execute_slash(
     );
 
     (true, 100_000, 0, vec![], ev.signer.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Airdrop claim + sweep (slice 4.4b)
+// ---------------------------------------------------------------------------
+
+/// Base gas for a `ClaimAirdrop` tx (covers state lookups + balance writes).
+const AIRDROP_CLAIM_BASE_GAS: u64 = 30_000;
+
+/// Per-proof-level gas for the Poseidon2 pair hash that reconstructs the
+/// root. Calibrated to be strictly above the measured cost of one
+/// `poseidon2_pair` call in `crypto/benches/poseidon2_bench.rs` (≈ 3.5µs
+/// on M-series hardware at a 1 gas ≈ 1ns target ratio). Rounded up to
+/// give headroom for slower hardware + CI variance.
+const AIRDROP_CLAIM_PER_LEVEL_GAS: u64 = 5_000;
+
+/// Flat gas for `SweepAirdrop`: three reads (deadline, pool account,
+/// treasury account) + two balance writes.
+const AIRDROP_SWEEP_GAS: u64 = 40_000;
+
+fn execute_claim_airdrop(
+    tx: &Transaction,
+    smt: &mut dyn pyde_state::smt::StateAccess,
+    block_ctx: &BlockContext,
+    sender_balance: &mut u128,
+) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
+    let payload = match crate::airdrop::ClaimPayload::decode(&tx.data) {
+        Some(p) => p,
+        None => {
+            return (
+                false,
+                AIRDROP_CLAIM_BASE_GAS,
+                0,
+                vec![],
+                b"airdrop payload malformed".to_vec(),
+            );
+        }
+    };
+
+    let gas = AIRDROP_CLAIM_BASE_GAS
+        .saturating_add(AIRDROP_CLAIM_PER_LEVEL_GAS.saturating_mul(payload.proof.len() as u64));
+
+    // Deadline — if no deadline is configured the airdrop isn't active.
+    let deadline = match read_airdrop_deadline(smt) {
+        Some(d) => d,
+        None => {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"airdrop not configured".to_vec(),
+            );
+        }
+    };
+    if block_ctx.height > deadline {
+        return (false, gas, 0, vec![], b"airdrop deadline passed".to_vec());
+    }
+
+    // Root — required alongside deadline, but check defensively in case
+    // of partially-written genesis state.
+    let root = match read_airdrop_root(smt) {
+        Some(r) => r,
+        None => {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"airdrop root missing".to_vec(),
+            );
+        }
+    };
+
+    // Anti-replay check BEFORE proof verification so repeated failed
+    // claims don't waste Poseidon2 cycles on the validator.
+    if is_airdrop_claimed(smt, payload.leaf_index) {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"airdrop leaf already claimed".to_vec(),
+        );
+    }
+
+    if !crate::airdrop::verify_proof(
+        payload.leaf_index,
+        &tx.from,
+        payload.amount,
+        &payload.proof,
+        &root,
+    ) {
+        return (false, gas, 0, vec![], b"airdrop proof invalid".to_vec());
+    }
+
+    // Debit pool, credit claimer. Pool underfund should be caught at
+    // genesis by the `expected_sum >= pool_balance` check, but we
+    // defend in depth in case the expected sum was wrong and late
+    // claimers hit a drained pool.
+    let pool_addr = pyde_account::address::airdrop_pool_address();
+    let mut pool = load_account(smt, &pool_addr);
+    if pool.balance < payload.amount {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"airdrop pool insufficient".to_vec(),
+        );
+    }
+    pool.balance -= payload.amount;
+    if store_account(smt, &pool).is_err() {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"airdrop pool write failed".to_vec(),
+        );
+    }
+
+    *sender_balance = sender_balance.saturating_add(payload.amount);
+    mark_airdrop_claimed(smt, payload.leaf_index);
+
+    (true, gas, 0, vec![], payload.amount.to_le_bytes().to_vec())
+}
+
+fn execute_sweep_airdrop(
+    smt: &mut dyn pyde_state::smt::StateAccess,
+    block_ctx: &BlockContext,
+) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
+    let deadline = match read_airdrop_deadline(smt) {
+        Some(d) => d,
+        None => {
+            return (
+                false,
+                AIRDROP_SWEEP_GAS,
+                0,
+                vec![],
+                b"airdrop not configured".to_vec(),
+            );
+        }
+    };
+    if block_ctx.height <= deadline {
+        return (
+            false,
+            AIRDROP_SWEEP_GAS,
+            0,
+            vec![],
+            b"airdrop still active".to_vec(),
+        );
+    }
+
+    let pool_addr = pyde_account::address::airdrop_pool_address();
+    let mut pool = load_account(smt, &pool_addr);
+    let residue = pool.balance;
+    if residue == 0 {
+        return (true, AIRDROP_SWEEP_GAS, 0, vec![], vec![]);
+    }
+
+    let treasury_addr = pyde_account::address::treasury_address();
+    let mut treasury = load_account(smt, &treasury_addr);
+    pool.balance = 0;
+    treasury.balance = treasury.balance.saturating_add(residue);
+
+    if store_account(smt, &pool).is_err() || store_account(smt, &treasury).is_err() {
+        return (
+            false,
+            AIRDROP_SWEEP_GAS,
+            0,
+            vec![],
+            b"sweep state write failed".to_vec(),
+        );
+    }
+
+    (true, AIRDROP_SWEEP_GAS, 0, vec![], residue.to_le_bytes().to_vec())
 }
 
 /// Currently executes groups sequentially on the shared SMT. True thread-level
@@ -3186,5 +3435,304 @@ mod tests {
         let tx = build_slash_tx(submitter, &ssk, vec![SLASH_EVIDENCE_VERSION, 0x00]);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!receipt.success);
+    }
+
+    // ========== Slice 4.4b: airdrop claim + sweep ==========
+
+    /// Seed airdrop state: root, deadline, pool balance, and optional
+    /// expected-sum. Returns the claimer address + secret key + the
+    /// computed proof for `leaf_index`.
+    fn airdrop_fixture(
+        smt: &mut dyn pyde_state::smt::StateAccess,
+        leaves: Vec<(Address, u128)>,
+        leaf_index: usize,
+        deadline: u64,
+        pool_balance: u128,
+    ) -> (
+        pyde_crypto::falcon::FalconPublicKey,
+        pyde_crypto::falcon::FalconSecretKey,
+        Address,
+        Vec<[u8; 32]>,
+    ) {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let claimer = derive_eoa_address(pk.as_bytes());
+
+        // Replace the placeholder at leaf_index with the real claimer
+        // address so the proof binds to a signable account.
+        let mut leaves = leaves;
+        let amount = leaves[leaf_index].1;
+        leaves[leaf_index] = (claimer, amount);
+
+        let (root, proofs) = crate::airdrop::build_tree(&leaves);
+        let proof = proofs[leaf_index].clone();
+
+        write_airdrop_root(smt, &root);
+        write_airdrop_deadline(smt, deadline);
+
+        // Fund the pool.
+        let pool_addr = pyde_account::address::airdrop_pool_address();
+        let mut pool_account = pyde_account::types::Account {
+            address: pool_addr,
+            nonce: 0,
+            balance: pool_balance,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        pool_account.balance = pool_balance;
+        store_account(smt, &pool_account).unwrap();
+
+        fund_account_with_pk(smt, &claimer, 1_000_000_000_000, pk.as_bytes());
+
+        (pk, sk, claimer, proof)
+    }
+
+    fn build_claim_tx(
+        from: Address,
+        sk: &pyde_crypto::falcon::FalconSecretKey,
+        leaf_index: u64,
+        amount: u128,
+        proof: Vec<[u8; 32]>,
+        nonce: u64,
+    ) -> Transaction {
+        let payload = crate::airdrop::ClaimPayload {
+            leaf_index,
+            amount,
+            proof,
+        };
+        let mut tx = Transaction {
+            from,
+            to: [0u8; 32],
+            value: 0,
+            data: payload.encode(),
+            gas_limit: 200_000,
+            nonce,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::ClaimAirdrop,
+        };
+        sign_tx(&mut tx, sk);
+        tx
+    }
+
+    #[test]
+    fn airdrop_claim_debits_pool_and_credits_claimer() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128), ([0xBB; 32], 2_000u128)];
+        let (_pk, sk, claimer, proof) = airdrop_fixture(&mut smt, leaves, 0, 10_000, 5_000);
+
+        let starting_balance = load_account(&smt, &claimer).balance;
+
+        let tx = build_claim_tx(claimer, &sk, 0, 1_000, proof, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(receipt.success, "valid claim should succeed");
+
+        // Pool debited
+        let pool = load_account(&smt, &pyde_account::address::airdrop_pool_address());
+        assert_eq!(pool.balance, 4_000);
+
+        // Claimer credited — minus gas cost
+        let after = load_account(&smt, &claimer);
+        let gas_cost = receipt.gas_used as u128 * ctx.base_fee;
+        assert_eq!(after.balance, starting_balance + 1_000 - gas_cost);
+
+        // Claimed flag set
+        assert!(is_airdrop_claimed(&smt, 0));
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_double_claim() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128), ([0xBB; 32], 2_000u128)];
+        let (_pk, sk, claimer, proof) = airdrop_fixture(&mut smt, leaves, 0, 10_000, 5_000);
+
+        let tx1 = build_claim_tx(claimer, &sk, 0, 1_000, proof.clone(), 0);
+        let r1 = execute_transaction(&tx1, &mut smt, &ctx).unwrap();
+        assert!(r1.success);
+
+        let tx2 = build_claim_tx(claimer, &sk, 0, 1_000, proof, 1);
+        let r2 = execute_transaction(&tx2, &mut smt, &ctx).unwrap();
+        assert!(!r2.success, "second claim for same leaf must fail");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_wrong_amount() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128), ([0xBB; 32], 2_000u128)];
+        let (_pk, sk, claimer, proof) = airdrop_fixture(&mut smt, leaves, 0, 10_000, 5_000);
+
+        // Claim more than the leaf allocates.
+        let tx = build_claim_tx(claimer, &sk, 0, 9_999, proof, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "wrong-amount claim must fail proof check");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_wrong_claimer() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128), ([0xBB; 32], 2_000u128)];
+        // Install fixture for leaf 0, but have a different funded account
+        // try to submit. Proof commits to leaf 0's address, so an impostor
+        // fails verification.
+        let (_pk, _sk, _legit_claimer, proof) =
+            airdrop_fixture(&mut smt, leaves, 0, 10_000, 5_000);
+
+        let (imp_pk, imp_sk) = falcon_keygen().unwrap();
+        let impostor = derive_eoa_address(imp_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &impostor, 1_000_000_000_000, imp_pk.as_bytes());
+
+        let tx = build_claim_tx(impostor, &imp_sk, 0, 1_000, proof, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "impostor must fail proof verify");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_past_deadline() {
+        let mut smt = PydeSMT::new();
+        // Block height 100 — set deadline below that to simulate expiry.
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128), ([0xBB; 32], 2_000u128)];
+        let (_pk, sk, claimer, proof) = airdrop_fixture(&mut smt, leaves, 0, 50, 5_000);
+
+        let tx = build_claim_tx(claimer, &sk, 0, 1_000, proof, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "post-deadline claim must fail");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_when_not_configured() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let (pk, sk) = falcon_keygen().unwrap();
+        let claimer = derive_eoa_address(pk.as_bytes());
+        fund_account_with_pk(&mut smt, &claimer, 1_000_000_000_000, pk.as_bytes());
+
+        let tx = build_claim_tx(claimer, &sk, 0, 1_000, vec![], 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "must reject with no airdrop configured");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_pool_underfunded() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 10_000u128)];
+        // Pool balance 500 < leaf amount 10_000. Expected-sum check
+        // should have caught this at genesis, but we defend in depth.
+        let (_pk, sk, claimer, proof) = airdrop_fixture(&mut smt, leaves, 0, 10_000, 500);
+
+        let tx = build_claim_tx(claimer, &sk, 0, 10_000, proof, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "underfunded pool must reject claim");
+    }
+
+    #[test]
+    fn airdrop_claim_rejects_malformed_payload() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128)];
+        let (pk, sk, claimer, _proof) = airdrop_fixture(&mut smt, leaves, 0, 10_000, 5_000);
+
+        let mut tx = Transaction {
+            from: claimer,
+            to: [0u8; 32],
+            value: 0,
+            data: vec![0x01, 0x02], // truncated
+            gas_limit: 200_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::ClaimAirdrop,
+        };
+        sign_tx(&mut tx, &sk);
+        let _ = pk;
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "malformed payload must fail");
+    }
+
+    #[test]
+    fn airdrop_sweep_moves_residue_to_treasury() {
+        let mut smt = PydeSMT::new();
+        let mut ctx = make_block_ctx();
+        let leaves = vec![([0xAA; 32], 1_000u128)];
+        let (_pk, sk, claimer, _proof) = airdrop_fixture(&mut smt, leaves, 0, 50, 5_000);
+
+        // Advance block height past deadline.
+        ctx.height = 100; // already > 50
+
+        let mut sweep_tx = Transaction {
+            from: claimer,
+            to: [0u8; 32],
+            value: 0,
+            data: vec![],
+            gas_limit: 200_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::SweepAirdrop,
+        };
+        sign_tx(&mut sweep_tx, &sk);
+
+        let treasury_before =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+
+        let receipt = execute_transaction(&sweep_tx, &mut smt, &ctx).unwrap();
+        assert!(receipt.success, "sweep after deadline should succeed");
+
+        let pool = load_account(&smt, &pyde_account::address::airdrop_pool_address());
+        let treasury = load_account(&smt, &pyde_account::address::treasury_address());
+        assert_eq!(pool.balance, 0, "pool drained");
+        // Treasury gets both the swept residue (5000) AND the 10% of this
+        // tx's gas fee. Assert the residue landed; fee share is orthogonal.
+        assert!(
+            treasury.balance >= treasury_before + 5_000,
+            "treasury should gain at least 5000 from sweep; got {} - {}",
+            treasury.balance,
+            treasury_before
+        );
+    }
+
+    #[test]
+    fn airdrop_sweep_rejected_before_deadline() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx(); // height = 100
+        let leaves = vec![([0xAA; 32], 1_000u128)];
+        // Deadline 1000 > current 100 → still active.
+        let (_pk, sk, claimer, _proof) = airdrop_fixture(&mut smt, leaves, 0, 1_000, 5_000);
+
+        let mut sweep_tx = Transaction {
+            from: claimer,
+            to: [0u8; 32],
+            value: 0,
+            data: vec![],
+            gas_limit: 200_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::SweepAirdrop,
+        };
+        sign_tx(&mut sweep_tx, &sk);
+
+        let receipt = execute_transaction(&sweep_tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "pre-deadline sweep must be rejected");
     }
 }

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -34,6 +34,16 @@ pub enum TransactionType {
     /// `last_claimed_at` to the current accumulator. Gas is paid normally
     /// — a zero-reward claim still costs gas but is otherwise a no-op.
     ClaimReward = 6,
+    /// Claim a genesis airdrop allocation (Phase 4 slice 4.4b). `tx.data`
+    /// carries `[leaf_index:8 LE][amount:16 LE][proof_len:1][siblings: 32×N]`.
+    /// Handler verifies the Merkle proof against the on-chain `airdrop_root`,
+    /// checks the deadline + not-already-claimed, debits the airdrop pool,
+    /// credits `tx.from`, and sets the claimed flag.
+    ClaimAirdrop = 7,
+    /// Sweep leftover airdrop funds to the treasury (Phase 4 slice 4.4b).
+    /// Permissionless; only callable once the airdrop deadline has passed.
+    /// Transfers the full remaining pool balance to `treasury_address()`.
+    SweepAirdrop = 8,
 }
 
 impl TransactionType {
@@ -46,6 +56,8 @@ impl TransactionType {
             4 => Some(Self::StakeWithdraw),
             5 => Some(Self::Slash),
             6 => Some(Self::ClaimReward),
+            7 => Some(Self::ClaimAirdrop),
+            8 => Some(Self::SweepAirdrop),
             _ => None,
         }
     }
@@ -467,6 +479,9 @@ mod tests {
             TransactionType::StakeDeposit,
             TransactionType::StakeWithdraw,
             TransactionType::Slash,
+            TransactionType::ClaimReward,
+            TransactionType::ClaimAirdrop,
+            TransactionType::SweepAirdrop,
         ];
         for ty in all {
             let tag = ty as u8;


### PR DESCRIPTION
## Summary

Adds `TransactionType::ClaimAirdrop` and `TransactionType::SweepAirdrop`. A genesis-committed Merkle root of `(address, amount)` pairs can be redeemed by legitimate holders; post-deadline residue goes to the treasury.

## Design highlights

**Merkle format**
- Leaf: `poseidon2(0x00 || index_le_8 || address || amount_le_16)`
- Internal: `poseidon2_pair(left, right)` with index-bit direction
- Leading `0x00` domain-separates leaves from internal nodes (blocks sorted-pair second-preimage attacks). Index-bit direction commits each leaf to its position.

**Claim gating**
- Must be signed by the address in the leaf (FALCON).
- Rejected if: not configured, past deadline, leaf already claimed, proof fails verification, pool underfunded, payload malformed, or `tx.gas_limit` below required cost (the gas-limit guard closes an economic hole where state writes would commit while fee capped at claimer's budget).

**Sweep**
- Permissionless post-deadline transfer of remaining pool balance to `treasury_address()`. Same gas-limit guard.

**Genesis integration**
- `airdrop.expected_claim_sum` enforced `<= pool_total_amount` at boot — underfunding fails the ceremony, not the first failed claim.
- Pool allocation flows into `initial_supply` (4.4a sanity check still holds) and the `"airdrop"` bucket (4.4a caps still apply).

**Gas**
- Calibrated against `crypto/benches/poseidon2_bench.rs` (measured ~1µs/pair). 5_000 gas per proof level is 5× measured to cover slower hardware + state I/O. Claim base 30_000; sweep flat 40_000.

## Remaining from original slice 4.4b scope

- **Off-chain Merkle builder CLI** — deferred to a small utility crate post-mainnet-core. The on-chain `build_tree()` is public so any off-chain tool can share leaf/node formulation and stay in sync.