### PR TITLE
chore: clippy cleanup sweep — 121+38 warnings/errors → 0 (slice 5.5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,33 @@ members = [
     "crates/pyde-crypto-wasm",
 ]
 
+# Workspace-wide clippy lint configuration (slice 5.5).
+#
+# Each member crate picks these up via `[lints] workspace = true` in its
+# own Cargo.toml. The rationale for each allow:
+#
+# - `too_many_arguments`: consensus/pipeline functions naturally carry 8-12
+#   primitive args (slot + base_fee + chain_id + validator + ...). Packing
+#   into a struct adds indirection without improving readability.
+#
+# - `needless_range_loop`: crypto polynomial / share math (`for i in 0..N
+#   { arr[i] = ... }`) reads more cleanly than `iter_mut().enumerate()`
+#   when the domain is fixed-size and multiple arrays share the index.
+#
+# - `type_complexity`: compiler + VM internals pass around nested generics
+#   where the shape IS the documentation; aliasing would add names to
+#   learn without improving readability.
+#
+# - `doc_lazy_continuation` / `empty_line_after_doc_comments`: doc-format
+#   style preferences that vary between projects; ours aligns with the
+#   existing codebase rather than clippy's current defaults.
+[workspace.lints.clippy]
+too_many_arguments = "allow"
+needless_range_loop = "allow"
+type_complexity = "allow"
+doc_lazy_continuation = "allow"
+empty_line_after_doc_comments = "allow"
+
 # ── Release profile: maximum performance ──────────────────────────────
 [profile.release]
 opt-level = 3

--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 pyde-crypto = { path = "../crypto" }
 pyde-state = { path = "../state" }
 sparse-merkle-tree = "0.6"
+
+[lints]
+workspace = true

--- a/crates/account/src/auth.rs
+++ b/crates/account/src/auth.rs
@@ -193,7 +193,7 @@ mod tests {
         let (pk2, sk2) = falcon_keygen().unwrap();
         let (pk3, _sk3) = falcon_keygen().unwrap();
 
-        let mut account = Account::new_eoa(&pk1.as_bytes().to_vec());
+        let mut account = Account::new_eoa(pk1.as_bytes());
         account.auth_keys = AuthKeys::MultiSig {
             keys: vec![pk1.as_bytes().to_vec(), pk2.as_bytes().to_vec(), pk3.as_bytes().to_vec()],
             threshold: 2,
@@ -214,7 +214,7 @@ mod tests {
         let (pk2, _sk2) = falcon_keygen().unwrap();
         let (pk3, _sk3) = falcon_keygen().unwrap();
 
-        let mut account = Account::new_eoa(&pk1.as_bytes().to_vec());
+        let mut account = Account::new_eoa(pk1.as_bytes());
         account.auth_keys = AuthKeys::MultiSig {
             keys: vec![pk1.as_bytes().to_vec(), pk2.as_bytes().to_vec(), pk3.as_bytes().to_vec()],
             threshold: 2,

--- a/crates/aot/Cargo.toml
+++ b/crates/aot/Cargo.toml
@@ -21,3 +21,6 @@ ethnum = "1"
 [[bench]]
 name = "aot_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -3,6 +3,22 @@
 //! These functions bridge between native code and VM state (memory, storage,
 //! crypto, events). The AOT code receives an opaque `*mut VmContext` pointer
 //! and calls these functions for any operation that touches VM state.
+//!
+//! ## Pointer safety contract
+//!
+//! Every function here is `extern "C"` and takes `*mut VmCtx` as its first
+//! argument. The pointer comes from the AOT JIT (`aot/src/codegen.rs`),
+//! which emits call-site code that loads a live `&mut Vm` address into the
+//! platform ABI's first register.
+//!
+//! Clippy's `not_unsafe_ptr_arg_deref` is correct in principle — these
+//! functions ARE unsafe to call with an invalid pointer. Marking every
+//! signature `unsafe extern "C" fn` would force matching `unsafe { }` blocks
+//! at every JIT emission site, which is purely ergonomic friction (the
+//! generated assembly already dereferences the pointer unconditionally).
+//! Reviewers of this module should verify the JIT's callsite emission
+//! whenever host signatures change.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use pyde_vm::vm::Vm;
 use pyde_vm::wide::U256;
@@ -539,8 +555,8 @@ pub extern "C" fn host_memcpy(ctx: *mut VmCtx, dst: u64, src: u64, len: u64) -> 
 pub extern "C" fn host_sync_gp_to_vm(ctx: *mut VmCtx, regs_ptr: *const u64) {
     let vm = unsafe { &mut *ctx };
     let regs = unsafe { std::slice::from_raw_parts(regs_ptr, 16) };
-    for i in 0..16 {
-        vm.cpu.write_gp(i as u8, regs[i]);
+    for (i, r) in regs.iter().enumerate() {
+        vm.cpu.write_gp(i as u8, *r);
     }
 }
 
@@ -549,8 +565,8 @@ pub extern "C" fn host_sync_gp_to_vm(ctx: *mut VmCtx, regs_ptr: *const u64) {
 pub extern "C" fn host_sync_gp_from_vm(ctx: *mut VmCtx, regs_ptr: *mut u64) {
     let vm = unsafe { &mut *ctx };
     let regs = unsafe { std::slice::from_raw_parts_mut(regs_ptr, 16) };
-    for i in 0..16 {
-        regs[i] = vm.cpu.read_gp(i as u8);
+    for (i, r) in regs.iter_mut().enumerate() {
+        *r = vm.cpu.read_gp(i as u8);
     }
 }
 

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -9,3 +9,6 @@ pyde-account = { path = "../account" }
 pyde-tx = { path = "../tx" }
 pyde-slashing = { path = "../slashing" }
 sparse-merkle-tree = "0.6"
+
+[lints]
+workspace = true

--- a/crates/consensus/src/block.rs
+++ b/crates/consensus/src/block.rs
@@ -25,7 +25,7 @@ pub fn quorum_for_committee(committee_size: usize) -> usize {
         return 0;
     }
     // ceil(2/3 * n) = (2*n + 2) / 3
-    (2 * committee_size + 2) / 3
+    (2 * committee_size).div_ceil(3)
 }
 
 /// Blocks per epoch (~1000 blocks, ~6.6 minutes at 400ms).
@@ -260,6 +260,11 @@ pub fn genesis_block(
 }
 
 #[cfg(test)]
+// `cloned_ref_to_slice_refs` — tests build 1-element `&[tx.clone()]`
+// slices for determinism assertions. The clone is harmless here and
+// the `std::slice::from_ref(&tx)` rewrite makes each call site noisier
+// without test-level benefit.
+#[allow(clippy::cloned_ref_to_slice_refs)]
 mod tests {
     use super::*;
     use pyde_account::address::derive_eoa_address;
@@ -414,6 +419,7 @@ mod tests {
     // ========== Epoch ==========
 
     #[test]
+    #[allow(clippy::erasing_op)] // `0 / EPOCH_LENGTH` is deliberate — the test's point is "genesis slot = epoch 0"
     fn epoch_from_slot() {
         assert_eq!(0 / EPOCH_LENGTH, 0);
         assert_eq!(999 / EPOCH_LENGTH, 0);

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -303,6 +303,9 @@ pub fn create_timeout(
 }
 
 #[cfg(test)]
+// Same test-module rationale as `block.rs` — keep `&[tx.clone()]`
+// idiom for 1-element slice assertions rather than `from_ref` rewrite.
+#[allow(clippy::cloned_ref_to_slice_refs)]
 mod tests {
     use super::*;
     use crate::block::QuorumCert;

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -26,3 +26,6 @@ harness = false
 [[bench]]
 name = "vrf_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/crypto/src/poseidon2.rs
+++ b/crates/crypto/src/poseidon2.rs
@@ -65,7 +65,7 @@ fn bytes_to_elements(data: &[u8]) -> Vec<Goldilocks> {
     if data.is_empty() {
         return vec![Goldilocks::ZERO];
     }
-    let mut elements = Vec::with_capacity((data.len() + CHUNK - 1) / CHUNK + 1);
+    let mut elements = Vec::with_capacity(data.len().div_ceil(CHUNK) + 1);
     for chunk in data.chunks(CHUNK) {
         let mut buf = [0u8; 8];
         buf[..chunk.len()].copy_from_slice(chunk);
@@ -111,7 +111,7 @@ pub fn poseidon2_pair(left: Hash256, right: Hash256) -> Hash256 {
 /// Hash multiple Hash256 values together (variable-length sponge).
 pub fn poseidon2_many(hashes: &[Hash256]) -> Hash256 {
     let sponge = make_sponge();
-    let elements: Vec<Goldilocks> = hashes.iter().flat_map(|h| hash256_to_elements(h)).collect();
+    let elements: Vec<Goldilocks> = hashes.iter().flat_map(hash256_to_elements).collect();
     let out = sponge.hash_iter(elements);
     elements_to_hash(out)
 }

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -1,3 +1,9 @@
+// Crypto-style index loops (`for i in 0..N { arr[i] = ... }`) read more
+// cleanly than clippy's preferred `iter_mut().enumerate()` when the
+// domain is fixed-size polynomial / share math and multiple arrays
+// share the index. Kept as-is throughout this module.
+#![allow(clippy::needless_range_loop)]
+
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -865,10 +871,10 @@ pub fn verify_resharing_contribution(
 /// `from_old_index` values. Returns `None` if fewer than `old_threshold`
 /// contributions are available. All new members converge on the same
 /// polynomial when they apply this rule.
-pub fn canonical_resharing_subset<'a>(
-    pool: &'a [ResharingContribution],
+pub fn canonical_resharing_subset(
+    pool: &[ResharingContribution],
     old_threshold: usize,
-) -> Option<Vec<&'a ResharingContribution>> {
+) -> Option<Vec<&ResharingContribution>> {
     if pool.len() < old_threshold {
         return None;
     }
@@ -1385,7 +1391,7 @@ mod tests {
         assert!(verify_resharing_contribution(&contrib, 5, 8));
 
         // Tamper: flip a value in one of the non-interpolation rows.
-        contrib.sub_shares[6][2] = contrib.sub_shares[6][2] + gl(1);
+        contrib.sub_shares[6][2] += gl(1);
         assert!(!verify_resharing_contribution(&contrib, 5, 8));
     }
 

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 pyde-crypto = { path = "../crypto" }
 pyde-account = { path = "../account" }
 pyde-tx = { path = "../tx" }
+
+[lints]
+workspace = true

--- a/crates/mempool/src/decryption.rs
+++ b/crates/mempool/src/decryption.rs
@@ -32,7 +32,7 @@ impl BlockDecryptor {
     ///
     /// Returns an error if `threshold` is 0 or greater than 128 (committee size).
     pub fn new(encrypted_txs: Vec<EncryptedTx>, threshold: usize) -> Result<Self, String> {
-        if threshold < 1 || threshold > 128 {
+        if !(1..=128).contains(&threshold) {
             return Err(format!(
                 "decryption threshold must be in [1, 128], got {}",
                 threshold

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -147,7 +147,7 @@ impl Mempool {
             clock_ms: wallclock_ms,
             max_size: DEFAULT_MAX_POOL_SIZE,
             current_block: 0,
-            block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+            block_gas_limit: pyde_tx::fee::GAS_CEILING,
         }
     }
 
@@ -164,7 +164,7 @@ impl Mempool {
             clock_ms: wallclock_ms,
             max_size,
             current_block: 0,
-            block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+            block_gas_limit: pyde_tx::fee::GAS_CEILING,
         }
     }
 
@@ -681,7 +681,7 @@ mod tests {
         let selected = pool.select_for_block(100_000, 0);
         let total_gas: u64 = selected.iter().map(|t| t.gas_limit).sum();
         assert!(total_gas <= 100_000);
-        assert!(selected.len() >= 1);
+        assert!(!selected.is_empty());
     }
 
     #[test]
@@ -779,7 +779,7 @@ mod tests {
     // `Mempool::set_clock`. (Regular comment, not a doc comment — `///`
     // doesn't attach to `thread_local!` macro items.)
     thread_local! {
-        static TEST_CLOCK: std::cell::Cell<u64> = std::cell::Cell::new(0);
+        static TEST_CLOCK: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
     }
     fn test_clock_ms() -> u64 {
         TEST_CLOCK.with(|c| c.get())

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -16,3 +16,6 @@ getrandom = "0.2"
 tokio = { version = "1", features = ["full", "test-util"] }
 serde_json = "1"
 futures = "0.3"
+
+[lints]
+workspace = true

--- a/crates/net/src/propagation.rs
+++ b/crates/net/src/propagation.rs
@@ -173,8 +173,8 @@ pub fn compute_erasure_params(block_size: usize) -> Option<ErasureParams> {
 
     // Target chunk size: 64KB
     let chunk_size = 64 * 1024;
-    let data_chunks = (block_size + chunk_size - 1) / chunk_size;
-    let parity_chunks = (data_chunks + 1) / 2; // 50% redundancy
+    let data_chunks = block_size.div_ceil(chunk_size);
+    let parity_chunks = data_chunks.div_ceil(2); // 50% redundancy
 
     Some(ErasureParams {
         data_chunks,

--- a/crates/net/tests/reshare_handshake.rs
+++ b/crates/net/tests/reshare_handshake.rs
@@ -114,26 +114,26 @@ async fn resharing_end_to_end_over_gossipsub() {
             }
             tokio::select! {
                 ev = swarm_a.select_next_some() => {
-                    match ev {
-                        SwarmEvent::Behaviour(GossipOnlyEvent::Gossipsub(
+                    if let SwarmEvent::Behaviour(GossipOnlyEvent::Gossipsub(
                             gossipsub::Event::Subscribed { peer_id: _, .. }
-                        )) => {
-                            // Gossipsub mesh is now ready between the two peers.
-                            // Drain the queued contributions.
-                            for bytes in to_publish.drain(..) {
-                                // Retry on publish error (topic may still be
-                                // bootstrapping heartbeats).
-                                let mut attempt = 0;
-                                while let Err(_) = swarm_a.behaviour_mut()
-                                    .gossipsub.publish(topic.clone(), bytes.clone())
-                                {
-                                    attempt += 1;
-                                    if attempt > 10 { break; }
-                                    tokio::time::sleep(Duration::from_millis(50)).await;
-                                }
+                        )) = ev {
+                        // Gossipsub mesh is now ready between the two peers.
+                        // Drain the queued contributions.
+                        for bytes in to_publish.drain(..) {
+                            // Retry on publish error (topic may still be
+                            // bootstrapping heartbeats).
+                            let mut attempt = 0;
+                            while swarm_a
+                                .behaviour_mut()
+                                .gossipsub
+                                .publish(topic.clone(), bytes.clone())
+                                .is_err()
+                            {
+                                attempt += 1;
+                                if attempt > 10 { break; }
+                                tokio::time::sleep(Duration::from_millis(50)).await;
                             }
                         }
-                        _ => {}
                     }
                 }
                 ev = swarm_b.select_next_some() => {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -67,3 +67,6 @@ tempfile = "3"
 [[bench]]
 name = "rpc_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -60,7 +60,7 @@ impl BlockProcessor {
             height: slot,
             timestamp: block.header.timestamp,
             base_fee: chain.base_fee,
-            block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+            block_gas_limit: pyde_tx::fee::GAS_CEILING,
             chain_id: chain.chain_id,
             validator_address: block.header.proposer,
             dev_skip_signature: false,
@@ -351,7 +351,7 @@ impl BlockProcessor {
         // on a background task, allowing the next block to start immediately.
 
         // 6. Adjust base fee for next block (EIP-1559)
-        let gas_target = pyde_tx::fee::GAS_TARGET as u64;
+        let gas_target = pyde_tx::fee::GAS_TARGET;
         chain.base_fee = adjust_base_fee(chain.base_fee, total_gas, gas_target);
 
         // 7. Advance chain head
@@ -397,7 +397,7 @@ impl BlockProcessor {
     ) -> Result<(u64, u64), String> {
         Self::validate_header_with_checkpoint(&header, chain, ws_checkpoint_slot)?;
 
-        let gas_target = pyde_tx::fee::GAS_TARGET as u64;
+        let gas_target = pyde_tx::fee::GAS_TARGET;
         chain.base_fee = adjust_base_fee(chain.base_fee, 0, gas_target);
         chain.advance(header);
 
@@ -436,14 +436,13 @@ impl BlockProcessor {
                 ));
             }
         }
-        if !chain.is_genesis() {
-            if header.slot <= chain.head_slot {
+        if !chain.is_genesis()
+            && header.slot <= chain.head_slot {
                 return Err(format!(
                     "block slot {} is not ahead of head {}",
                     header.slot, chain.head_slot
                 ));
             }
-        }
         Ok(())
     }
 

--- a/crates/node/src/block_store.rs
+++ b/crates/node/src/block_store.rs
@@ -45,7 +45,7 @@ impl BlockStore {
         let mut hash_key = Vec::with_capacity(2 + 32);
         hash_key.extend_from_slice(b"i:");
         hash_key.extend_from_slice(&block_hash);
-        self.db.put(&hash_key, &slot.to_le_bytes())
+        self.db.put(&hash_key, slot.to_le_bytes())
             .map_err(|e| format!("failed to store hash index: {}", e))?;
 
         Ok(())

--- a/crates/node/src/chain.rs
+++ b/crates/node/src/chain.rs
@@ -41,7 +41,7 @@ impl ChainState {
     /// Advance chain head after processing a block.
     pub fn advance(&mut self, header: BlockHeader) {
         let slot = header.slot;
-        let epoch = slot / EPOCH_LENGTH as u64;
+        let epoch = slot / EPOCH_LENGTH;
 
         self.head_slot = slot;
         self.epoch = epoch;
@@ -86,7 +86,7 @@ mod tests {
     fn dummy_header(slot: u64, parent_hash: [u8; 32]) -> BlockHeader {
         BlockHeader {
             slot,
-            epoch: slot / EPOCH_LENGTH as u64,
+            epoch: slot / EPOCH_LENGTH,
             parent_hash,
             proposer: ZERO_ADDRESS,
             vrf_proof: vec![],

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 /// Top-level node configuration (loaded from TOML).
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct NodeConfig {
     #[serde(default)]
     pub node: NodeSection,
@@ -203,20 +204,6 @@ impl Default for LoggingSection {
     }
 }
 
-impl Default for NodeConfig {
-    fn default() -> Self {
-        Self {
-            node: NodeSection::default(),
-            network: NetworkSection::default(),
-            consensus: ConsensusSection::default(),
-            storage: StorageSection::default(),
-            rpc: RpcSection::default(),
-            fast_tx: FastTxSection::default(),
-            metrics: MetricsSection::default(),
-            logging: LoggingSection::default(),
-        }
-    }
-}
 
 impl NodeConfig {
     /// Load config from a TOML file, falling back to defaults for missing fields.

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -625,8 +625,8 @@ mod tests {
 
         let a = [0xAA; 32];
         let b = [0xBB; 32];
-        store.save_seen_proposal(5, &a, &dummy_header(5), &vec![0x11; 10]).unwrap();
-        store.save_seen_proposal(5, &b, &dummy_header(5), &vec![0x22; 10]).unwrap();
+        store.save_seen_proposal(5, &a, &dummy_header(5), &[0x11; 10]).unwrap();
+        store.save_seen_proposal(5, &b, &dummy_header(5), &[0x22; 10]).unwrap();
 
         let all = store.load_all_seen_proposals();
         assert_eq!(all.len(), 2);
@@ -638,8 +638,8 @@ mod tests {
         let store = ConsensusStateStore::open(dir.path()).unwrap();
 
         for slot in 1..=15u64 {
-            store.save_seen_proposal(slot, &[0xAA; 32], &dummy_header(slot), &vec![0x11; 10]).unwrap();
-            store.save_seen_vote(slot, 0, &[0x77; 32], &vec![0x22; 10]).unwrap();
+            store.save_seen_proposal(slot, &[0xAA; 32], &dummy_header(slot), &[0x11; 10]).unwrap();
+            store.save_seen_vote(slot, 0, &[0x77; 32], &[0x22; 10]).unwrap();
         }
 
         assert_eq!(store.load_all_seen_proposals().len(), 15);
@@ -778,8 +778,8 @@ mod tests {
         let store = ConsensusStateStore::open(dir.path()).unwrap();
 
         store.save(&populated_state()).unwrap();
-        store.save_seen_proposal(50, &[0xAA; 32], &dummy_header(50), &vec![0x11; 10]).unwrap();
-        store.save_seen_vote(50, 1, &[0x99; 32], &vec![0x22; 10]).unwrap();
+        store.save_seen_proposal(50, &[0xAA; 32], &dummy_header(50), &[0x11; 10]).unwrap();
+        store.save_seen_vote(50, 1, &[0x99; 32], &[0x22; 10]).unwrap();
 
         assert!(store.load().unwrap().is_some());
         assert_eq!(store.load_all_seen_proposals().len(), 1);

--- a/crates/node/src/faucet.rs
+++ b/crates/node/src/faucet.rs
@@ -248,7 +248,7 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
             }
 
             // Parse: "GET /path?query HTTP/1.1"
-            let parts: Vec<&str> = request_line.trim().split_whitespace().collect();
+            let parts: Vec<&str> = request_line.split_whitespace().collect();
             if parts.len() < 2 {
                 let _ = writer.write_all(json_response(400, r#"{"error":"bad request"}"#).as_bytes()).await;
                 return;
@@ -266,9 +266,9 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
                 "/faucet" => {
                     let address = query.split('&')
                         .find_map(|p| {
-                            let mut kv = p.splitn(2, '=');
-                            let k = kv.next()?;
-                            let v = kv.next()?;
+                            let (k, v) = p.split_once('=')?;
+                            
+                            
                             if k == "address" { Some(v.to_string()) } else { None }
                         });
 

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -745,7 +745,7 @@ pub fn generate_testnet(
     use pyde_crypto::falcon::falcon_keygen;
     use std::fs;
 
-    if num_validators < 2 || num_validators > 128 {
+    if !(2..=128).contains(&num_validators) {
         return Err("validators must be between 2 and 128".into());
     }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -543,9 +543,9 @@ impl PydeNode {
                             // Generate a fresh nonce, record it, send the request.
                             // We only authenticate to peers once; if a response is
                             // already pending we skip to avoid stacking nonces.
-                            if !pending_auth_nonces.contains_key(&peer) {
+                            if let std::collections::hash_map::Entry::Vacant(e) = pending_auth_nonces.entry(peer) {
                                 let nonce = pyde_net::auth::generate_nonce();
-                                pending_auth_nonces.insert(peer, nonce);
+                                e.insert(nonce);
                                 let req = pyde_net::auth::PydeAuthReq { nonce };
                                 let _ = swarm.behaviour_mut().auth.send_request(&peer, req);
                             }
@@ -1400,7 +1400,21 @@ impl PydeNode {
                                                                                 dev_skip_signature: false,
                                                                             };
                                                                             for dtx in &decrypted_txs {
-                                                                                match pyde_tx::pipeline::execute_transaction(dtx, &mut *state_w.smt_mut(), &block_ctx) {
+                                                                                // Bind the execute_transaction result BEFORE the
+                                                                                // match so the `state_w.smt_mut()` MutexGuard
+                                                                                // temporary is dropped at this semicolon. Without
+                                                                                // this binding the guard lives through the match
+                                                                                // body, which includes `receipts.write().await` —
+                                                                                // the tokio scheduler could move the future to
+                                                                                // another thread holding a std Mutex guard, a
+                                                                                // well-known deadlock / UB pattern. Surfaced by
+                                                                                // slice 5.5 clippy sweep.
+                                                                                let exec_result = pyde_tx::pipeline::execute_transaction(
+                                                                                    dtx,
+                                                                                    &mut *state_w.smt_mut(),
+                                                                                    &block_ctx,
+                                                                                );
+                                                                                match exec_result {
                                                                                     Ok(receipt) => {
                                                                                         let mut receipts_w = receipts.write().await;
                                                                                         receipts_w.insert_block_receipts(current_slot, vec![receipt]);
@@ -2041,10 +2055,11 @@ fn handle_swarm_event(
                 .as_ref()
                 .and_then(|e| e.finality.latest_checkpoint.as_ref().map(|cp| cp.slot));
             chain_sync.on_response(request_id, response, chain, state, block_store, ws_slot);
-            // If chunked snapshot needs more chunks, signal the event loop
-            if chain_sync.needs_next_chunk().is_some() {
-                PostEventAction::ContinueSync // caller will request next chunk
-            } else if chain_sync.is_syncing() {
+            // Signal the event loop to continue if chunked snapshot needs
+            // more chunks OR we're otherwise still syncing. Both branches
+            // produced the same ContinueSync return — collapsed into a
+            // single `||` expression (spotted by slice 5.5 clippy sweep).
+            if chain_sync.needs_next_chunk().is_some() || chain_sync.is_syncing() {
                 PostEventAction::ContinueSync
             } else {
                 PostEventAction::None

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1001,7 +1001,7 @@ async fn parse_call_object(
         height: chain.head_slot,
         timestamp: chain.head_slot * 400,
         base_fee: chain.base_fee,
-        block_gas_limit: pyde_tx::fee::GAS_CEILING as u64,
+        block_gas_limit: pyde_tx::fee::GAS_CEILING,
         chain_id: chain.chain_id,
         validator_address: [0u8; 32],
         dev_skip_signature: false,

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -107,7 +107,7 @@ mod tests {
         let now_ms = current_time_ms();
         let clock = SlotClock::new(now_ms - 2000);
         let slot = clock.current_slot();
-        assert!(slot >= 4 && slot <= 6, "expected ~5, got {}", slot);
+        assert!((4..=6).contains(&slot), "expected ~5, got {}", slot);
     }
 
     #[test]

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -522,7 +522,7 @@ impl ChainSync {
                 }
 
                 let cs = (*chunk_size as usize).max(1);
-                let total_chunks = ((snap.entries.len() + cs - 1) / cs).max(1) as u32;
+                let total_chunks = snap.entries.len().div_ceil(cs).max(1) as u32;
                 let start = (*chunk_index as usize) * cs;
 
                 if start >= snap.entries.len() {

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -990,10 +990,7 @@ impl ValidatorEngine {
         if idx >= self.committee_keys.len() {
             return None;
         }
-        let pk = match pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[idx]) {
-            Some(pk) => pk,
-            None => return None,
-        };
+        let pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[idx])?;
         if !verify_share(&share, &pk, collector.epoch) {
             warn!(epoch = collector.epoch, validator = idx, "invalid randomness share");
             return None;
@@ -1403,12 +1400,11 @@ impl ValidatorEngine {
         };
 
         // Verify vote signature
-        if voter_index < self.committee_keys.len() {
-            if !verify_vote(&vote, &self.committee_keys[voter_index]) {
+        if voter_index < self.committee_keys.len()
+            && !verify_vote(&vote, &self.committee_keys[voter_index]) {
                 warn!(slot, voter_index, "invalid vote signature");
                 return None;
             }
-        }
 
         // --- Double-vote (equivocation) detection ---
         let vote_key = (slot, voter_index as u8);
@@ -2240,7 +2236,7 @@ mod tests {
             })
             .collect();
         let mut helper_ids: Vec<ValidatorIdentity> =
-            (3..=6).map(|i| make_identity(i)).collect();
+            (3..=6).map(make_identity).collect();
         for (i, (engine, id)) in helpers.iter_mut().zip(helper_ids.iter_mut()).enumerate() {
             engine.prepare_for_reshare_reception(1, new_committee_keys.clone(), i + 3);
             for c in &contribs {
@@ -2917,9 +2913,9 @@ mod tests {
             let store = ConsensusStateStore::open(dir.path()).unwrap();
             for slot in 1..=15u64 {
                 store
-                    .save_seen_proposal(slot, &[0xAA; 32], &evidence_header(slot, [0x33; 32]), &vec![0x11; 10])
+                    .save_seen_proposal(slot, &[0xAA; 32], &evidence_header(slot, [0x33; 32]), &[0x11; 10])
                     .unwrap();
-                store.save_seen_vote(slot, 0, &[0x99; 32], &vec![0x22; 10]).unwrap();
+                store.save_seen_vote(slot, 0, &[0x99; 32], &[0x22; 10]).unwrap();
             }
         }
 
@@ -3501,8 +3497,8 @@ mod tests {
         engine.consensus.current_slot = 14;
         engine.advance_slot(); // now at 15
 
-        assert!(engine.votes.get(&1).is_none()); // pruned
-        assert!(engine.votes.get(&5).is_some()); // kept (>= 5)
+        assert!(!engine.votes.contains_key(&1)); // pruned
+        assert!(engine.votes.contains_key(&5)); // kept (>= 5)
     }
 
     #[test]

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -715,7 +715,7 @@ fn full_production_benchmark() {
     let metrics_path = dir.join("metrics.txt");
     let mut metrics_out = String::new();
     for m in &all_metrics {
-        let label = m.label.replace(' ', "_").replace('(', "").replace(')', "");
+        let label = m.label.replace(' ', "_").replace(['(', ')'], "");
         let tps = if m.exec_ms > 0.0 { m.ok_count as f64 / (m.exec_ms / 1000.0) } else { 0.0 };
         metrics_out += &format!("pyde_bench_tps{{workload=\"{}\"}} {:.0}\n", label, tps);
         metrics_out += &format!("pyde_bench_exec_ms{{workload=\"{}\"}} {:.1}\n", label, m.exec_ms);

--- a/crates/node/tests/loadgen.rs
+++ b/crates/node/tests/loadgen.rs
@@ -265,7 +265,7 @@ fn load_test_full_pipeline() {
 
         // Deploy contracts — submit to ALL nodes for fastest inclusion
         println!("  Deploying {} contracts (to all 4 nodes)...", deploy_txs.len());
-        for (_i, dtx) in deploy_txs.iter().enumerate() {
+        for dtx in deploy_txs.iter() {
             let params = format!("\"{}\"", dtx);
             // Submit to all 4 nodes simultaneously
             for url in &rpc_urls {
@@ -327,7 +327,7 @@ fn load_test_full_pipeline() {
         if use_binary {
             println!("  Using fast binary TX endpoint (port 9545-9548)");
             let concurrency = 32usize;
-            let chunk_size = (raw_txs.len() + concurrency - 1) / concurrency;
+            let chunk_size = raw_txs.len().div_ceil(concurrency);
             let mut tasks = Vec::new();
 
             for c in 0..concurrency {
@@ -372,7 +372,7 @@ fn load_test_full_pipeline() {
         } else {
             println!("  Using HTTP RPC (fast TX endpoint not available)");
             let concurrency = 32usize;
-            let chunk_size = (signed_txs_hex.len() + concurrency - 1) / concurrency;
+            let chunk_size = signed_txs_hex.len().div_ceil(concurrency);
             let mut tasks = Vec::new();
 
             for c in 0..concurrency {

--- a/crates/node/tests/production_e2e.rs
+++ b/crates/node/tests/production_e2e.rs
@@ -313,9 +313,10 @@ fn production_signed_deploy_and_call() {
     std::thread::sleep(std::time::Duration::from_secs(5));
 
     // Verify get_count() = 1
+    let selector_hex = format!("{:08x}", otic::codegen::compute_selector("get_count"));
     let resp = rpc_call(&rpc, "pyde_call", &format!(
         r#"{{"from":"0x{}","to":"{}","data":"0x{}","gas":100000000}}"#,
-        hex::encode(address), contract_hex, format!("{:08x}", otic::codegen::compute_selector("get_count"))
+        hex::encode(address), contract_hex, selector_hex
     ));
     let count = get_result_string(&resp);
     println!("[{}] get_count() = {} (expected 0x1)", if count == "0x1" { "PASS" } else { "INFO" }, count);

--- a/crates/node/tests/production_sim.rs
+++ b/crates/node/tests/production_sim.rs
@@ -449,12 +449,12 @@ fn production_simulation() {
     // Verify all signatures
     let t0 = Instant::now();
     for (i, tx) in deploy_txs.iter().enumerate() {
-        let acc_idx = i % 20;
-        let pk_bytes = if acc_idx < 10 {
-            accounts[acc_idx].pk.as_bytes()
-        } else {
-            accounts[acc_idx].pk.as_bytes()
-        };
+        // Both arms of the previous `if acc_idx < 10 { ... } else { ... }`
+        // indexed the same `accounts` vec with the same value — a leftover
+        // from a refactor where deploy vs non-deploy accounts lived in
+        // separate collections. Collapsed to a direct index; caught by
+        // slice 5.5 clippy sweep (clippy::if_same_then_else).
+        let pk_bytes = accounts[i % 20].pk.as_bytes();
         assert!(tx.verify_signature(pk_bytes), "sig verify failed for deploy tx {}", i);
     }
     println!("    Verified 20 sigs: {:.0}ms", t0.elapsed().as_secs_f64() * 1000.0);

--- a/crates/otic/Cargo.toml
+++ b/crates/otic/Cargo.toml
@@ -10,3 +10,6 @@ ethnum = "1.5.2"
 [dev-dependencies]
 pyde-state = { path = "../state" }
 sparse-merkle-tree = "0.6"
+
+[lints]
+workspace = true

--- a/crates/otic/src/abi.rs
+++ b/crates/otic/src/abi.rs
@@ -455,7 +455,7 @@ fn ty_to_string(ty: &Ty) -> String {
         Ty::Vec(inner) => format!("Vec<{}>", ty_to_string(inner)),
         Ty::Map(k, v) => format!("Map<{}, {}>", ty_to_string(k), ty_to_string(v)),
         Ty::Tuple(items) => {
-            let parts: Vec<String> = items.iter().map(|t| ty_to_string(t)).collect();
+            let parts: Vec<String> = items.iter().map(ty_to_string).collect();
             format!("({})", parts.join(", "))
         }
         Ty::Struct(name) => name.clone(),

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -19,6 +19,12 @@
 //!   - Dispatch entries decode calldata → arg registers → Call → Halt
 //!   - All functions end with Ret (dispatch wrapper emits Halt)
 
+// Register encoding patterns like `(14 & 0xF) << 2` are deliberately
+// written with the `& 0xF` mask to document the 4-bit-wide register
+// field. Clippy flags these as redundant when the constant already
+// fits; keeping them improves readability of the bit-packed immediate.
+#![allow(clippy::eq_op)]
+
 use std::collections::{HashMap, HashSet};
 
 use ethnum::U256;
@@ -280,6 +286,12 @@ pub struct CodeGen {
     current_label_remap: Option<HashMap<Label, Label>>,
     /// Current function's return type (for blob return serialization).
     current_return_ty: Ty,
+}
+
+impl Default for CodeGen {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CodeGen {
@@ -619,7 +631,7 @@ impl CodeGen {
 
     /// Fallback: search all structs for a field name (backward compat for untyped access).
     fn find_field_offset_any(&self, field_name: &str) -> u32 {
-        for (_sname, fmap) in &self.field_offsets {
+        for fmap in self.field_offsets.values() {
             if let Some((off, _)) = fmap.get(field_name) {
                 return *off;
             }
@@ -1041,7 +1053,7 @@ impl CodeGen {
                             );
                         }
                         // Advance heap past header + data (aligned)
-                        let total = memory::VEC_DATA_OFFSET as u32 + ((byte_len + 7) / 8) * 8;
+                        let total = memory::VEC_DATA_OFFSET + byte_len.div_ceil(8) * 8;
                         self.load_u32_to_reg(15, total);
                         self.emit_op(Opcode::Add, 12, 12, 15);
                     }
@@ -1846,7 +1858,7 @@ impl CodeGen {
             Inst::TupleGet(dst, tuple, idx) => {
                 let rd = self.alloc_gp(*dst);
                 let rt = self.get_reg(*tuple);
-                let offset = (*idx) * (memory::WORD_SIZE as u32);
+                let offset = (*idx) * memory::WORD_SIZE;
                 self.emit_load(rd, rt, offset as i32);
             }
 
@@ -1854,7 +1866,7 @@ impl CodeGen {
                 let rd = self.alloc_gp(*dst);
                 // Reserve header (16 bytes) + data, matching Vec layout for IndexGet
                 let data_size = (regs.len() as u32) * memory::WORD_SIZE;
-                let total = memory::VEC_DATA_OFFSET as u32 + data_size;
+                let total = memory::VEC_DATA_OFFSET + data_size;
                 self.emit_op(Opcode::Add, rd, 12, 0);
                 self.emit_op(Opcode::Addi, 12, 12, total);
                 // Write length/capacity header
@@ -1864,7 +1876,7 @@ impl CodeGen {
                                             // Write elements at VEC_DATA_OFFSET
                 for (i, reg) in regs.iter().enumerate() {
                     let r = self.get_reg(*reg);
-                    let offset = memory::VEC_DATA_OFFSET as u32 + (i as u32) * memory::WORD_SIZE;
+                    let offset = memory::VEC_DATA_OFFSET + (i as u32) * memory::WORD_SIZE;
                     self.emit_store(r, rd, offset as i32);
                 }
             }
@@ -1875,7 +1887,7 @@ impl CodeGen {
                 // Save val to stack — load_u32_to_reg(15, count) clobbers r15 (and r14 as scratch)
                 self.emit_op(Opcode::Push, rv, 0, 0);
                 let data_size = (*count as u32) * memory::WORD_SIZE;
-                let total = memory::VEC_DATA_OFFSET as u32 + data_size;
+                let total = memory::VEC_DATA_OFFSET + data_size;
                 self.emit_op(Opcode::Add, rd, 12, 0);
                 self.emit_op(Opcode::Addi, 12, 12, total);
                 self.load_u32_to_reg(15, *count as u32);
@@ -1884,7 +1896,7 @@ impl CodeGen {
                                             // Restore val from stack
                 self.emit_op(Opcode::Pop, 15, 0, 0); // r15 = val (restored)
                 for i in 0..*count {
-                    let offset = memory::VEC_DATA_OFFSET as u32 + (i as u32) * memory::WORD_SIZE;
+                    let offset = memory::VEC_DATA_OFFSET + (i as u32) * memory::WORD_SIZE;
                     self.emit_store(15, rd, offset as i32);
                 }
             }
@@ -2908,13 +2920,13 @@ impl CodeGen {
                         let offset = (i as u32) * memory::WORD_SIZE;
                         self.emit_op(Opcode::Push, val_reg, 0, 0);
                         // Load field value from struct
-                        if is_wide_type(&fty) {
+                        if is_wide_type(fty) {
                             self.emit_op(Opcode::Addi, 15, val_reg, offset);
                             self.emit_op(Opcode::Wload, WIDE_SCRATCH2, 15, 0);
-                            self.emit_serialize(&fty, WIDE_SCRATCH2);
+                            self.emit_serialize(fty, WIDE_SCRATCH2);
                         } else {
                             self.emit_load(14, val_reg, offset as i32);
-                            self.emit_serialize(&fty, 14);
+                            self.emit_serialize(fty, 14);
                         }
                         // Restore struct base for next field iteration
                         self.emit_op(Opcode::Pop, val_reg, 0, 0);
@@ -3426,8 +3438,8 @@ impl CodeGen {
                     for (i, (_, fty)) in fields.iter().enumerate() {
                         let offset = (i as u32) * memory::WORD_SIZE;
                         // Deserialize field from src into temp register, then store to struct
-                        if is_wide_type(&fty) {
-                            self.emit_deserialize(&fty, src_reg, 14); // wide → but we use 14 as GP temp
+                        if is_wide_type(fty) {
+                            self.emit_deserialize(fty, src_reg, 14); // wide → but we use 14 as GP temp
                                                                       // For wide fields in struct, store the wide value at struct+offset
                                                                       // Actually wide fields need 32 bytes but struct layout uses 8 per field (pointer)
                                                                       // This is a limitation — skip for now
@@ -3435,7 +3447,7 @@ impl CodeGen {
                             self.emit_op(Opcode::Push, 15, 0, 0);
                             self.emit_store(14, 15, offset as i32);
                         } else {
-                            self.emit_deserialize(&fty, src_reg, 14);
+                            self.emit_deserialize(fty, src_reg, 14);
                             // Store field value/pointer at struct[offset]
                             self.emit_op(Opcode::Pop, 15, 0, 0); // peek struct base
                             self.emit_op(Opcode::Push, 15, 0, 0);
@@ -3578,6 +3590,15 @@ pub fn compute_selector(name: &str) -> u32 {
 }
 
 #[cfg(test)]
+// `arc_with_non_send_sync`: the storage_backend closures in these tests
+// capture raw `*const PydeSMT` pointers, which are !Send/!Sync by design.
+// Tests run single-threaded against a local SMT, so the Arc here is used
+// purely as reference-counted storage, not for cross-thread sharing. The
+// alternative (switching the `storage_backend` field from Arc to Rc
+// project-wide) is a non-trivial refactor that only matters if we ever
+// parallelize VM execution across threads — which would require replacing
+// the raw pointer anyway. Scoped allow is the honest minimum here.
+#[allow(clippy::arc_with_non_send_sync)]
 mod tests {
     use super::*;
     use crate::lexer::Lexer;
@@ -4277,7 +4298,7 @@ mod tests {
         "#,
         );
         assert_eq!(compiled.bytecode.len(), compiled.instruction_count * 4);
-        assert!(compiled.bytecode.len() > 0);
+        assert!(!compiled.bytecode.is_empty());
     }
 
     #[test]
@@ -4294,7 +4315,7 @@ mod tests {
         "#,
         );
         assert_eq!(compiled.name, "Token");
-        assert!(compiled.bytecode.len() > 0);
+        assert!(!compiled.bytecode.is_empty());
         assert_eq!(compiled.selectors.len(), 1);
         assert_eq!(compiled.selectors[0].1, "get_supply");
     }
@@ -4973,7 +4994,7 @@ mod tests {
             "increment should succeed"
         );
         assert!(
-            vm.storage.len() > 0,
+            !vm.storage.is_empty(),
             "vm.storage should have entries after Sstore"
         );
     }
@@ -6043,7 +6064,7 @@ mod tests {
                         panic!("too many steps at step {}", steps);
                     }
                     // Print last 10 instructions before fault (around step 180-190)
-                    if steps >= 150 && steps <= 245 {
+                    if (150..=245).contains(&steps) {
                         let pc = vm.pc as usize;
                         if pc + 4 <= compiled.bytecode.len() {
                             let w = u32::from_le_bytes(

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -2,6 +2,13 @@
 //!
 //! Pipeline: source → lexer → parser → resolve → type check → safety → IR → optimize → codegen → .pyc
 
+// Compiler + VM internals pass around nested generics (HashMap of
+// Vec of tuples, etc.) where the shape IS the documentation; clippy
+// flags these as `type_complexity`. Adding aliases would add names
+// to learn without improving readability. Scoped allow at the
+// module level; narrow to specific items if this grows.
+#![allow(clippy::type_complexity)]
+
 pub mod token;
 pub mod lexer;
 pub mod ast;
@@ -58,7 +65,7 @@ fn resolve_ast_type(ty: &ast::Type) -> Ty {
                 _ => Ty::Struct(name.to_string()),
             }
         }
-        ast::Type::Tuple(types, _) => Ty::Tuple(types.iter().map(|t| resolve_ast_type(t)).collect()),
+        ast::Type::Tuple(types, _) => Ty::Tuple(types.iter().map(resolve_ast_type).collect()),
     }
 }
 
@@ -83,7 +90,7 @@ fn extract_all_contract_signatures(
                             .map(|p| (p.name.name.clone(), resolve_ast_type(&p.ty)))
                             .collect();
                         let ret = f.return_type.as_ref()
-                            .map(|t| resolve_ast_type(t))
+                            .map(resolve_ast_type)
                             .unwrap_or(Ty::Unit);
                         pub_fns.push((f.name.name.clone(), params, ret));
                     }

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -3,6 +3,13 @@
 //! Walks the AST and emits flat IR instructions into basic blocks.
 //! Variable names are mapped to virtual registers.
 
+// Compiler + VM internals pass around nested generics (HashMap of
+// Vec of tuples, etc.) where the shape IS the documentation; clippy
+// flags these as `type_complexity`. Adding aliases would add names
+// to learn without improving readability. Scoped allow at the
+// module level; narrow to specific items if this grows.
+#![allow(clippy::type_complexity)]
+
 use std::collections::HashMap;
 
 use ethnum::U256;
@@ -278,10 +285,8 @@ impl Lowerer {
             Expr::Index(obj, _, _) => {
                 if let Expr::FieldAccess(inner, field, _) = obj.as_ref() {
                     if matches!(inner.as_ref(), Expr::SelfExpr(_)) {
-                        if let Some(map_ty) = self.storage_types.get(&field.name) {
-                            if let Ty::Map(_, val_ty) = map_ty {
-                                return Some(*val_ty.clone());
-                            }
+                        if let Some(Ty::Map(_, val_ty)) = self.storage_types.get(&field.name) {
+                            return Some(*val_ty.clone());
                         }
                     }
                 }
@@ -803,14 +808,12 @@ impl Lowerer {
                         // Copy: existing_reg = value (critical for loops)
                         self.emit(Inst::Cast(existing, value, Ty::Unknown));
                     }
-                } else {
-                    if let Some(scope) = self.locals.last_mut() {
-                        scope.insert(ident.name.clone(), value);
-                    }
+                } else if let Some(scope) = self.locals.last_mut() {
+                    scope.insert(ident.name.clone(), value);
                 }
             }
             _ => {
-                self.emit(Inst::Comment(format!("unhandled assign target")));
+                self.emit(Inst::Comment("unhandled assign target".to_string()));
             }
         }
     }
@@ -1009,13 +1012,12 @@ impl Lowerer {
 
             Expr::FieldAccess(obj, field, _) => {
                 // self.field → storage.get
-                if matches!(obj.as_ref(), Expr::SelfExpr(_)) {
-                    if self.storage_slots.contains_key(&field.name) {
+                if matches!(obj.as_ref(), Expr::SelfExpr(_))
+                    && self.storage_slots.contains_key(&field.name) {
                         let dst = self.alloc_reg();
                         self.emit(Inst::StorageGet(dst, field.name.clone()));
                         return dst;
                     }
-                }
 
                 // msg.sender, msg.value, msg.data → builtins (cached per function)
                 if let Expr::Ident(ident) = obj.as_ref() {
@@ -1306,8 +1308,8 @@ impl Lowerer {
                             // revert!() — bare revert with no data
                             self.emit(Inst::Revert("Error".into(), vec![]));
                         }
-                        let dst = self.alloc_reg();
-                        dst
+                        
+                        self.alloc_reg()
                     }
                     "cross_call" => {
                         let mut target_reg = None;

--- a/crates/otic/src/main.rs
+++ b/crates/otic/src/main.rs
@@ -253,7 +253,7 @@ fn cmd_test(path: &str) {
             }
         }
 
-        let should_panic = func.doc.as_ref().map_or(false, |d| d.contains("should_panic"));
+        let should_panic = func.doc.as_ref().is_some_and(|d| d.contains("should_panic"));
 
         let ok = match result {
             Some(pyde_vm::vm::ExecResult::Halt) => !should_panic,

--- a/crates/otic/src/resolve.rs
+++ b/crates/otic/src/resolve.rs
@@ -140,6 +140,12 @@ pub struct Resolver {
     module_exports: ExternalModuleExports,
 }
 
+impl Default for Resolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Resolver {
     pub fn new() -> Self {
         Self {
@@ -608,14 +614,13 @@ impl Resolver {
                 }
                 let item = &import.path[import.path.len() - 1];
                 // Validate the item is actually exported (if we know the module)
-                if !all_but_last.is_empty() && self.is_known_module(&all_but_last) {
-                    if !self.is_exported(&all_but_last, &item.name) {
+                if !all_but_last.is_empty() && self.is_known_module(&all_but_last)
+                    && !self.is_exported(&all_but_last, &item.name) {
                         self.error(
                             format!("'{}' is not exported from module '{}'", item.name, all_but_last.replace('/', "::")),
                             item.span,
                         );
                     }
-                }
                 self.declare(&item.name, SymbolKind::Contract, item.span);
             }
             return;
@@ -899,7 +904,7 @@ impl Resolver {
                 // Verify the struct/error name exists
                 if let Some(first) = name_segments.first() {
                     if !self.is_type_defined(&first.name)
-                        && self.lookup(&first.name).map(|s| matches!(s.kind, SymbolKind::Error)).unwrap_or(false) == false
+                        && !self.lookup(&first.name).map(|s| matches!(s.kind, SymbolKind::Error)).unwrap_or(false)
                         && self.lookup(&first.name).is_none()
                     {
                         self.error(

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -64,6 +64,12 @@ pub struct SafetyChecker {
     contract_functions: Vec<String>,
 }
 
+impl Default for SafetyChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SafetyChecker {
     pub fn new() -> Self {
         Self {
@@ -457,6 +463,7 @@ impl SafetyChecker {
     }
 
     /// Collect self.method() call targets from an expression.
+    #[allow(clippy::only_used_in_recursion)] // `&self` kept for call-site symmetry with sibling methods
     fn collect_calls_in_expr(&self, expr: &Expr, targets: &mut Vec<String>) {
         match expr {
             Expr::Call(callee, args, _, _) => {
@@ -597,6 +604,7 @@ impl SafetyChecker {
         }
     }
 
+    #[allow(clippy::only_used_in_recursion)] // `&self` kept for call-site symmetry with sibling methods
     fn is_storage_access(&self, expr: &Expr) -> bool {
         match expr {
             Expr::FieldAccess(obj, _, _) => {
@@ -652,7 +660,7 @@ impl SafetyChecker {
                     || self.expr_accesses_msg_value(&a.value)
             }
             Stmt::Return(r) => {
-                r.value.as_ref().map_or(false, |v| self.expr_accesses_msg_value(v))
+                r.value.as_ref().is_some_and(|v| self.expr_accesses_msg_value(v))
             }
             Stmt::Emit(e) => {
                 e.fields.iter().any(|f| self.expr_accesses_msg_value(&f.value))
@@ -696,7 +704,7 @@ impl SafetyChecker {
             Expr::If(cond, then_block, else_clause, _) => {
                 self.expr_accesses_msg_value(cond)
                     || self.block_accesses_msg_value(then_block)
-                    || else_clause.as_ref().map_or(false, |c| match c {
+                    || else_clause.as_ref().is_some_and(|c| match c {
                         ElseClause::ElseBlock(b) => self.block_accesses_msg_value(b),
                         ElseClause::ElseIf(e) => self.expr_accesses_msg_value(e),
                     })

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -4,6 +4,13 @@
 //! Infers types for expressions, checks assignments, function calls,
 //! struct inits, emit statements, and casts.
 
+// Compiler + VM internals pass around nested generics (HashMap of
+// Vec of tuples, etc.) where the shape IS the documentation; clippy
+// flags these as `type_complexity`. Adding aliases would add names
+// to learn without improving readability. Scoped allow at the
+// module level; narrow to specific items if this grows.
+#![allow(clippy::type_complexity)]
+
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::*;
@@ -121,6 +128,12 @@ pub struct TypeChecker {
     in_contract: bool,
     /// The expected return type of the current function (for return stmt checking).
     current_return_type: Option<Ty>,
+}
+
+impl Default for TypeChecker {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TypeChecker {
@@ -535,8 +548,8 @@ impl TypeChecker {
         self.check_block(&func.body);
 
         // Check that non-void functions have a return path
-        if ret_ty != Ty::Unit && ret_ty != Ty::Unknown {
-            if !self.block_has_return(&func.body) {
+        if ret_ty != Ty::Unit && ret_ty != Ty::Unknown
+            && !self.block_has_return(&func.body) {
                 self.error(
                     format!(
                         "function '{}' must return {} but body may not return a value",
@@ -545,7 +558,6 @@ impl TypeChecker {
                     func.span,
                 );
             }
-        }
 
         self.current_return_type = None;
         self.env.pop_scope();
@@ -577,7 +589,7 @@ impl TypeChecker {
                             ElseClause::ElseIf(e) => {
                                 if let Expr::If(_, tb, ec, _) = e.as_ref() {
                                     self.block_has_return(tb)
-                                        && ec.as_ref().map_or(false, |c| match c {
+                                        && ec.as_ref().is_some_and(|c| match c {
                                             ElseClause::ElseBlock(b) => self.block_has_return(b),
                                             _ => false,
                                         })
@@ -758,15 +770,19 @@ impl TypeChecker {
         {
             match a.op {
                 AssignOp::Assign => {
-                    if target_ty != value_ty
+                    // Clippy offers a De-Morgan rewrite to a single big `!(A || B || ...)`,
+                    // but the chain-of-ANDs form with per-line comments is what makes
+                    // the compatibility matrix readable. Keeping as-is.
+                    #[allow(clippy::nonminimal_bool)]
+                    let type_mismatch = target_ty != value_ty
                         && !self.is_int_literal_compatible(&a.value, &target_ty)
                         && !value_ty.can_widen_to(&target_ty)
                         && !(target_ty.is_numeric() && value_ty.is_numeric()) // allow numeric narrowing
                         && !(target_ty.is_enum() && value_ty.is_enum()) // same-kind enum assignment
                         && !(target_ty.is_numeric() && value_ty.is_enum()) // Enum → numeric
                         && !(target_ty.is_enum() && value_ty.is_numeric()) // numeric → Enum
-                        && !self.is_compatible_init(&value_ty, &target_ty)
-                    {
+                        && !self.is_compatible_init(&value_ty, &target_ty);
+                    if type_mismatch {
                         self.error(
                             format!("type mismatch in assignment: {} = {}", target_ty, value_ty),
                             a.span,
@@ -961,12 +977,8 @@ impl TypeChecker {
                     }
                 }
                 // Address.balance → u256
-                if obj_ty == Ty::Address {
-                    match field.name.as_str() {
-                        "balance" => return Ty::U256,
-                        _ => {}
-                    }
-                }
+                if obj_ty == Ty::Address
+                    && field.name.as_str() == "balance" { return Ty::U256 }
                 // struct.field → field type
                 if let Ty::Struct(name) = &obj_ty {
                     if let Some(fields) = self.env.struct_defs.get(name) {

--- a/crates/pvm/Cargo.toml
+++ b/crates/pvm/Cargo.toml
@@ -12,3 +12,6 @@ tracing = "0.1"
 [[bench]]
 name = "interpreter_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -20,6 +20,13 @@
 //! - Gas cost prevents unbounded growth; memory freed after tx.
 //! - MEMCPY instruction for efficient reallocation (bulk memory copy with per-byte gas).
 
+// Compiler + VM internals pass around nested generics (HashMap of
+// Vec of tuples, etc.) where the shape IS the documentation; clippy
+// flags these as `type_complexity`. Adding aliases would add names
+// to learn without improving readability. Scoped allow at the
+// module level; narrow to specific items if this grows.
+#![allow(clippy::type_complexity)]
+
 use crate::cpu::{Cpu, Trap};
 use crate::isa::{
     decode, decode_mem_offset, decode_mem_width, sign_extend_18, DecodedInstruction, Instruction,
@@ -779,7 +786,7 @@ impl Vm {
                 let len = (d.rs2_or_imm & 0xF) as u8;
                 let byte_len = self.cpu.read_gp(len) as usize;
                 // Dynamic gas: 250 per 32 bytes (Poseidon2 permutation ≈ 250ns each)
-                let dynamic_gas = ((byte_len as u64 + 31) / 32) * 250;
+                let dynamic_gas = (byte_len as u64).div_ceil(32) * 250;
                 self.gas_used_total += dynamic_gas;
                 if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                     return Err(Trap::OutOfGas);
@@ -828,9 +835,9 @@ impl Vm {
                     }
                 });
                 // Cache backend result in overlay
-                if !self.storage.contains_key(&key) {
+                if let std::collections::hash_map::Entry::Vacant(e) = self.storage.entry(key) {
                     if let Some(ref val) = storage_value {
-                        self.storage.insert(key, val.clone());
+                        e.insert(val.clone());
                     }
                 }
 
@@ -850,7 +857,7 @@ impl Vm {
                         let ptr_reg = ((d.rs2_or_imm >> 2) & 0xF) as u8;
                         let ptr = self.cpu.read_gp(ptr_reg) as u32;
                         if let Some(data) = storage_value.as_ref() {
-                            let dynamic_gas = ((data.len() as u64 + 7) / 8) * 3;
+                            let dynamic_gas = (data.len() as u64).div_ceil(8) * 3;
                             self.gas_used_total += dynamic_gas;
                             if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                                 return Err(Trap::OutOfGas);
@@ -920,7 +927,7 @@ impl Vm {
                         let ptr = self.cpu.read_gp(ptr_reg) as u32;
                         let len = self.cpu.read_gp(len_reg) as usize;
                         // Dynamic gas: 3 per 8 bytes of data written to storage
-                        let dynamic_gas = ((len as u64 + 7) / 8) * 3;
+                        let dynamic_gas = (len as u64).div_ceil(8) * 3;
                         self.gas_used_total += dynamic_gas;
                         if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                             return Err(Trap::OutOfGas);
@@ -1224,7 +1231,7 @@ impl Vm {
                 let len = self.cpu.read_gp(len_reg) as usize;
                 if len > 0 {
                     // Charge dynamic gas: 3 per 8 bytes copied (same rate as Load/Store)
-                    let dynamic_gas = ((len as u64 + 7) / 8) * 3;
+                    let dynamic_gas = (len as u64).div_ceil(8) * 3;
                     self.gas_used_total += dynamic_gas;
                     if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                         return Err(Trap::OutOfGas);
@@ -3269,8 +3276,8 @@ mod tests {
         // w3 should contain first 32 bytes only
         let loaded = vm.cpu.read_wide(3);
         let bytes = loaded.to_le_bytes();
-        for i in 0..32 {
-            assert_eq!(bytes[i], (i + 1) as u8);
+        for (i, b) in bytes.iter().enumerate() {
+            assert_eq!(*b, (i + 1) as u8);
         }
     }
 

--- a/crates/pyde-crypto-wasm/Cargo.toml
+++ b/crates/pyde-crypto-wasm/Cargo.toml
@@ -23,3 +23,6 @@ hex = "0.4"
 [profile.release]
 opt-level = "s"
 lto = true
+
+[lints]
+workspace = true

--- a/crates/pyde-dev/Cargo.toml
+++ b/crates/pyde-dev/Cargo.toml
@@ -40,3 +40,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/pyde-dev/src/cheatcodes.rs
+++ b/crates/pyde-dev/src/cheatcodes.rs
@@ -43,6 +43,12 @@ pub struct CheatcodeState {
     pub prank_persistent: bool,
 }
 
+impl Default for CheatcodeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CheatcodeState {
     pub fn new() -> Self {
         Self {
@@ -123,11 +129,10 @@ pub fn execute_with_cheatcodes(vm: &mut Vm, cheat_state: &mut CheatcodeState) ->
 
         // Clear single-use prank after any non-cheatcode CallExt
         if let Some(d) = maybe_instr {
-            if d.opcode == Opcode::CallExt && !cheat_state.prank_persistent {
-                if cheat_state.prank_caller.is_some() {
+            if d.opcode == Opcode::CallExt && !cheat_state.prank_persistent
+                && cheat_state.prank_caller.is_some() {
                     cheat_state.prank_caller = None;
                 }
-            }
         }
     };
 
@@ -279,11 +284,10 @@ pub fn execute_with_tracing(
 
         // Clear single-use prank
         if let Some(d) = maybe_instr {
-            if d.opcode == Opcode::CallExt && !cheat_state.prank_persistent {
-                if cheat_state.prank_caller.is_some() {
+            if d.opcode == Opcode::CallExt && !cheat_state.prank_persistent
+                && cheat_state.prank_caller.is_some() {
                     cheat_state.prank_caller = None;
                 }
-            }
         }
     };
 

--- a/crates/pyde-dev/src/doc.rs
+++ b/crates/pyde-dev/src/doc.rs
@@ -139,7 +139,7 @@ pub fn run() -> Result<(), String> {
                         top_level_md.push_str(&format!("# {}\n\n", file_stem));
                         has_top_level = true;
                     }
-                    let ty_str = c.ty.as_ref().map(|t| format_type(t)).unwrap_or("unknown".into());
+                    let ty_str = c.ty.as_ref().map(format_type).unwrap_or("unknown".into());
                     top_level_md.push_str(&format!("## const {} : `{}`\n\n", c.name.name, ty_str));
                 }
                 _ => {}
@@ -375,7 +375,7 @@ fn format_type(ty: &otic::ast::Type) -> String {
         otic::ast::Type::Map(k, v, _) => format!("Map<{}, {}>", format_type(k), format_type(v)),
         otic::ast::Type::Named(path) => path.iter().map(|i| i.name.as_str()).collect::<Vec<_>>().join("::"),
         otic::ast::Type::Tuple(types, _) => {
-            let inner: Vec<String> = types.iter().map(|t| format_type(t)).collect();
+            let inner: Vec<String> = types.iter().map(format_type).collect();
             format!("({})", inner.join(", "))
         }
     }

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -24,17 +24,13 @@ pub struct Dependency {
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(default)]
+#[derive(Default)]
 pub struct TestSection {
     /// Default verbosity for execution traces (0=silent, 1=calls, 2=storage, 3=full).
     /// CLI -v flag overrides this.
     pub verbosity: u8,
 }
 
-impl Default for TestSection {
-    fn default() -> Self {
-        Self { verbosity: 0 }
-    }
-}
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ProjectSection {

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -205,7 +205,7 @@ pub fn run(file: &str, network: &str, signer: &crate::signer::Signer) -> Result<
 
     // Build selector → function info map for view/non-view detection
     let mut selector_info: std::collections::HashMap<u32, FnInfo> = std::collections::HashMap::new();
-    for (_, fns) in &build_result.contract_functions {
+    for fns in build_result.contract_functions.values() {
         for (name, _params, ret_ty) in fns {
             let sel = otic::codegen::compute_selector(name);
             selector_info.insert(sel, FnInfo {

--- a/crates/pyde-dev/src/test_runner.rs
+++ b/crates/pyde-dev/src/test_runner.rs
@@ -268,7 +268,7 @@ pub fn run(filter: Option<&str>, verbosity: u8) -> Result<(), String> {
 
         println!();
         println!("  Gas Profile");
-        println!("  {:<col_width$}  {:>12}  {:>8}  {}", "Test", "Gas Used", "% Limit", "Status");
+        println!("  {:<col_width$}  {:>12}  {:>8}  Status", "Test", "Gas Used", "% Limit");
         println!("  {}", "-".repeat(col_width + 30));
         for entry in &gas_profile {
             let pct = (entry.gas_used as f64 / gas_limit as f64) * 100.0;

--- a/crates/pyde-dev/src/trace.rs
+++ b/crates/pyde-dev/src/trace.rs
@@ -128,6 +128,12 @@ pub struct ExecutionTrace {
     pub depth: u32,
 }
 
+impl Default for ExecutionTrace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ExecutionTrace {
     pub fn new() -> Self {
         Self {

--- a/crates/pyde-rust-sdk/Cargo.toml
+++ b/crates/pyde-rust-sdk/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.8"
 
 # Error handling
 thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/pyde-rust-sdk/src/abi.rs
+++ b/crates/pyde-rust-sdk/src/abi.rs
@@ -450,7 +450,7 @@ impl<'a> Contract<'a> {
                 buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
                 buf.extend_from_slice(bytes);
                 let pad = (8 - (bytes.len() % 8)) % 8;
-                buf.extend(std::iter::repeat(0u8).take(pad));
+                buf.extend(std::iter::repeat_n(0u8, pad));
             }
             "Bytes" | "bytes" => {
                 let s = value.as_str()
@@ -461,7 +461,7 @@ impl<'a> Contract<'a> {
                 buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
                 buf.extend_from_slice(&bytes);
                 let pad = (8 - (bytes.len() % 8)) % 8;
-                buf.extend(std::iter::repeat(0u8).take(pad));
+                buf.extend(std::iter::repeat_n(0u8, pad));
             }
             // Tuple "(T1, T2, ...)" — sequential fields, no length prefix
             _ if ty.starts_with('(') && ty.ends_with(')') => {
@@ -901,7 +901,7 @@ fn parse_json_i128(v: &serde_json::Value) -> Option<i128> {
 }
 
 fn parse_json_u256(v: &serde_json::Value) -> Option<ethnum::U256> {
-    v.as_u64().map(|n| ethnum::U256::from(n))
+    v.as_u64().map(ethnum::U256::from)
         .or_else(|| v.as_str().and_then(|s| {
             if let Some(hex) = s.strip_prefix("0x") {
                 ethnum::U256::from_str_radix(hex, 16).ok()
@@ -912,7 +912,7 @@ fn parse_json_u256(v: &serde_json::Value) -> Option<ethnum::U256> {
 }
 
 fn parse_json_i256(v: &serde_json::Value) -> Option<ethnum::I256> {
-    v.as_i64().map(|n| ethnum::I256::from(n))
+    v.as_i64().map(ethnum::I256::from)
         .or_else(|| v.as_u64().map(|n| ethnum::I256::from(n as i128)))
         .or_else(|| v.as_str().and_then(|s| {
             if let Some(hex) = s.strip_prefix("0x") {

--- a/crates/pyde-rust-sdk/src/client.rs
+++ b/crates/pyde-rust-sdk/src/client.rs
@@ -117,7 +117,7 @@ impl Provider {
     /// Static call with overrides (from, value, gas).
     pub async fn call_with(&self, to: &Address, data: &[u8], overrides: Option<&CallOverrides>) -> Result<Vec<u8>> {
         let mut params = serde_json::json!({
-            "from": overrides.and_then(|o| o.from.as_ref()).map(|a| format_address(a))
+            "from": overrides.and_then(|o| o.from.as_ref()).map(format_address)
                 .unwrap_or_else(|| "0x".to_string() + &"00".repeat(32)),
             "to": format_address(to),
             "data": format!("0x{}", hex::encode(data)),
@@ -138,7 +138,7 @@ impl Provider {
     /// Estimate gas with overrides (from, value, gas).
     pub async fn estimate_gas_with(&self, to: &Address, data: &[u8], overrides: Option<&CallOverrides>) -> Result<u64> {
         let mut params = serde_json::json!({
-            "from": overrides.and_then(|o| o.from.as_ref()).map(|a| format_address(a))
+            "from": overrides.and_then(|o| o.from.as_ref()).map(format_address)
                 .unwrap_or_else(|| "0x".to_string() + &"00".repeat(32)),
             "to": format_address(to),
             "data": format!("0x{}", hex::encode(data)),

--- a/crates/pyde-rust-sdk/src/contract.rs
+++ b/crates/pyde-rust-sdk/src/contract.rs
@@ -162,7 +162,7 @@ impl ContractCall {
         self.args.extend_from_slice(bytes);
         // Pad to 8-byte alignment
         let padding = (8 - (bytes.len() % 8)) % 8;
-        self.args.extend(std::iter::repeat(0u8).take(padding));
+        self.args.extend(std::iter::repeat_n(0u8, padding));
         self
     }
 
@@ -369,7 +369,7 @@ impl DeployData {
         self.args.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
         self.args.extend_from_slice(bytes);
         let padding = (8 - (bytes.len() % 8)) % 8;
-        self.args.extend(std::iter::repeat(0u8).take(padding));
+        self.args.extend(std::iter::repeat_n(0u8, padding));
         self
     }
     // Raw bytes

--- a/crates/slashing/Cargo.toml
+++ b/crates/slashing/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 description = "Shared slashing constants and evidence schema version for Pyde. Leaf crate with zero deps — intentionally kept minimal so both pyde-tx (slash-tx handler) and pyde-consensus (slash-result computation) can depend on it without creating a dep cycle."
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -13,3 +13,6 @@ tempfile = "3"
 [[bench]]
 name = "smt_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/state/src/backend.rs
+++ b/crates/state/src/backend.rs
@@ -438,6 +438,7 @@ mod tests {
     use crate::smt::{key_from_seed, Poseidon2Hasher, SmtValue};
     use sparse_merkle_tree::SparseMerkleTree;
 
+    #[allow(clippy::upper_case_acronyms)] // SMT = Sparse Merkle Tree
     type SMT<S> = SparseMerkleTree<Poseidon2Hasher, SmtValue, S>;
 
     // ========== Task 0293: Backend get/put/delete roundtrip ==========

--- a/crates/state/src/keys.rs
+++ b/crates/state/src/keys.rs
@@ -374,12 +374,10 @@ mod tests {
     #[test]
     fn account_keys_all_different() {
         let a = test_addr(0xAAAA);
-        let keys = vec![
-            balance_key(&a),
+        let keys = [balance_key(&a),
             nonce_key(&a),
             code_key(&a),
-            code_hash_key(&a),
-        ];
+            code_hash_key(&a)];
         for i in 0..keys.len() {
             for j in (i + 1)..keys.len() {
                 assert_ne!(keys[i], keys[j], "collision between metadata {i} and {j}");

--- a/crates/state/src/snapshot.rs
+++ b/crates/state/src/snapshot.rs
@@ -118,7 +118,7 @@ pub fn apply_incremental(smt: &mut PydeSMT, inc: &IncrementalSnapshot) -> Result
 
 /// Split a snapshot into chunks of `chunk_size` entries each.
 pub fn chunk_snapshot(snapshot: &Snapshot, chunk_size: usize) -> Vec<SnapshotChunk> {
-    let total_chunks = (snapshot.entries.len() + chunk_size - 1) / chunk_size;
+    let total_chunks = snapshot.entries.len().div_ceil(chunk_size);
     let total = total_chunks.max(1) as u32;
 
     snapshot
@@ -183,7 +183,7 @@ mod tests {
 
     fn populate_smt(count: u64) -> (PydeSMT, Vec<Key>) {
         let mut smt = PydeSMT::new();
-        let keys: Vec<Key> = (0..count).map(|i| key_from_seed(i)).collect();
+        let keys: Vec<Key> = (0..count).map(key_from_seed).collect();
         for (i, k) in keys.iter().enumerate() {
             smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }

--- a/crates/state/src/tiers.rs
+++ b/crates/state/src/tiers.rs
@@ -294,6 +294,7 @@ mod tests {
     use sparse_merkle_tree::traits::Value;
     use sparse_merkle_tree::SparseMerkleTree;
 
+    #[allow(clippy::upper_case_acronyms)] // SMT = Sparse Merkle Tree
     type SMT<S> = SparseMerkleTree<Poseidon2Hasher, SmtValue, S>;
 
     fn make_tiered() -> TieredBackend<InMemoryBackend, NullColdStorage> {

--- a/crates/state/src/witness.rs
+++ b/crates/state/src/witness.rs
@@ -245,7 +245,7 @@ mod tests {
         for i in 0..10u64 {
             smt.insert(key_from_seed(i), format!("val_{i}").into_bytes()).unwrap();
         }
-        let keys: Vec<Key> = (0..10).map(|i| key_from_seed(i)).collect();
+        let keys: Vec<Key> = (0..10).map(key_from_seed).collect();
 
         let witness = generate_witnesses(&smt, &keys).unwrap();
         assert!(verify_witnesses(&witness));
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn witness_state_map_matches_full_state() {
         let mut smt = PydeSMT::new();
-        let keys: Vec<Key> = (0..10).map(|i| key_from_seed(i)).collect();
+        let keys: Vec<Key> = (0..10).map(key_from_seed).collect();
         for (i, k) in keys.iter().enumerate() {
             smt.insert(*k, format!("val_{i}").into_bytes()).unwrap();
         }
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn batch_proof_smaller_than_individual() {
         let mut smt = PydeSMT::new();
-        let keys: Vec<Key> = (0..100).map(|i| key_from_seed(i)).collect();
+        let keys: Vec<Key> = (0..100).map(key_from_seed).collect();
         for (i, k) in keys.iter().enumerate() {
             smt.insert(*k, format!("v{i}").into_bytes()).unwrap();
         }

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -18,3 +18,6 @@ ethnum = "1.5.2"
 [dev-dependencies]
 otic = { path = "../otic" }
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/tx/src/multisig.rs
+++ b/crates/tx/src/multisig.rs
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn signer_set_rejects_over_max() {
-        let mut bytes = vec![(MAX_SIGNERS + 1) as u8];
+        let mut bytes = vec![MAX_SIGNERS + 1];
         bytes.extend_from_slice(&vec![0u8; (MAX_SIGNERS as usize + 1) * 897]);
         assert!(decode_signer_set(&bytes).is_none());
     }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -231,12 +231,12 @@ fn execute_transaction_inner(
         &mut gas_tank_balance,
         block_ctx.base_fee,
     )
-    .map_err(|e| PipelineError::ExecutionFailed(e))?;
+    .map_err(PipelineError::ExecutionFailed)?;
     sender.gas_tank = gas_tank_balance;
 
     // 5. Value transfer
     transfer_value(&mut sender.balance, &mut recipient.balance, tx.value)
-        .map_err(|e| PipelineError::ExecutionFailed(e))?;
+        .map_err(PipelineError::ExecutionFailed)?;
 
     // 6. PVM execution (if contract call or deployment)
     let (success, gas_used, gas_refund, logs, return_data) = match tx.tx_type {
@@ -729,7 +729,6 @@ fn execute_in_pvm(
         let ok = output.outcome == Outcome::Success;
         (ok, output.gas_used)
     };
-    let success = success;
 
     // Persist VM storage changes back to SMT.
     // Use the derived key directly (same as what the VM uses internally).
@@ -1866,7 +1865,7 @@ fn execute_rotate_multisig(
                 b"rotate contains malformed pk".to_vec(),
             );
         }
-        if seen.iter().any(|p| *p == pk.as_slice()) {
+        if seen.contains(&pk.as_slice()) {
             return (
                 false,
                 gas,
@@ -2611,6 +2610,10 @@ mod tests {
 
     // ========== E2E: Otigen compile → deploy → call (struct + Vec + while loop) ==========
 
+    // `arc_with_non_send_sync`: the storage_backend closure captures a
+    // raw `*const PydeSMT` pointer (!Send/!Sync). Single-thread test
+    // context; same rationale as otic/src/codegen.rs tests module.
+    #[allow(clippy::arc_with_non_send_sync)]
     #[test]
     fn e2e_rank_contract() {
         // Compile the RankTest contract from source
@@ -2702,7 +2705,7 @@ mod tests {
         calldata.extend_from_slice(&1u64.to_le_bytes()); // bid = 1
 
         let ctx = pyde_vm::vm::ExecutionContext {
-            self_address: contract_addr.into(),
+            self_address: contract_addr,
             ..Default::default()
         };
         let mut vm = pyde_vm::vm::Vm::with_gas_limit_and_context(100_000_000, ctx);

--- a/crates/tx/tests/prop_integration_nonce.rs
+++ b/crates/tx/tests/prop_integration_nonce.rs
@@ -28,7 +28,7 @@ proptest! {
         // Scripted sequence of (good_sig_count) per attempted spend.
         attempts in prop::collection::vec(0u8..=8, 1..=5),
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let mut smt = PydeSMT::new();
         let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
@@ -37,8 +37,13 @@ proptest! {
         let ctx = block_ctx(100);
 
         let mut expected_nonce = 0u64;
+        // `outer_nonce` tracks the submitter's tx-level nonce. It happens
+        // to equal `i` in this loop, but the semantic is distinct (tx
+        // nonce, not attempt index) — keep the named binding rather
+        // than reusing `i`.
         let mut outer_nonce = 0u64;
 
+        #[allow(clippy::explicit_counter_loop)]
         for (i, good_sig_count) in attempts.iter().enumerate() {
             let good = (*good_sig_count as usize).min(n);
             let spend = multisig::MultisigSpend {
@@ -52,7 +57,7 @@ proptest! {
                 data_digest: [0xAA; 32],
             };
             let indices: Vec<u8> = (0..good as u8).collect();
-            let sks_slice: Vec<_> = sks[..good].iter().copied().collect();
+            let sks_slice: Vec<_> = sks[..good].to_vec();
             let sigs = sign_multisig_spend(&spend, &sks_slice, &indices, expected_nonce);
             let payload = multisig::MultisigPayload::Spend { spend, sigs };
             let tx = build_multisig_tx(submitter, sub_sk, payload.encode(), outer_nonce);
@@ -86,7 +91,7 @@ proptest! {
         threshold in 1u8..=8,
         good_sigs in 0u8..=8,
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let good = (good_sigs as usize).min(n);
 
@@ -150,7 +155,7 @@ proptest! {
         threshold in 2u8..=6,
         duration in 10u64..=1_000_000,
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let mut smt = PydeSMT::new();
         let sks = install_multisig(&mut smt, n, threshold, 1_000_000_000);
@@ -159,7 +164,7 @@ proptest! {
 
         // Pause with full threshold.
         let indices: Vec<u8> = (0..threshold).collect();
-        let sks_thr: Vec<_> = sks[..threshold as usize].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..threshold as usize].to_vec();
         let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
         let pause_payload = multisig::EmergencyPausePayload {
             duration_slots: duration,

--- a/crates/tx/tests/prop_integration_pause.rs
+++ b/crates/tx/tests/prop_integration_pause.rs
@@ -86,7 +86,7 @@ proptest! {
 
         // Pause.
         let indices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..t].to_vec();
         let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
         let pause_payload = multisig::EmergencyPausePayload {
             duration_slots: duration,
@@ -125,7 +125,7 @@ proptest! {
         let ctx = block_ctx(100);
 
         let indices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..t].to_vec();
         let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
         let pause_payload = multisig::EmergencyPausePayload {
             duration_slots: duration,
@@ -169,7 +169,7 @@ proptest! {
         let ctx = block_ctx(100);
 
         let indices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..t].to_vec();
         let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
         let pause_payload = multisig::EmergencyPausePayload {
             duration_slots: duration,
@@ -208,7 +208,7 @@ proptest! {
         let ctx_at_pause = block_ctx(pause_slot);
 
         let indices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..t].to_vec();
         let pause_sigs = sign_pause(duration, &sks_thr, &indices, 0);
         let pause_payload = multisig::EmergencyPausePayload {
             duration_slots: duration,

--- a/crates/tx/tests/prop_integration_replay.rs
+++ b/crates/tx/tests/prop_integration_replay.rs
@@ -49,7 +49,7 @@ proptest! {
         threshold in 1u8..=6,
         value in 100u128..=100_000,
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let t = threshold as usize;
 
@@ -64,7 +64,7 @@ proptest! {
             data_digest: [0xAA; 32],
         };
         let indices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = sks[..t].to_vec();
         let sigs = sign_multisig_spend(&spend, &sks_thr, &indices, 0);
         let payload = multisig::MultisigPayload::Spend {
             spend: spend.clone(),
@@ -93,7 +93,7 @@ proptest! {
         n_signers in 2u8..=6,
         threshold in 1u8..=6,
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let t = threshold as usize;
 
@@ -145,7 +145,7 @@ proptest! {
         n_signers in 2u8..=6,
         threshold in 1u8..=6,
     ) {
-        prop_assume!(threshold as u8 <= n_signers);
+        prop_assume!(threshold <= n_signers);
         let n = n_signers as usize;
         let t = threshold as usize;
 
@@ -185,7 +185,7 @@ proptest! {
             data_digest: [0xBB; 32],
         };
         let sindices: Vec<u8> = (0..t as u8).collect();
-        let sks_thr: Vec<_> = old_sks[..t].iter().copied().collect();
+        let sks_thr: Vec<_> = old_sks[..t].to_vec();
         let sigs = sign_multisig_spend(&spend, &sks_thr, &sindices, 1);
         let spayload = multisig::MultisigPayload::Spend { spend, sigs };
         let stx = build_multisig_tx(submitter, sub_sk, spayload.encode(), 1);


### PR DESCRIPTION
## Summary

Mirror of slice 5.4 for clippy. Drives workspace clippy from **121 warnings + 38 hidden deny-by-default errors → 0** errors + 1 cargo config warning (the `[profile.release]` in `pyde-crypto-wasm` that cargo ignores in workspace context — not emitted by clippy, so `-D warnings` won't trip on it).

**Unlocks task 048 fully** — slice 5.6 can now wire `cargo clippy --workspace -- -D warnings` into CI as a trivial YAML addition.

## Real bugs the sweep caught

- **`node/src/node.rs::handle_decrypted_block_execution`** — a `MutexGuard` from `state_w.smt_mut()` was held across a `.await` inside the match body (on `receipts.write()`). Tokio's scheduler can move futures between threads; holding a std `Mutex` guard across an await is a well-known deadlock / UB pattern. Fixed by binding `execute_transaction`'s result **before** the match so the temporary guard drops at the semicolon.

- **`node/tests/production_sim.rs`** — `if acc_idx < 10 { accounts[acc_idx].pk.as_bytes() } else { accounts[acc_idx].pk.as_bytes() }` — both arms identical (leftover from a refactor where deploy vs non-deploy accounts lived in separate collections). Collapsed.

- **`node/src/node.rs::PostEventAction`** — two `if` arms both returned `ContinueSync`. Collapsed into `if A || B { ContinueSync } else { None }`.

- **`tx/src/pipeline.rs`** — `let success = success;` dead rebinding from a refactor. Removed.

## Workspace-level lint configuration

Added `[workspace.lints.clippy]` in root `Cargo.toml` with per-crate opt-in via `[lints] workspace = true`. Documents project-wide style decisions where clippy's defaults don't match codebase convention:

- `too_many_arguments` — consensus + pipeline functions carry 8-12 primitive args naturally
- `needless_range_loop` — crypto polynomial/share math reads better as `for i in 0..N`
- `type_complexity` — VM/compiler internals pass around nested generics where shape IS documentation
- `doc_lazy_continuation` / `empty_line_after_doc_comments` — align with existing codebase style

## Scoped (per-module / per-function) allows

Each with an explanatory comment documenting **why** the allow is warranted, not just that it exists:

- `arc_with_non_send_sync` on test modules capturing raw `*const PydeSMT` pointers (otic/codegen.rs, tx/pipeline.rs). Alternative: switching `Vm::storage_backend` from Arc to Rc project-wide — a refactor that only matters if we ever parallelize VM execution.
- `not_unsafe_ptr_arg_deref` at `aot/src/host.rs` module level. Host functions are `extern "C"` taking `*mut VmCtx` from the JIT. Marking them `unsafe extern "C" fn` would force `unsafe { }` at every JIT emission site — purely ergonomic friction.
- `eq_op` at `otic/src/codegen.rs` — patterns like `(14 & 0xF) << 2` deliberately keep the 4-bit mask to document register-encoding field width.
- `erasing_op` on one `block.rs` test asserting `0 / EPOCH_LENGTH == 0` (genesis sanity).
- `cloned_ref_to_slice_refs` on test modules with `&[tx.clone()]` determinism asserts.
- `only_used_in_recursion` on two `otic/safety.rs` methods keeping `&self` for call-site symmetry.
- `explicit_counter_loop` on one prop_integration test (`outer_nonce` = tx-level nonce, semantically distinct from attempt index).
- `nonminimal_bool` on `otic/typecheck.rs` type-compat check — chain-of-ANDs with per-line comments is what makes the compatibility matrix readable; clippy's De-Morgan rewrite loses that.

## Mechanical fixes via `cargo clippy --fix`

Redundant closures, same-type casts, `map_or` simplifications, `is_err()` over `while let Err(_) = ...`, `contains_key(&k)` over `get(&k).is_some()`, etc. Applied across ~70 files.

## Stats

- **70 files modified** (15 Cargo.toml files with new `[lints]` block), +395 / -218 lines
- **Workspace tests: 2322 passed, 0 failed** (unchanged from pre-5.5)

## Follow-up

- **Slice 5.6** — task 048: `cargo clippy --workspace -- -D warnings` in CI. Now trivial.