### PR TITLE
test: property tests for governance primitives + vesting cliff fix (slice 5.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,6 +3424,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pyde-account"
 version = "0.1.0"
 dependencies = [
@@ -3598,6 +3632,7 @@ dependencies = [
  "ethnum",
  "hex",
  "otic",
+ "proptest",
  "pyde-account",
  "pyde-aot",
  "pyde-crypto",
@@ -3632,6 +3667,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -3796,6 +3837,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand_xoshiro"
@@ -4134,6 +4184,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -4993,6 +5055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5159,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -360,6 +360,16 @@ pub fn initialize_genesis(
         // the protocol subtracts the locked portion from the spendable
         // balance during tx validation. Empty schedule is a no-op.
         if let Some(v) = &alloc.vesting {
+            // `cliff > duration` is semantically nonsense (the cliff
+            // would fall past the already-complete vesting window).
+            // Reject at genesis so the config is sane by the time it
+            // ships — a bug surfaced by slice 5.1 property tests.
+            if v.cliff_slots > v.duration_slots {
+                return Err(format!(
+                    "vesting for {}: cliff_slots {} exceeds duration_slots {}",
+                    alloc.address, v.cliff_slots, v.duration_slots
+                ));
+            }
             let schedule = pyde_tx::vesting::VestingSchedule {
                 start_slot: v.start_slot,
                 cliff_slots: v.cliff_slots,
@@ -1706,5 +1716,41 @@ mod tests {
         };
         let err = initialize_genesis(&mut state, &config).unwrap_err();
         assert!(err.contains("signer_public_keys count"), "got: {}", err);
+    }
+
+    // ========== Slice 5.1: surfaced vesting misconfig ==========
+
+    #[test]
+    fn genesis_rejects_vesting_cliff_exceeds_duration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(tmp.path(), 1024).unwrap();
+        let alloc = GenesisAllocation {
+            address: hex::encode([0xAB; 32]),
+            balance: "1000".to_string(),
+            public_key: None,
+            bucket: None,
+            vesting: Some(GenesisVesting {
+                start_slot: 0,
+                cliff_slots: 1000,
+                duration_slots: 100, // cliff > duration: nonsense
+            }),
+        };
+        let config = GenesisConfig {
+            chain_id: 1,
+            timestamp: 0,
+            allocations: vec![alloc],
+            validators: Vec::new(),
+            initial_supply: String::new(),
+            validator_subsidy: None,
+            bucket_caps: std::collections::HashMap::new(),
+            airdrop: None,
+            multisig: None,
+        };
+        let err = initialize_genesis(&mut state, &config).unwrap_err();
+        assert!(
+            err.contains("cliff_slots") && err.contains("exceeds duration_slots"),
+            "got: {}",
+            err
+        );
     }
 }

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -17,3 +17,4 @@ ethnum = "1.5.2"
 
 [dev-dependencies]
 otic = { path = "../otic" }
+proptest = "1"

--- a/crates/tx/src/vesting.rs
+++ b/crates/tx/src/vesting.rs
@@ -75,12 +75,18 @@ impl VestingSchedule {
         if self.duration_slots == 0 {
             return self.total_amount;
         }
-        if current_slot < self.start_slot.saturating_add(self.cliff_slots) {
-            return 0;
-        }
+        // End-of-vesting takes priority over the cliff check. An
+        // ill-configured schedule with `cliff_slots > duration_slots`
+        // is rejected at genesis, but defend in depth at runtime: once
+        // `current_slot >= start + duration`, the full amount MUST be
+        // unlocked even if the (invalid) cliff is still in the future.
+        // Without this, a malformed config would lock funds forever.
         let end = self.start_slot.saturating_add(self.duration_slots);
         if current_slot >= end {
             return self.total_amount;
+        }
+        if current_slot < self.start_slot.saturating_add(self.cliff_slots) {
+            return 0;
         }
         let elapsed = current_slot.saturating_sub(self.start_slot) as u128;
         let duration = self.duration_slots as u128;
@@ -174,5 +180,17 @@ mod tests {
     #[test]
     fn decode_rejects_truncated() {
         assert!(VestingSchedule::decode(&[0u8; 39]).is_none());
+    }
+
+    #[test]
+    fn cliff_exceeding_duration_still_fully_unlocks_past_end() {
+        // Regression guard for the property test surfaced in slice 5.1:
+        // if an ill-configured schedule has cliff > duration, the
+        // runtime must still return `total_amount` once current_slot
+        // passes end_slot. End-of-vesting takes priority over cliff.
+        let s = sched(0, 100, 10, 1_000);
+        assert_eq!(s.unlocked_at(10), 1_000, "end_slot reached");
+        assert_eq!(s.unlocked_at(9), 0, "pre-end + pre-cliff = locked");
+        assert_eq!(s.locked_at(10), 0);
     }
 }

--- a/crates/tx/tests/prop_airdrop.rs
+++ b/crates/tx/tests/prop_airdrop.rs
@@ -1,0 +1,127 @@
+//! Property tests for airdrop claim + Merkle verification (slice 4.4b).
+
+use proptest::prelude::*;
+use pyde_tx::airdrop::{build_tree, leaf_hash, verify_proof, ClaimPayload, MAX_PROOF_LEN};
+
+fn any_address() -> impl Strategy<Value = [u8; 32]> {
+    prop::array::uniform32(any::<u8>())
+}
+
+fn any_proof() -> impl Strategy<Value = Vec<[u8; 32]>> {
+    prop::collection::vec(prop::array::uniform32(any::<u8>()), 0..=MAX_PROOF_LEN)
+}
+
+/// Arbitrary leaf set for tree construction. Bounded to 64 leaves so
+/// tree building stays cheap (256 proptest cases × tree build).
+fn any_leaves() -> impl Strategy<Value = Vec<([u8; 32], u128)>> {
+    prop::collection::vec((any_address(), any::<u128>()), 1..=64)
+}
+
+proptest! {
+    /// ClaimPayload encode→decode roundtrip for arbitrary inputs.
+    #[test]
+    fn claim_payload_roundtrip(
+        leaf_index in any::<u64>(),
+        amount in any::<u128>(),
+        proof in any_proof(),
+    ) {
+        let payload = ClaimPayload { leaf_index, amount, proof };
+        let bytes = payload.encode();
+        let decoded = ClaimPayload::decode(&bytes).unwrap();
+        prop_assert_eq!(payload, decoded);
+    }
+
+    /// Decoder must never panic on arbitrary bytes.
+    #[test]
+    fn claim_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=16_000)) {
+        let _ = ClaimPayload::decode(&bytes);
+    }
+
+    /// `leaf_hash` must differ whenever any of (index, address, amount)
+    /// differ. Proves the hash domain separates each input field.
+    #[test]
+    fn leaf_hash_distinguishes_inputs(
+        i1 in any::<u64>(),
+        i2 in any::<u64>(),
+        a1 in any_address(),
+        a2 in any_address(),
+        v1 in any::<u128>(),
+        v2 in any::<u128>(),
+    ) {
+        prop_assume!((i1, a1, v1) != (i2, a2, v2));
+        prop_assert_ne!(leaf_hash(i1, &a1, v1), leaf_hash(i2, &a2, v2));
+    }
+
+    /// For any tree built from a leaf set, every leaf's generated
+    /// proof must verify against the tree's root. This is the
+    /// fundamental soundness property of the airdrop commitment.
+    #[test]
+    fn every_generated_proof_verifies(leaves in any_leaves()) {
+        let (root, proofs) = build_tree(&leaves);
+        for (i, (addr, amt)) in leaves.iter().enumerate() {
+            prop_assert!(
+                verify_proof(i as u64, addr, *amt, &proofs[i], &root),
+                "proof {} did not verify",
+                i
+            );
+        }
+    }
+
+    /// Mutating any byte of a valid proof must cause verification
+    /// to fail. This is the tamper-detection property: an attacker
+    /// can't flip a single sibling bit and have the proof still
+    /// verify for the same leaf.
+    #[test]
+    fn mutated_proof_bit_breaks_verify(
+        leaves in any_leaves(),
+        leaf_select in 0usize..64,
+        sibling_select in 0usize..64,
+        bit_select in 0usize..256,
+    ) {
+        let (root, proofs) = build_tree(&leaves);
+        let leaf_idx = leaf_select % leaves.len();
+        let proof = &proofs[leaf_idx];
+        // Skip leaves whose proof is empty (single-leaf tree) — no
+        // sibling to mutate.
+        prop_assume!(!proof.is_empty());
+        let sibling_idx = sibling_select % proof.len();
+        let byte_idx = (bit_select / 8) % 32;
+        let bit_idx = bit_select % 8;
+
+        let mut mutated = proof.clone();
+        mutated[sibling_idx][byte_idx] ^= 1 << bit_idx;
+
+        let (addr, amt) = leaves[leaf_idx];
+        prop_assert!(
+            !verify_proof(leaf_idx as u64, &addr, amt, &mutated, &root),
+            "mutated proof unexpectedly verified"
+        );
+    }
+
+    /// Claiming with the wrong address must fail verification even if
+    /// everything else is correct.
+    #[test]
+    fn wrong_address_breaks_verify(leaves in any_leaves(), imposter in any_address()) {
+        let (root, proofs) = build_tree(&leaves);
+        let idx = 0usize;
+        let (legit_addr, amt) = leaves[idx];
+        prop_assume!(imposter != legit_addr);
+        prop_assert!(
+            !verify_proof(idx as u64, &imposter, amt, &proofs[idx], &root),
+            "imposter unexpectedly verified"
+        );
+    }
+
+    /// Claiming the wrong amount must fail verification.
+    #[test]
+    fn wrong_amount_breaks_verify(leaves in any_leaves(), wrong_amt in any::<u128>()) {
+        let (root, proofs) = build_tree(&leaves);
+        let idx = 0usize;
+        let (addr, legit_amt) = leaves[idx];
+        prop_assume!(wrong_amt != legit_amt);
+        prop_assert!(
+            !verify_proof(idx as u64, &addr, wrong_amt, &proofs[idx], &root),
+            "wrong-amount unexpectedly verified"
+        );
+    }
+}

--- a/crates/tx/tests/prop_emergency.rs
+++ b/crates/tx/tests/prop_emergency.rs
@@ -1,0 +1,130 @@
+//! Property tests for emergency pause/resume wire formats (slice 4.6).
+
+use proptest::prelude::*;
+use pyde_tx::multisig::{
+    EmergencyPausePayload, EmergencyResumePayload, SigEntry, MAX_SIGNERS,
+};
+
+/// Strategy: generate a `SigEntry` with any valid signer_index + a
+/// signature-sized byte vec within the range FalconSignature accepts
+/// (500..=1000). We don't need real FALCON sigs to test wire-format
+/// roundtrip — just bytes of valid length.
+fn any_sig_entry() -> impl Strategy<Value = SigEntry> {
+    (0u8..MAX_SIGNERS, 500usize..=1000).prop_flat_map(|(idx, len)| {
+        prop::collection::vec(any::<u8>(), len..=len).prop_map(move |bytes| SigEntry {
+            signer_index: idx,
+            signature: bytes,
+        })
+    })
+}
+
+fn any_sig_slate() -> impl Strategy<Value = Vec<SigEntry>> {
+    prop::collection::vec(any_sig_entry(), 1..=MAX_SIGNERS as usize)
+}
+
+proptest! {
+    /// Encode then decode should yield an identical payload for any
+    /// syntactically valid input. Guards against off-by-one cursor
+    /// bugs in the length-prefixed sig array.
+    #[test]
+    fn pause_payload_roundtrip(duration in 1u64..=10_000_000, sigs in any_sig_slate()) {
+        let payload = EmergencyPausePayload {
+            duration_slots: duration,
+            sigs,
+        };
+        let bytes = payload.encode();
+        let decoded = EmergencyPausePayload::decode(&bytes).unwrap();
+        prop_assert_eq!(payload, decoded);
+    }
+
+    #[test]
+    fn resume_payload_roundtrip(sigs in any_sig_slate()) {
+        let payload = EmergencyResumePayload { sigs };
+        let bytes = payload.encode();
+        let decoded = EmergencyResumePayload::decode(&bytes).unwrap();
+        prop_assert_eq!(payload, decoded);
+    }
+
+    /// Decoders must never panic on arbitrary bytes. Malformed inputs
+    /// return None; well-formed inputs parse. No input should trigger
+    /// an index-out-of-bounds or allocation panic.
+    #[test]
+    fn pause_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=4096)) {
+        let _ = EmergencyPausePayload::decode(&bytes);
+    }
+
+    #[test]
+    fn resume_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=4096)) {
+        let _ = EmergencyResumePayload::decode(&bytes);
+    }
+
+    /// Cross-action decoding must reject: pause bytes decoded as resume
+    /// (and vice versa) returns None. Protects against a caller
+    /// accidentally feeding a pause payload to the resume handler.
+    #[test]
+    fn pause_bytes_reject_resume_decode(
+        duration in 1u64..=10_000_000,
+        sigs in any_sig_slate(),
+    ) {
+        let payload = EmergencyPausePayload {
+            duration_slots: duration,
+            sigs,
+        };
+        let bytes = payload.encode();
+        prop_assert!(EmergencyResumePayload::decode(&bytes).is_none());
+    }
+
+    #[test]
+    fn resume_bytes_reject_pause_decode(sigs in any_sig_slate()) {
+        let payload = EmergencyResumePayload { sigs };
+        let bytes = payload.encode();
+        prop_assert!(EmergencyPausePayload::decode(&bytes).is_none());
+    }
+
+    /// Pause signing_bytes must differ whenever ANY of (nonce, duration)
+    /// differ. This is what binds signatures to a specific execution;
+    /// if two distinct nonce/duration pairs produced the same hash, a
+    /// signature for one could be replayed as authorization for the
+    /// other.
+    #[test]
+    fn pause_signing_bytes_distinguish_nonce_duration(
+        n1 in 0u64..u64::MAX,
+        n2 in 0u64..u64::MAX,
+        d1 in 1u64..=10_000_000,
+        d2 in 1u64..=10_000_000,
+    ) {
+        // Skip the identity case — duplicate inputs produce duplicate bytes
+        // and that's expected.
+        prop_assume!((n1, d1) != (n2, d2));
+        let p1 = EmergencyPausePayload { duration_slots: d1, sigs: vec![] };
+        let p2 = EmergencyPausePayload { duration_slots: d2, sigs: vec![] };
+        prop_assert_ne!(p1.signing_bytes(n1), p2.signing_bytes(n2));
+    }
+
+    /// Resume signing_bytes must differ by nonce.
+    #[test]
+    fn resume_signing_bytes_distinguish_nonce(
+        n1 in 0u64..u64::MAX,
+        n2 in 0u64..u64::MAX,
+    ) {
+        prop_assume!(n1 != n2);
+        prop_assert_ne!(
+            EmergencyResumePayload::signing_bytes(n1),
+            EmergencyResumePayload::signing_bytes(n2)
+        );
+    }
+
+    /// Pause vs resume bytes must never collide. Signatures for a
+    /// pause action must not verify as a resume (or vice versa) — the
+    /// action label in the signed preimage is what prevents this.
+    #[test]
+    fn pause_resume_signing_bytes_never_collide(
+        nonce in 0u64..u64::MAX,
+        duration in 1u64..=10_000_000,
+    ) {
+        let pause_bytes =
+            EmergencyPausePayload { duration_slots: duration, sigs: vec![] }.signing_bytes(nonce);
+        let resume_bytes = EmergencyResumePayload::signing_bytes(nonce);
+        prop_assert_ne!(pause_bytes, resume_bytes);
+    }
+}

--- a/crates/tx/tests/prop_multisig.rs
+++ b/crates/tx/tests/prop_multisig.rs
@@ -1,0 +1,166 @@
+//! Property tests for multisig wire formats + logic invariants
+//! (slice 4.5).
+
+use proptest::prelude::*;
+use pyde_tx::multisig::{
+    count_valid_sigs, decode_signer_set, encode_signer_set, MultisigPayload, MultisigRotate,
+    MultisigSpend, SigEntry, MAX_SIGNERS,
+};
+
+fn any_address() -> impl Strategy<Value = [u8; 32]> {
+    prop::array::uniform32(any::<u8>())
+}
+
+fn any_sig_entry() -> impl Strategy<Value = SigEntry> {
+    (0u8..MAX_SIGNERS, 500usize..=1000).prop_flat_map(|(idx, len)| {
+        prop::collection::vec(any::<u8>(), len..=len).prop_map(move |bytes| SigEntry {
+            signer_index: idx,
+            signature: bytes,
+        })
+    })
+}
+
+fn any_sig_slate() -> impl Strategy<Value = Vec<SigEntry>> {
+    prop::collection::vec(any_sig_entry(), 1..=MAX_SIGNERS as usize)
+}
+
+fn any_pk_bytes() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(any::<u8>(), 897..=897)
+}
+
+fn any_signer_set() -> impl Strategy<Value = Vec<Vec<u8>>> {
+    prop::collection::vec(any_pk_bytes(), 1..=MAX_SIGNERS as usize)
+}
+
+proptest! {
+    /// Spend payload encode→decode roundtrip for arbitrary fields.
+    #[test]
+    fn spend_payload_roundtrip(
+        target in any_address(),
+        value in any::<u128>(),
+        digest in any_address(),
+        sigs in any_sig_slate(),
+    ) {
+        let payload = MultisigPayload::Spend {
+            spend: MultisigSpend { target, value, data_digest: digest },
+            sigs,
+        };
+        let bytes = payload.encode();
+        let decoded = MultisigPayload::decode(&bytes).unwrap();
+        prop_assert_eq!(payload, decoded);
+    }
+
+    /// Rotate payload encode→decode roundtrip.
+    #[test]
+    fn rotate_payload_roundtrip(
+        new_pks in any_signer_set(),
+        new_threshold in 1u8..=MAX_SIGNERS,
+        sigs in any_sig_slate(),
+    ) {
+        let payload = MultisigPayload::Rotate {
+            rotate: MultisigRotate {
+                new_signer_pks: new_pks,
+                new_threshold,
+            },
+            sigs,
+        };
+        let bytes = payload.encode();
+        let decoded = MultisigPayload::decode(&bytes).unwrap();
+        prop_assert_eq!(payload, decoded);
+    }
+
+    /// Decoder must never panic on arbitrary input.
+    #[test]
+    fn multisig_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=8192)) {
+        let _ = MultisigPayload::decode(&bytes);
+    }
+
+    /// Signer-set encode→decode roundtrip.
+    #[test]
+    fn signer_set_roundtrip(pks in any_signer_set()) {
+        let bytes = encode_signer_set(&pks);
+        let decoded = decode_signer_set(&bytes).unwrap();
+        prop_assert_eq!(pks, decoded);
+    }
+
+    /// Signer-set decoder robustness.
+    #[test]
+    fn signer_set_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=20_000)) {
+        let _ = decode_signer_set(&bytes);
+    }
+
+    /// Spend signing_bytes must differ whenever ANY field differs
+    /// (nonce, target, value, digest). A sig authorizing spend X must
+    /// not verify as authorization for spend Y.
+    #[test]
+    fn spend_signing_bytes_distinguish_fields(
+        n1 in 0u64..u64::MAX,
+        n2 in 0u64..u64::MAX,
+        t1 in any_address(),
+        t2 in any_address(),
+        v1 in any::<u128>(),
+        v2 in any::<u128>(),
+        d1 in any_address(),
+        d2 in any_address(),
+    ) {
+        prop_assume!((n1, t1, v1, d1) != (n2, t2, v2, d2));
+        let s1 = MultisigSpend { target: t1, value: v1, data_digest: d1 };
+        let s2 = MultisigSpend { target: t2, value: v2, data_digest: d2 };
+        prop_assert_ne!(s1.signing_bytes(n1), s2.signing_bytes(n2));
+    }
+
+    /// Rotate signing_bytes must differ whenever the new set or
+    /// threshold or nonce differs. Protects against signer
+    /// authorizing one new set and having the sig reused to install
+    /// a different set.
+    #[test]
+    fn rotate_signing_bytes_distinguish_fields(
+        n1 in 0u64..u64::MAX,
+        n2 in 0u64..u64::MAX,
+        pks1 in any_signer_set(),
+        pks2 in any_signer_set(),
+        t1 in 1u8..=MAX_SIGNERS,
+        t2 in 1u8..=MAX_SIGNERS,
+    ) {
+        prop_assume!((n1, pks1.clone(), t1) != (n2, pks2.clone(), t2));
+        let r1 = MultisigRotate { new_signer_pks: pks1, new_threshold: t1 };
+        let r2 = MultisigRotate { new_signer_pks: pks2, new_threshold: t2 };
+        prop_assert_ne!(r1.signing_bytes(n1), r2.signing_bytes(n2));
+    }
+
+    /// `count_valid_sigs` must reject any slate with duplicate
+    /// signer_index. This is the anti-replay defense — without it,
+    /// one signer could fill half the quorum by submitting their own
+    /// sig twice under distinct slate positions.
+    #[test]
+    fn count_valid_sigs_rejects_any_duplicate(
+        dup_idx in 0u8..MAX_SIGNERS,
+        other in any_sig_entry(),
+        pks in any_signer_set(),
+    ) {
+        let msg = [0u8; 32];
+        let dup_a = SigEntry { signer_index: dup_idx, signature: vec![0xAB; 666] };
+        let dup_b = SigEntry { signer_index: dup_idx, signature: vec![0xCD; 666] };
+        // Put the duplicate pair anywhere in the slate; always error.
+        for slate in [
+            vec![dup_a.clone(), dup_b.clone()],
+            vec![dup_a.clone(), other.clone(), dup_b.clone()],
+            vec![other.clone(), dup_a.clone(), dup_b.clone()],
+        ] {
+            let result = count_valid_sigs(&slate, &pks, &msg);
+            prop_assert!(result.is_err(), "duplicate index must error");
+        }
+    }
+
+    /// `count_valid_sigs` must reject any signer_index >= MAX_SIGNERS
+    /// regardless of how many pks are configured.
+    #[test]
+    fn count_valid_sigs_rejects_over_max_index(
+        bad_idx in MAX_SIGNERS..=u8::MAX,
+        pks in any_signer_set(),
+    ) {
+        let entry = SigEntry { signer_index: bad_idx, signature: vec![0xAB; 666] };
+        let result = count_valid_sigs(&[entry], &pks, &[0u8; 32]);
+        prop_assert!(result.is_err());
+    }
+}

--- a/crates/tx/tests/prop_vesting.proptest-regressions
+++ b/crates/tx/tests/prop_vesting.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 78102b977c0ead9a524f775b6b793fb9d868797dc91461fd274ce14a9dc0b44b # shrinks to sched = VestingSchedule { start_slot: 0, cliff_slots: 351411539, duration_slots: 1, total_amount: 1 }

--- a/crates/tx/tests/prop_vesting.rs
+++ b/crates/tx/tests/prop_vesting.rs
@@ -1,0 +1,108 @@
+//! Property tests for vesting schedule math (slice 4.4).
+
+use proptest::prelude::*;
+use pyde_tx::vesting::VestingSchedule;
+
+fn any_schedule() -> impl Strategy<Value = VestingSchedule> {
+    (
+        0u64..=1_000_000_000,
+        0u64..=1_000_000_000,
+        1u64..=1_000_000_000,
+        any::<u128>(),
+    )
+        .prop_map(
+            |(start_slot, cliff_slots, duration_slots, total_amount)| VestingSchedule {
+                start_slot,
+                cliff_slots,
+                duration_slots,
+                total_amount,
+            },
+        )
+}
+
+proptest! {
+    /// Encode→decode roundtrip must preserve every field. VestingSchedule
+    /// has a fixed-size encoding (40 bytes) — if the encode/decode
+    /// offsets ever drift, this catches it.
+    #[test]
+    fn schedule_encode_decode_roundtrip(sched in any_schedule()) {
+        let bytes = sched.encode();
+        prop_assert_eq!(bytes.len(), VestingSchedule::ENCODED_LEN);
+        let decoded = VestingSchedule::decode(&bytes).unwrap();
+        prop_assert_eq!(sched.start_slot, decoded.start_slot);
+        prop_assert_eq!(sched.cliff_slots, decoded.cliff_slots);
+        prop_assert_eq!(sched.duration_slots, decoded.duration_slots);
+        prop_assert_eq!(sched.total_amount, decoded.total_amount);
+    }
+
+    /// Decoder must never panic on arbitrary bytes.
+    #[test]
+    fn schedule_decode_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..=200)) {
+        let _ = VestingSchedule::decode(&bytes);
+    }
+
+    /// Core invariant: unlocked + locked == total_amount for any slot.
+    /// This is the fundamental accounting invariant. If unlocked_at()
+    /// and locked_at() ever diverge, a bug lets a vesting holder
+    /// spend more than they should OR less than vested unlocks.
+    #[test]
+    fn unlocked_plus_locked_equals_total(
+        sched in any_schedule(),
+        slot in 0u64..=u64::MAX,
+    ) {
+        let unlocked = sched.unlocked_at(slot);
+        let locked = sched.locked_at(slot);
+        prop_assert_eq!(
+            unlocked.checked_add(locked),
+            Some(sched.total_amount),
+            "unlocked + locked must equal total (no overflow, no loss)"
+        );
+    }
+
+    /// Monotonic unlock: unlocked_at is non-decreasing in slot. If it
+    /// could ever go DOWN, tokens that were spendable in an earlier
+    /// slot would become locked again — breaking expected semantics.
+    #[test]
+    fn unlocked_is_monotonic(
+        sched in any_schedule(),
+        slot_a in 0u64..=1_000_000_000,
+        delta in 0u64..=1_000_000_000,
+    ) {
+        let slot_b = slot_a.saturating_add(delta);
+        let u_a = sched.unlocked_at(slot_a);
+        let u_b = sched.unlocked_at(slot_b);
+        prop_assert!(u_b >= u_a, "unlocked decreased across slot boundary");
+    }
+
+    /// Before the cliff, nothing unlocks — but only for valid
+    /// schedules where the cliff falls inside the vesting window.
+    /// `cliff_slots > duration_slots` is ill-configured and rejected
+    /// at genesis; runtime falls through to the end-of-vesting check
+    /// which returns `total_amount` past `end_slot`.
+    #[test]
+    fn pre_cliff_unlocked_is_zero(sched in any_schedule()) {
+        prop_assume!(sched.cliff_slots <= sched.duration_slots);
+        let cliff_end = sched.start_slot.saturating_add(sched.cliff_slots);
+        if cliff_end > 0 {
+            let pre_cliff_slot = cliff_end.saturating_sub(1);
+            if pre_cliff_slot >= sched.start_slot {
+                let u = sched.unlocked_at(pre_cliff_slot);
+                prop_assert_eq!(u, 0, "unlocked must be 0 strictly before cliff");
+            }
+        }
+    }
+
+    /// After the full duration, everything unlocks.
+    #[test]
+    fn post_duration_fully_unlocked(sched in any_schedule()) {
+        let end_slot = sched.start_slot.saturating_add(sched.duration_slots);
+        // Test at end_slot AND beyond.
+        for future in [end_slot, end_slot.saturating_add(1_000_000), u64::MAX] {
+            let u = sched.unlocked_at(future);
+            prop_assert_eq!(
+                u, sched.total_amount,
+                "full amount must be unlocked at or after end_slot"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 hardening starts here. Adds proptest-based property tests over Phase 4 governance + economics code:

- **31 new properties** across 4 modules (~500 LOC)
- **Default 256 cases/property** ≈ 7,900 additional test invocations per test run
- Targets wire-format roundtrips, decoder panic-freedom, and logic invariants

## Real bug caught and fixed

Vesting math leaked locked funds when `cliff_slots > duration_slots`. The cliff check fired before the end-of-vesting check, locking balances indefinitely past what should have been full vesting.

**Minimal failing input from proptest:**
```
VestingSchedule { start_slot: 0, cliff_slots: 351_411_539, duration_slots: 1, total_amount: 1 }
at slot=1 → unlocked_at returned 0, expected 1
```

**Fix is two-layered:**
1. Genesis now rejects `cliff > duration` configs at boot (primary defense)
2. `unlocked_at()` prioritizes end-of-vesting over cliff (runtime defense — malformed state won't leak if the genesis check is ever bypassed)

Regression guards:
- `crates/tx/src/vesting.rs`: new unit test `cliff_exceeding_duration_still_fully_unlocks_past_end`
- `crates/node/src/genesis.rs`: new genesis test `genesis_rejects_vesting_cliff_exceeds_duration`
- `crates/tx/tests/prop_vesting.proptest-regressions`: committed per proptest convention so the specific failing seed re-runs forever

## Property coverage

| Module | Properties | Focus |
|---|---|---|
| `prop_emergency` | 9 | Pause/Resume wire roundtrip, panic-freedom, cross-action rejection, signing-bytes distinguish nonce/duration |
| `prop_multisig` | 9 | Spend/Rotate roundtrip, signer-set roundtrip, signing-bytes distinguish fields, duplicate-index + over-max-index defenses |
| `prop_airdrop` | 7 | ClaimPayload roundtrip, leaf-hash distinguishes inputs, generated-proof verifies, mutated-bit breaks verify, wrong-address/amount reject |
| `prop_vesting` | 6 | Encode/decode roundtrip, `unlocked + locked = total` invariant, monotonic unlock, pre-cliff-is-zero, post-duration-is-total |

## Out of scope (deferred to future slices)

- **Integration-style property tests** — wire+logic only here. `execute_transaction_inner` end-to-end with arbitrary multisig/signer-set/tx slates needs richer proptest scaffolding; its own slice.
- **Extended proptest CI run** (`PROPTEST_CASES=10_000` or multi-hour periodic). Default 256 cases found one bug; more cases will find more.
- **`cargo-fuzz` harnesses** — overlapping goal, different tool, requires nightly. Task 053 in the plan.