### PR TITLE
chore: warning cleanup sweep — rustc warnings 251 → 1 (slice 5.4)

### DIFF
--- a/crates/account/src/auth.rs
+++ b/crates/account/src/auth.rs
@@ -138,7 +138,7 @@ pub fn build_rotation_message(account: &Account, new_keys: &AuthKeys) -> Vec<u8>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::AccountType;
+    
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 
     fn make_eoa_with_real_key() -> (Account, pyde_crypto::falcon::FalconSecretKey) {

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -599,7 +599,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                     // Wide comparisons: result written to GP register rd
                     Opcode::Weq | Opcode::Wlt => {
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
-                        let regs_ptr_val = builder.use_var(Variable::from_u32(VAR_REGS_PTR));
+                        let _regs_ptr_val = builder.use_var(Variable::from_u32(VAR_REGS_PTR));
                         let op = builder.ins().iconst(I64, d.opcode.to_u8() as i64);
                         let wd = builder.ins().iconst(I64, d.rd as i64);
                         let ws1 = builder.ins().iconst(I64, d.rs1 as i64);

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -56,7 +56,7 @@ mod tests {
         let interp_output = vm.execute();
 
         // AOT
-        let (aot_status, aot_gas, aot_regs) = run_aot(code, gas_limit);
+        let (aot_status, _aot_gas, aot_regs) = run_aot(code, gas_limit);
 
         // Compare outcome
         match interp_output.outcome {

--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -10,7 +10,6 @@ use pyde_account::address::Address;
 use pyde_crypto::poseidon2::poseidon2_hash;
 use pyde_tx::parallel::ExecutionSchedule;
 use pyde_tx::types::Transaction;
-use sparse_merkle_tree::H256;
 
 /// Committee size (128 validators per epoch).
 pub const COMMITTEE_SIZE: usize = 128;

--- a/crates/consensus/src/epoch_randomness.rs
+++ b/crates/consensus/src/epoch_randomness.rs
@@ -18,7 +18,7 @@
 
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{FalconPublicKey, FalconSecretKey};
-use pyde_crypto::poseidon2::{poseidon2_hash, poseidon2_many};
+use pyde_crypto::poseidon2::poseidon2_many;
 use pyde_crypto::hash::Hash256;
 use pyde_crypto::vrf::{vrf_prove, vrf_verify, VrfOutput, VrfProof};
 

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -8,10 +8,9 @@
 //! Pipelined: certify for slot N overlaps with propose for slot N+1.
 //! Finality: block finalized when referenced by 2 consecutive QCs.
 
-use crate::block::{BlockHeader, QuorumCert, COMMITTEE_SIZE, QUORUM_THRESHOLD, quorum_for_committee};
+use crate::block::{BlockHeader, QuorumCert, quorum_for_committee};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
-use pyde_crypto::poseidon2::poseidon2_hash;
 
 /// Canonical message bytes that both proposers and voters sign for a
 /// block at a given slot: `slot_le || block_hash`.

--- a/crates/consensus/src/proposer.rs
+++ b/crates/consensus/src/proposer.rs
@@ -18,7 +18,6 @@
 //! - `node.rs:769` — triggered at epoch boundary
 //! - `node.rs:1406` — share collection via gossipsub
 
-use crate::validator::Committee;
 use pyde_account::address::Address;
 use pyde_crypto::falcon::FalconPublicKey;
 use pyde_crypto::vrf::{vrf_prove, vrf_verify, VrfOutput, VrfProof};

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -13,8 +13,7 @@
 //! Evidence submitter receives 10% finder's fee from slashed stake.
 //! No time limit on evidence — previous epoch evidence is still valid.
 
-use crate::block::BlockHeader;
-use crate::validator::{Validator, ValidatorSet, ValidatorStatus, VALIDATOR_STAKE};
+use crate::validator::{ValidatorSet, ValidatorStatus, VALIDATOR_STAKE};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 
@@ -260,7 +259,7 @@ pub fn apply_slash(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::block::QuorumCert;
+    use crate::block::{BlockHeader, QuorumCert};
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 

--- a/crates/consensus/src/validator.rs
+++ b/crates/consensus/src/validator.rs
@@ -5,7 +5,7 @@
 //! - Epoch rotation every 1,000 blocks
 //! - 14-day unbonding period on deregistration
 
-use crate::block::{COMMITTEE_SIZE, EPOCH_LENGTH};
+use crate::block::COMMITTEE_SIZE;
 use pyde_account::address::Address;
 use pyde_crypto::poseidon2::poseidon2_hash;
 

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -8,7 +8,7 @@
 //!
 //! Liveness: guaranteed if 86+ of 128 validators are honest and online.
 
-use crate::block::{BlockHeader, QuorumCert, COMMITTEE_SIZE, QUORUM_THRESHOLD};
+use crate::block::{BlockHeader, QuorumCert, QUORUM_THRESHOLD};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey, FalconSignature};
 

--- a/crates/mempool/src/decryption.rs
+++ b/crates/mempool/src/decryption.rs
@@ -9,11 +9,10 @@
 //! The decryption happens AFTER ordering is committed (QC formed).
 
 use crate::encrypted::{decrypt_payload, EncryptedTx};
-use pyde_account::address::Address;
 use pyde_crypto::threshold::{
-    combine_shares, generate_decryption_share, DecryptionShare, KeyShare, ThresholdCiphertext,
+    generate_decryption_share, DecryptionShare, KeyShare,
 };
-use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
 
 /// Decryption state for a single block's worth of encrypted transactions.
 #[derive(Debug)]
@@ -161,8 +160,9 @@ impl BlockDecryptor {
 mod tests {
     use super::*;
     use crate::encrypted::encrypt_transaction;
-    use pyde_account::address::derive_eoa_address;
+    use pyde_account::address::{derive_eoa_address, Address};
     use pyde_crypto::threshold;
+    use pyde_crypto::threshold::KeyShare;
     use pyde_tx::types::AccessEntry;
 
     fn make_keys(n: usize, t: usize) -> (threshold::ThresholdPublicKey, Vec<KeyShare>) {

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -12,7 +12,7 @@
 use pyde_account::address::Address;
 use pyde_crypto::poseidon2::poseidon2_hash;
 use pyde_crypto::threshold::{
-    self, DecryptionShare, KeyShare, ThresholdCiphertext, ThresholdPublicKey,
+    self, DecryptionShare, ThresholdCiphertext, ThresholdPublicKey,
 };
 use pyde_tx::types::AccessEntry;
 
@@ -217,6 +217,7 @@ pub fn decrypt_payload(
 mod tests {
     use super::*;
     use pyde_account::address::derive_eoa_address;
+    use pyde_crypto::threshold::KeyShare;
 
     fn make_threshold_keys() -> (ThresholdPublicKey, Vec<KeyShare>) {
         threshold::threshold_keygen(3, 2).unwrap() // 2-of-3

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -774,9 +774,10 @@ mod tests {
         ).unwrap()
     }
 
-    /// Test clock backed by a thread-local counter. `set_test_clock_ms`
-    /// moves the needle; `test_clock_ms` is the function pointer fed to
-    /// `Mempool::set_clock`.
+    // Test clock backed by a thread-local counter. `set_test_clock_ms`
+    // moves the needle; `test_clock_ms` is the function pointer fed to
+    // `Mempool::set_clock`. (Regular comment, not a doc comment — `///`
+    // doesn't attach to `thread_local!` macro items.)
     thread_local! {
         static TEST_CLOCK: std::cell::Cell<u64> = std::cell::Cell::new(0);
     }

--- a/crates/net/src/discovery.rs
+++ b/crates/net/src/discovery.rs
@@ -7,7 +7,7 @@
 //! 4. Maintains a set of known peers for reconnection
 
 use libp2p::{Multiaddr, PeerId};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Instant;
 
 /// Default bootstrap peers for mainnet (empty until launch).

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -9,8 +9,7 @@ use crate::config::NetworkConfig;
 use crate::sync_protocol::{self, SyncReq, SyncResp};
 use libp2p::{
     gossipsub, identify, identity,
-    kad::{self, store::MemoryStore},
-    noise, request_response,
+    kad::{self, store::MemoryStore}, request_response,
     swarm::NetworkBehaviour,
     Multiaddr, PeerId, Swarm, SwarmBuilder,
 };

--- a/crates/node/src/aot_cache.rs
+++ b/crates/node/src/aot_cache.rs
@@ -92,6 +92,7 @@ impl AotCache {
     }
 
     /// Mark a contract as AOT-incompatible (use interpreter permanently).
+    #[allow(dead_code)]
     pub fn blacklist(&self, address: [u8; 32]) {
         if let Ok(mut set) = self.blacklisted.write() {
             set.insert(address);

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -17,6 +17,7 @@ impl BlockProcessor {
     /// Executes each tx against the state, collects receipts, updates chain head.
     /// Optionally triggers AOT background compilation for new contracts.
     /// Returns (tx_count, total_gas_used, receipts).
+    #[allow(dead_code)]
     pub fn process_full_block(
         chain: &mut ChainState,
         state: &mut StateManager,
@@ -27,6 +28,7 @@ impl BlockProcessor {
 
     /// Process a full block with optional AOT cache for background compilation.
     /// Delegates to the checkpoint-aware variant with `None` (no WS check).
+    #[allow(dead_code)]
     pub fn process_full_block_with_aot(
         chain: &mut ChainState,
         state: &mut StateManager,
@@ -108,7 +110,7 @@ impl BlockProcessor {
                     let code_key = pyde_state::keys::code_key(&tx.to);
                     if let Some(bytecode) = state.get(&code_key) {
                         crate::aot_cache::compile_in_background(
-                            cache.clone().clone(),
+                            std::sync::Arc::clone(cache),
                             tx.to,
                             bytecode,
                         );
@@ -375,6 +377,7 @@ impl BlockProcessor {
 
     /// Process a header-only block (no transactions — used during header sync).
     /// Returns (0, 0) since no txs are executed.
+    #[allow(dead_code)]
     pub fn process_block(
         chain: &mut ChainState,
         state: &mut StateManager,
@@ -401,6 +404,7 @@ impl BlockProcessor {
         Ok((0, 0))
     }
 
+    #[allow(dead_code)]
     fn validate_header(header: &BlockHeader, chain: &ChainState) -> Result<(), String> {
         Self::validate_header_with_checkpoint(header, chain, None)
     }
@@ -797,10 +801,10 @@ mod tests {
     use crate::chain::ChainState;
     use crate::genesis::{initialize_genesis, devnet_genesis};
     use crate::state_manager::StateManager;
-    use pyde_account::address::{derive_eoa_address, ZERO_ADDRESS};
+    use pyde_account::address::ZERO_ADDRESS;
     use pyde_consensus::block::{BlockBody, QuorumCert};
     use pyde_tx::parallel::ExecutionSchedule;
-    use pyde_tx::types::{AccessEntry, FeePayer, TransactionType};
+    use pyde_tx::types::{FeePayer, TransactionType};
 
     fn dummy_header(slot: u64) -> BlockHeader {
         BlockHeader {
@@ -906,7 +910,7 @@ mod tests {
             proposer_signature: vec![],
         };
 
-        let (tx_count, gas_used, receipts) =
+        let (tx_count, _gas_used, receipts) =
             BlockProcessor::process_full_block(&mut chain, &mut state, &block).unwrap();
 
         assert_eq!(tx_count, 1);

--- a/crates/node/src/block_store.rs
+++ b/crates/node/src/block_store.rs
@@ -60,6 +60,7 @@ impl BlockStore {
     }
 
     /// Look up a slot by block hash.
+    #[allow(dead_code)]
     pub fn get_slot_by_hash(&self, hash: &[u8; 32]) -> Option<u64> {
         let mut key = Vec::with_capacity(34);
         key.extend_from_slice(b"i:");
@@ -72,6 +73,7 @@ impl BlockStore {
     }
 
     /// Get a header by block hash.
+    #[allow(dead_code)]
     pub fn get_header_by_hash(&self, hash: &[u8; 32]) -> Option<BlockHeader> {
         let slot = self.get_slot_by_hash(hash)?;
         self.get_header(slot)
@@ -121,6 +123,7 @@ impl BlockStore {
     }
 
     /// Check if full block data exists for this slot.
+    #[allow(dead_code)]
     pub fn has_block_data(&self, slot: u64) -> bool {
         self.get_block_raw(slot).is_some()
     }

--- a/crates/node/src/chain.rs
+++ b/crates/node/src/chain.rs
@@ -1,4 +1,4 @@
-use pyde_consensus::block::{BlockHeader, QuorumCert, EPOCH_LENGTH};
+use pyde_consensus::block::{BlockHeader, EPOCH_LENGTH};
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -15,6 +15,7 @@ pub struct ChainState {
     /// Block hash → slot index (for getBlockByHash lookups).
     pub hash_to_slot: HashMap<[u8; 32], u64>,
     /// Genesis block hash.
+    #[allow(dead_code)]
     pub genesis_hash: [u8; 32],
     /// Base fee for EIP-1559 gas pricing.
     pub base_fee: u128,
@@ -80,6 +81,7 @@ impl ChainState {
 mod tests {
     use super::*;
     use pyde_account::address::ZERO_ADDRESS;
+    use pyde_consensus::block::QuorumCert;
 
     fn dummy_header(slot: u64, parent_hash: [u8; 32]) -> BlockHeader {
         BlockHeader {

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -185,6 +185,7 @@ impl ConsensusStateStore {
     /// Remove any persisted reshare state. Used when an epoch's rotation
     /// completes successfully; keeping stale state around causes confused
     /// behavior on a subsequent restart.
+    #[allow(dead_code)]
     pub fn clear_reshare_state(&self) -> Result<(), String> {
         self.db
             .delete_opt(RESHARE_STATE_KEY, &self.sync_opts)

--- a/crates/node/src/faucet.rs
+++ b/crates/node/src/faucet.rs
@@ -54,6 +54,7 @@ impl RateLimiter {
 /// Faucet signing key (loaded once at startup).
 pub struct FaucetSigner {
     pub address: [u8; 32],
+    #[allow(dead_code)]
     pub public_key: pyde_crypto::falcon::FalconPublicKey,
     pub secret_key: pyde_crypto::falcon::FalconSecretKey,
 }
@@ -230,7 +231,7 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
     tracing::info!("  rate limit: {} seconds per address", config.cooldown_secs);
 
     loop {
-        let (mut stream, _) = listener.accept().await
+        let (stream, _) = listener.accept().await
             .map_err(|e| format!("accept: {}", e))?;
 
         let limiter = limiter.clone();

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -11,7 +11,6 @@
 use crate::state_manager::StateManager;
 use pyde_account::address::Address;
 use pyde_consensus::block::{genesis_block, Block};
-use pyde_tx::fee::GENESIS_BASE_FEE;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tracing::{debug, info};
@@ -1092,6 +1091,7 @@ json = false
 }
 
 /// Parse a hex-encoded 32-byte address.
+#[allow(dead_code)]
 pub fn parse_hex_address_pub(hex_str: &str) -> Result<Address, String> {
     parse_hex_address(hex_str)
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -21,8 +21,7 @@ use libp2p::PeerId;
 use pyde_net::channels::Channel;
 use pyde_net::config::NetworkConfig;
 use pyde_net::node::{
-    create_node, generate_keypair, keypair_from_bytes, keypair_to_bytes, subscribe_topics,
-    PydeBehaviour, PydeBehaviourEvent,
+    create_node, generate_keypair, keypair_from_bytes, keypair_to_bytes, subscribe_topics, PydeBehaviourEvent,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -1055,12 +1054,12 @@ impl PydeNode {
                                     // Always produce blocks to advance the chain.
                                     // Empty blocks are needed for QC chain progression.
                                     {
-                                    let tx_count = txs.len();
+                                    let _tx_count = txs.len();
 
                                     // Build block with transactions
                                     let chain_r = chain.read().await;
                                     let parent_hash = chain_r.state_root;
-                                    let head = chain_r.head_slot;
+                                    let _head = chain_r.head_slot;
                                     drop(chain_r);
 
                                     // Auto-infer access lists for parallel scheduling.
@@ -1387,7 +1386,7 @@ impl PydeNode {
                                                                                 "encrypted txs decrypted — executing"
                                                                             );
                                                                             // Execute decrypted txs
-                                                                            let mut chain_w = chain.write().await;
+                                                                            let chain_w = chain.write().await;
                                                                             let mut state_w = state.write().await;
                                                                             let proposer = block_store.get_header(current_slot)
                                                                                 .map(|h| h.proposer).unwrap_or(identity.address);
@@ -1431,7 +1430,7 @@ impl PydeNode {
                         // Check for timeout (no proposal received within 200ms)
                         if engine.is_timed_out() {
                             if let Some(identity) = validator_identity.as_ref() {
-                                if let Some(vc_msg) = engine.on_timeout(identity) {
+                                if let Some(_vc_msg) = engine.on_timeout(identity) {
                                     let vc_bytes = wire::encode_consensus_message(
                                         &pyde_consensus::hotstuff::ConsensusMessage::Timeout {
                                             slot: current_slot,
@@ -1530,11 +1529,12 @@ impl PydeNode {
     }
 }
 
-use pyde_net::sync_protocol::{SyncReq, SyncResp};
+use pyde_net::sync_protocol::SyncResp;
 
 /// Action to take after processing a swarm event (avoids borrow conflicts with swarm).
 enum PostEventAction {
     None,
+    #[allow(dead_code)]
     RequestChainTip(PeerId),
     SendSyncResponse(request_response::ResponseChannel<SyncResp>, SyncResp),
     ContinueSync,
@@ -1545,6 +1545,7 @@ enum PostEventAction {
     /// gossip and local detection arrive in the same tick).
     BroadcastConsensusMany(Vec<Vec<u8>>),
     AcceptTransaction(pyde_tx::types::Transaction),
+    #[allow(dead_code)]
     StoreReceipts(u64, Vec<pyde_tx::execution::Receipt>),
     AddPeerToKademlia(PeerId, Vec<libp2p::Multiaddr>),
     BlockProcessed {
@@ -1572,7 +1573,7 @@ fn handle_swarm_event(
     event: SwarmEvent<PydeBehaviourEvent>,
     chain: &mut ChainState,
     state: &mut StateManager,
-    tx_relay: &mut TxRelay,
+    _tx_relay: &mut TxRelay,
     chain_sync: &mut ChainSync,
     validator_engine: &mut Option<ValidatorEngine>,
     validator_identity: &mut Option<ValidatorIdentity>,
@@ -1990,7 +1991,7 @@ fn handle_swarm_event(
                                             info!(slot, "view change QC formed — fallback proposer can proceed");
                                         }
                                     }
-                                    ConsensusMessage::NewView { slot, highest_qc, voter_address, signature } => {
+                                    ConsensusMessage::NewView { slot, highest_qc, voter_address: _, signature: _ } => {
                                         debug!(slot, "received new view");
                                         // NewView carries the highest QC from a validator after view change.
                                         // Update our highest QC if theirs is higher.

--- a/crates/node/src/receipt_store.rs
+++ b/crates/node/src/receipt_store.rs
@@ -79,6 +79,7 @@ impl ReceiptStore {
     }
 
     /// Number of stored receipts.
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.receipts.len()
     }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -11,7 +11,7 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use pyde_tx::execution::Receipt;
-use pyde_tx::pipeline::{execute_transaction, BlockContext};
+use pyde_tx::pipeline::BlockContext;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -553,7 +553,7 @@ impl PydeApiServer for RpcServer {
             let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
             storage_snapshot(&smt_key)
         }));
-        let output = vm.execute();
+        let _output = vm.execute();
 
         // Return gas used + 10% margin for real execution overhead (nonce check, balance deduct, etc.)
         // The VM simulation already includes all cold storage surcharges.
@@ -637,7 +637,7 @@ impl PydeApiServer for RpcServer {
             let smt_key = sparse_merkle_tree::H256::from(key.to_le_bytes());
             storage_snapshot(&smt_key)
         }));
-        let output = vm.execute();
+        let _output = vm.execute();
 
         // Build access list from VM's tracked RAW slots (pre-derivation).
         // The pipeline's pre_derive_access_list_keys will derive them,
@@ -961,6 +961,7 @@ fn parse_hash(input: &str) -> Result<[u8; 32], ErrorObjectOwned> {
 }
 
 /// Parse a JSON call object into a Transaction + BlockContext for simulation.
+#[allow(dead_code)]
 async fn parse_call_object(
     obj: &serde_json::Value,
     rpc_state: &RpcState,
@@ -1052,6 +1053,7 @@ fn decode_u128(data: &[u8]) -> u128 {
     } else { 0 }
 }
 
+#[allow(dead_code)]
 fn decode_u64(data: &[u8]) -> u64 {
     if data.len() >= 8 {
         let mut buf = [0u8; 8];

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -13,6 +13,7 @@ pub struct SlotClock {
     /// Genesis Unix timestamp in ms (for absolute time reference).
     genesis_timestamp_ms: u64,
     /// Slot duration.
+    #[allow(dead_code)]
     slot_duration: Duration,
 }
 
@@ -43,6 +44,7 @@ impl SlotClock {
     }
 
     /// Time remaining in the current slot.
+    #[allow(dead_code)]
     pub fn time_remaining(&self) -> Duration {
         let elapsed = self.genesis_instant.elapsed();
         let elapsed_ms = elapsed.as_millis() as u64;
@@ -52,6 +54,7 @@ impl SlotClock {
     }
 
     /// Duration until a specific slot starts.
+    #[allow(dead_code)]
     pub fn duration_until_slot(&self, slot: u64) -> Duration {
         let slot_start_ms = slot * BLOCK_TIME_MS;
         let elapsed_ms = self.genesis_instant.elapsed().as_millis() as u64;
@@ -68,6 +71,7 @@ impl SlotClock {
     }
 
     /// Slot duration.
+    #[allow(dead_code)]
     pub fn slot_duration(&self) -> Duration {
         self.slot_duration
     }

--- a/crates/node/src/state_manager.rs
+++ b/crates/node/src/state_manager.rs
@@ -105,6 +105,7 @@ impl StateManager {
         Ok(self.root)
     }
 
+    #[allow(dead_code)]
     pub fn delete(&mut self, key: &Key) -> Result<bool, String> {
         self.tracked_keys.remove(key);
         let mut smt = self.smt.lock().map_err(|e| format!("smt lock: {}", e))?;
@@ -184,6 +185,7 @@ impl StateManager {
     }
 
     /// Get immutable SMT access. Returns MutexGuard.
+    #[allow(dead_code)]
     pub fn smt_ref(&self) -> std::sync::MutexGuard<'_, PersistentSMT> {
         self.smt.lock().expect("smt lock poisoned")
     }
@@ -224,6 +226,7 @@ impl StateManager {
         Ok(self.root)
     }
 
+    #[allow(dead_code)]
     pub fn entry_count(&self) -> usize {
         self.tracked_keys.len()
     }

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -11,7 +11,7 @@ use crate::block_processor::BlockProcessor;
 use crate::block_store::BlockStore;
 use crate::chain::ChainState;
 use crate::state_manager::StateManager;
-use libp2p::request_response::{self, OutboundRequestId, ResponseChannel};
+use libp2p::request_response::OutboundRequestId;
 use libp2p::{PeerId, Swarm};
 use pyde_net::node::PydeBehaviour;
 use pyde_net::sync::SyncManager;
@@ -67,6 +67,7 @@ impl ChainSync {
     }
 
     /// Called when we learn a peer's chain tip (from ChainTip response or identify).
+    #[allow(dead_code)]
     pub fn on_peer_tip(&mut self, peer: PeerId, tip_slot: u64) {
         let old_tip = self.manager.network_tip;
         self.manager.update_network_tip(tip_slot);
@@ -153,6 +154,7 @@ impl ChainSync {
 
     /// Request a state snapshot from a peer (for fast sync when far behind).
     /// Uses chunked transfer for production, falls back to bulk for small states.
+    #[allow(dead_code)]
     pub fn request_state_snapshot(
         &mut self,
         swarm: &mut Swarm<PydeBehaviour>,
@@ -196,6 +198,7 @@ impl ChainSync {
     }
 
     /// Threshold: if behind by more than this many slots, use snapshot sync.
+    #[allow(dead_code)]
     pub const SNAPSHOT_THRESHOLD: u64 = 1000;
 
     /// Handle a sync response from a peer.

--- a/crates/node/src/tx_relay.rs
+++ b/crates/node/src/tx_relay.rs
@@ -1,6 +1,6 @@
 use pyde_mempool::encrypted::EncryptedTx;
 use pyde_mempool::pool::Mempool;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Transaction relay: receives encrypted txs from gossipsub, validates, stores in mempool.
 pub struct TxRelay {
@@ -14,6 +14,7 @@ impl TxRelay {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_capacity(max_size: usize) -> Self {
         Self {
             mempool: Mempool::with_capacity(max_size),
@@ -21,6 +22,7 @@ impl TxRelay {
     }
 
     /// Update the current block height (for expiry checks).
+    #[allow(dead_code)]
     pub fn set_current_block(&mut self, block: u64) {
         self.mempool.set_current_block(block);
     }
@@ -71,6 +73,7 @@ impl TxRelay {
     }
 
     /// Get a mutable reference to the mempool.
+    #[allow(dead_code)]
     pub fn mempool_mut(&mut self) -> &mut Mempool {
         &mut self.mempool
     }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -11,7 +11,6 @@ use pyde_crypto::vrf::VrfProof;
 use pyde_consensus::block::quorum_for_committee;
 use pyde_consensus::epoch_randomness::{
     RandomnessCollector, RandomnessShare, generate_share, verify_share,
-    combine_shares_dynamic,
 };
 use pyde_crypto::threshold::{
     RefreshContribution, ResharingContribution, aggregate_new_share, apply_refresh,
@@ -19,7 +18,7 @@ use pyde_crypto::threshold::{
     verify_refresh_contribution, verify_resharing_contribution,
 };
 use pyde_consensus::slashing::{
-    DoubleSignEvidence, slash_double_sign, verify_double_sign,
+    DoubleSignEvidence, slash_double_sign,
 };
 use pyde_consensus::validator::VALIDATOR_STAKE;
 use pyde_consensus::view_change::{
@@ -194,6 +193,7 @@ pub fn process_unbonding(
 
 /// Collected votes for a slot, used to form QCs.
 struct SlotVotes {
+    #[allow(dead_code)]
     block_hash: [u8; 32],
     votes: Vec<ConsensusMessage>,
 }
@@ -201,6 +201,7 @@ struct SlotVotes {
 /// A buffered proposal with verified VRF score.
 struct BufferedProposal {
     header: BlockHeader,
+    #[allow(dead_code)]
     proposer_signature: Vec<u8>,
     vrf_score: u64,
 }
@@ -1234,6 +1235,7 @@ impl ValidatorEngine {
 
     /// True when a slot was flagged via `flag_inclusion_violation`.
     /// Exposed for tests.
+    #[allow(dead_code)]
     pub fn is_inclusion_violated(&self, slot: u64) -> bool {
         self.inclusion_violated_slots.contains(&slot)
     }
@@ -1626,6 +1628,7 @@ impl ValidatorEngine {
     /// Re-queue previously drained evidence, e.g. after a failed block
     /// build. No-op if `evidence` is empty. Preserves insertion order by
     /// appending at the tail.
+    #[allow(dead_code)]
     pub fn push_evidence(&mut self, evidence: Vec<DoubleSignEvidence>) {
         if evidence.is_empty() {
             return;
@@ -1837,6 +1840,7 @@ impl ValidatorEngine {
 
     /// Create a BlockDecryptor and seed it with our own shares.
     /// Other committee members' shares are added as they arrive via gossipsub.
+    #[allow(dead_code)]
     pub fn start_decryption(
         &self,
         identity: &ValidatorIdentity,
@@ -2458,7 +2462,7 @@ mod tests {
         engine.prepare_for_reshare_reception(1, new_committee, 1);
         let mut new_id = make_identity(0);
 
-        let mut bad = generate_resharing_contribution(&old_shares[0], 4, 3, 1, b"e");
+        let bad = generate_resharing_contribution(&old_shares[0], 4, 3, 1, b"e");
         // Flip one sub-share to break the polynomial.
         bad.to_bytes(); // sanity
         // Expose a mutation path: rebuild via from_bytes after a byte flip.

--- a/crates/node/src/ws_sub.rs
+++ b/crates/node/src/ws_sub.rs
@@ -5,11 +5,10 @@
 //! but the WS frame isn't written to the client.
 
 use futures_util::{SinkExt, StreamExt};
-use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, mpsc};
 use tokio_tungstenite::tungstenite::Message;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 pub async fn start_ws_server(
     listen: &str,

--- a/crates/node/tests/bench_mempool.rs
+++ b/crates/node/tests/bench_mempool.rs
@@ -3,7 +3,7 @@
 //! block processor — exactly how mainnet processes blocks.
 
 use pyde_account::address::derive_eoa_address;
-use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+use pyde_crypto::falcon::falcon_keygen;
 use pyde_state::smt::{PersistentSMT, StateAccess, StateOverlay};
 use pyde_tx::pipeline::{execute_transaction, BlockContext};
 use pyde_tx::types::*;
@@ -65,7 +65,7 @@ fn bench_preloaded_mempool() {
         (addr, pk.as_bytes().to_vec(), sk.as_bytes().to_vec())
     }).collect();
 
-    for (addr, pk_bytes, _) in &accounts {
+    for (addr, _pk_bytes, _) in &accounts {
         let account = pyde_account::types::Account {
             address: *addr, nonce: 0, balance: 1_000_000_000_000_000,
             code_hash: sparse_merkle_tree::H256::zero(),
@@ -149,7 +149,7 @@ fn bench_preloaded_mempool() {
             }
         }
     }
-    let aot_map: std::collections::HashMap<[u8; 32], unsafe fn(*mut u64, u64, *mut pyde_vm::vm::Vm) -> u64> =
+    let _aot_map: std::collections::HashMap<[u8; 32], unsafe fn(*mut u64, u64, *mut pyde_vm::vm::Vm) -> u64> =
         aot_fns.iter().map(|(addr, code)| (*addr, code.as_fn())).collect();
 
     println!("  {} contracts deployed ({} instrs, {} AOT compiled)", num_contracts,

--- a/crates/node/tests/benchmark.rs
+++ b/crates/node/tests/benchmark.rs
@@ -1,7 +1,6 @@
 //! Comprehensive throughput benchmark — measures REAL TPS with diverse workloads.
 
 use pyde_account::address::derive_eoa_address;
-use pyde_crypto::falcon::falcon_keygen;
 use pyde_tx::parallel::schedule;
 use pyde_tx::pipeline::{execute_transaction, BlockContext};
 use pyde_tx::types::*;
@@ -24,7 +23,7 @@ fn fund_account(smt: &mut pyde_state::smt::PydeSMT, idx: u64) -> ([u8; 32], u64)
     let mut pk_bytes = vec![0u8; 897];
     pk_bytes[..8].copy_from_slice(&seed);
     let address = derive_eoa_address(&pk_bytes);
-    let mut account = pyde_account::types::Account {
+    let account = pyde_account::types::Account {
         address, nonce: 0, balance: 1_000_000_000_000_000,
         code_hash: sparse_merkle_tree::H256::zero(),
         storage_root: sparse_merkle_tree::H256::zero(),
@@ -243,8 +242,6 @@ fn benchmark_throughput() {
 #[ignore = "benchmark — run with --ignored"]
 fn benchmark_realistic_block() {
     use pyde_state::smt::PersistentSMT;
-    use rayon::prelude::*;
-    use pyde_state::smt::{StateAccess, StateOverlay};
 
     let dir = std::env::temp_dir().join(format!("pyde-bench-realistic-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
@@ -454,7 +451,7 @@ fn benchmark_production_block() {
     use pyde_state::smt::StateOverlay;
     use pyde_tx::pipeline::execute_transaction_aot;
     use rayon::prelude::*;
-    use std::sync::Arc;
+    
 
     let dir = std::env::temp_dir().join("pyde-bench-production");
     let _ = std::fs::remove_dir_all(&dir);
@@ -482,9 +479,14 @@ fn benchmark_production_block() {
             gas_tank: 0, key_nonce: 0,
         };
         let key = pyde_state::keys::balance_key(&address);
-        &mut persistent.insert(key, account.to_bytes()).unwrap();
+        persistent.insert(key, account.to_bytes()).unwrap();
         let nonce_key = pyde_state::keys::nonce_key(&address);
-        &mut persistent.insert(nonce_key, pyde_account::nonce::NonceState::new().to_bytes().to_vec()).unwrap();
+        persistent
+            .insert(
+                nonce_key,
+                pyde_account::nonce::NonceState::new().to_bytes().to_vec(),
+            )
+            .unwrap();
         accounts.push((address, 0));
     }
 

--- a/crates/node/tests/contracts.rs
+++ b/crates/node/tests/contracts.rs
@@ -1,5 +1,12 @@
 //! Test contract sources for the production benchmark.
 //! 30+ contracts covering every Otigen feature.
+//!
+//! `#![allow(dead_code)]` — each `tests/*.rs` file is its own binary
+//! crate. Only a subset of these `pub const`s is referenced by any
+//! given test binary; Rust reports the rest as unused. `-D warnings`
+//! in CI would fail without this allow.
+
+#![allow(dead_code)]
 
 // ═══════════════════════════════════════════════════════════════════
 // SIMPLE CONTRACTS (10) — basic patterns, light storage

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -44,6 +44,7 @@ struct BlockMetrics {
     ok_count: usize,
     fail_count: usize,
     exec_ms: f64,
+    #[allow(dead_code)]
     commit_ms: f64,
     sign_ms: f64,
     events: usize,

--- a/crates/node/tests/integration.rs
+++ b/crates/node/tests/integration.rs
@@ -8,7 +8,6 @@
 use pyde_account::address::derive_eoa_address;
 use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 use pyde_state::smt::PydeSMT;
-use pyde_tx::execution::Receipt;
 use pyde_tx::pipeline::{execute_transaction, BlockContext};
 use pyde_tx::types::*;
 
@@ -812,7 +811,7 @@ fn reentrancy_attack_blocked() {
     // on_hook() tries to re-enter Vault.withdraw() — should be BLOCKED by guard
     // The entire tx should revert because the re-entry fails
     let tx = call_tx(sender, attacker_addr, "attack", 100u64.to_le_bytes().to_vec(), 3, &sk);
-    let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+    let _r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
 
     // The re-entry is blocked by the guard. The first withdraw (100) is legit
     // and succeeds. The re-entry attempt from on_hook() fails silently.

--- a/crates/node/tests/lifecycle_bench.rs
+++ b/crates/node/tests/lifecycle_bench.rs
@@ -16,7 +16,6 @@ use pyde_tx::parallel::schedule;
 use pyde_tx::pipeline::execute_transaction;
 use pyde_tx::types::*;
 use rayon::prelude::*;
-use std::collections::HashMap;
 use std::time::Instant;
 
 struct Acct {

--- a/crates/node/tests/loadgen.rs
+++ b/crates/node/tests/loadgen.rs
@@ -265,7 +265,7 @@ fn load_test_full_pipeline() {
 
         // Deploy contracts — submit to ALL nodes for fastest inclusion
         println!("  Deploying {} contracts (to all 4 nodes)...", deploy_txs.len());
-        for (i, dtx) in deploy_txs.iter().enumerate() {
+        for (_i, dtx) in deploy_txs.iter().enumerate() {
             let params = format!("\"{}\"", dtx);
             // Submit to all 4 nodes simultaneously
             for url in &rpc_urls {

--- a/crates/node/tests/production_sigs.rs
+++ b/crates/node/tests/production_sigs.rs
@@ -103,7 +103,7 @@ fn production_chain_id_1_full_lifecycle() {
     }
 
     let mut ok = 0;
-    let mut fail = 0;
+    let fail = 0;
 
     // ── 1. Native transfer (chain_id=1, FALCON sig verified) ─────
     println!("\n  1. Native transfer (chain_id=1, FALCON verified)");
@@ -360,7 +360,7 @@ fn production_chain_id_1_full_lifecycle() {
         sync_nonces(&mut accounts, &smt);
         let to = accounts[8].address;
         let acc = &mut accounts[7];
-        let mut tx = Transaction {
+        let tx = Transaction {
             from: acc.address,
             to,
             value: 1_000,

--- a/crates/node/tests/production_sim.rs
+++ b/crates/node/tests/production_sim.rs
@@ -3,9 +3,9 @@
 //! and diverse workloads. Measures real TPS across the entire pipeline.
 
 use pyde_account::address::derive_eoa_address;
-use pyde_consensus::block::{BlockHeader, QuorumCert, quorum_for_committee};
-use pyde_consensus::hotstuff::{ConsensusState, ConsensusMessage, create_vote, verify_vote, try_form_qc};
-use pyde_crypto::falcon::{falcon_keygen, falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey};
+use pyde_consensus::block::{BlockHeader, QuorumCert};
+use pyde_consensus::hotstuff::{ConsensusState, create_vote, verify_vote, try_form_qc};
+use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey};
 use pyde_crypto::poseidon2::poseidon2_hash;
 use pyde_state::smt::{PersistentSMT, StateAccess, StateOverlay};
 use pyde_tx::parallel::schedule;
@@ -45,6 +45,7 @@ fn compile_single(source: &str) -> Vec<u8> {
 
 /// Compile multi-contract file, return deploy data for the LAST contract
 /// (the one that references earlier contracts via deploy!/at()).
+#[allow(dead_code)]
 fn compile_last(source: &str) -> Vec<u8> {
     let compiled = otic::compile_all(source);
     let (_, c) = compiled.last().unwrap();
@@ -118,6 +119,7 @@ fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
     tx.signature = falcon_sign(sk, &hash).unwrap().as_bytes().to_vec();
 }
 
+#[allow(dead_code)]
 fn deploy_and_get_addr(
     tx: &Transaction,
     smt: &mut dyn StateAccess,

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -81,12 +81,14 @@ pub struct CompiledContract {
 /// Spill event: the CodeGen must emit Store/Load for register pressure.
 enum SpillAction {
     /// Store this physical register to spill slot before reusing it.
+    #[allow(dead_code)]
     Save(u8, u32), // (physical_reg, spill_slot_offset)
 }
 
 /// Restore event: the CodeGen must emit Load to bring a spilled value back.
 enum RestoreAction {
     /// Load from spill slot into this physical register.
+    #[allow(dead_code)]
     Restore(u8, u32), // (physical_reg, spill_slot_offset)
 }
 
@@ -205,6 +207,7 @@ impl RegAlloc {
     }
 
     /// Get the physical register (backward compat — panics on spill).
+    #[allow(dead_code)]
     fn get(&self, vreg: Reg) -> u8 {
         *self.mapping.get(&vreg).unwrap_or(&0)
     }
@@ -1043,10 +1046,6 @@ impl CodeGen {
                         self.emit_op(Opcode::Add, 12, 12, 15);
                     }
                     IrConst::Unit => {}
-                    _ => {
-                        let rd = self.alloc_gp(*dst);
-                        self.emit_op(Opcode::Addi, rd, 0, 0);
-                    }
                 }
             }
 
@@ -1270,7 +1269,7 @@ impl CodeGen {
                 let key_ty = map_key_type(&map_ty);
                 let val_ty = map_value_type(&map_ty);
                 let key_wide = is_wide_type(&key_ty);
-                let wide_value = is_wide_type(&val_ty);
+                let _wide_value = is_wide_type(&val_ty);
 
                 let rk = self.get_reg(*key);
                 self.emit_map_key_derivation(slot, rk, key_wide);
@@ -1584,7 +1583,7 @@ impl CodeGen {
                 self.emit_store(15, 12, 24);
 
                 // Topics 1-3: indexed fields (stored as 32-byte LE values)
-                for (i, (freg, ty, _)) in indexed_fields.iter().enumerate() {
+                for (i, (freg, _ty, _)) in indexed_fields.iter().enumerate() {
                     if i >= 3 { break; }
                     let topic_offset = (1 + i) * 32;
                     if self.regs.is_wide(*freg) {
@@ -3506,6 +3505,7 @@ fn map_key_type(ty: &Ty) -> Ty {
 }
 
 /// Compute byte size of a struct field.
+#[allow(dead_code)]
 fn field_byte_size(ty: &Ty) -> u32 {
     if is_wide_type(ty) {
         memory::WIDE_SIZE
@@ -3544,7 +3544,7 @@ fn serialized_elem_size(ty: &Ty) -> Option<u32> {
 /// Used by emit_flatten/emit_unflatten to decide between bulk Memcpy (fixed) and
 /// per-element loop (variable). Unlike `serialized_elem_size`, this correctly
 /// returns `Some(N*8)` for all-fixed-field structs (enabling bulk copy for Vec<Struct>).
-fn flat_elem_size(ty: &Ty, struct_defs: &HashMap<String, Vec<(String, Ty)>>) -> Option<u32> {
+fn flat_elem_size(ty: &Ty, _struct_defs: &HashMap<String, Vec<(String, Ty)>>) -> Option<u32> {
     match ty {
         Ty::U8
         | Ty::U16
@@ -4876,7 +4876,7 @@ mod tests {
     #[test]
     fn pvm_dispatch_with_calldata() {
         // Test the full dispatch path: selector matching + calldata decode
-        let compiled = compile(
+        let _compiled = compile(
             r#"
             contract T {
                 pub fn add(a: u64, b: u64) -> u64 {
@@ -5895,7 +5895,7 @@ mod tests {
         };
 
         // Helper: create a lazy backend from SMT
-        let load_from_smt = |smt: &pyde_state::smt::PydeSMT,
+        let _load_from_smt = |smt: &pyde_state::smt::PydeSMT,
                              storage: &mut std::collections::HashMap<ethnum::U256, Vec<u8>>,
                              keys: &[ethnum::U256]| {
             for key in keys {

--- a/crates/otic/src/lexer.rs
+++ b/crates/otic/src/lexer.rs
@@ -65,6 +65,7 @@ impl<'a> Lexer<'a> {
         self.src.get(self.pos).copied()
     }
 
+    #[allow(dead_code)]
     fn peek2(&self) -> Option<u8> {
         self.src.get(self.pos + 1).copied()
     }
@@ -420,7 +421,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn lex_attribute(&mut self, start: usize, start_line: u32, start_col: u32) -> TokenKind {
+    fn lex_attribute(&mut self, _start: usize, start_line: u32, start_col: u32) -> TokenKind {
         // Already consumed #[, now read until ]
         let content_start = self.pos;
         let mut depth = 1u32;
@@ -567,7 +568,7 @@ impl<'a> Lexer<'a> {
         TokenKind::IntLiteral(val)
     }
 
-    fn lex_ident_or_keyword(&mut self, first: u8, start: usize) -> TokenKind {
+    fn lex_ident_or_keyword(&mut self, _first: u8, start: usize) -> TokenKind {
         let ident_start = start;
         while let Some(ch) = self.peek() {
             if ch.is_ascii_alphanumeric() || ch == b'_' {

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -9,7 +9,7 @@ use ethnum::U256;
 
 use crate::ast;
 use crate::ast::*;
-use crate::ir::{self, IrProgram, IrFunction, BasicBlock, Label, Reg, Inst, IrConst, BinOp, UnOp, CmpOp, BuiltinOp, StorageFieldDef};
+use crate::ir::{self, IrProgram, IrFunction, Label, Reg, Inst, IrConst, BinOp, UnOp, CmpOp, BuiltinOp, StorageFieldDef};
 use crate::types::Ty;
 
 /// Lower a source file into an IR program.

--- a/crates/otic/src/optimize.rs
+++ b/crates/otic/src/optimize.rs
@@ -13,7 +13,6 @@ use std::collections::{HashMap, HashSet};
 use ethnum::U256;
 
 use crate::ir::*;
-use crate::types::Ty;
 
 /// Run all optimization passes on an IR program.
 pub fn optimize(program: &mut IrProgram) {

--- a/crates/otic/src/parser.rs
+++ b/crates/otic/src/parser.rs
@@ -289,7 +289,7 @@ impl Parser {
         Ok(ModuleDef { name, span: start })
     }
 
-    fn parse_contract(&mut self, attrs: Vec<Attribute>) -> Result<ContractDef, ()> {
+    fn parse_contract(&mut self, _attrs: Vec<Attribute>) -> Result<ContractDef, ()> {
         let start = self.peek_span();
         self.expect(&TokenKind::Contract)?;
         let name = self.expect_ident()?;
@@ -1193,7 +1193,7 @@ impl Parser {
     /// vs a block (`{ stmt; ... }`)? Look ahead for `ident :`.
     fn looks_like_struct_init(&self) -> bool {
         // Look at tokens after `{`: if we see `ident :` it's struct init
-        let mut i = self.pos + 1; // skip the `{`
+        let i = self.pos + 1; // skip the `{`
         if let Some(tok) = self.tokens.get(i) {
             if matches!(tok.kind, TokenKind::Ident(_)) {
                 if let Some(next) = self.tokens.get(i + 1) {
@@ -1335,7 +1335,7 @@ impl Parser {
                 // Check for range pattern: `100..200`
                 if self.at(&TokenKind::DotDot) {
                     self.advance(); // eat ..
-                    let end_span = self.peek_span();
+                    let _end_span = self.peek_span();
                     match self.peek().clone() {
                         TokenKind::IntLiteral(end_v) => {
                             self.advance();

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -92,6 +92,7 @@ pub struct Symbol {
 #[derive(Clone, Debug)]
 struct Scope {
     symbols: HashMap<String, Symbol>,
+    #[allow(dead_code)]
     kind: ScopeKind,
 }
 
@@ -854,7 +855,7 @@ impl Resolver {
                 }
             }
 
-            Expr::Path(segments, span) => {
+            Expr::Path(segments, _span) => {
                 // First segment should be a known name
                 if let Some(first) = segments.first() {
                     if self.lookup(&first.name).is_none()
@@ -877,7 +878,7 @@ impl Resolver {
                 }
             }
 
-            Expr::MacroCall(name, args, span) => {
+            Expr::MacroCall(name, args, _span) => {
                 // Built-in macros: require!, revert!, cross_call!, raw_call!
                 let known_macros = ["require", "revert", "assert", "cross_call", "raw_call", "create", "deploy"];
                 if !known_macros.contains(&name.name.as_str()) {
@@ -894,7 +895,7 @@ impl Resolver {
                 }
             }
 
-            Expr::StructInit(name_segments, fields, span) => {
+            Expr::StructInit(name_segments, fields, _span) => {
                 // Verify the struct/error name exists
                 if let Some(first) = name_segments.first() {
                     if !self.is_type_defined(&first.name)
@@ -964,7 +965,7 @@ impl Resolver {
 
     fn resolve_pattern(&mut self, pattern: &Pattern) {
         match pattern {
-            Pattern::Path(segments, span) => {
+            Pattern::Path(segments, _span) => {
                 // Verify enum variant path exists (e.g., Status::Active)
                 if segments.len() >= 2 {
                     let qualified = segments.iter()

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -206,7 +206,7 @@ impl SafetyChecker {
     fn check_function_attrs(&mut self, func: &FunctionDef) {
         let mut has_constructor = false;
         let mut has_view = false;
-        let mut has_sponsored = false;
+        let mut _has_sponsored = false; // TODO see note at "sponsored" arm below
         let mut has_reentrant = false;
         let mut has_payable = false;
         let mut has_test = false;
@@ -236,7 +236,15 @@ impl SafetyChecker {
                     has_view = true;
                 }
                 "sponsored" => {
-                    has_sponsored = true;
+                    // TODO(post-slice-5.4): #[sponsored] has no conflict-
+                    // detection below (unlike every other attribute here).
+                    // Determining which attributes conflict with #[sponsored]
+                    // requires a design decision, not a style fix — leaving
+                    // the assignment live so `cargo fix` doesn't silently
+                    // drop it. Likely candidates to forbid: #[view] (view
+                    // functions read state and don't consume gas),
+                    // #[constructor] (constructors run once at deploy).
+                    _has_sponsored = true;
                 }
                 "reentrant" => {
                     has_reentrant = true;
@@ -851,7 +859,7 @@ impl SafetyChecker {
         }
     }
 
-    fn scan_expr_cross_calls(&mut self, expr: &Expr, span: Span) {
+    fn scan_expr_cross_calls(&mut self, expr: &Expr, _span: Span) {
         match expr {
             Expr::MacroCall(name, args, macro_span) => {
                 if name.name == "cross_call" {

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -177,8 +177,9 @@ impl TypeChecker {
             // Unknown/Error declared type accepts anything
             (_, Ty::Unknown) | (_, Ty::Error) => true,
             (Ty::Unknown, _) | (Ty::Error, _) => true,
-            // Struct inferred matches unknown declared
-            (Ty::Struct(_), Ty::Unknown) => true,
+            // NB: `(Ty::Struct(_), Ty::Unknown)` used to live here but
+            // is already subsumed by `(_, Ty::Unknown)` above — leaving
+            // it caused a `#[warn(unreachable_patterns)]`.
             _ => false,
         }
     }
@@ -990,7 +991,7 @@ impl TypeChecker {
                 }
             }
 
-            Expr::Call(callee, args, call_value, span) => {
+            Expr::Call(callee, args, _call_value, span) => {
                 // Infer all argument types
                 let arg_types: Vec<Ty> = args.iter().map(|arg| self.infer_expr(arg)).collect();
 
@@ -1381,7 +1382,7 @@ impl TypeChecker {
                 }
             }
 
-            Expr::StructInit(name_segments, fields, span) => {
+            Expr::StructInit(name_segments, fields, _span) => {
                 let struct_name = name_segments.first().map(|s| s.name.as_str()).unwrap_or("");
 
                 // Check if it's a struct init or error init

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -404,6 +404,7 @@ impl Vm {
     }
 
     /// Fetch the instruction at the current PC.
+    #[allow(dead_code)]
     fn fetch(&self) -> Result<Instruction, Trap> {
         self.check_pc_bounds()?;
         let addr = crate::memory::CODE_START + self.pc;
@@ -818,7 +819,7 @@ impl Vm {
                     if let Some(ref backend) = self.storage_backend {
                         let val = backend(&key);
                         // Cache in overlay for future reads
-                        if let Some(ref v) = val {
+                        if let Some(ref _v) = val {
                             // Can't borrow self.storage mutably here, cache after match
                         }
                         val
@@ -3710,6 +3711,7 @@ mod tests {
     // --- M1.13: Contract Call Instruction tests ---
 
     /// Helper: create a VM with a contract registry containing the given contracts.
+    #[allow(dead_code)]
     fn vm_with_contracts(contracts: Vec<(Address, Vec<u8>)>) -> Vm {
         let mut vm = Vm::new();
         for (a, code) in contracts {
@@ -4022,7 +4024,7 @@ mod tests {
 
     #[test]
     fn calldata_readable_via_load_instruction() {
-        let heap = crate::memory::HEAP_START;
+        let _heap = crate::memory::HEAP_START;
         let mut vm = Vm::new();
         // Calldata: 8 bytes representing u64 value 42
         vm.calldata = 42u64.to_le_bytes().to_vec();

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -42,6 +42,7 @@ pub struct ModuleExports {
 
 impl ModuleExports {
     /// Check if a name is exported by this module.
+    #[allow(dead_code)]
     pub fn has(&self, name: &str) -> bool {
         self.contracts.iter().any(|n| n == name)
             || self.interfaces.iter().any(|n| n == name)
@@ -257,7 +258,7 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     let mut compiled_registry: HashMap<String, Vec<u8>> = HashMap::new();
     let mut contract_functions: HashMap<String, Vec<FnSig>> = HashMap::new();
     let mut contract_constructors: HashMap<String, Vec<(String, otic::types::Ty)>> = HashMap::new();
-    let mut module_exports: HashMap<String, ModuleExports> = HashMap::new();
+    let module_exports: HashMap<String, ModuleExports> = HashMap::new();
     let mut result = BuildResult {
         contracts: Vec::new(),
         total_bytecode: 0,

--- a/crates/pyde-dev/src/doc.rs
+++ b/crates/pyde-dev/src/doc.rs
@@ -9,7 +9,6 @@
 
 use crate::project;
 use std::fs;
-use std::path::Path;
 
 pub fn run() -> Result<(), String> {
     let (config, root) = project::load_config()?;

--- a/crates/pyde-dev/src/fmt.rs
+++ b/crates/pyde-dev/src/fmt.rs
@@ -13,7 +13,6 @@
 
 use crate::project;
 use std::fs;
-use std::path::Path;
 
 pub fn run() -> Result<(), String> {
     let (config, root) = project::load_config()?;

--- a/crates/pyde-dev/src/install.rs
+++ b/crates/pyde-dev/src/install.rs
@@ -97,7 +97,7 @@ fn install_package(
         .unwrap_or_else(|| rev.unwrap_or("main").to_string());
 
     // Conflict detection
-    if let Some((existing_git, existing_rev)) = versions.get(pkg_name) {
+    if let Some((_existing_git, existing_rev)) = versions.get(pkg_name) {
         if existing_rev != &pinned_rev {
             let _ = fs::remove_dir_all(&pkg_dir);
             return Err(format!(

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -281,7 +281,7 @@ fn execute_with_rpc_bridge(
 ) -> Result<Outcome, String> {
     vm.clear_journal();
     let client = reqwest::blocking::Client::new();
-    let zero_addr = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    let _zero_addr = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
     loop {
         let idx = (vm.pc / 4) as usize;

--- a/crates/pyde-dev/src/signer.rs
+++ b/crates/pyde-dev/src/signer.rs
@@ -16,6 +16,7 @@ use pyde_tx::types::Transaction;
 
 pub struct Signer {
     pub address: [u8; 32],
+    #[allow(dead_code)]
     pub public_key: FalconPublicKey,
     pub secret_key: FalconSecretKey,
 }

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -42,6 +42,7 @@ pub fn run(filter: Option<&str>, verbosity: u8) -> Result<(), String> {
 
     // Gas profiling: collect per-test gas usage for summary
     struct GasEntry {
+        #[allow(dead_code)]
         file: String,
         test_name: String,
         gas_used: u64,

--- a/crates/pyde-dev/src/trace.rs
+++ b/crates/pyde-dev/src/trace.rs
@@ -50,6 +50,7 @@ pub enum TraceEvent {
         /// Target contract address (32 bytes).
         target: [u8; 32],
         /// Function selector (4 bytes).
+        #[allow(dead_code)]
         selector: u32,
         /// Function name (resolved from selector, or "unknown").
         function_name: String,
@@ -110,6 +111,7 @@ pub enum TraceEvent {
     /// Revert with error data.
     Revert {
         /// Error selector (first 4 bytes of revert data).
+        #[allow(dead_code)]
         error_selector: Option<u32>,
         /// Error name (resolved).
         error_name: Option<String>,
@@ -122,6 +124,7 @@ pub enum TraceEvent {
 #[derive(Clone, Debug)]
 pub struct ExecutionTrace {
     pub events: Vec<TraceEvent>,
+    #[allow(dead_code)]
     pub depth: u32,
 }
 
@@ -137,14 +140,17 @@ impl ExecutionTrace {
         self.events.push(event);
     }
 
+    #[allow(dead_code)]
     pub fn enter_call(&mut self) {
         self.depth += 1;
     }
 
+    #[allow(dead_code)]
     pub fn exit_call(&mut self) {
         self.depth = self.depth.saturating_sub(1);
     }
 
+    #[allow(dead_code)]
     pub fn current_depth(&self) -> u32 {
         self.depth
     }

--- a/crates/pyde-dev/src/wallet.rs
+++ b/crates/pyde-dev/src/wallet.rs
@@ -5,7 +5,7 @@ use aes_gcm::{
 use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconSecretKey, FalconPublicKey};
 use pyde_crypto::poseidon2::poseidon2_hash;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const WALLET_DIR: &str = ".pyde/wallets";
 const KEYSTORE_VERSION: u32 = 1;
@@ -23,6 +23,7 @@ pub struct Keystore {
 
 /// Decrypted wallet ready for signing.
 pub struct Wallet {
+    #[allow(dead_code)]
     pub name: String,
     pub address: [u8; 32],
     pub public_key: FalconPublicKey,
@@ -62,11 +63,12 @@ pub fn create(name: &str, password: &str) -> Result<Wallet, String> {
 }
 
 /// Import an existing secret key.
-pub fn import(name: &str, sk_hex: &str, password: &str) -> Result<Wallet, String> {
+#[allow(dead_code)]
+pub fn import(_name: &str, sk_hex: &str, _password: &str) -> Result<Wallet, String> {
     let sk_bytes = hex::decode(sk_hex.trim_start_matches("0x"))
         .map_err(|e| format!("invalid secret key hex: {}", e))?;
 
-    let sk = FalconSecretKey::from_bytes(&sk_bytes)
+    let _sk = FalconSecretKey::from_bytes(&sk_bytes)
         .ok_or("invalid FALCON-512 secret key (expected 1281 bytes)")?;
 
     // Derive public key by signing a test message and... we can't derive pk from sk directly.
@@ -295,6 +297,7 @@ pub fn prompt_password(prompt: &str) -> Result<String, String> {
 
 /// Load a wallet by name, prompt for password, return the address hex.
 /// Used by deploy/script/console when --wallet is specified.
+#[allow(dead_code)]
 pub fn resolve_wallet_address(name: &str) -> Result<String, String> {
     let password = prompt_password("  Enter wallet password: ")?;
     let w = load(name, &password)?;

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -734,7 +734,9 @@ impl<'a> Contract<'a> {
 /// Standalone ABI encoder/decoder (no contract address or provider needed).
 pub struct Interface {
     functions: HashMap<String, AbiFunction>,
+    #[allow(dead_code)]
     events: HashMap<String, AbiEvent>,
+    #[allow(dead_code)]
     events_by_topic: HashMap<String, AbiEvent>,
     structs: HashMap<String, AbiStructDef>,
     enums: HashMap<String, AbiEnumDef>,

--- a/crates/pyde-rust-sdk/src/contract.rs
+++ b/crates/pyde-rust-sdk/src/contract.rs
@@ -540,7 +540,7 @@ mod tests {
         assert_eq!(decode_bool(&1u64.to_le_bytes()), Some(true));
         assert_eq!(decode_bool(&0u64.to_le_bytes()), Some(false));
 
-        let mut addr = [0xAA; 32];
+        let addr = [0xAA; 32];
         assert_eq!(decode_address(&addr), Some(addr));
     }
 

--- a/crates/pyde-rust-sdk/tests/live_test.rs
+++ b/crates/pyde-rust-sdk/tests/live_test.rs
@@ -52,17 +52,19 @@ async fn g01_provider_basics() {
     assert!(fee.gas_price > 0);
     assert!(fee.base_fee > 0);
 
-    // getBlockByNumber — try recent blocks (RPC may error on missing slots)
+    // getBlockByNumber — try recent blocks (RPC may error on missing slots).
+    // Result is not asserted: in-memory nodes may only retain a recent window,
+    // so a "no block found" result is valid. We're just exercising the RPC
+    // path. The meaningful assertion is that `get_block_number` itself
+    // returned a positive slot (checked below).
     let current = p.get_block_number().await.unwrap();
-    let mut found_block = false;
     for slot in (1..=current).rev().take(10) {
         match p.get_block_by_number(slot).await {
-            Ok(Some(_)) => { found_block = true; break; }
+            Ok(Some(_)) => break,
             Ok(None) => continue,
             Err(_) => continue, // block not stored in memory
         }
     }
-    // Block store may be empty for in-memory nodes that only store recent blocks
     assert!(current > 0, "node should have produced blocks (block_number={})", current);
 
     println!("[PASS] Group 1: Provider Basics (7/7)");

--- a/crates/state/src/tiers.rs
+++ b/crates/state/src/tiers.rs
@@ -7,11 +7,11 @@
 //! Keys are promoted on access (cold → warm → hot) and demoted when
 //! not accessed for a configurable number of blocks.
 
-use crate::smt::{Key, SmtValue};
+use crate::smt::SmtValue;
 use sparse_merkle_tree::traits::{StoreReadOps, StoreWriteOps};
 use sparse_merkle_tree::{BranchKey, BranchNode, H256};
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// Configuration for tier demotion.
 const DEFAULT_HOT_EVICT_BLOCKS: u64 = 128;
@@ -318,11 +318,11 @@ mod tests {
 
     #[test]
     fn reads_promote_to_hot() {
-        let mut warm = InMemoryBackend::new();
+        let _warm = InMemoryBackend::new();
         // Pre-populate warm tier
         let key = key_from_seed(1);
         let val = SmtValue(b"warm_data".to_vec());
-        let leaf_key = val.to_h256();
+        let _leaf_key = val.to_h256();
 
         // We need to write through a real SMT to populate correctly
         let mut warm_smt = SMT::new(H256::zero(), InMemoryBackend::new());

--- a/crates/state/src/versioning.rs
+++ b/crates/state/src/versioning.rs
@@ -264,7 +264,7 @@ mod tests {
         assert_eq!(vs.height, 3);
 
         // Undo 2 blocks
-        let root = vs.undo_blocks(2).unwrap().unwrap();
+        let _root = vs.undo_blocks(2).unwrap().unwrap();
         assert_eq!(vs.height, 1);
         assert_eq!(vs.get(&k1), Some(b"a".to_vec()));
         assert_eq!(vs.get(&k2), None);

--- a/crates/tx/src/access_infer.rs
+++ b/crates/tx/src/access_infer.rs
@@ -3,7 +3,7 @@
 //! without requiring users to manually declare access lists.
 
 use crate::types::{AccessEntry, Transaction};
-use pyde_state::smt::{Key, StateAccess};
+use pyde_state::smt::StateAccess;
 
 /// Simulate a transaction to discover which storage keys it reads/writes.
 /// Returns a list of AccessEntry with the discovered keys.
@@ -31,7 +31,7 @@ pub fn infer_access_list(
     };
 
     // Load sender account for simulation
-    let sender = match state.get(&pyde_state::keys::balance_key(&tx.from)) {
+    let _sender = match state.get(&pyde_state::keys::balance_key(&tx.from)) {
         Some(bytes) => match pyde_account::types::Account::from_bytes(&bytes) {
             Some(a) => a,
             None => return vec![],

--- a/crates/tx/src/execution.rs
+++ b/crates/tx/src/execution.rs
@@ -9,10 +9,8 @@
 //! 5. Fee distribution: 70% burn, 20% validator, 10% treasury
 //! 6. Generate receipt
 
-use crate::types::{FeePayer, Transaction, TransactionType};
-use pyde_account::address::{Address, ZERO_ADDRESS};
-use pyde_account::types::Account;
-use pyde_crypto::poseidon2::poseidon2_hash;
+use crate::types::{FeePayer, Transaction};
+use pyde_account::address::Address;
 use sparse_merkle_tree::H256;
 
 /// Fee distribution ratios (percentages).
@@ -215,7 +213,7 @@ pub fn generate_receipt(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{AccessEntry, TransactionType};
+    use crate::types::TransactionType;
     use pyde_account::address::derive_eoa_address;
 
     fn make_tx(value: u128, gas_limit: u64) -> Transaction {

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -15,7 +15,6 @@ use crate::execution::{
     distribute_fee, generate_receipt, post_execution_refund, pre_execution_charge, transfer_value,
     LogEntry, Receipt,
 };
-use crate::fee::adjust_base_fee;
 use crate::types::{FeePayer, Transaction, TransactionType};
 use crate::validation::{validate_transaction, ValidationContext, ValidationError};
 
@@ -24,8 +23,7 @@ use pyde_account::nonce::NonceState;
 use pyde_account::types::Account;
 use pyde_crypto::poseidon2::poseidon2_hash;
 use pyde_state::keys;
-use pyde_state::smt::{Key, PydeSMT};
-use pyde_vm::vm::{ExecResult, ExecutionContext, Outcome, Vm};
+use pyde_vm::vm::{ExecutionContext, Outcome, Vm};
 use pyde_vm::wide::U256;
 use sparse_merkle_tree::H256;
 
@@ -270,7 +268,7 @@ fn execute_transaction_inner(
             // Increment sender nonce so the next deploy gets a different address
             sender.nonce += 1;
 
-            let (runtime_code, gas_used) = if tx.data.len() >= 8 {
+            let (_runtime_code, gas_used) = if tx.data.len() >= 8 {
                 let mut clen_bytes = [0u8; 4];
                 clen_bytes.copy_from_slice(&tx.data[..4]);
                 let constructor_len = u32::from_le_bytes(clen_bytes) as usize;
@@ -321,7 +319,7 @@ fn execute_transaction_inner(
                         contract = hex::encode(new_addr),
                         "executing constructor"
                     );
-                    let (success, gas, _, logs, _) =
+                    let (success, gas, _, _logs, _) =
                         execute_in_pvm(&constructor_tx, &sender, constructor, smt, block_ctx, None);
                     if !success {
                         tracing::warn!(gas, "constructor execution failed (reverted or trapped)");
@@ -524,7 +522,7 @@ fn execute_transaction_inner(
             let val_key = pyde_state::keys::validator_key(&tx.from);
             match smt.get(&val_key) {
                 Some(val_data) => match ValidatorEntry::decode(&val_data) {
-                    Some(mut entry) if entry.status == 0x02 => (
+                    Some(entry) if entry.status == 0x02 => (
                         false,
                         21_000u64,
                         0u64,
@@ -632,7 +630,7 @@ fn execute_transaction_inner(
 /// If `aot_fn` is provided, runs native compiled code instead of the interpreter.
 fn execute_in_pvm(
     tx: &Transaction,
-    sender: &Account,
+    _sender: &Account,
     code: &[u8],
     smt: &mut dyn pyde_state::smt::StateAccess,
     block_ctx: &BlockContext,
@@ -672,7 +670,7 @@ fn execute_in_pvm(
     // During execution, state is only read (writes go to vm.storage overlay).
     // SAFETY: smt is not mutated during vm.execute(). The pointer is valid for
     // the duration of execute_in_pvm. The closure is dropped before smt is mutated again.
-    let smt_ptr = smt as *const dyn pyde_state::smt::StateAccess as *const () as usize;
+    let _smt_ptr = smt as *const dyn pyde_state::smt::StateAccess as *const () as usize;
     let smt_vtable =
         unsafe { std::mem::transmute::<&dyn pyde_state::smt::StateAccess, [usize; 2]>(smt) };
     vm.storage_backend = Some(std::sync::Arc::new(move |key: &U256| {
@@ -696,7 +694,7 @@ fn execute_in_pvm(
     ));
 
     // Try AOT compiled native code first, fall back to interpreter on failure.
-    let (success, gas_used_raw) = if let Some(func) = aot_fn {
+    let (success, _gas_used_raw) = if let Some(func) = aot_fn {
         if vm.load(code).is_err() {
             return (false, tx.gas_limit, 0, vec![], vec![]);
         }
@@ -2194,6 +2192,7 @@ mod tests {
     use super::*;
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+    use pyde_state::smt::PydeSMT;
 
     fn make_block_ctx() -> BlockContext {
         BlockContext {
@@ -2466,7 +2465,7 @@ mod tests {
 
         // Create sender account with huge balance
         let sender_addr = [0x01u8; 32];
-        let mut sender = Account {
+        let sender = Account {
             address: sender_addr,
             nonce: 0,
             balance: 10_000_000_000_000_000_000u128,
@@ -2557,8 +2556,8 @@ mod tests {
             vm.cpu.read_gp(1)
         };
 
-        let enc_u64 = |v: u64| -> Vec<u8> { v.to_le_bytes().to_vec() };
-        let mut cd = |name: &str, args: &[u64]| -> Vec<u8> {
+        let _enc_u64 = |v: u64| -> Vec<u8> { v.to_le_bytes().to_vec() };
+        let cd = |name: &str, args: &[u64]| -> Vec<u8> {
             let mut data = sel(name).to_be_bytes().to_vec();
             for a in args {
                 data.extend_from_slice(&a.to_le_bytes());

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn wrong_key_fails_verification() {
-        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (_pk1, sk1) = falcon_keygen().unwrap();
         let (pk2, _sk2) = falcon_keygen().unwrap();
         let mut tx = make_test_tx();
 

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -272,7 +272,7 @@ mod tests {
     use super::*;
     use crate::types::{AccessEntry, FeePayer, TransactionType};
     use pyde_account::address::{derive_eoa_address, ZERO_ADDRESS};
-    use pyde_account::types::{Account, AuthKeys};
+    use pyde_account::types::Account;
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 
     fn make_valid_tx_and_account() -> (Transaction, Account, NonceState) {
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn nonce_outside_window_rejected() {
-        let (mut tx, account, nonce) = make_valid_tx_and_account();
+        let (mut tx, _account, nonce) = make_valid_tx_and_account();
         tx.nonce = 100; // way outside [0, 15]
         // Re-sign with correct hash
         let (pk, sk) = falcon_keygen().unwrap();
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn future_deadline_passes() {
-        let (tx, account, nonce) = make_valid_tx_and_account();
+        let (tx, _account, _nonce) = make_valid_tx_and_account();
         let mut tx = tx;
         // Need to re-sign with deadline
         let (pk, sk) = falcon_keygen().unwrap();
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn gas_limit_too_low_rejected() {
-        let (mut tx, account, nonce) = make_valid_tx_and_account();
+        let (mut tx, _account, _nonce) = make_valid_tx_and_account();
         tx.gas_limit = 1_000; // below 21,000 minimum
         let ctx = default_ctx();
         // Skip sig check — gas limit is checked before execution

--- a/crates/tx/tests/common/mod.rs
+++ b/crates/tx/tests/common/mod.rs
@@ -5,6 +5,13 @@
 //! once per test binary via `OnceLock` and let strategies pick from
 //! the pool by index. This keeps a 256-case proptest suite under a
 //! second instead of minutes.
+//!
+//! `#![allow(dead_code)]` because each `tests/*.rs` file is its own
+//! binary crate and only uses a subset of the helpers; Rust reports
+//! everything else as dead per-binary, which makes `-D warnings` in
+//! CI impossible without this allow.
+
+#![allow(dead_code)]
 
 use pyde_account::address::{derive_eoa_address, Address};
 use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey};

--- a/crates/tx/tests/prop_integration_conservation.rs
+++ b/crates/tx/tests/prop_integration_conservation.rs
@@ -20,7 +20,7 @@ mod common;
 
 use common::*;
 use proptest::prelude::*;
-use pyde_account::address::{derive_eoa_address, Address};
+use pyde_account::address::Address;
 use pyde_state::smt::PydeSMT;
 use pyde_tx::pipeline::{execute_transaction, load_account};
 use pyde_tx::types::{FeePayer, Transaction, TransactionType};


### PR DESCRIPTION
## Summary

Drives workspace rustc warnings from **251 → 1** (the lone remainder is a `[profile.release]` in `pyde-crypto-wasm/Cargo.toml` that cargo ignores in workspace context — emitted by cargo itself, not rustc, so it won't trip `-D warnings` in CI).

First half of the CI-enforcement track. Clippy has a separate ~121 warnings; slice 5.5 will handle that. Task 048 (`cargo clippy -- -D warnings` in CI) lands after both are green.

## Real bugs the sweep surfaced

Worth noting as audit-trail:

- **`otic/src/safety.rs`** — `has_sponsored` flag assigned but never read. Every other `has_*` flag has conflict-detection rules (view+reentrant, constructor+test, etc.); `#[sponsored]` was added without any. Conservative fix: renamed to `_has_sponsored` with inline TODO. Fixing correctly is a language-design decision (likely forbid `#[sponsored]` with `#[view]` and `#[constructor]`) not a style fix.
- **`otic/src/typecheck.rs`** — `(Ty::Struct(_), Ty::Unknown)` arm was dead (subsumed by `(_, Ty::Unknown)` above). Removed.
- **`otic/src/codegen.rs::lower_const`** — unreachable `_ => {...}` arm after exhaustive match on 6-variant `IrConst`. Removed.
- **`block_processor.rs`** — `cache.clone().clone()` anti-pattern (first clone returned `&Arc<T>`, second actually cloned). Replaced with `Arc::clone(cache)`.
- **`node/tests/benchmark.rs`** — `&mut persistent.insert(...).unwrap()` took a pointless mut-borrow of `()`. Simplified.
- **`pyde-rust-sdk/tests/live_test.rs::g01_provider_basics`** — `found_block` was set in a loop but never checked; assertion only validated `current > 0`. Dead write removed; block-probe loop retained.

## Cleanup breakdown

| Category | Count | How |
|---|---|---|
| unused imports / unused vars / unneeded mut | ~170 | `cargo fix --workspace` (twice) |
| fn-parameter unused-variable | ~54 | Python script parses `--message-format=json`, adds `_` prefix per var |
| Dead code (methods/fields/fns/variants never used) | ~60 | Same script, inserts `#[allow(dead_code)]` per site |
| Test-binary shared helpers | N/A | Module-level `#![allow(dead_code)]` on `tests/common/mod.rs` + `tests/contracts.rs` with a comment explaining Rust's per-binary integration-test model |

## Test-module import repairs

`cargo fix` removed library-level `use PydeSMT`, `use Address`, `use BlockHeader`, `use QuorumCert`, `use KeyShare` because the library itself didn't use them — but the module's test submodules inherited them via `use super::*`. Re-added inside the affected test modules: `pipeline.rs`, `decryption.rs`, `encrypted.rs`, `slashing.rs`, `chain.rs`.

## Stats

- **70 files modified**, +210 / -141 lines
- **Workspace tests: 2322 passed, 0 failed** (unchanged from pre-5.4)

## Follow-ups

- **Slice 5.5** — clippy sweep (same methodology, ~121 warnings)
- **Slice 5.6** — task 048: `cargo clippy -- -D warnings` in CI (trivial once 5.5 lands)
- **Flagged TODO in `otic/safety.rs`** — ratify `#[sponsored]` conflict rules