### PR TITLE
feat: 4-node tx-propagation test + plumb dev-sig-skip through block processor

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -55,7 +55,16 @@ impl BlockProcessor {
         // 1. Validate header
         Self::validate_header_with_checkpoint(&block.header, chain, ws_checkpoint_slot)?;
 
-        // 2. Build block context for tx execution
+        // 2. Build block context for tx execution.
+        //
+        // `dev_skip_signature` follows `chain_id == 31337` (devnet) so the
+        // pipeline-level validation matches the batch-verification skip
+        // below and the `pyde_sendTransaction` RPC dev-mode gate. This is
+        // a chain-wide property (consensus would fork if half the nodes
+        // accepted unsigned txs and half rejected them), so tying it to
+        // chain_id — which is consensus-critical and identical across
+        // every validator — is the only sound choice.
+        let dev_skip_signature = chain.chain_id == 31337;
         let block_ctx = BlockContext {
             height: slot,
             timestamp: block.header.timestamp,
@@ -63,7 +72,7 @@ impl BlockProcessor {
             block_gas_limit: pyde_tx::fee::GAS_CEILING,
             chain_id: chain.chain_id,
             validator_address: block.header.proposer,
-            dev_skip_signature: false,
+            dev_skip_signature,
         };
 
         // 3. Batch signature verification (parallel across all CPU cores).

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -173,6 +173,170 @@ impl TestNetwork {
     pub fn state_root(&self, node_idx: usize) -> Result<String, String> {
         rpc_state_root(&self.nodes[node_idx].rpc_url())
     }
+
+    // --------------------------------------------------------------
+    // Tx lifecycle helpers (slice 6.2)
+    // --------------------------------------------------------------
+
+    /// Pre-funded addresses from `node-0`'s `genesis.toml`. Includes
+    /// every validator (staked account), 5 extra non-validator accounts,
+    /// and the faucet. Useful sources for test transfers.
+    pub fn funded_addresses(&self) -> Result<Vec<[u8; 32]>, String> {
+        let path = self.nodes[0].datadir.join("genesis.toml");
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("read {}: {}", path.display(), e))?;
+        // Lightweight scrape of `address = "hex..."` lines. A full TOML
+        // decoder would pull in another dep; this is plenty for the
+        // harness's needs.
+        let mut out = Vec::new();
+        for line in content.lines() {
+            let t = line.trim();
+            if let Some(rest) = t.strip_prefix("address = \"") {
+                if let Some(hex) = rest.strip_suffix('"') {
+                    if let Ok(bytes) = hex::decode(hex) {
+                        if bytes.len() == 32 {
+                            let mut a = [0u8; 32];
+                            a.copy_from_slice(&bytes);
+                            // genesis.toml lists validators twice (once
+                            // in `[[allocations]]`, once in
+                            // `[[validators]]`) — dedupe.
+                            if !out.contains(&a) {
+                                out.push(a);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if out.is_empty() {
+            return Err(format!("no addresses found in {}", path.display()));
+        }
+        Ok(out)
+    }
+
+    /// Submit a dev-mode transfer from `from` to `to` for `value`
+    /// quanta via node `node_idx`. Returns the tx hash.
+    ///
+    /// No signature is constructed — devnet's `chain_id == 31337`
+    /// path in the RPC handler skips signature verification, and the
+    /// network was spawned with `dev = true` specifically to unlock
+    /// this path.
+    pub fn submit_transfer(
+        &self,
+        node_idx: usize,
+        from: &[u8; 32],
+        to: &[u8; 32],
+        value: u128,
+    ) -> Result<String, String> {
+        let params = format!(
+            r#"[{{"from":"0x{}","to":"0x{}","value":"{}","gas":100000}}]"#,
+            hex::encode(from),
+            hex::encode(to),
+            value
+        );
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_sendTransaction",
+            &params,
+        )?;
+        // `pyde_sendTransaction` returns a JSON-stringified object as
+        // its `result` field, so the raw wire format is:
+        //   {"jsonrpc":"2.0","id":1,"result":"{\"txHash\":\"0x...\"}"}
+        // The inner quotes are escaped. Scan for the escaped
+        // `txHash` pattern directly rather than trying to unescape
+        // the string first.
+        parse_escaped_tx_hash(&resp).map_err(|e| {
+            format!(
+                "pyde_sendTransaction parse failed: {}; raw response:\n{}",
+                e, resp
+            )
+        })
+    }
+
+    /// Balance in quanta. Returns `0` if the account is unknown.
+    pub fn get_balance(&self, node_idx: usize, address: &[u8; 32]) -> Result<u128, String> {
+        let params = format!(r#"["0x{}"]"#, hex::encode(address));
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getBalance",
+            &params,
+        )?;
+        // `pyde_getBalance` returns the balance as a decimal string
+        // (see `balance.to_string()` in `rpc.rs::get_balance`). Not
+        // hex, despite the `0x`-ish feel of the sibling RPCs.
+        let raw = parse_hex_result(&resp)?;
+        raw.parse::<u128>()
+            .map_err(|e| format!("parse balance {:?}: {}", raw, e))
+    }
+
+    /// Get the receipt for a tx. Returns `Ok(None)` if the node has
+    /// not yet indexed the tx (e.g. it hasn't been included yet).
+    pub fn get_receipt(
+        &self,
+        node_idx: usize,
+        tx_hash: &str,
+    ) -> Result<Option<ReceiptView>, String> {
+        let params = format!(r#"["{}"]"#, tx_hash);
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getTransactionReceipt",
+            &params,
+        )?;
+        // Response: `"result":null` or `"result":{...}`.
+        let body = resp.trim();
+        if body.contains(r#""result":null"#) {
+            return Ok(None);
+        }
+        // Extract success flag + block slot from JSON. Use simple
+        // string matching to avoid pulling serde into the harness.
+        let success = extract_bool_field(body, "status")
+            .or_else(|| extract_bool_field(body, "success"))
+            .unwrap_or(false);
+        let block_slot = extract_u64_field(body, "blockNumber")
+            .or_else(|| extract_u64_field(body, "slot"));
+        Ok(Some(ReceiptView {
+            raw: body.to_string(),
+            success,
+            block_slot,
+        }))
+    }
+
+    /// Poll every node until each reports a receipt for `tx_hash` or
+    /// the deadline elapses. Returns the per-node receipt snapshots.
+    pub fn wait_for_receipt_on_all(
+        &self,
+        tx_hash: &str,
+        timeout: Duration,
+    ) -> Result<Vec<ReceiptView>, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let mut all: Vec<Option<ReceiptView>> = Vec::with_capacity(self.nodes.len());
+            for n in &self.nodes {
+                all.push(self.get_receipt(n.index, tx_hash).ok().flatten());
+            }
+            if all.iter().all(|r| r.is_some()) {
+                return Ok(all.into_iter().map(Option::unwrap).collect());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "receipt for {} never appeared on all nodes within {:?}; per-node: {:?}",
+                    tx_hash,
+                    timeout,
+                    all.iter().map(|r| r.is_some()).collect::<Vec<_>>()
+                ));
+            }
+            thread::sleep(Duration::from_millis(250));
+        }
+    }
+}
+
+/// Lightweight receipt representation. Full receipt JSON is kept as
+/// `raw` so tests can drill into fields the harness doesn't expose.
+#[derive(Clone, Debug)]
+pub struct ReceiptView {
+    pub raw: String,
+    pub success: bool,
+    pub block_slot: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -400,4 +564,68 @@ fn parse_hex_result(resp: &str) -> Result<String, String> {
         .find('"')
         .ok_or_else(|| format!("unterminated result in {:?}", resp))?;
     Ok(tail[..end].to_string())
+}
+
+/// Extract the `txHash` from a `pyde_sendTransaction` response.
+///
+/// The handler in `crates/node/src/rpc.rs` wraps the hash in a
+/// JSON-stringified object (`Result<String, _>` where the string is
+/// itself a serialized JSON object). On the wire, that produces
+/// `"result":"{\"txHash\":\"0x...\"}"` — so we scan for the escaped
+/// `\"txHash\":\"` pattern directly.
+fn parse_escaped_tx_hash(resp: &str) -> Result<String, String> {
+    let needle = r#"\"txHash\":\""#;
+    let idx = resp
+        .find(needle)
+        .ok_or_else(|| format!("no txHash in {:?}", resp))?;
+    let tail = &resp[idx + needle.len()..];
+    let end = tail
+        .find(r#"\""#)
+        .ok_or_else(|| format!("unterminated txHash in {:?}", resp))?;
+    Ok(tail[..end].to_string())
+}
+
+/// Extract `"<field>": true|false` from a JSON blob. Returns `None`
+/// if the field isn't present. Tolerant of whitespace but assumes
+/// no nested object shares the key name.
+fn extract_bool_field(body: &str, field: &str) -> Option<bool> {
+    let needle = format!(r#""{}""#, field);
+    let start = body.find(&needle)? + needle.len();
+    let tail = &body[start..];
+    let colon = tail.find(':')? + 1;
+    let rest = tail[colon..].trim_start();
+    if rest.starts_with("true") {
+        Some(true)
+    } else if rest.starts_with("false") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Extract `"<field>": 123` or `"<field>": "0x..."` as a u64.
+fn extract_u64_field(body: &str, field: &str) -> Option<u64> {
+    let needle = format!(r#""{}""#, field);
+    let start = body.find(&needle)? + needle.len();
+    let tail = &body[start..];
+    let colon = tail.find(':')? + 1;
+    let rest = tail[colon..].trim_start();
+    if rest.starts_with('"') {
+        // Quoted string — look for closing quote.
+        let inner = &rest[1..];
+        let end = inner.find('"')?;
+        let s = &inner[..end];
+        if let Some(hex) = s.strip_prefix("0x") {
+            u64::from_str_radix(hex, 16).ok()
+        } else {
+            s.parse().ok()
+        }
+    } else {
+        // Bare number — read until a non-digit.
+        let end = rest
+            .bytes()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        rest[..end].parse().ok()
+    }
 }

--- a/crates/node/tests/multi_node_propagation.rs
+++ b/crates/node/tests/multi_node_propagation.rs
@@ -1,0 +1,180 @@
+//! End-to-end transaction lifecycle test (slice 6.2, plan task 064).
+//!
+//! Submits a real transfer to node-0's RPC and verifies every node
+//! observes the resulting state change: same receipt, same sender
+//! debit, same recipient credit. This is the first test that
+//! exercises the tx propagation path end-to-end — slice 6.1 only
+//! covered block production + state-root convergence on otherwise
+//! empty blocks.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::Duration;
+
+/// Task 064: tx submitted to node-0 propagates to every node and
+/// produces identical state on every node.
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn transfer_propagates_and_balances_match() {
+    let net = TestNetwork::spawn(4, true).unwrap_or_else(|e| {
+        panic!("spawn 4-node testnet: {}", e);
+    });
+
+    // Pick sender + recipient from genesis allocations. `funded_addresses()`
+    // dedupes validators listed in both `[[allocations]]` and
+    // `[[validators]]`. Slots 0..4 are validator addresses; slots 4+
+    // are the 5 test-only accounts `generate_testnet` creates.
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("read funded: {}", e));
+    assert!(
+        funded.len() >= 6,
+        "expected >= 6 funded addresses from genesis (4 validators + 5 test + faucet), got {}",
+        funded.len()
+    );
+    // Use two test-only accounts (not validators) to avoid interaction
+    // with validator fee crediting and to keep the expected delta clean.
+    let sender = funded[4];
+    let recipient = funded[5];
+    let transfer_value: u128 = 1_000_000_000; // 1 PYDE
+
+    // Wait for chain to advance — submitting before nodes finish
+    // bootstrap can flake.
+    net.wait_for_slot(3, Duration::from_secs(30))
+        .unwrap_or_else(|e| panic!("initial warm-up: {}", e));
+
+    // Snapshot pre-tx balances on every node — they must all agree.
+    let pre_balances = sample_balances(&net, &sender, &recipient);
+    assert_convergent(&pre_balances, "pre-transfer balance divergence");
+
+    // Submit via node-0.
+    let tx_hash = net
+        .submit_transfer(0, &sender, &recipient, transfer_value)
+        .unwrap_or_else(|e| panic!("submit_transfer: {}", e));
+    eprintln!(
+        "tx_hash returned by submit_transfer: bytes={:?} string={}",
+        tx_hash.as_bytes(),
+        tx_hash
+    );
+
+    // Wait for every node to see the receipt. 60s is generous — one
+    // block at 400ms + gossip + execution should be well under 10s.
+    let receipts = net
+        .wait_for_receipt_on_all(&tx_hash, Duration::from_secs(60))
+        .unwrap_or_else(|e| {
+            let dumps = per_node_dump(&net);
+            panic!("{}\n{}", e, dumps);
+        });
+
+    // Every receipt must report success.
+    for (i, r) in receipts.iter().enumerate() {
+        // Print raw JSON for debugging — helpful when the receipt
+        // parser logic disagrees with reality.
+        eprintln!("node-{} receipt: {}", i, r.raw);
+        assert!(
+            r.success,
+            "node-{} reported a failed receipt:\nraw: {}",
+            i, r.raw
+        );
+    }
+
+    // Every receipt must reference the same block slot.
+    let block_slot = receipts[0].block_slot;
+    for (i, r) in receipts.iter().enumerate().skip(1) {
+        assert_eq!(
+            r.block_slot, block_slot,
+            "node-{} saw tx in slot {:?} but node-0 saw slot {:?}",
+            i, r.block_slot, block_slot
+        );
+    }
+
+    // Every node's state_root must match — no fork.
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let root = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            root, reference_root,
+            "state_root divergence after tx:\n  node-0:  {}\n  node-{}: {}",
+            reference_root, n.index, root
+        );
+    }
+
+    // Final balance check: sender down by at least `transfer_value`
+    // (plus gas), recipient up by exactly `transfer_value`.
+    let post_balances = sample_balances(&net, &sender, &recipient);
+    assert_convergent(&post_balances, "post-transfer balance divergence");
+
+    let pre_sender = pre_balances[0].0;
+    let post_sender = post_balances[0].0;
+    let pre_recipient = pre_balances[0].1;
+    let post_recipient = post_balances[0].1;
+
+    assert!(
+        post_sender < pre_sender,
+        "sender balance did not decrease: pre {} post {}",
+        pre_sender,
+        post_sender
+    );
+    let sender_debit = pre_sender - post_sender;
+    assert!(
+        sender_debit >= transfer_value,
+        "sender debit {} is less than transfer_value {} (should include gas)",
+        sender_debit,
+        transfer_value
+    );
+
+    assert_eq!(
+        post_recipient, pre_recipient + transfer_value,
+        "recipient should receive exactly transfer_value; pre {} post {}",
+        pre_recipient, post_recipient
+    );
+}
+
+/// Read (sender, recipient) balances from every node.
+fn sample_balances(
+    net: &TestNetwork,
+    sender: &[u8; 32],
+    recipient: &[u8; 32],
+) -> Vec<(u128, u128)> {
+    net.nodes
+        .iter()
+        .map(|n| {
+            let s = net.get_balance(n.index, sender).unwrap_or(u128::MAX);
+            let r = net.get_balance(n.index, recipient).unwrap_or(u128::MAX);
+            (s, r)
+        })
+        .collect()
+}
+
+/// Assert every node reports the same (sender, recipient) balance.
+/// Fails with a readable message showing per-node divergence.
+fn assert_convergent(balances: &[(u128, u128)], context: &str) {
+    let first = balances[0];
+    for (i, b) in balances.iter().enumerate().skip(1) {
+        assert_eq!(
+            *b, first,
+            "{}: node-0 = {:?}, node-{} = {:?}",
+            context, first, i, b
+        );
+    }
+}
+
+fn per_node_dump(net: &TestNetwork) -> String {
+    net.nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "\n=== node-{} (rpc port {}) ===\n{}",
+                n.index,
+                n.rpc_port,
+                n.output_snapshot()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}


### PR DESCRIPTION
## Summary

- End-to-end 4-node tx lifecycle test: transfer submitted to node-0 must produce an identical successful receipt on every node, matching state roots, and convergent balance deltas (sender debit ≥ transfer_value, recipient credit == transfer_value).
- Fixes `block_processor::apply_block` hardcoding `dev_skip_signature = false` while the adjacent batch-verification step and the `pyde_sendTransaction` RPC already treated `chain_id == 31337` as the devnet marker. Unsigned dev-mode txs were being accepted into the mempool and then uniformly rejected during execution with `Validation(InvalidSignature)`. Aligning the pipeline flag with the existing chain-id convention closes the gap.
- Signature-skip is strictly chain-wide (forking otherwise) and scoped to chain_id 31337. Testnet and mainnet run different chain_ids, so FALCON-512 signature verification runs on every tx there unchanged.

## Test-harness additions (`crates/node/tests/common/mod.rs`)

- `funded_addresses()` — scrapes genesis.toml for validator + test-account + faucet addresses, dedupes validators that appear in both `[[allocations]]` and `[[validators]]`.
- `submit_transfer()` — POSTs `pyde_sendTransaction`.
- `get_balance()` — parses the decimal string the handler emits (not hex; this also fixes a latent parsing bug).
- `get_receipt()` / `wait_for_receipt_on_all()` — per-node polling until every node indexes the tx.
- `parse_escaped_tx_hash()` — `pyde_sendTransaction` wraps its result in a JSON-stringified object, so the `txHash` lives inside escaped quotes on the wire; targeted extractor avoids pulling serde_json into the harness.

## Verification

- Workspace: 2322 passed, 0 failed.
- Multi-node ignored suite (`cargo test -p pyde-node --test multi_node_finality --test multi_node_propagation -- --ignored`): 2 passed, 0 failed.