### PR TITLE
feat: multisig governance + signer rotation (slice 4.5)

### DIFF
--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -58,6 +58,62 @@ pub struct GenesisConfig {
     /// can verify proofs against the commitment.
     #[serde(default)]
     pub airdrop: Option<AirdropConfig>,
+    /// Governance multisig (slice 4.5). Declares the initial signer
+    /// set + threshold used by `MultisigTx` / `RotateMultisig`. When
+    /// absent, the chain has no on-chain governance — treasury
+    /// balance accumulates with no way to spend until a hard fork
+    /// installs a multisig.
+    #[serde(default)]
+    pub multisig: Option<MultisigConfig>,
+}
+
+/// Genesis multisig configuration (slice 4.5).
+///
+/// `signer_public_keys` are hex-encoded FALCON-512 public keys (897
+/// bytes each). The on-chain signer set is derived from these; the
+/// EOA addresses `derive_eoa_address(pk)` are not stored separately
+/// because they're derivable.
+///
+/// Note: these signers are the INITIAL set. After launch, `threshold`
+/// sigs from the current set can install a new set via
+/// `RotateMultisig`, enabling signer rotation (annual validator-rep
+/// turnover, compromised-key replacement) without a hard fork.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MultisigConfig {
+    /// Hex-encoded FALCON-512 public keys (897 bytes each).
+    pub signer_public_keys: Vec<String>,
+    /// Required number of valid signatures. Must be 1..=signer count.
+    pub threshold: u8,
+}
+
+impl MultisigConfig {
+    pub fn decode_pks(&self) -> Result<Vec<Vec<u8>>, String> {
+        let mut out = Vec::with_capacity(self.signer_public_keys.len());
+        for (i, hex_pk) in self.signer_public_keys.iter().enumerate() {
+            let s = hex_pk.strip_prefix("0x").unwrap_or(hex_pk);
+            let bytes = hex::decode(s).map_err(|e| {
+                format!(
+                    "invalid multisig.signer_public_keys[{}] hex: {}",
+                    i, e
+                )
+            })?;
+            if bytes.len() != 897 {
+                return Err(format!(
+                    "multisig.signer_public_keys[{}] must be 897 bytes, got {}",
+                    i,
+                    bytes.len()
+                ));
+            }
+            if pyde_crypto::falcon::FalconPublicKey::from_bytes(&bytes).is_none() {
+                return Err(format!(
+                    "multisig.signer_public_keys[{}] is not a valid FALCON pk",
+                    i
+                ));
+            }
+            out.push(bytes);
+        }
+        Ok(out)
+    }
 }
 
 /// Genesis airdrop commitment (slice 4.4b).
@@ -233,6 +289,7 @@ impl Default for GenesisConfig {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         }
     }
 }
@@ -396,6 +453,53 @@ pub fn initialize_genesis(
     // Store validator count
     let count_key = pyde_state::keys::validator_count_key();
     entries.push((count_key, val_count.to_le_bytes().to_vec()));
+
+    // Slice 4.5: install governance multisig signer set + threshold.
+    //
+    // The signer set is used by MultisigTx (treasury spend) and
+    // RotateMultisig (signer-set rotation). Nonce starts at 0 — each
+    // successful multisig operation increments it so signatures bind
+    // to a single execution.
+    if let Some(ms) = &config.multisig {
+        let pks = ms.decode_pks()?;
+        if pks.is_empty() || pks.len() > pyde_tx::multisig::MAX_SIGNERS as usize {
+            return Err(format!(
+                "multisig.signer_public_keys count {} outside 1..={}",
+                pks.len(),
+                pyde_tx::multisig::MAX_SIGNERS
+            ));
+        }
+        if ms.threshold == 0 || ms.threshold as usize > pks.len() {
+            return Err(format!(
+                "multisig.threshold {} must be in 1..={}",
+                ms.threshold,
+                pks.len()
+            ));
+        }
+        // Duplicate-pk check.
+        for i in 0..pks.len() {
+            for j in (i + 1)..pks.len() {
+                if pks[i] == pks[j] {
+                    return Err(format!(
+                        "multisig.signer_public_keys contains duplicate pk at indices {} and {}",
+                        i, j
+                    ));
+                }
+            }
+        }
+        entries.push((
+            pyde_state::keys::multisig_signers_key(),
+            pyde_tx::multisig::encode_signer_set(&pks),
+        ));
+        entries.push((
+            pyde_state::keys::multisig_threshold_key(),
+            vec![ms.threshold],
+        ));
+        entries.push((
+            pyde_state::keys::multisig_nonce_key(),
+            0u64.to_le_bytes().to_vec(),
+        ));
+    }
 
     // Slice 4.4b: pre-mint airdrop pool + install commitment.
     //
@@ -612,6 +716,7 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
         validator_subsidy: None,
         bucket_caps: std::collections::HashMap::new(),
         airdrop: None,
+        multisig: None,
     };
 
     (config, accounts)
@@ -709,6 +814,7 @@ pub fn generate_testnet(
         validator_subsidy: None,
         bucket_caps: std::collections::HashMap::new(),
         airdrop: None,
+        multisig: None,
     };
 
     // Write shared genesis.toml
@@ -1095,6 +1201,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         };
         initialize_genesis(&mut state, &config).expect("matching sum should accept");
     }
@@ -1112,6 +1219,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("genesis supply mismatch"), "got: {}", err);
@@ -1132,6 +1240,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
     }
@@ -1152,6 +1261,7 @@ mod tests {
             }),
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
 
@@ -1177,6 +1287,7 @@ mod tests {
             }),
             bucket_caps: std::collections::HashMap::new(),
             airdrop: None,
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("duration_slots must be > 0"));
@@ -1212,6 +1323,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: caps,
             airdrop: None,
+            multisig: None,
         };
         initialize_genesis(&mut state, &config).unwrap();
     }
@@ -1235,6 +1347,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: caps,
             airdrop: None,
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("bucket 'team' exceeds cap"), "got: {}", err);
@@ -1257,6 +1370,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: caps,
             airdrop: None,
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("requires initial_supply"), "got: {}", err);
@@ -1277,6 +1391,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: caps,
             airdrop: None,
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("not a valid percentage"), "got: {}", err);
@@ -1327,6 +1442,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: Some(airdrop_cfg(root, 1000, 1000, 10_000)),
+            multisig: None,
         };
         initialize_genesis(&mut state, &config).expect("airdrop genesis should accept");
 
@@ -1361,6 +1477,7 @@ mod tests {
             bucket_caps: std::collections::HashMap::new(),
             // expected_claim_sum (2000) > pool_total (1000) → underfunded
             airdrop: Some(airdrop_cfg(root, 1000, 2000, 10_000)),
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("airdrop underfunded"), "got: {}", err);
@@ -1385,6 +1502,7 @@ mod tests {
             validator_subsidy: None,
             bucket_caps: std::collections::HashMap::new(),
             airdrop: Some(airdrop_cfg(root, 400, 400, 10_000)),
+            multisig: None,
         };
         // 300 + 400 = 700, matches declared → accepts.
         initialize_genesis(&mut state, &config).expect("declared supply includes pool");
@@ -1408,6 +1526,7 @@ mod tests {
                 pool_total_amount: "100".to_string(),
                 expected_claim_sum: "100".to_string(),
             }),
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("invalid airdrop root hex"), "got: {}", err);
@@ -1437,8 +1556,155 @@ mod tests {
             bucket_caps: caps,
             // Pool is 300 quanta = 30% of 1000 → exceeds 20% cap.
             airdrop: Some(airdrop_cfg(root, 300, 300, 10_000)),
+            multisig: None,
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("bucket 'airdrop' exceeds cap"), "got: {}", err);
+    }
+
+    // ========== Slice 4.5: multisig governance ==========
+
+    fn multisig_cfg(n: usize, threshold: u8) -> (MultisigConfig, Vec<pyde_crypto::falcon::FalconSecretKey>) {
+        use pyde_crypto::falcon::falcon_keygen;
+        let mut pk_hexes = Vec::with_capacity(n);
+        let mut sks = Vec::with_capacity(n);
+        for _ in 0..n {
+            let (pk, sk) = falcon_keygen().unwrap();
+            pk_hexes.push(hex::encode(pk.as_bytes()));
+            sks.push(sk);
+        }
+        (
+            MultisigConfig {
+                signer_public_keys: pk_hexes,
+                threshold,
+            },
+            sks,
+        )
+    }
+
+    #[test]
+    fn genesis_installs_multisig() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (ms_cfg, _) = multisig_cfg(5, 3);
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: Some(ms_cfg),
+        };
+        initialize_genesis(&mut state, &config).expect("multisig genesis should accept");
+
+        // Threshold stored.
+        let threshold_bytes = state
+            .get(&pyde_state::keys::multisig_threshold_key())
+            .unwrap();
+        assert_eq!(threshold_bytes, vec![3u8]);
+
+        // Nonce initialized to 0.
+        let nonce_bytes = state
+            .get(&pyde_state::keys::multisig_nonce_key())
+            .unwrap();
+        assert_eq!(nonce_bytes, 0u64.to_le_bytes().to_vec());
+
+        // Signer set parseable.
+        let set_bytes = state
+            .get(&pyde_state::keys::multisig_signers_key())
+            .unwrap();
+        let decoded = pyde_tx::multisig::decode_signer_set(&set_bytes).unwrap();
+        assert_eq!(decoded.len(), 5);
+    }
+
+    #[test]
+    fn genesis_rejects_multisig_threshold_over_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (mut ms_cfg, _) = multisig_cfg(3, 2);
+        ms_cfg.threshold = 10; // > count
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: Some(ms_cfg),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("multisig.threshold"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_rejects_multisig_zero_threshold() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (mut ms_cfg, _) = multisig_cfg(3, 2);
+        ms_cfg.threshold = 0;
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: Some(ms_cfg),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("multisig.threshold"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_rejects_duplicate_multisig_pk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (mut ms_cfg, _) = multisig_cfg(3, 2);
+        ms_cfg.signer_public_keys[1] = ms_cfg.signer_public_keys[0].clone();
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: Some(ms_cfg),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("duplicate pk"), "got: {}", err);
+    }
+
+    #[test]
+    fn genesis_rejects_multisig_over_max_signers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let (ms_cfg, _) = multisig_cfg(pyde_tx::multisig::MAX_SIGNERS as usize + 1, 2);
+
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: Some(ms_cfg),
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(err.contains("signer_public_keys count"), "got: {}", err);
     }
 }

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -67,6 +67,17 @@ pub mod discriminator {
     /// Enforced at genesis: `airdrop_pool.balance >= AIRDROP_EXPECTED_SUM`.
     /// u128 LE.
     pub const AIRDROP_EXPECTED_SUM: u8 = 0x1B;
+    /// Multisig signer set (slice 4.5). Length-prefixed array of
+    /// FALCON-512 public keys (897 bytes each). Addresses are derived
+    /// via `derive_eoa_address(pk)` at verification time.
+    pub const MULTISIG_SIGNERS: u8 = 0x1C;
+    /// Multisig threshold (slice 4.5). u8 — required number of valid
+    /// signatures for MultisigTx / RotateMultisig acceptance.
+    pub const MULTISIG_THRESHOLD: u8 = 0x1D;
+    /// Multisig nonce (slice 4.5). u64 LE — increments on every
+    /// successful multisig operation to bind signatures to a specific
+    /// operation and prevent replay.
+    pub const MULTISIG_NONCE: u8 = 0x1E;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +298,23 @@ pub fn airdrop_claimed_key(leaf_index: u64) -> H256 {
     input.push(discriminator::AIRDROP_CLAIMED);
     input.extend_from_slice(&leaf_index.to_le_bytes());
     H256::from(poseidon2_hash(&input).to_bytes())
+}
+
+/// Multisig signer set key (slice 4.5). Value is a length-prefixed
+/// array of FALCON-512 public keys: `[count:1][pk:897]...[pk:897]`.
+pub fn multisig_signers_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::MULTISIG_SIGNERS]).to_bytes())
+}
+
+/// Multisig threshold key (slice 4.5). Value is a single u8.
+pub fn multisig_threshold_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::MULTISIG_THRESHOLD]).to_bytes())
+}
+
+/// Multisig nonce key (slice 4.5). Value is u64 LE — increments each
+/// successful MultisigTx or RotateMultisig execution.
+pub fn multisig_nonce_key() -> H256 {
+    H256::from(poseidon2_hash(&[discriminator::MULTISIG_NONCE]).to_bytes())
 }
 
 #[cfg(test)]

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -5,6 +5,7 @@ pub mod airdrop;
 pub mod execution;
 pub mod fee;
 pub mod gas_tank;
+pub mod multisig;
 pub mod parallel;
 pub mod pipeline;
 pub mod types;

--- a/crates/tx/src/multisig.rs
+++ b/crates/tx/src/multisig.rs
@@ -1,0 +1,556 @@
+//! Multisig governance primitives (slice 4.5).
+//!
+//! Two on-chain operations:
+//!
+//! 1. `MultisigTx` — debit `treasury_address()` and credit a target with
+//!    a given value, provided ≥ threshold FALCON sigs from the declared
+//!    signer set authorize the spend.
+//!
+//! 2. `RotateMultisig` — replace the signer set + threshold, provided
+//!    ≥ current threshold sigs from the current set authorize the new
+//!    configuration.
+//!
+//! Both operations sign a message that includes the **current multisig
+//! nonce** so that a signed payload can be executed at most once —
+//! after execution the nonce increments and old signatures no longer
+//! verify against the new nonce.
+//!
+//! Wire format (common to both):
+//!
+//! ```text
+//! [op_version:1][op_body:variable][sig_count:1][sig_entry_0]...[sig_entry_N-1]
+//! sig_entry = [signer_index:1][sig_len:2 LE][falcon_sig:sig_len]
+//! ```
+//!
+//! `op_version` currently `0x01` for both types. `op_body` differs per
+//! type (see `MultisigSpend` / `MultisigRotate`).
+
+use pyde_account::address::Address;
+use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
+use pyde_crypto::poseidon2::poseidon2_hash;
+
+/// Current wire-format version. Incrementing this is a hard-fork event
+/// (handlers check the first byte and reject unknown versions).
+pub const MULTISIG_VERSION: u8 = 0x01;
+
+/// Hard cap on signer set size. 16 is plenty for a foundation + community +
+/// validator-rep mix while keeping MultisigTx gas costs bounded.
+pub const MAX_SIGNERS: u8 = 16;
+
+/// One signature + the index of the signer in the declared set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SigEntry {
+    pub signer_index: u8,
+    pub signature: Vec<u8>,
+}
+
+/// Spend-from-treasury operation body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigSpend {
+    pub target: Address,
+    pub value: u128,
+    /// `hash(pip_file_contents)` for the PIP that rationalized the
+    /// spend. All-zero is technically legal but strongly discouraged —
+    /// it strips the audit trail that links spends to PIPs.
+    pub data_digest: [u8; 32],
+}
+
+/// Rotate-signer-set operation body.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigRotate {
+    /// New public-key list. Each entry is a full FALCON-512 pk (897B).
+    pub new_signer_pks: Vec<Vec<u8>>,
+    pub new_threshold: u8,
+}
+
+/// Decoded multisig payload of either type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MultisigPayload {
+    Spend {
+        spend: MultisigSpend,
+        sigs: Vec<SigEntry>,
+    },
+    Rotate {
+        rotate: MultisigRotate,
+        sigs: Vec<SigEntry>,
+    },
+}
+
+impl MultisigSpend {
+    /// Bytes over which signers compute their FALCON signature. Includes
+    /// the on-chain nonce so each signature is bound to a specific
+    /// execution. Signers must coordinate on the current nonce before
+    /// signing.
+    pub fn signing_bytes(&self, nonce: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 32 + 16 + 32);
+        buf.extend_from_slice(&nonce.to_le_bytes());
+        buf.extend_from_slice(&self.target);
+        buf.extend_from_slice(&self.value.to_le_bytes());
+        buf.extend_from_slice(&self.data_digest);
+        poseidon2_hash(&buf).to_bytes().to_vec()
+    }
+
+    fn encode_body(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(32 + 16 + 32);
+        out.extend_from_slice(&self.target);
+        out.extend_from_slice(&self.value.to_le_bytes());
+        out.extend_from_slice(&self.data_digest);
+        out
+    }
+
+    fn decode_body(bytes: &[u8]) -> Option<(Self, &[u8])> {
+        if bytes.len() < 32 + 16 + 32 {
+            return None;
+        }
+        let mut target = [0u8; 32];
+        target.copy_from_slice(&bytes[0..32]);
+        let value = u128::from_le_bytes(bytes[32..48].try_into().ok()?);
+        let mut data_digest = [0u8; 32];
+        data_digest.copy_from_slice(&bytes[48..80]);
+        Some((
+            Self {
+                target,
+                value,
+                data_digest,
+            },
+            &bytes[80..],
+        ))
+    }
+}
+
+impl MultisigRotate {
+    pub fn signing_bytes(&self, nonce: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 1 + self.new_signer_pks.len() * 897 + 1);
+        buf.extend_from_slice(&nonce.to_le_bytes());
+        buf.push(self.new_signer_pks.len() as u8);
+        for pk in &self.new_signer_pks {
+            buf.extend_from_slice(pk);
+        }
+        buf.push(self.new_threshold);
+        poseidon2_hash(&buf).to_bytes().to_vec()
+    }
+
+    fn encode_body(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(1 + self.new_signer_pks.len() * 897 + 1);
+        out.push(self.new_signer_pks.len() as u8);
+        for pk in &self.new_signer_pks {
+            assert_eq!(pk.len(), 897, "FALCON-512 pk must be 897 bytes");
+            out.extend_from_slice(pk);
+        }
+        out.push(self.new_threshold);
+        out
+    }
+
+    fn decode_body(bytes: &[u8]) -> Option<(Self, &[u8])> {
+        if bytes.is_empty() {
+            return None;
+        }
+        let count = bytes[0] as usize;
+        if count == 0 || count > MAX_SIGNERS as usize {
+            return None;
+        }
+        let needed = 1 + count * 897 + 1;
+        if bytes.len() < needed {
+            return None;
+        }
+        let mut pks = Vec::with_capacity(count);
+        for i in 0..count {
+            let off = 1 + i * 897;
+            pks.push(bytes[off..off + 897].to_vec());
+        }
+        let new_threshold = bytes[1 + count * 897];
+        Some((
+            Self {
+                new_signer_pks: pks,
+                new_threshold,
+            },
+            &bytes[needed..],
+        ))
+    }
+}
+
+impl MultisigPayload {
+    /// Tag byte distinguishing Spend (0x01) from Rotate (0x02).
+    const SPEND_TAG: u8 = 0x01;
+    const ROTATE_TAG: u8 = 0x02;
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(MULTISIG_VERSION);
+        match self {
+            MultisigPayload::Spend { spend, sigs } => {
+                out.push(Self::SPEND_TAG);
+                out.extend_from_slice(&spend.encode_body());
+                encode_sigs(&mut out, sigs);
+            }
+            MultisigPayload::Rotate { rotate, sigs } => {
+                out.push(Self::ROTATE_TAG);
+                out.extend_from_slice(&rotate.encode_body());
+                encode_sigs(&mut out, sigs);
+            }
+        }
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 2 {
+            return None;
+        }
+        if bytes[0] != MULTISIG_VERSION {
+            return None;
+        }
+        let tag = bytes[1];
+        let rest = &bytes[2..];
+        match tag {
+            Self::SPEND_TAG => {
+                let (spend, rest) = MultisigSpend::decode_body(rest)?;
+                let sigs = decode_sigs(rest)?;
+                Some(MultisigPayload::Spend { spend, sigs })
+            }
+            Self::ROTATE_TAG => {
+                let (rotate, rest) = MultisigRotate::decode_body(rest)?;
+                let sigs = decode_sigs(rest)?;
+                Some(MultisigPayload::Rotate { rotate, sigs })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn sigs(&self) -> &[SigEntry] {
+        match self {
+            MultisigPayload::Spend { sigs, .. } => sigs,
+            MultisigPayload::Rotate { sigs, .. } => sigs,
+        }
+    }
+}
+
+fn encode_sigs(out: &mut Vec<u8>, sigs: &[SigEntry]) {
+    assert!(sigs.len() <= MAX_SIGNERS as usize, "too many sigs");
+    out.push(sigs.len() as u8);
+    for entry in sigs {
+        out.push(entry.signer_index);
+        let len = entry.signature.len() as u16;
+        out.extend_from_slice(&len.to_le_bytes());
+        out.extend_from_slice(&entry.signature);
+    }
+}
+
+fn decode_sigs(bytes: &[u8]) -> Option<Vec<SigEntry>> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let count = bytes[0] as usize;
+    if count == 0 || count > MAX_SIGNERS as usize {
+        return None;
+    }
+    let mut out = Vec::with_capacity(count);
+    let mut cursor = 1usize;
+    for _ in 0..count {
+        if cursor + 3 > bytes.len() {
+            return None;
+        }
+        let signer_index = bytes[cursor];
+        let len = u16::from_le_bytes([bytes[cursor + 1], bytes[cursor + 2]]) as usize;
+        cursor += 3;
+        if cursor + len > bytes.len() {
+            return None;
+        }
+        let signature = bytes[cursor..cursor + len].to_vec();
+        cursor += len;
+        out.push(SigEntry {
+            signer_index,
+            signature,
+        });
+    }
+    // Trailing garbage after the declared sigs is not allowed — protects
+    // against adversarial payloads that hide extra data past the end.
+    if cursor != bytes.len() {
+        return None;
+    }
+    Some(out)
+}
+
+// ---------------------------------------------------------------------------
+// Signer-set encoding in state
+// ---------------------------------------------------------------------------
+
+/// Encode a signer set for storage in `MULTISIG_SIGNERS`:
+/// `[count:1][pk:897]...[pk:897]`.
+pub fn encode_signer_set(pks: &[Vec<u8>]) -> Vec<u8> {
+    assert!(pks.len() <= MAX_SIGNERS as usize, "too many signers");
+    let mut out = Vec::with_capacity(1 + pks.len() * 897);
+    out.push(pks.len() as u8);
+    for pk in pks {
+        assert_eq!(pk.len(), 897);
+        out.extend_from_slice(pk);
+    }
+    out
+}
+
+pub fn decode_signer_set(bytes: &[u8]) -> Option<Vec<Vec<u8>>> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let count = bytes[0] as usize;
+    if count == 0 || count > MAX_SIGNERS as usize {
+        return None;
+    }
+    if bytes.len() != 1 + count * 897 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let off = 1 + i * 897;
+        out.push(bytes[off..off + 897].to_vec());
+    }
+    Some(out)
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+/// Verify a single `SigEntry` against the signer set.
+///
+/// Returns `Some(signer_index)` on success, `None` on any failure
+/// (unknown signer index, bad signature encoding, sig doesn't verify).
+pub fn verify_sig_entry(
+    entry: &SigEntry,
+    signer_pks: &[Vec<u8>],
+    signing_bytes: &[u8],
+) -> Option<u8> {
+    let idx = entry.signer_index as usize;
+    if idx >= signer_pks.len() {
+        return None;
+    }
+    let pk = FalconPublicKey::from_bytes(&signer_pks[idx])?;
+    let sig = FalconSignature::from_bytes(&entry.signature)?;
+    if falcon_verify(&pk, signing_bytes, &sig) {
+        Some(entry.signer_index)
+    } else {
+        None
+    }
+}
+
+/// Verify a slate of sigs against a signing-bytes hash. Counts the
+/// number of UNIQUE signers whose sigs verify. Returns `Ok(count)` on
+/// clean verification, `Err(reason)` if any entry was malformed or a
+/// signer_index was duplicated.
+///
+/// Duplicate-index defense is important: without it, one cooperating
+/// signer could fill half the quorum by submitting N copies of their
+/// own sig with identical `signer_index`.
+pub fn count_valid_sigs(
+    sigs: &[SigEntry],
+    signer_pks: &[Vec<u8>],
+    signing_bytes: &[u8],
+) -> Result<usize, &'static str> {
+    let mut seen = [false; MAX_SIGNERS as usize];
+    let mut valid = 0usize;
+    for entry in sigs {
+        let idx = entry.signer_index as usize;
+        if idx >= MAX_SIGNERS as usize {
+            return Err("signer_index out of bounds");
+        }
+        if seen[idx] {
+            return Err("duplicate signer_index in payload");
+        }
+        seen[idx] = true;
+        if verify_sig_entry(entry, signer_pks, signing_bytes).is_some() {
+            valid += 1;
+        }
+    }
+    Ok(valid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconSecretKey};
+
+    fn gen_signers(n: usize) -> (Vec<Vec<u8>>, Vec<FalconSecretKey>) {
+        let mut pks = Vec::with_capacity(n);
+        let mut sks = Vec::with_capacity(n);
+        for _ in 0..n {
+            let (pk, sk) = falcon_keygen().unwrap();
+            pks.push(pk.as_bytes().to_vec());
+            sks.push(sk);
+        }
+        (pks, sks)
+    }
+
+    fn sign_at(sk: &FalconSecretKey, msg: &[u8], idx: u8) -> SigEntry {
+        let sig = falcon_sign(sk, msg).unwrap();
+        SigEntry {
+            signer_index: idx,
+            signature: sig.as_bytes().to_vec(),
+        }
+    }
+
+    #[test]
+    fn spend_payload_roundtrip() {
+        let spend = MultisigSpend {
+            target: [0x11; 32],
+            value: 42,
+            data_digest: [0x22; 32],
+        };
+        let payload = MultisigPayload::Spend {
+            spend: spend.clone(),
+            sigs: vec![SigEntry {
+                signer_index: 3,
+                signature: vec![0xAB; 666],
+            }],
+        };
+        let bytes = payload.encode();
+        let decoded = MultisigPayload::decode(&bytes).unwrap();
+        assert_eq!(payload, decoded);
+    }
+
+    #[test]
+    fn rotate_payload_roundtrip() {
+        let (pks, _) = gen_signers(3);
+        let rotate = MultisigRotate {
+            new_signer_pks: pks,
+            new_threshold: 2,
+        };
+        let payload = MultisigPayload::Rotate {
+            rotate,
+            sigs: vec![SigEntry {
+                signer_index: 0,
+                signature: vec![0xCD; 700],
+            }],
+        };
+        let bytes = payload.encode();
+        let decoded = MultisigPayload::decode(&bytes).unwrap();
+        assert_eq!(payload, decoded);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_version() {
+        let mut bytes = vec![0xFF, 0x01];
+        bytes.extend_from_slice(&[0u8; 80]);
+        bytes.push(0); // sig_count = 0
+        assert!(MultisigPayload::decode(&bytes).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_unknown_tag() {
+        let mut bytes = vec![MULTISIG_VERSION, 0x99];
+        bytes.extend_from_slice(&[0u8; 80]);
+        bytes.push(0);
+        assert!(MultisigPayload::decode(&bytes).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_trailing_garbage() {
+        let payload = MultisigPayload::Spend {
+            spend: MultisigSpend {
+                target: [0; 32],
+                value: 0,
+                data_digest: [0; 32],
+            },
+            sigs: vec![SigEntry {
+                signer_index: 0,
+                signature: vec![0xAB; 500],
+            }],
+        };
+        let mut bytes = payload.encode();
+        bytes.push(0xFF); // extra byte past declared sigs
+        assert!(MultisigPayload::decode(&bytes).is_none());
+    }
+
+    #[test]
+    fn signer_set_roundtrip() {
+        let (pks, _) = gen_signers(5);
+        let bytes = encode_signer_set(&pks);
+        let decoded = decode_signer_set(&bytes).unwrap();
+        assert_eq!(pks, decoded);
+    }
+
+    #[test]
+    fn signer_set_rejects_bad_length() {
+        let mut bytes = vec![2u8];
+        bytes.extend_from_slice(&[0u8; 500]); // too short for 2 pks
+        assert!(decode_signer_set(&bytes).is_none());
+    }
+
+    #[test]
+    fn signer_set_rejects_over_max() {
+        let mut bytes = vec![(MAX_SIGNERS + 1) as u8];
+        bytes.extend_from_slice(&vec![0u8; (MAX_SIGNERS as usize + 1) * 897]);
+        assert!(decode_signer_set(&bytes).is_none());
+    }
+
+    #[test]
+    fn count_valid_sigs_happy_path() {
+        let (pks, sks) = gen_signers(5);
+        let spend = MultisigSpend {
+            target: [0x33; 32],
+            value: 100,
+            data_digest: [0x44; 32],
+        };
+        let msg = spend.signing_bytes(7);
+        let sigs = vec![
+            sign_at(&sks[0], &msg, 0),
+            sign_at(&sks[2], &msg, 2),
+            sign_at(&sks[4], &msg, 4),
+        ];
+        let valid = count_valid_sigs(&sigs, &pks, &msg).unwrap();
+        assert_eq!(valid, 3);
+    }
+
+    #[test]
+    fn count_valid_sigs_rejects_duplicate_index() {
+        let (pks, sks) = gen_signers(3);
+        let spend = MultisigSpend {
+            target: [0; 32],
+            value: 0,
+            data_digest: [0; 32],
+        };
+        let msg = spend.signing_bytes(0);
+        let sigs = vec![sign_at(&sks[1], &msg, 1), sign_at(&sks[1], &msg, 1)];
+        let err = count_valid_sigs(&sigs, &pks, &msg).unwrap_err();
+        assert!(err.contains("duplicate"));
+    }
+
+    #[test]
+    fn count_valid_sigs_skips_bad_sig() {
+        let (pks, sks) = gen_signers(3);
+        let spend = MultisigSpend {
+            target: [0; 32],
+            value: 0,
+            data_digest: [0; 32],
+        };
+        let msg = spend.signing_bytes(0);
+        // Signer 2 signs a DIFFERENT message — should fail verify.
+        let wrong_msg = spend.signing_bytes(99);
+        let sigs = vec![sign_at(&sks[0], &msg, 0), sign_at(&sks[2], &wrong_msg, 2)];
+        let valid = count_valid_sigs(&sigs, &pks, &msg).unwrap();
+        assert_eq!(valid, 1, "only signer 0's sig is valid");
+    }
+
+    #[test]
+    fn count_valid_sigs_rejects_out_of_range_index() {
+        let (pks, sks) = gen_signers(3);
+        let spend = MultisigSpend {
+            target: [0; 32],
+            value: 0,
+            data_digest: [0; 32],
+        };
+        let msg = spend.signing_bytes(0);
+        // signer_index = 99 is beyond MAX_SIGNERS → hard error.
+        let sigs = vec![sign_at(&sks[0], &msg, 99)];
+        let err = count_valid_sigs(&sigs, &pks, &msg).unwrap_err();
+        assert!(err.contains("out of bounds"));
+    }
+
+    #[test]
+    fn signing_bytes_changes_with_nonce() {
+        let spend = MultisigSpend {
+            target: [0x55; 32],
+            value: 123,
+            data_digest: [0x66; 32],
+        };
+        assert_ne!(spend.signing_bytes(0), spend.signing_bytes(1));
+    }
+}

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -488,6 +488,8 @@ fn execute_transaction_inner(
         TransactionType::SweepAirdrop => {
             execute_sweep_airdrop(tx, smt, block_ctx)
         }
+        TransactionType::MultisigTx => execute_multisig_spend(tx, smt),
+        TransactionType::RotateMultisig => execute_rotate_multisig(tx, smt),
         TransactionType::ClaimReward => {
             // Pull the sender's accrued pool share. Valid only for
             // Active (0x00) and Unbonding (0x01) entries — Exited
@@ -928,6 +930,63 @@ pub fn write_validator_subsidy(
     let _ = smt.insert(
         pyde_state::keys::validator_subsidy_key(),
         schedule.encode(),
+    );
+}
+
+/// Read the multisig signer public keys (slice 4.5). Returns the raw
+/// byte list; caller decodes via `crate::multisig::decode_signer_set`.
+pub fn read_multisig_signers_raw(
+    smt: &dyn pyde_state::smt::StateAccess,
+) -> Option<Vec<u8>> {
+    smt.get(&pyde_state::keys::multisig_signers_key())
+}
+
+pub fn read_multisig_signers(
+    smt: &dyn pyde_state::smt::StateAccess,
+) -> Option<Vec<Vec<u8>>> {
+    let bytes = read_multisig_signers_raw(smt)?;
+    crate::multisig::decode_signer_set(&bytes)
+}
+
+pub fn write_multisig_signers(
+    smt: &mut dyn pyde_state::smt::StateAccess,
+    pks: &[Vec<u8>],
+) {
+    let _ = smt.insert(
+        pyde_state::keys::multisig_signers_key(),
+        crate::multisig::encode_signer_set(pks),
+    );
+}
+
+/// Read the multisig threshold (slice 4.5). Returns 0 when absent —
+/// handlers should treat 0 as "no multisig configured" and reject.
+pub fn read_multisig_threshold(smt: &dyn pyde_state::smt::StateAccess) -> u8 {
+    smt.get(&pyde_state::keys::multisig_threshold_key())
+        .and_then(|b| b.first().copied())
+        .unwrap_or(0)
+}
+
+pub fn write_multisig_threshold(smt: &mut dyn pyde_state::smt::StateAccess, t: u8) {
+    let _ = smt.insert(pyde_state::keys::multisig_threshold_key(), vec![t]);
+}
+
+/// Read the multisig nonce (slice 4.5). Defaults to 0.
+pub fn read_multisig_nonce(smt: &dyn pyde_state::smt::StateAccess) -> u64 {
+    smt.get(&pyde_state::keys::multisig_nonce_key())
+        .and_then(|b| {
+            if b.len() >= 8 {
+                Some(u64::from_le_bytes(b[..8].try_into().ok()?))
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}
+
+pub fn write_multisig_nonce(smt: &mut dyn pyde_state::smt::StateAccess, n: u64) {
+    let _ = smt.insert(
+        pyde_state::keys::multisig_nonce_key(),
+        n.to_le_bytes().to_vec(),
     );
 }
 
@@ -1496,6 +1555,332 @@ fn execute_sweep_airdrop(
     }
 
     (true, AIRDROP_SWEEP_GAS, 0, vec![], residue.to_le_bytes().to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Multisig governance (slice 4.5)
+// ---------------------------------------------------------------------------
+
+/// Base gas for a MultisigTx (state reads + one treasury debit + one
+/// target credit + nonce bump). Verification cost of each FALCON sig is
+/// charged per-sig below.
+const MULTISIG_SPEND_BASE_GAS: u64 = 50_000;
+
+/// Per-sig verification cost. FALCON-512 verify measured at ~21 µs via
+/// `crypto/benches/falcon_bench.rs`, so at the 1 ns/gas target a single
+/// verify is ~21_000 gas of pure crypto. Charged at 50_000 gas per sig
+/// (≈ 2.4× measured) to absorb slower hardware, per-sig bookkeeping,
+/// and the overhead of building the signing-bytes preimage.
+const MULTISIG_PER_SIG_GAS: u64 = 50_000;
+
+/// Base gas for a RotateMultisig (same reads + signer set write).
+const MULTISIG_ROTATE_BASE_GAS: u64 = 60_000;
+
+/// Per-new-signer gas for the signer-set write. 16 signers = 14.4KB of
+/// pk bytes, charged at 10_000 per pk.
+const MULTISIG_ROTATE_PER_NEW_SIGNER_GAS: u64 = 10_000;
+
+fn execute_multisig_spend(
+    tx: &Transaction,
+    smt: &mut dyn pyde_state::smt::StateAccess,
+) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
+    let payload = match crate::multisig::MultisigPayload::decode(&tx.data) {
+        Some(p) => p,
+        None => {
+            return (
+                false,
+                MULTISIG_SPEND_BASE_GAS,
+                0,
+                vec![],
+                b"multisig payload malformed".to_vec(),
+            );
+        }
+    };
+    let (spend, sigs) = match payload {
+        crate::multisig::MultisigPayload::Spend { spend, sigs } => (spend, sigs),
+        crate::multisig::MultisigPayload::Rotate { .. } => {
+            return (
+                false,
+                MULTISIG_SPEND_BASE_GAS,
+                0,
+                vec![],
+                b"wrong payload tag for MultisigTx".to_vec(),
+            );
+        }
+    };
+
+    let gas = MULTISIG_SPEND_BASE_GAS
+        .saturating_add(MULTISIG_PER_SIG_GAS.saturating_mul(sigs.len() as u64));
+
+    // Early gas guard — same pattern as ClaimAirdrop. Reject before
+    // state writes if the sender under-budgeted.
+    if tx.gas_limit < gas {
+        return (
+            false,
+            tx.gas_limit,
+            0,
+            vec![],
+            b"multisig gas_limit below required cost".to_vec(),
+        );
+    }
+
+    // Structural checks on the spend itself before any crypto work.
+    if spend.value == 0 {
+        return (false, gas, 0, vec![], b"multisig value must be > 0".to_vec());
+    }
+    if spend.target == [0u8; 32] {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"multisig target must not be zero".to_vec(),
+        );
+    }
+    let treasury = pyde_account::address::treasury_address();
+    if spend.target == treasury {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"multisig cannot spend to treasury itself".to_vec(),
+        );
+    }
+    // The pipeline's post-execution stage unconditionally writes back
+    // `sender` (the submitter account) and `recipient` (tx.to). Both
+    // writebacks happen AFTER the handler. If our handler credits
+    // `spend.target` and then the pipeline writes `sender` or
+    // `recipient` back to the same balance key, our credit is
+    // clobbered — treasury gets debited but the target never sees the
+    // funds. Block the two collision paths.
+    if spend.target == tx.from {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"multisig target must not be the submitter".to_vec(),
+        );
+    }
+    if tx.to != [0u8; 32] {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"MultisigTx must set tx.to = ZERO_ADDRESS".to_vec(),
+        );
+    }
+
+    let signer_pks = match read_multisig_signers(smt) {
+        Some(p) => p,
+        None => {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"multisig not configured".to_vec(),
+            );
+        }
+    };
+    let threshold = read_multisig_threshold(smt);
+    if threshold == 0 {
+        return (false, gas, 0, vec![], b"multisig threshold = 0".to_vec());
+    }
+
+    let nonce = read_multisig_nonce(smt);
+    let msg = spend.signing_bytes(nonce);
+    let valid = match crate::multisig::count_valid_sigs(&sigs, &signer_pks, &msg) {
+        Ok(v) => v,
+        Err(e) => return (false, gas, 0, vec![], e.as_bytes().to_vec()),
+    };
+
+    if valid < threshold as usize {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            format!(
+                "multisig below threshold: {} valid of {} required",
+                valid, threshold
+            )
+            .into_bytes(),
+        );
+    }
+
+    // Check treasury balance.
+    let mut treasury_account = load_account(smt, &treasury);
+    if treasury_account.balance < spend.value {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"treasury balance insufficient".to_vec(),
+        );
+    }
+
+    let mut target_account = load_account(smt, &spend.target);
+    treasury_account.balance -= spend.value;
+    target_account.balance = target_account.balance.saturating_add(spend.value);
+
+    if store_account(smt, &treasury_account).is_err()
+        || store_account(smt, &target_account).is_err()
+    {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"multisig state write failed".to_vec(),
+        );
+    }
+
+    // Bump nonce — binds THIS payload to THIS nonce, preventing replay.
+    write_multisig_nonce(smt, nonce.saturating_add(1));
+
+    (true, gas, 0, vec![], spend.value.to_le_bytes().to_vec())
+}
+
+fn execute_rotate_multisig(
+    tx: &Transaction,
+    smt: &mut dyn pyde_state::smt::StateAccess,
+) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
+    let payload = match crate::multisig::MultisigPayload::decode(&tx.data) {
+        Some(p) => p,
+        None => {
+            return (
+                false,
+                MULTISIG_ROTATE_BASE_GAS,
+                0,
+                vec![],
+                b"multisig payload malformed".to_vec(),
+            );
+        }
+    };
+    let (rotate, sigs) = match payload {
+        crate::multisig::MultisigPayload::Rotate { rotate, sigs } => (rotate, sigs),
+        crate::multisig::MultisigPayload::Spend { .. } => {
+            return (
+                false,
+                MULTISIG_ROTATE_BASE_GAS,
+                0,
+                vec![],
+                b"wrong payload tag for RotateMultisig".to_vec(),
+            );
+        }
+    };
+
+    let gas = MULTISIG_ROTATE_BASE_GAS
+        .saturating_add(MULTISIG_PER_SIG_GAS.saturating_mul(sigs.len() as u64))
+        .saturating_add(
+            MULTISIG_ROTATE_PER_NEW_SIGNER_GAS.saturating_mul(rotate.new_signer_pks.len() as u64),
+        );
+
+    if tx.gas_limit < gas {
+        return (
+            false,
+            tx.gas_limit,
+            0,
+            vec![],
+            b"multisig rotate gas_limit below required cost".to_vec(),
+        );
+    }
+
+    // New-set structural checks.
+    if rotate.new_signer_pks.is_empty()
+        || rotate.new_signer_pks.len() > crate::multisig::MAX_SIGNERS as usize
+    {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            b"rotate signer count out of range".to_vec(),
+        );
+    }
+    if rotate.new_threshold == 0 || rotate.new_threshold as usize > rotate.new_signer_pks.len() {
+        return (false, gas, 0, vec![], b"rotate threshold invalid".to_vec());
+    }
+    // Every pk must be 897 bytes AND parseable — decoder already
+    // enforced length; verify pk parses cleanly, and detect duplicates.
+    let mut seen: Vec<&[u8]> = Vec::with_capacity(rotate.new_signer_pks.len());
+    for pk in &rotate.new_signer_pks {
+        if pyde_crypto::falcon::FalconPublicKey::from_bytes(pk).is_none() {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"rotate contains malformed pk".to_vec(),
+            );
+        }
+        if seen.iter().any(|p| *p == pk.as_slice()) {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"rotate contains duplicate pk".to_vec(),
+            );
+        }
+        seen.push(pk.as_slice());
+    }
+
+    // Load current config for authorization check.
+    let current_signers = match read_multisig_signers(smt) {
+        Some(p) => p,
+        None => {
+            return (
+                false,
+                gas,
+                0,
+                vec![],
+                b"multisig not configured".to_vec(),
+            );
+        }
+    };
+    let current_threshold = read_multisig_threshold(smt);
+    if current_threshold == 0 {
+        return (false, gas, 0, vec![], b"multisig threshold = 0".to_vec());
+    }
+
+    let nonce = read_multisig_nonce(smt);
+    let msg = rotate.signing_bytes(nonce);
+    let valid = match crate::multisig::count_valid_sigs(&sigs, &current_signers, &msg) {
+        Ok(v) => v,
+        Err(e) => return (false, gas, 0, vec![], e.as_bytes().to_vec()),
+    };
+    if valid < current_threshold as usize {
+        return (
+            false,
+            gas,
+            0,
+            vec![],
+            format!(
+                "rotate below threshold: {} valid of {} required",
+                valid, current_threshold
+            )
+            .into_bytes(),
+        );
+    }
+
+    // Install new set + threshold + bump nonce.
+    write_multisig_signers(smt, &rotate.new_signer_pks);
+    write_multisig_threshold(smt, rotate.new_threshold);
+    write_multisig_nonce(smt, nonce.saturating_add(1));
+
+    let signer_count = rotate.new_signer_pks.len() as u8;
+    (
+        true,
+        gas,
+        0,
+        vec![],
+        vec![signer_count, rotate.new_threshold],
+    )
 }
 
 /// Currently executes groups sequentially on the shared SMT. True thread-level
@@ -3849,5 +4234,595 @@ mod tests {
 
         let receipt = execute_transaction(&sweep_tx, &mut smt, &ctx).unwrap();
         assert!(!receipt.success, "pre-deadline sweep must be rejected");
+    }
+
+    // ========== Slice 4.5: multisig governance ==========
+
+    /// Set up a multisig configuration on the SMT and return the signer
+    /// secret keys so the test can sign. Also funds the treasury so
+    /// MultisigTx spends have something to pull from.
+    fn multisig_fixture(
+        smt: &mut dyn pyde_state::smt::StateAccess,
+        n: usize,
+        threshold: u8,
+        treasury_balance: u128,
+    ) -> Vec<pyde_crypto::falcon::FalconSecretKey> {
+        let mut pks = Vec::with_capacity(n);
+        let mut sks = Vec::with_capacity(n);
+        for _ in 0..n {
+            let (pk, sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+            pks.push(pk.as_bytes().to_vec());
+            sks.push(sk);
+        }
+        write_multisig_signers(smt, &pks);
+        write_multisig_threshold(smt, threshold);
+        write_multisig_nonce(smt, 0);
+
+        // Fund treasury
+        let treasury = pyde_account::address::treasury_address();
+        let account = pyde_account::types::Account {
+            address: treasury,
+            nonce: 0,
+            balance: treasury_balance,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        store_account(smt, &account).unwrap();
+
+        sks
+    }
+
+    /// Build a signed outer tx (the submitter is any funded account —
+    /// their role is to pay gas and submit; authority comes from the
+    /// multisig signatures inside tx.data).
+    fn build_multisig_spend_tx(
+        submitter: Address,
+        submitter_sk: &pyde_crypto::falcon::FalconSecretKey,
+        payload: crate::multisig::MultisigPayload,
+    ) -> Transaction {
+        let mut tx = Transaction {
+            from: submitter,
+            to: [0u8; 32],
+            value: 0,
+            data: payload.encode(),
+            gas_limit: 2_000_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::MultisigTx,
+        };
+        sign_tx(&mut tx, submitter_sk);
+        tx
+    }
+
+    fn build_multisig_rotate_tx(
+        submitter: Address,
+        submitter_sk: &pyde_crypto::falcon::FalconSecretKey,
+        payload: crate::multisig::MultisigPayload,
+    ) -> Transaction {
+        let mut tx = build_multisig_spend_tx(submitter, submitter_sk, payload);
+        tx.tx_type = TransactionType::RotateMultisig;
+        sign_tx(&mut tx, submitter_sk);
+        tx
+    }
+
+    fn make_spend(target: Address, value: u128) -> crate::multisig::MultisigSpend {
+        crate::multisig::MultisigSpend {
+            target,
+            value,
+            data_digest: [0xAA; 32],
+        }
+    }
+
+    fn sign_spend(
+        spend: &crate::multisig::MultisigSpend,
+        sks: &[&pyde_crypto::falcon::FalconSecretKey],
+        indices: &[u8],
+        nonce: u64,
+    ) -> Vec<crate::multisig::SigEntry> {
+        let msg = spend.signing_bytes(nonce);
+        sks.iter()
+            .zip(indices.iter())
+            .map(|(sk, idx)| {
+                let sig = pyde_crypto::falcon::falcon_sign(sk, &msg).unwrap();
+                crate::multisig::SigEntry {
+                    signer_index: *idx,
+                    signature: sig.as_bytes().to_vec(),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn multisig_spend_debits_treasury_and_credits_target() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 5, 3, 10_000_000);
+
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let target = [0xEE; 32];
+        let spend = make_spend(target, 1_000_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1], &sks[2]], &[0, 1, 2], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(receipt.success, "valid multisig spend should succeed");
+
+        let target_acc = load_account(&smt, &target);
+        // Target got exactly the spend amount. Treasury dynamics are
+        // complicated by 10% fee share flowing in from the submitter's
+        // gas — net treasury change = fee_share - spend_value, which can
+        // be negative or positive depending on gas usage. Asserting the
+        // target credit is the clean invariant.
+        assert_eq!(target_acc.balance, 1_000_000, "target received spend");
+
+        // Nonce should have incremented.
+        assert_eq!(read_multisig_nonce(&smt), 1);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_below_threshold() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 5, 3, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 1_000_000);
+        // Only 2 sigs but threshold = 3.
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "below-threshold must fail");
+        // Nonce untouched.
+        assert_eq!(read_multisig_nonce(&smt), 0);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_replay_after_success() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 500_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend: spend.clone(), sigs: sigs.clone() };
+        let tx1 = build_multisig_spend_tx(submitter, &sub_sk, payload.clone());
+        let r1 = execute_transaction(&tx1, &mut smt, &ctx).unwrap();
+        assert!(r1.success);
+
+        // Resubmit the SAME signed payload. Nonce has advanced so sigs
+        // now verify against a stale message → 0 valid sigs → reject.
+        let mut tx2 = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        tx2.nonce = 1; // advance outer nonce (tx-level); inner multisig nonce is what matters
+        sign_tx(&mut tx2, &sub_sk);
+        let r2 = execute_transaction(&tx2, &mut smt, &ctx).unwrap();
+        assert!(!r2.success, "replay of exact payload must fail after nonce advance");
+    }
+
+    #[test]
+    fn multisig_spend_rejects_zero_value() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_zero_target() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0u8; 32], 1_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_treasury_self_target() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend(pyde_account::address::treasury_address(), 1_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_insufficient_treasury() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 500); // only 500 in treasury
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 1_000_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_duplicate_signer_index() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 1_000);
+        // Same signer_index twice — hard reject at sig-count stage.
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[0]], &[0, 0], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_target_equal_submitter() {
+        // Regression guard: if submitter == target, the pipeline's
+        // post-exec sender writeback clobbers the handler's target
+        // credit. Treasury would be debited while the target sees
+        // nothing — ledger integrity violation. Must reject early.
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend(submitter, 500_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+
+        let treasury_before =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "submitter-as-target must reject");
+
+        // Treasury must not have been debited by the spend — nonce
+        // also must be unchanged.
+        let treasury_after =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        assert!(treasury_after >= treasury_before, "treasury must not lose value");
+        assert_eq!(read_multisig_nonce(&smt), 0);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_nonzero_tx_to() {
+        // Regression guard: tx.to is unconditionally loaded + written
+        // back by the pipeline. If tx.to matches spend.target, the
+        // recipient writeback clobbers the handler's target credit.
+        // Enforce tx.to = ZERO_ADDRESS for MultisigTx.
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let target = [0xEE; 32];
+        let spend = make_spend(target, 500_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let mut tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        tx.to = target; // non-zero tx.to — would clobber target credit
+        sign_tx(&mut tx, &sub_sk);
+
+        let treasury_before =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success, "non-zero tx.to must reject");
+
+        let treasury_after =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        assert!(treasury_after >= treasury_before);
+        assert_eq!(read_multisig_nonce(&smt), 0);
+    }
+
+    #[test]
+    fn rotate_installs_new_signer_set() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let old_sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let mut new_pks = Vec::new();
+        for _ in 0..5 {
+            let (pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+            new_pks.push(pk.as_bytes().to_vec());
+        }
+        let rotate = crate::multisig::MultisigRotate {
+            new_signer_pks: new_pks.clone(),
+            new_threshold: 3,
+        };
+        let msg = rotate.signing_bytes(0);
+        let sigs = vec![
+            crate::multisig::SigEntry {
+                signer_index: 0,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[0], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+            crate::multisig::SigEntry {
+                signer_index: 1,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[1], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+        ];
+        let payload = crate::multisig::MultisigPayload::Rotate { rotate, sigs };
+        let tx = build_multisig_rotate_tx(submitter, &sub_sk, payload);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(receipt.success);
+
+        // New signer set installed.
+        let stored = read_multisig_signers(&smt).unwrap();
+        assert_eq!(stored, new_pks);
+        assert_eq!(read_multisig_threshold(&smt), 3);
+        assert_eq!(read_multisig_nonce(&smt), 1);
+    }
+
+    #[test]
+    fn rotate_rejects_invalid_new_threshold() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let old_sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let (new_pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let rotate = crate::multisig::MultisigRotate {
+            new_signer_pks: vec![new_pk.as_bytes().to_vec()],
+            new_threshold: 5, // > signer count
+        };
+        let msg = rotate.signing_bytes(0);
+        let sigs = vec![
+            crate::multisig::SigEntry {
+                signer_index: 0,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[0], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+            crate::multisig::SigEntry {
+                signer_index: 1,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[1], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+        ];
+        let payload = crate::multisig::MultisigPayload::Rotate { rotate, sigs };
+        let tx = build_multisig_rotate_tx(submitter, &sub_sk, payload);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn rotate_rejects_duplicate_new_pk() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let old_sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let (dup_pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let dup = dup_pk.as_bytes().to_vec();
+        let rotate = crate::multisig::MultisigRotate {
+            new_signer_pks: vec![dup.clone(), dup.clone()],
+            new_threshold: 1,
+        };
+        let msg = rotate.signing_bytes(0);
+        let sigs = vec![
+            crate::multisig::SigEntry {
+                signer_index: 0,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[0], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+            crate::multisig::SigEntry {
+                signer_index: 1,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[1], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+        ];
+        let payload = crate::multisig::MultisigPayload::Rotate { rotate, sigs };
+        let tx = build_multisig_rotate_tx(submitter, &sub_sk, payload);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn spend_after_rotate_requires_new_signers() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let old_sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        // Rotate to a fresh set with threshold 2.
+        let (new_pk_a, new_sk_a) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let (new_pk_b, new_sk_b) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let (new_pk_c, _new_sk_c) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let new_pks = vec![
+            new_pk_a.as_bytes().to_vec(),
+            new_pk_b.as_bytes().to_vec(),
+            new_pk_c.as_bytes().to_vec(),
+        ];
+        let rotate = crate::multisig::MultisigRotate {
+            new_signer_pks: new_pks,
+            new_threshold: 2,
+        };
+        let rmsg = rotate.signing_bytes(0);
+        let rsigs = vec![
+            crate::multisig::SigEntry {
+                signer_index: 0,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[0], &rmsg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+            crate::multisig::SigEntry {
+                signer_index: 1,
+                signature: pyde_crypto::falcon::falcon_sign(&old_sks[1], &rmsg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            },
+        ];
+        let rpayload = crate::multisig::MultisigPayload::Rotate { rotate, sigs: rsigs };
+        let rtx = build_multisig_rotate_tx(submitter, &sub_sk, rpayload);
+        let rr = execute_transaction(&rtx, &mut smt, &ctx).unwrap();
+        assert!(rr.success);
+
+        // Spend signed by OLD signers should now fail.
+        let spend = make_spend([0xEE; 32], 1_000);
+        let old_sigs = sign_spend(&spend, &[&old_sks[0], &old_sks[1]], &[0, 1], 1);
+        let old_payload = crate::multisig::MultisigPayload::Spend {
+            spend: spend.clone(),
+            sigs: old_sigs,
+        };
+        let mut old_tx = build_multisig_spend_tx(submitter, &sub_sk, old_payload);
+        old_tx.nonce = 1;
+        sign_tx(&mut old_tx, &sub_sk);
+        let orr = execute_transaction(&old_tx, &mut smt, &ctx).unwrap();
+        assert!(!orr.success, "old signers must no longer authorize");
+
+        // Spend signed by NEW signers should succeed.
+        let new_sigs = sign_spend(&spend, &[&new_sk_a, &new_sk_b], &[0, 1], 1);
+        let new_payload = crate::multisig::MultisigPayload::Spend { spend, sigs: new_sigs };
+        let mut new_tx = build_multisig_spend_tx(submitter, &sub_sk, new_payload);
+        new_tx.nonce = 2;
+        sign_tx(&mut new_tx, &sub_sk);
+        let nrr = execute_transaction(&new_tx, &mut smt, &ctx).unwrap();
+        assert!(nrr.success, "new signers should authorize");
+    }
+
+    #[test]
+    fn multisig_spend_rejects_when_not_configured() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        // Fund treasury but do NOT configure multisig.
+        let treasury = pyde_account::address::treasury_address();
+        let acc = pyde_account::types::Account {
+            address: treasury,
+            nonce: 0,
+            balance: 1_000_000,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        store_account(&mut smt, &acc).unwrap();
+
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 1_000);
+        let payload = crate::multisig::MultisigPayload::Spend {
+            spend,
+            sigs: vec![crate::multisig::SigEntry {
+                signer_index: 0,
+                signature: vec![0xAB; 666],
+            }],
+        };
+        let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+    }
+
+    #[test]
+    fn multisig_spend_rejects_insufficient_gas_limit() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx();
+        let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
+        let (sub_pk, sub_sk) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let submitter = derive_eoa_address(sub_pk.as_bytes());
+        fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
+
+        let spend = make_spend([0xEE; 32], 1_000);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
+        let mut tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
+        // Needed: 50k base + 2*50k = 150k. Set below.
+        tx.gas_limit = 100_000;
+        sign_tx(&mut tx, &sub_sk);
+
+        let treasury_before =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(!receipt.success);
+        // Treasury balance unchanged by multisig handler (may gain fee
+        // share from gas distribution, but not spend).
+        let treasury_after =
+            load_account(&smt, &pyde_account::address::treasury_address()).balance;
+        assert!(
+            treasury_after >= treasury_before,
+            "treasury must not have been debited"
+        );
+        assert_eq!(read_multisig_nonce(&smt), 0);
     }
 }

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -44,6 +44,19 @@ pub enum TransactionType {
     /// Permissionless; only callable once the airdrop deadline has passed.
     /// Transfers the full remaining pool balance to `treasury_address()`.
     SweepAirdrop = 8,
+    /// Governance treasury spend (Phase 4 slice 4.5). `tx.data` carries
+    /// an encoded `MultisigPayload` with target / value / data_digest
+    /// and ≥ threshold FALCON signatures from the declared signer set.
+    /// Debits `treasury_address()`, credits the target. The data_digest
+    /// should be `hash(pip_file_contents)` so the spend is auditably
+    /// linked to its rationale on-chain.
+    MultisigTx = 9,
+    /// Rotate multisig signer set + threshold (Phase 4 slice 4.5).
+    /// `tx.data` carries an encoded `RotatePayload` with the new
+    /// signer list + new threshold + ≥ current-threshold sigs from
+    /// the current set. Enables signer-set turnover (incl. annual
+    /// validator-rep rotation) without a hard fork.
+    RotateMultisig = 10,
 }
 
 impl TransactionType {
@@ -58,6 +71,8 @@ impl TransactionType {
             6 => Some(Self::ClaimReward),
             7 => Some(Self::ClaimAirdrop),
             8 => Some(Self::SweepAirdrop),
+            9 => Some(Self::MultisigTx),
+            10 => Some(Self::RotateMultisig),
             _ => None,
         }
     }
@@ -482,6 +497,8 @@ mod tests {
             TransactionType::ClaimReward,
             TransactionType::ClaimAirdrop,
             TransactionType::SweepAirdrop,
+            TransactionType::MultisigTx,
+            TransactionType::RotateMultisig,
         ];
         for ty in all {
             let tag = ty as u8;


### PR DESCRIPTION
## Summary

Adds the two on-chain governance primitives described in the PIP-0001 spec (zarah-s/pips):

- **`MultisigTx`** (tx_type 9) — debits `treasury_address()` and credits a target given ≥ threshold FALCON-512 signatures from the declared signer set.
- **`RotateMultisig`** (tx_type 10) — replaces the signer set + threshold atomically given ≥ current-threshold sigs from the current set. Enables annual validator-rep turnover and compromised-key replacement without a hard fork.

Protocol-rule changes (gas schedules, new tx types, consensus rules) still go through PIP + hard fork. The multisig operates WITHIN the protocol, not on it.

## Key design points

- **Nonce replay protection**: signatures bind to an on-chain `MULTISIG_NONCE` counter. Each successful exec increments the nonce; stale signatures fail verification against the new nonce.
- **Duplicate-index defense** in `count_valid_sigs`: one cooperating signer can't fill half the quorum by replaying their own sig under different indices.
- **data_digest** (32 bytes in MultisigTx payload): operators should set this to `hash(pip_file_contents)` so every treasury spend is auditably linked to its rationale on-chain.
- **State-writeback clobber paths closed**: rejects `spend.target == tx.from` and non-zero `tx.to` to prevent the pipeline's post-exec sender/recipient writeback from overwriting the handler's target credit.
- **Validator-rep election is off-chain** — the social role is decoupled from consensus; annual rep turnover installs via `RotateMultisig` from the current signer set. Saves ~200 LOC of on-chain election state + attack surface.

## Gas calibration

Measured via `crypto/benches/falcon_bench.rs` (FALCON-512 verify ≈ 21 µs):

- `MultisigTx`: 50_000 base + 50_000 per sig (≈ 2.4× measured margin)
- `RotateMultisig`: 60_000 base + 50_000 per sig + 10_000 per new signer

## Not in scope

- No `EmergencyPause` / `EmergencyResume` — those land in slice 4.6.
- No on-chain validator-rep election (deliberate; handled socially + installed via `RotateMultisig`).
- No recovery if all signer keys are lost — on-chain enforcement has no built-in recovery path; mitigations are off-chain operational (hardware wallets, disclosed identities, geographic distribution, succession policy).