### PR TITLE
test: integration property tests for execute_transaction (slice 5.2)

### DIFF
--- a/crates/tx/tests/common/mod.rs
+++ b/crates/tx/tests/common/mod.rs
@@ -1,0 +1,247 @@
+//! Shared integration-test fixtures (slice 5.2).
+//!
+//! FALCON-512 keygen is ~4.4 ms per call, so proptest runs with
+//! hundreds of cases need a keypair pool. We pre-generate 32 keypairs
+//! once per test binary via `OnceLock` and let strategies pick from
+//! the pool by index. This keeps a 256-case proptest suite under a
+//! second instead of minutes.
+
+use pyde_account::address::{derive_eoa_address, Address};
+use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey};
+use pyde_state::smt::PydeSMT;
+use pyde_tx::multisig;
+use pyde_tx::pipeline::{
+    store_account, write_multisig_nonce, write_multisig_signers, write_multisig_threshold,
+    BlockContext,
+};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+use std::sync::OnceLock;
+
+/// Pool size — enough signers for any realistic multisig config
+/// (MAX_SIGNERS = 16) plus headroom for submitters and random targets.
+pub const POOL_SIZE: usize = 32;
+
+/// Lazily-initialized keypair pool.
+static POOL: OnceLock<Vec<(FalconPublicKey, FalconSecretKey)>> = OnceLock::new();
+
+pub fn pool() -> &'static [(FalconPublicKey, FalconSecretKey)] {
+    POOL.get_or_init(|| {
+        let mut out = Vec::with_capacity(POOL_SIZE);
+        for _ in 0..POOL_SIZE {
+            out.push(falcon_keygen().expect("FALCON keygen must not fail in tests"));
+        }
+        out
+    })
+    .as_slice()
+}
+
+/// Standard block context for tests. `dev_skip_signature = true` so
+/// unsigned fixtures validate.
+pub fn block_ctx(height: u64) -> BlockContext {
+    BlockContext {
+        height,
+        timestamp: 1_000_000 + height * 400,
+        base_fee: 1_000,
+        block_gas_limit: 400_000_000,
+        chain_id: 1,
+        validator_address: derive_eoa_address(b"validator"),
+        dev_skip_signature: true,
+    }
+}
+
+/// Install a multisig on the SMT using the first `n` keypairs from
+/// the pool and the given threshold. Funds the treasury to
+/// `treasury_balance`. Returns the signer secret keys for signing
+/// payloads.
+pub fn install_multisig(
+    smt: &mut PydeSMT,
+    n: usize,
+    threshold: u8,
+    treasury_balance: u128,
+) -> Vec<&'static FalconSecretKey> {
+    assert!(n >= 1 && n <= multisig::MAX_SIGNERS as usize);
+    assert!(threshold as usize >= 1 && threshold as usize <= n);
+    let pool = pool();
+    let pks: Vec<Vec<u8>> = pool[..n]
+        .iter()
+        .map(|(pk, _)| pk.as_bytes().to_vec())
+        .collect();
+    write_multisig_signers(smt, &pks);
+    write_multisig_threshold(smt, threshold);
+    write_multisig_nonce(smt, 0);
+
+    // Fund treasury.
+    let treasury = pyde_account::address::treasury_address();
+    let mut account = pyde_account::types::Account {
+        address: treasury,
+        nonce: 0,
+        balance: treasury_balance,
+        code_hash: sparse_merkle_tree::H256::zero(),
+        storage_root: sparse_merkle_tree::H256::zero(),
+        account_type: pyde_account::types::AccountType::EOA,
+        auth_keys: pyde_account::types::AuthKeys::None,
+        gas_tank: 0,
+        key_nonce: 0,
+    };
+    account.balance = treasury_balance;
+    store_account(smt, &account).unwrap();
+
+    pool[..n].iter().map(|(_, sk)| sk).collect()
+}
+
+/// Pick a pool member by index and fund them as a submitter. Returns
+/// (address, secret_key).
+pub fn fund_submitter(
+    smt: &mut PydeSMT,
+    pool_idx: usize,
+    balance: u128,
+) -> (Address, &'static FalconSecretKey) {
+    let (pk, sk) = &pool()[pool_idx];
+    let address = derive_eoa_address(pk.as_bytes());
+    let mut account = pyde_account::types::Account::new_eoa(pk.as_bytes());
+    account.address = address;
+    account.balance = balance;
+    store_account(smt, &account).unwrap();
+
+    // Initialize nonce state.
+    let nonce_state = pyde_account::nonce::NonceState::new();
+    let _ = smt.insert(
+        pyde_state::keys::nonce_key(&address),
+        nonce_state.to_bytes().to_vec(),
+    );
+
+    (address, sk)
+}
+
+/// Sign the outer tx (the transport layer) with the submitter's key.
+pub fn sign_outer_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
+    let hash = tx.hash();
+    tx.signature = falcon_sign(sk, &hash).unwrap().as_bytes().to_vec();
+}
+
+/// Build a signed MultisigTx wrapping a pre-made payload.
+pub fn build_multisig_tx(
+    submitter: Address,
+    submitter_sk: &FalconSecretKey,
+    payload_bytes: Vec<u8>,
+    outer_nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from: submitter,
+        to: [0u8; 32],
+        value: 0,
+        data: payload_bytes,
+        gas_limit: 2_000_000,
+        nonce: outer_nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::MultisigTx,
+    };
+    sign_outer_tx(&mut tx, submitter_sk);
+    tx
+}
+
+pub fn build_pause_tx(
+    submitter: Address,
+    submitter_sk: &FalconSecretKey,
+    payload_bytes: Vec<u8>,
+    outer_nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from: submitter,
+        to: [0u8; 32],
+        value: 0,
+        data: payload_bytes,
+        gas_limit: 2_000_000,
+        nonce: outer_nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::EmergencyPause,
+    };
+    sign_outer_tx(&mut tx, submitter_sk);
+    tx
+}
+
+pub fn build_resume_tx(
+    submitter: Address,
+    submitter_sk: &FalconSecretKey,
+    payload_bytes: Vec<u8>,
+    outer_nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from: submitter,
+        to: [0u8; 32],
+        value: 0,
+        data: payload_bytes,
+        gas_limit: 2_000_000,
+        nonce: outer_nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::EmergencyResume,
+    };
+    sign_outer_tx(&mut tx, submitter_sk);
+    tx
+}
+
+/// Sign a `MultisigSpend` with a set of pool signers. `indices` maps
+/// the position in `sks` to its signer_index slot — for the common
+/// case pass `&[0, 1, 2, ...]`.
+pub fn sign_multisig_spend(
+    spend: &multisig::MultisigSpend,
+    sks: &[&FalconSecretKey],
+    indices: &[u8],
+    multisig_nonce: u64,
+) -> Vec<multisig::SigEntry> {
+    let msg = spend.signing_bytes(multisig_nonce);
+    sks.iter()
+        .zip(indices)
+        .map(|(sk, idx)| multisig::SigEntry {
+            signer_index: *idx,
+            signature: falcon_sign(sk, &msg).unwrap().as_bytes().to_vec(),
+        })
+        .collect()
+}
+
+pub fn sign_pause(
+    duration_slots: u64,
+    sks: &[&FalconSecretKey],
+    indices: &[u8],
+    multisig_nonce: u64,
+) -> Vec<multisig::SigEntry> {
+    let msg_holder = multisig::EmergencyPausePayload {
+        duration_slots,
+        sigs: vec![],
+    };
+    let msg = msg_holder.signing_bytes(multisig_nonce);
+    sks.iter()
+        .zip(indices)
+        .map(|(sk, idx)| multisig::SigEntry {
+            signer_index: *idx,
+            signature: falcon_sign(sk, &msg).unwrap().as_bytes().to_vec(),
+        })
+        .collect()
+}
+
+pub fn sign_resume(
+    sks: &[&FalconSecretKey],
+    indices: &[u8],
+    multisig_nonce: u64,
+) -> Vec<multisig::SigEntry> {
+    let msg = multisig::EmergencyResumePayload::signing_bytes(multisig_nonce);
+    sks.iter()
+        .zip(indices)
+        .map(|(sk, idx)| multisig::SigEntry {
+            signer_index: *idx,
+            signature: falcon_sign(sk, &msg).unwrap().as_bytes().to_vec(),
+        })
+        .collect()
+}

--- a/crates/tx/tests/prop_integration_conservation.rs
+++ b/crates/tx/tests/prop_integration_conservation.rs
@@ -1,0 +1,127 @@
+//! Integration property test: value conservation across transfers
+//! (slice 5.2, plan 053b).
+//!
+//! Every successful standard transfer must preserve total ledger value
+//! *minus* the burned fraction of the fee. The fee distribution code
+//! at `execution.rs::distribute_fee` assigns the rounding remainder
+//! to treasury, so `burned + validator_share + treasury_share ==
+//! total_fee` exactly — no rounding loss.
+//!
+//! Property asserted here:
+//!
+//! ```text
+//! Δ(sender) + Δ(recipient) + Δ(validator) + Δ(treasury) == -burned
+//! ```
+//!
+//! where the deltas are before/after the tx. Equivalently, the sum of
+//! all on-chain balances drops by exactly the burned amount per tx.
+
+mod common;
+
+use common::*;
+use proptest::prelude::*;
+use pyde_account::address::{derive_eoa_address, Address};
+use pyde_state::smt::PydeSMT;
+use pyde_tx::pipeline::{execute_transaction, load_account};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+
+fn build_transfer(
+    from: Address,
+    from_sk: &pyde_crypto::falcon::FalconSecretKey,
+    to: Address,
+    value: u128,
+    gas_limit: u64,
+    nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from,
+        to,
+        value,
+        data: vec![],
+        gas_limit,
+        nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::Standard,
+    };
+    sign_outer_tx(&mut tx, from_sk);
+    tx
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// A successful Standard transfer preserves total value modulo the
+    /// burned portion of the fee. Sum of (sender, recipient, validator,
+    /// treasury) balance deltas equals `-burned`.
+    #[test]
+    fn transfer_conserves_value_minus_burn(
+        transfer_value in 1u128..=10_000,
+        gas_limit in 50_000u64..=200_000,
+        recipient_seed in 0u8..=0xFF,
+    ) {
+        let mut smt = PydeSMT::new();
+        let (sender, sender_sk) = fund_submitter(&mut smt, 0, 5_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        // Recipient: fresh address derived from the seed so it differs
+        // from sender/validator/treasury across shrinks.
+        let mut recipient = [0u8; 32];
+        recipient[0] = recipient_seed;
+        recipient[1] = 0xAB; // disambiguate from pool-derived addresses
+        prop_assume!(
+            recipient != sender
+                && recipient != ctx.validator_address
+                && recipient != pyde_account::address::treasury_address()
+                && recipient != [0u8; 32]
+        );
+
+        let validator_addr = ctx.validator_address;
+        let treasury_addr = pyde_account::address::treasury_address();
+
+        // Capture before-balances for the four participants.
+        let sender_before = load_account(&smt, &sender).balance;
+        let recipient_before = load_account(&smt, &recipient).balance;
+        let validator_before = load_account(&smt, &validator_addr).balance;
+        let treasury_before = load_account(&smt, &treasury_addr).balance;
+
+        let tx = build_transfer(sender, sender_sk, recipient, transfer_value, gas_limit, 0);
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        prop_assume!(receipt.success);
+
+        // After-balances.
+        let sender_after = load_account(&smt, &sender).balance;
+        let recipient_after = load_account(&smt, &recipient).balance;
+        let validator_after = load_account(&smt, &validator_addr).balance;
+        let treasury_after = load_account(&smt, &treasury_addr).balance;
+
+        // Signed deltas (widen to i256 would be cleaner, but i128
+        // suffices given our bounded fixtures — no participant can
+        // hold 2^127 quanta in this test).
+        let delta_sender = sender_after as i128 - sender_before as i128;
+        let delta_recipient = recipient_after as i128 - recipient_before as i128;
+        let delta_validator = validator_after as i128 - validator_before as i128;
+        let delta_treasury = treasury_after as i128 - treasury_before as i128;
+
+        let total_delta = delta_sender + delta_recipient + delta_validator + delta_treasury;
+        let burned = pyde_tx::execution::distribute_fee(
+            receipt.effective_gas,
+            ctx.base_fee,
+        )
+        .burned as i128;
+
+        // Invariant: sum of balance changes across all four
+        // participating accounts equals -burned. Any deviation
+        // indicates a bookkeeping bug in the pipeline.
+        prop_assert_eq!(
+            total_delta,
+            -burned,
+            "value conservation violated: deltas sum to {}, expected -{} (burned)",
+            total_delta,
+            burned
+        );
+    }
+}

--- a/crates/tx/tests/prop_integration_nonce.rs
+++ b/crates/tx/tests/prop_integration_nonce.rs
@@ -1,0 +1,181 @@
+//! Integration property tests: nonce invariants (slice 5.2, plan 053b).
+//!
+//! Drives arbitrary multisig-signed operations through
+//! `execute_transaction_inner` and asserts that the on-chain
+//! `multisig_nonce` counter advances in lockstep with the number of
+//! successful emergency/rotate/spend operations — and never on
+//! failure.
+
+mod common;
+
+use common::*;
+use proptest::prelude::*;
+use pyde_state::smt::PydeSMT;
+use pyde_tx::multisig;
+use pyde_tx::pipeline::{execute_transaction, read_multisig_nonce};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// Each successful `MultisigTx` must increment the on-chain
+    /// `multisig_nonce` by exactly one, and the new nonce must never
+    /// wrap (u64 headroom is astronomical). Failed txs leave it
+    /// untouched.
+    #[test]
+    fn spend_nonce_increments_only_on_success(
+        n_signers in 2u8..=8,
+        threshold in 1u8..=8,
+        // Scripted sequence of (good_sig_count) per attempted spend.
+        attempts in prop::collection::vec(0u8..=8, 1..=5),
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 5_000_000_000_000);
+
+        let ctx = block_ctx(100);
+
+        let mut expected_nonce = 0u64;
+        let mut outer_nonce = 0u64;
+
+        for (i, good_sig_count) in attempts.iter().enumerate() {
+            let good = (*good_sig_count as usize).min(n);
+            let spend = multisig::MultisigSpend {
+                // Pick a fresh target per attempt (no submitter-self).
+                target: {
+                    let mut t = [0u8; 32];
+                    t[0] = 0xE0 + (i as u8);
+                    t
+                },
+                value: 1_000,
+                data_digest: [0xAA; 32],
+            };
+            let indices: Vec<u8> = (0..good as u8).collect();
+            let sks_slice: Vec<_> = sks[..good].iter().copied().collect();
+            let sigs = sign_multisig_spend(&spend, &sks_slice, &indices, expected_nonce);
+            let payload = multisig::MultisigPayload::Spend { spend, sigs };
+            let tx = build_multisig_tx(submitter, sub_sk, payload.encode(), outer_nonce);
+            outer_nonce += 1;
+
+            let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+
+            let valid_threshold_met = good >= threshold as usize;
+            if valid_threshold_met {
+                prop_assert!(receipt.success, "should have succeeded with {} valid sigs", good);
+                expected_nonce += 1;
+            } else {
+                prop_assert!(!receipt.success, "should have failed with {} valid sigs", good);
+                // nonce UNCHANGED on failure
+            }
+
+            prop_assert_eq!(
+                read_multisig_nonce(&smt),
+                expected_nonce,
+                "multisig nonce drift after step {}",
+                i
+            );
+        }
+    }
+
+    /// `RotateMultisig` obeys the same nonce discipline: success bumps
+    /// the counter, failure doesn't.
+    #[test]
+    fn rotate_nonce_increments_only_on_success(
+        n_signers in 2u8..=8,
+        threshold in 1u8..=8,
+        good_sigs in 0u8..=8,
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let good = (good_sigs as usize).min(n);
+
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 5_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        // Use the next pool member for the new signer.
+        let new_pk = pool()[n + 1].0.as_bytes().to_vec();
+        let rotate = multisig::MultisigRotate {
+            new_signer_pks: vec![new_pk],
+            new_threshold: 1,
+        };
+        let msg = rotate.signing_bytes(0);
+        let indices: Vec<u8> = (0..good as u8).collect();
+        let sigs: Vec<multisig::SigEntry> = indices
+            .iter()
+            .enumerate()
+            .map(|(pos, idx)| multisig::SigEntry {
+                signer_index: *idx,
+                signature: pyde_crypto::falcon::falcon_sign(sks[pos], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            })
+            .collect();
+        let payload = multisig::MultisigPayload::Rotate { rotate, sigs };
+
+        let mut tx = pyde_tx::types::Transaction {
+            from: submitter,
+            to: [0u8; 32],
+            value: 0,
+            data: payload.encode(),
+            gas_limit: 2_000_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: pyde_tx::types::FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: pyde_tx::types::TransactionType::RotateMultisig,
+        };
+        sign_outer_tx(&mut tx, sub_sk);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        let expected_success = good >= threshold as usize;
+        if expected_success {
+            prop_assert!(receipt.success);
+            prop_assert_eq!(read_multisig_nonce(&smt), 1);
+        } else {
+            prop_assert!(!receipt.success);
+            prop_assert_eq!(read_multisig_nonce(&smt), 0);
+        }
+    }
+
+    /// EmergencyPause + Resume sequence: each success bumps nonce by 1.
+    #[test]
+    fn emergency_nonce_progression(
+        n_signers in 2u8..=6,
+        threshold in 2u8..=6,
+        duration in 10u64..=1_000_000,
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 5_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        // Pause with full threshold.
+        let indices: Vec<u8> = (0..threshold).collect();
+        let sks_thr: Vec<_> = sks[..threshold as usize].iter().copied().collect();
+        let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
+        let pause_payload = multisig::EmergencyPausePayload {
+            duration_slots: duration,
+            sigs: pause_sigs,
+        };
+        let pause_tx = build_pause_tx(submitter, sub_sk, pause_payload.encode(), 0);
+        let r1 = execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
+        prop_assert!(r1.success);
+        prop_assert_eq!(read_multisig_nonce(&smt), 1, "pause must bump nonce once");
+
+        // Resume with full threshold.
+        let resume_sigs = sign_resume(&sks_thr, &indices, 1);
+        let resume_payload = multisig::EmergencyResumePayload { sigs: resume_sigs };
+        let resume_tx = build_resume_tx(submitter, sub_sk, resume_payload.encode(), 1);
+        let r2 = execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
+        prop_assert!(r2.success);
+        prop_assert_eq!(read_multisig_nonce(&smt), 2, "resume must bump nonce once");
+    }
+}

--- a/crates/tx/tests/prop_integration_pause.rs
+++ b/crates/tx/tests/prop_integration_pause.rs
@@ -1,0 +1,243 @@
+//! Integration property tests: emergency pause gate + auto-expiry
+//! (slice 5.2, plan 053b).
+//!
+//! While paused, every tx type except `EmergencyResume` must be
+//! rejected BEFORE state writes or gas charging. Auto-expiry kicks in
+//! at `current_slot >= pause_end_slot` without any explicit resume tx.
+
+mod common;
+
+use common::*;
+use proptest::prelude::*;
+use pyde_account::address::derive_eoa_address;
+use pyde_state::smt::PydeSMT;
+use pyde_tx::multisig;
+use pyde_tx::pipeline::{execute_transaction, is_paused, read_multisig_nonce};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+
+/// Helper: assemble a transfer from pool member 0 to a random target.
+fn build_transfer(
+    from: pyde_account::address::Address,
+    from_sk: &pyde_crypto::falcon::FalconSecretKey,
+    to: pyde_account::address::Address,
+    value: u128,
+    nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from,
+        to,
+        value,
+        data: vec![],
+        gas_limit: 100_000,
+        nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::Standard,
+    };
+    sign_outer_tx(&mut tx, from_sk);
+    tx
+}
+
+/// Helper: submit a paused-chain spend tx. Returns Result from
+/// execute_transaction.
+fn attempt_spend(
+    smt: &mut PydeSMT,
+    sks: &[&pyde_crypto::falcon::FalconSecretKey],
+    submitter: pyde_account::address::Address,
+    sub_sk: &pyde_crypto::falcon::FalconSecretKey,
+    outer_nonce: u64,
+    multisig_nonce: u64,
+    ctx: &pyde_tx::pipeline::BlockContext,
+) -> Result<pyde_tx::execution::Receipt, pyde_tx::pipeline::PipelineError> {
+    let spend = multisig::MultisigSpend {
+        target: [0xEE; 32],
+        value: 1_000,
+        data_digest: [0xAA; 32],
+    };
+    let indices: Vec<u8> = (0..sks.len() as u8).collect();
+    let sigs = sign_multisig_spend(&spend, sks, &indices, multisig_nonce);
+    let payload = multisig::MultisigPayload::Spend { spend, sigs };
+    let tx = build_multisig_tx(submitter, sub_sk, payload.encode(), outer_nonce);
+    execute_transaction(&tx, smt, ctx)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// While paused, a standard transfer is rejected with no state
+    /// change. The sender's outer nonce is NOT consumed (the pause
+    /// gate returns before any pipeline state mutations).
+    #[test]
+    fn pause_gate_rejects_standard_transfer(
+        n_signers in 2u8..=6,
+        threshold in 2u8..=6,
+        duration in 100u64..=1_000_000,
+    ) {
+        prop_assume!(threshold <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        // Pause.
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
+        let pause_payload = multisig::EmergencyPausePayload {
+            duration_slots: duration,
+            sigs: pause_sigs,
+        };
+        let pause_tx = build_pause_tx(submitter, sub_sk, pause_payload.encode(), 0);
+        let r1 = execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
+        prop_assert!(r1.success);
+        prop_assert!(is_paused(&smt, ctx.height));
+
+        // Try a vanilla transfer — must be rejected before state mutation.
+        let (recv_pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let recipient = derive_eoa_address(recv_pk.as_bytes());
+        let transfer = build_transfer(submitter, sub_sk, recipient, 10, 1);
+        let result = execute_transaction(&transfer, &mut smt, &ctx);
+        prop_assert!(result.is_err(), "standard transfer must fail during pause");
+
+        // Multisig nonce untouched (pause gate is before any handler).
+        prop_assert_eq!(read_multisig_nonce(&smt), 1);
+    }
+
+    /// While paused, a `MultisigTx` spend is rejected. Treasury must
+    /// not be debited, multisig_nonce must not advance.
+    #[test]
+    fn pause_gate_rejects_multisig_spend(
+        n_signers in 2u8..=6,
+        threshold in 2u8..=6,
+        duration in 100u64..=1_000_000,
+    ) {
+        prop_assume!(threshold <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
+        let pause_payload = multisig::EmergencyPausePayload {
+            duration_slots: duration,
+            sigs: pause_sigs,
+        };
+        let pause_tx = build_pause_tx(submitter, sub_sk, pause_payload.encode(), 0);
+        execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
+
+        let treasury_before = pyde_tx::pipeline::load_account(
+            &smt,
+            &pyde_account::address::treasury_address(),
+        )
+        .balance;
+
+        let spend_result = attempt_spend(&mut smt, &sks_thr, submitter, sub_sk, 1, 1, &ctx);
+        prop_assert!(spend_result.is_err(), "multisig spend must fail during pause");
+
+        let treasury_after = pyde_tx::pipeline::load_account(
+            &smt,
+            &pyde_account::address::treasury_address(),
+        )
+        .balance;
+        prop_assert_eq!(treasury_before, treasury_after, "treasury must be untouched");
+        prop_assert_eq!(read_multisig_nonce(&smt), 1, "pause+0 = 1");
+    }
+
+    /// `EmergencyResume` passes the gate while paused and restores
+    /// normal operation: `is_paused` clears, multisig_nonce bumps.
+    #[test]
+    fn pause_gate_passes_resume(
+        n_signers in 2u8..=6,
+        threshold in 2u8..=6,
+        duration in 100u64..=1_000_000,
+    ) {
+        prop_assume!(threshold <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
+        let pause_payload = multisig::EmergencyPausePayload {
+            duration_slots: duration,
+            sigs: pause_sigs,
+        };
+        let pause_tx = build_pause_tx(submitter, sub_sk, pause_payload.encode(), 0);
+        execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
+        prop_assert!(is_paused(&smt, ctx.height));
+
+        let resume_sigs = sign_resume(&sks_thr, &indices, 1);
+        let resume_payload = multisig::EmergencyResumePayload { sigs: resume_sigs };
+        let resume_tx = build_resume_tx(submitter, sub_sk, resume_payload.encode(), 1);
+        let r = execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
+        prop_assert!(r.success);
+        prop_assert!(!is_paused(&smt, ctx.height));
+        prop_assert_eq!(read_multisig_nonce(&smt), 2);
+    }
+
+    /// Auto-expiry: for any valid pause (duration D at slot S), the
+    /// chain is paused at slots [S, S+D) and unpaused at slot S+D and
+    /// beyond. No resume tx needed.
+    #[test]
+    fn auto_expiry_boundary(
+        n_signers in 2u8..=6,
+        threshold in 2u8..=6,
+        duration in 10u64..=10_000,
+    ) {
+        prop_assume!(threshold <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+
+        let pause_slot = 100u64;
+        let ctx_at_pause = block_ctx(pause_slot);
+
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
+        let pause_payload = multisig::EmergencyPausePayload {
+            duration_slots: duration,
+            sigs: pause_sigs,
+        };
+        let pause_tx = build_pause_tx(submitter, sub_sk, pause_payload.encode(), 0);
+        execute_transaction(&pause_tx, &mut smt, &ctx_at_pause).unwrap();
+
+        let end_slot = pause_slot + duration;
+
+        // At end_slot - 1: still paused.
+        prop_assert!(is_paused(&smt, end_slot - 1), "paused at end_slot - 1");
+
+        // At end_slot: auto-unpaused.
+        prop_assert!(!is_paused(&smt, end_slot), "auto-unpaused at end_slot");
+
+        // Far beyond: still unpaused.
+        prop_assert!(
+            !is_paused(&smt, end_slot + 10_000_000),
+            "remains unpaused indefinitely without resume"
+        );
+
+        // Standard tx at end_slot should execute normally (no state writes
+        // blocked by the gate).
+        let ctx_after = block_ctx(end_slot);
+        let (recv_pk, _) = pyde_crypto::falcon::falcon_keygen().unwrap();
+        let recipient = derive_eoa_address(recv_pk.as_bytes());
+        let transfer = build_transfer(submitter, sub_sk, recipient, 10, 1);
+        let r = execute_transaction(&transfer, &mut smt, &ctx_after).unwrap();
+        prop_assert!(r.success, "transfer at end_slot must succeed (auto-unpaused)");
+    }
+}

--- a/crates/tx/tests/prop_integration_replay.rs
+++ b/crates/tx/tests/prop_integration_replay.rs
@@ -1,0 +1,198 @@
+//! Integration property tests: replay immunity (slice 5.2, plan 053b).
+//!
+//! After a successful multisig-style operation, the on-chain
+//! `multisig_nonce` advances. Re-submitting the SAME signed payload
+//! against the new nonce must fail because the sigs were bound to the
+//! old nonce and no longer verify against the new signing-bytes.
+
+mod common;
+
+use common::*;
+use proptest::prelude::*;
+use pyde_state::smt::PydeSMT;
+use pyde_tx::multisig;
+use pyde_tx::pipeline::{execute_transaction, read_multisig_nonce};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+
+fn build_rotate_tx(
+    submitter: pyde_account::address::Address,
+    submitter_sk: &pyde_crypto::falcon::FalconSecretKey,
+    payload_bytes: Vec<u8>,
+    outer_nonce: u64,
+) -> Transaction {
+    let mut tx = Transaction {
+        from: submitter,
+        to: [0u8; 32],
+        value: 0,
+        data: payload_bytes,
+        gas_limit: 2_000_000,
+        nonce: outer_nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::RotateMultisig,
+    };
+    sign_outer_tx(&mut tx, submitter_sk);
+    tx
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// After a successful `MultisigTx` spend, replaying the same
+    /// signed payload at a fresh outer nonce must fail.
+    #[test]
+    fn spend_replay_rejected(
+        n_signers in 2u8..=6,
+        threshold in 1u8..=6,
+        value in 100u128..=100_000,
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        let spend = multisig::MultisigSpend {
+            target: [0xEE; 32],
+            value,
+            data_digest: [0xAA; 32],
+        };
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sigs = sign_multisig_spend(&spend, &sks_thr, &indices, 0);
+        let payload = multisig::MultisigPayload::Spend {
+            spend: spend.clone(),
+            sigs,
+        };
+        let payload_bytes = payload.encode();
+
+        // First execution succeeds.
+        let tx1 = build_multisig_tx(submitter, sub_sk, payload_bytes.clone(), 0);
+        let r1 = execute_transaction(&tx1, &mut smt, &ctx).unwrap();
+        prop_assert!(r1.success);
+        prop_assert_eq!(read_multisig_nonce(&smt), 1);
+
+        // Replay — same payload bytes, fresh outer nonce.
+        let tx2 = build_multisig_tx(submitter, sub_sk, payload_bytes, 1);
+        let r2 = execute_transaction(&tx2, &mut smt, &ctx).unwrap();
+        prop_assert!(!r2.success, "replay of same signed payload must fail");
+        prop_assert_eq!(read_multisig_nonce(&smt), 1, "failed replay must not bump nonce");
+    }
+
+    /// After a successful `RotateMultisig`, replay fails. Also
+    /// exercises: new signer set is installed, old signers lose
+    /// authority immediately.
+    #[test]
+    fn rotate_replay_rejected(
+        n_signers in 2u8..=6,
+        threshold in 1u8..=6,
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+
+        let mut smt = PydeSMT::new();
+        let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        let new_pk = pool()[n + 1].0.as_bytes().to_vec();
+        let rotate = multisig::MultisigRotate {
+            new_signer_pks: vec![new_pk],
+            new_threshold: 1,
+        };
+        let msg = rotate.signing_bytes(0);
+        let indices: Vec<u8> = (0..t as u8).collect();
+        let sigs: Vec<multisig::SigEntry> = indices
+            .iter()
+            .enumerate()
+            .map(|(pos, idx)| multisig::SigEntry {
+                signer_index: *idx,
+                signature: pyde_crypto::falcon::falcon_sign(sks[pos], &msg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            })
+            .collect();
+        let payload = multisig::MultisigPayload::Rotate {
+            rotate: rotate.clone(),
+            sigs,
+        };
+        let payload_bytes = payload.encode();
+
+        let tx1 = build_rotate_tx(submitter, sub_sk, payload_bytes.clone(), 0);
+        let r1 = execute_transaction(&tx1, &mut smt, &ctx).unwrap();
+        prop_assert!(r1.success);
+        prop_assert_eq!(read_multisig_nonce(&smt), 1);
+
+        // Replay.
+        let tx2 = build_rotate_tx(submitter, sub_sk, payload_bytes, 1);
+        let r2 = execute_transaction(&tx2, &mut smt, &ctx).unwrap();
+        prop_assert!(!r2.success, "rotate replay must fail");
+        prop_assert_eq!(read_multisig_nonce(&smt), 1);
+    }
+
+    /// After rotation, a spend signed by the OLD signer set must
+    /// fail — the new set has sole authority immediately.
+    #[test]
+    fn spend_by_old_signers_after_rotation_fails(
+        n_signers in 2u8..=6,
+        threshold in 1u8..=6,
+    ) {
+        prop_assume!(threshold as u8 <= n_signers);
+        let n = n_signers as usize;
+        let t = threshold as usize;
+
+        let mut smt = PydeSMT::new();
+        let old_sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
+        let (submitter, sub_sk) = fund_submitter(&mut smt, n, 10_000_000_000_000);
+        let ctx = block_ctx(100);
+
+        // Rotate to a fresh single-signer set with threshold 1.
+        let new_pk = pool()[n + 1].0.as_bytes().to_vec();
+        let rotate = multisig::MultisigRotate {
+            new_signer_pks: vec![new_pk],
+            new_threshold: 1,
+        };
+        let rmsg = rotate.signing_bytes(0);
+        let rindices: Vec<u8> = (0..t as u8).collect();
+        let rsigs: Vec<multisig::SigEntry> = rindices
+            .iter()
+            .enumerate()
+            .map(|(pos, idx)| multisig::SigEntry {
+                signer_index: *idx,
+                signature: pyde_crypto::falcon::falcon_sign(old_sks[pos], &rmsg)
+                    .unwrap()
+                    .as_bytes()
+                    .to_vec(),
+            })
+            .collect();
+        let rpayload = multisig::MultisigPayload::Rotate { rotate, sigs: rsigs };
+        let rtx = build_rotate_tx(submitter, sub_sk, rpayload.encode(), 0);
+        let rr = execute_transaction(&rtx, &mut smt, &ctx).unwrap();
+        prop_assert!(rr.success);
+
+        // Attempt a spend signed by the old committee. Nonce is now 1.
+        let spend = multisig::MultisigSpend {
+            target: [0xCC; 32],
+            value: 1_000,
+            data_digest: [0xBB; 32],
+        };
+        let sindices: Vec<u8> = (0..t as u8).collect();
+        let sks_thr: Vec<_> = old_sks[..t].iter().copied().collect();
+        let sigs = sign_multisig_spend(&spend, &sks_thr, &sindices, 1);
+        let spayload = multisig::MultisigPayload::Spend { spend, sigs };
+        let stx = build_multisig_tx(submitter, sub_sk, spayload.encode(), 1);
+        let sr = execute_transaction(&stx, &mut smt, &ctx).unwrap();
+        prop_assert!(
+            !sr.success,
+            "spend by old signers after rotation must fail"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Plan task **053b**. Complements slice 5.1 (wire-format + logic properties) with **end-to-end properties** that drive arbitrary multisig configs, signer sets, and tx slates through `execute_transaction_inner` and assert invariants observable at the pipeline layer.

- **11 new properties** across 4 files
- **~340 proptest invocations** per test run, ~25s total runtime
- **Value conservation now proven**: `Δ(balances) + burned = 0` for Standard transfers (fee distribution leaves no rounding crumbs)

## Scaffolding

`crates/tx/tests/common/mod.rs` — shared across all integration proptest files:

- **32-keypair FALCON pool** via `OnceLock`, amortizing ~140 ms of keygen across all cases (vs. 4.4 ms × 256 cases × multiple keys-per-case = unusable)
- Fixture builders: `install_multisig`, `fund_submitter`, signing helpers

## Properties

| File | Count | Cases/each | Focus |
|---|---|---|---|
| `prop_integration_nonce.rs` | 3 | 32 | multisig_nonce advances iff op succeeds (spend / rotate / emergency) |
| `prop_integration_replay.rs` | 3 | 128 | Replay rejected (spend, rotate, old-signers-after-rotation) |
| `prop_integration_pause.rs` | 4 | 64 | Gate rejects Standard/MultisigTx/RotateMultisig while paused; Resume passes; auto-expiry boundary |
| `prop_integration_conservation.rs` | 1 | 64 | `Δ(sender) + Δ(recipient) + Δ(validator) + Δ(treasury) == -burned` for Standard transfers |

## Value conservation derivation

From `execution.rs::distribute_fee`:
```rust
let burned = total_fee * FEE_BURN_PCT as u128 / 100;
let validator = total_fee * FEE_VALIDATOR_PCT as u128 / 100;
let treasury = total_fee - burned - validator; // remainder goes here
```

Treasury absorbs the rounding remainder, so `burned + validator + treasury == total_fee` *exactly*. The conservation property asserts this cleanly without needing tolerance bounds.

## No new bugs surfaced

Phase 4 code was already well-reviewed via slice 5.1's wire/logic coverage. Slice 5.2 serves as **regression guards** going forward — if a future refactor breaks nonce discipline, replay immunity, the pause gate, or value conservation, these properties will flag it before the change merges.

## Scope limits (honest)

- Conservation tested for Standard transfers only. Multisig/Rotate/Emergency flows have different ledger shapes (treasury → target); slice 4.5 concrete tests cover those happy paths.
- Arbitrary-bytes-through-execute_transaction is cargo-fuzz territory (plan task **053**), not proptest.