### PR TITLE
feat: --full-nodes flag for pyde testnet + full-node tx relay test

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -65,6 +65,12 @@ pub enum Command {
         #[arg(long, default_value = "2")]
         validators: usize,
 
+        /// Number of non-validator full nodes (0-16). Full nodes relay
+        /// transactions and serve RPC but do not participate in
+        /// consensus. Ports continue after the validator range.
+        #[arg(long, default_value = "0")]
+        full_nodes: usize,
+
         /// Output directory for testnet files.
         #[arg(long, short, default_value = "./testnet")]
         out: std::path::PathBuf,

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -745,6 +745,7 @@ pub fn devnet_genesis() -> (GenesisConfig, Vec<DevnetAccount>) {
 pub fn generate_testnet(
     out_dir: &std::path::Path,
     num_validators: usize,
+    num_full_nodes: usize,
     base_port: u16,
     base_rpc_port: u16,
     dev_mode: bool,
@@ -756,6 +757,9 @@ pub fn generate_testnet(
 
     if !(2..=128).contains(&num_validators) {
         return Err("validators must be between 2 and 128".into());
+    }
+    if num_full_nodes > 16 {
+        return Err("full_nodes must be 0..=16".into());
     }
 
     fs::create_dir_all(out_dir)
@@ -870,8 +874,17 @@ pub fn generate_testnet(
 
     // Pre-generate node identity keys (Ed25519 for libp2p) so we know peer IDs
     // and can write full bootstrap multiaddrs in each config.
-    let mut node_keypairs: Vec<(libp2p::identity::Keypair, libp2p::PeerId)> = Vec::new();
-    for _ in 0..num_validators {
+    //
+    // Indexing convention: slots 0..num_validators hold validator keypairs;
+    // slots num_validators..num_validators+num_full_nodes hold full-node
+    // keypairs. Validator bootstrap lists include every OTHER validator;
+    // full-node bootstrap lists include every validator (but no other full
+    // nodes — they find each other via gossipsub once connected to a
+    // validator).
+    let total_nodes = num_validators + num_full_nodes;
+    let mut node_keypairs: Vec<(libp2p::identity::Keypair, libp2p::PeerId)> =
+        Vec::with_capacity(total_nodes);
+    for _ in 0..total_nodes {
         let kp = pyde_net::node::generate_keypair();
         let peer_id = libp2p::PeerId::from(kp.public());
         node_keypairs.push((kp, peer_id));
@@ -933,6 +946,95 @@ pub fn generate_testnet(
         let config_toml = format!(
             r#"[node]
 role = "validator"
+chain_id = {chain_id}
+datadir = "{datadir}"
+dev_mode = {dev}
+
+[network]
+port = {p2p_port}
+max_peers = 50
+max_inbound = 30
+max_outbound = 20
+rate_limit_per_ip = 5
+bootstrap_peers = {bootstrap}
+
+[consensus]
+block_time_ms = 400
+gas_target = 400000000
+gas_ceiling = 1600000000
+
+[storage]
+db_path = "state"
+cache_size = 65536
+
+[rpc]
+enabled = true
+listen = "127.0.0.1"
+port = {rpc_port}
+
+[metrics]
+enabled = true
+port = {metrics_port}
+
+[logging]
+level = "info"
+json = false
+"#,
+            datadir = node_dir.display(),
+            dev = dev_mode,
+            p2p_port = p2p_port,
+            rpc_port = rpc_port,
+            metrics_port = metrics_port,
+            bootstrap = bootstrap,
+        );
+
+        fs::write(node_dir.join("config.toml"), config_toml)
+            .map_err(|e| format!("failed to write config.toml: {}", e))?;
+    }
+
+    // Write per-full-node directories. Full nodes share the same genesis
+    // and threshold.pk as validators but have no validator.key, no
+    // threshold.share, and a config with role = "full". Their bootstrap
+    // list points to every validator.
+    for f in 0..num_full_nodes {
+        let i = num_validators + f;
+        let node_dir = out_dir.join(format!("node-{}", i));
+        fs::create_dir_all(&node_dir)
+            .map_err(|e| format!("failed to create {}: {}", node_dir.display(), e))?;
+
+        // node.key
+        let node_key_bytes = pyde_net::node::keypair_to_bytes(&node_keypairs[i].0)
+            .map_err(|e| format!("failed to serialize node key: {}", e))?;
+        fs::write(node_dir.join("node.key"), &node_key_bytes)
+            .map_err(|e| format!("failed to write node.key: {}", e))?;
+
+        // threshold.pk (shared — same for every node).
+        fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
+            .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+
+        // Copy genesis.toml.
+        fs::write(node_dir.join("genesis.toml"), genesis_config.to_toml())
+            .map_err(|e| format!("failed to write genesis.toml: {}", e))?;
+
+        // Bootstrap list: all validators.
+        let mut bootstrap_addrs: Vec<String> = Vec::new();
+        for j in 0..num_validators {
+            let other_port = base_port + j as u16;
+            let other_peer_id = &node_keypairs[j].1;
+            bootstrap_addrs.push(format!(
+                "\"/ip4/127.0.0.1/udp/{}/quic-v1/p2p/{}\"",
+                other_port, other_peer_id
+            ));
+        }
+        let bootstrap = format!("[{}]", bootstrap_addrs.join(", "));
+
+        let p2p_port = base_port + i as u16;
+        let rpc_port = base_rpc_port + i as u16;
+        let metrics_port = 9090 + i as u16;
+
+        let config_toml = format!(
+            r#"[node]
+role = "full"
 chain_id = {chain_id}
 datadir = "{datadir}"
 dev_mode = {dev}

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -42,15 +42,22 @@ fn main() {
         }
         Command::Testnet {
             validators,
+            full_nodes,
             out,
             base_port,
             base_rpc_port,
             dev,
             chain_id,
         } => {
-            if let Err(e) =
-                genesis::generate_testnet(&out, validators, base_port, base_rpc_port, dev, chain_id)
-            {
+            if let Err(e) = genesis::generate_testnet(
+                &out,
+                validators,
+                full_nodes,
+                base_port,
+                base_rpc_port,
+                dev,
+                chain_id,
+            ) {
                 eprintln!("error: {}", e);
                 std::process::exit(1);
             }

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -70,12 +70,29 @@ impl TestNetwork {
     /// Spawn an N-validator testnet. `dev=true` uses `chain_id=31337`
     /// and skips signature validation (required for ad-hoc devnets).
     pub fn spawn(validators: usize, dev: bool) -> Result<Self, String> {
+        Self::spawn_mixed(validators, 0, dev)
+    }
+
+    /// Spawn V validators + F full nodes. Full nodes bootstrap to every
+    /// validator and relay txs but don't participate in consensus.
+    pub fn spawn_mixed(
+        validators: usize,
+        full_nodes: usize,
+        dev: bool,
+    ) -> Result<Self, String> {
         if !(2..=8).contains(&validators) {
             return Err(format!(
                 "validators must be 2..=8 for the harness; got {}",
                 validators
             ));
         }
+        if full_nodes > 4 {
+            return Err(format!(
+                "full_nodes must be 0..=4 for the harness; got {}",
+                full_nodes
+            ));
+        }
+        let total = validators + full_nodes;
 
         let tempdir = tempfile::tempdir().map_err(|e| format!("create tempdir: {}", e))?;
         let net_dir = tempdir.path().join("net");
@@ -85,13 +102,14 @@ impl TestNetwork {
         // Find contiguous free port ranges for p2p (UDP — used by QUIC)
         // and rpc (TCP). `pyde testnet` computes bootstrap multiaddrs as
         // `base_port + i`, so the range must be contiguous + free at
-        // startup. We probe by binding then immediately releasing.
-        let (p2p_base, _p2p_holders) = allocate_contiguous_udp_ports(validators)?;
-        let (rpc_base, _rpc_holders) = allocate_contiguous_tcp_ports(validators)?;
+        // startup for EVERY node (validators + full nodes). We probe by
+        // binding then immediately releasing.
+        let (p2p_base, _p2p_holders) = allocate_contiguous_udp_ports(total)?;
+        let (rpc_base, _rpc_holders) = allocate_contiguous_tcp_ports(total)?;
 
         // Run `pyde testnet` to set up genesis + per-node configs.
         run_testnet_cli(
-            &pyde_bin, validators, &net_dir, dev, chain_id, p2p_base, rpc_base,
+            &pyde_bin, validators, full_nodes, &net_dir, dev, chain_id, p2p_base, rpc_base,
         )?;
 
         // Drop the port-holder sockets just before spawning. There's
@@ -101,15 +119,17 @@ impl TestNetwork {
         drop(_p2p_holders);
         drop(_rpc_holders);
 
-        // Spawn all validators.
-        let mut nodes: Vec<TestNode> = Vec::with_capacity(validators);
-        for i in 0..validators {
+        // Spawn validators, then full nodes. Same launch path for both;
+        // only the `--role` flag differs (read from config.toml).
+        let mut nodes: Vec<TestNode> = Vec::with_capacity(total);
+        for i in 0..total {
+            let role: &'static str = if i < validators { "validator" } else { "full" };
             let node_dir = net_dir.join(format!("node-{}", i));
             let rpc_port = rpc_base + i as u16;
             let p2p_port = p2p_base + i as u16;
             let mut n = TestNode {
                 index: i,
-                role: "validator",
+                role,
                 rpc_port,
                 p2p_port,
                 datadir: node_dir,
@@ -126,9 +146,10 @@ impl TestNetwork {
         for node in &nodes {
             wait_rpc_up(&node.rpc_url(), deadline).map_err(|e| {
                 format!(
-                    "{}\n--- node-{} output ---\n{}",
+                    "{}\n--- node-{} ({}) output ---\n{}",
                     e,
                     node.index,
+                    node.role,
                     node.output_snapshot()
                 )
             })?;
@@ -139,6 +160,24 @@ impl TestNetwork {
             chain_id,
             _tempdir: tempdir,
         })
+    }
+
+    /// Indices of every validator node.
+    pub fn validator_indices(&self) -> Vec<usize> {
+        self.nodes
+            .iter()
+            .filter(|n| n.role == "validator")
+            .map(|n| n.index)
+            .collect()
+    }
+
+    /// Indices of every full-node.
+    pub fn full_node_indices(&self) -> Vec<usize> {
+        self.nodes
+            .iter()
+            .filter(|n| n.role == "full")
+            .map(|n| n.index)
+            .collect()
     }
 
     /// Poll each node's `pyde_blockNumber` until all ≥ `target_slot`
@@ -416,6 +455,7 @@ fn rand_port_seed(attempt: u32) -> u32 {
 fn run_testnet_cli(
     pyde: &Path,
     validators: usize,
+    full_nodes: usize,
     out: &Path,
     dev: bool,
     chain_id: u64,
@@ -426,6 +466,8 @@ fn run_testnet_cli(
     cmd.arg("testnet")
         .arg("--validators")
         .arg(validators.to_string())
+        .arg("--full-nodes")
+        .arg(full_nodes.to_string())
         .arg("--out")
         .arg(out)
         .arg("--base-port")

--- a/crates/node/tests/multi_node_full_node_relay.rs
+++ b/crates/node/tests/multi_node_full_node_relay.rs
@@ -1,0 +1,185 @@
+//! Full-node tx relay test (slice 6.3, plan task 065).
+//!
+//! Spins up 3 validators + 1 full node. Submits a transfer via the
+//! full node's RPC (NOT a validator), and verifies:
+//!   - a validator includes the tx in a block,
+//!   - every validator + the full node reports the same success
+//!     receipt, same block slot, matching state roots, and
+//!     convergent balances.
+//!
+//! This exercises the tx-gossip path from full node to validator and
+//! the block-gossip path back to the full node — the key thing that
+//! separates 6.3 from 6.2 (which submitted directly to a validator).
+
+mod common;
+
+use common::TestNetwork;
+use std::time::Duration;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn tx_via_full_node_reaches_validator() {
+    let net = TestNetwork::spawn_mixed(3, 1, true)
+        .unwrap_or_else(|e| panic!("spawn 3v+1f testnet: {}", e));
+
+    // Sanity: we got exactly one full node and it's indexed after the
+    // validators.
+    let fulls = net.full_node_indices();
+    assert_eq!(fulls.len(), 1, "expected 1 full node, got {}", fulls.len());
+    let full_idx = fulls[0];
+    assert_eq!(
+        full_idx, 3,
+        "full node should be at index 3 (after 3 validators)"
+    );
+    let validators = net.validator_indices();
+    assert_eq!(validators.len(), 3);
+
+    // Wait for the network to advance so we know gossip is live and
+    // the proposer lottery is producing blocks.
+    net.wait_for_slot(3, Duration::from_secs(30))
+        .unwrap_or_else(|e| panic!("initial warm-up: {}", e));
+
+    // Pick sender + recipient from genesis test accounts (slots 3..8
+    // are the 5 non-validator test accounts since we have 3 validators).
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("read funded: {}", e));
+    assert!(
+        funded.len() >= 3 + 5 + 1,
+        "expected >= 9 funded addresses (3 validators + 5 test + faucet), got {}",
+        funded.len()
+    );
+    let sender = funded[3];
+    let recipient = funded[4];
+    let transfer_value: u128 = 1_000_000_000;
+
+    // Pre-tx balance snapshot must agree across every node, including
+    // the full node.
+    let pre_balances = sample_balances(&net, &sender, &recipient);
+    assert_convergent(&pre_balances, "pre-transfer balance divergence");
+
+    // Submit via the FULL NODE, not a validator. This is the feature
+    // under test: the full node has no stake, doesn't propose, yet its
+    // RPC must accept the tx, gossip it, and the validators must
+    // include it in a block.
+    let tx_hash = net
+        .submit_transfer(full_idx, &sender, &recipient, transfer_value)
+        .unwrap_or_else(|e| panic!("submit_transfer via full node: {}", e));
+    eprintln!("tx_hash (submitted via node-{}): {}", full_idx, tx_hash);
+
+    // Wait for the receipt to land on every node.
+    let receipts = net
+        .wait_for_receipt_on_all(&tx_hash, Duration::from_secs(60))
+        .unwrap_or_else(|e| {
+            let dumps = per_node_dump(&net);
+            panic!("{}\n{}", e, dumps);
+        });
+
+    for (i, r) in receipts.iter().enumerate() {
+        let role = net.nodes[i].role;
+        eprintln!("node-{} ({}) receipt: {}", i, role, r.raw);
+        assert!(
+            r.success,
+            "node-{} ({}) reported a failed receipt:\nraw: {}",
+            i, role, r.raw
+        );
+    }
+
+    // Every receipt must point at the same block slot — the tx can't
+    // land in two different blocks on two different nodes.
+    let block_slot = receipts[0].block_slot;
+    for (i, r) in receipts.iter().enumerate().skip(1) {
+        assert_eq!(
+            r.block_slot, block_slot,
+            "node-{} saw tx in slot {:?}; node-0 saw slot {:?}",
+            i, r.block_slot, block_slot
+        );
+    }
+
+    // State roots must match across validators AND the full node.
+    // Divergence here would mean the full node is executing a
+    // different chain than the validators.
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let root = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            root, reference_root,
+            "state_root divergence after tx:\n  node-0:  {}\n  node-{} ({}): {}",
+            reference_root, n.index, n.role, root
+        );
+    }
+
+    // Balance deltas: sender debit ≥ transfer_value (gas added on top);
+    // recipient credit == transfer_value exactly.
+    let post_balances = sample_balances(&net, &sender, &recipient);
+    assert_convergent(&post_balances, "post-transfer balance divergence");
+
+    let pre_sender = pre_balances[0].0;
+    let post_sender = post_balances[0].0;
+    let pre_recipient = pre_balances[0].1;
+    let post_recipient = post_balances[0].1;
+
+    assert!(
+        post_sender < pre_sender,
+        "sender balance did not decrease: pre {} post {}",
+        pre_sender, post_sender
+    );
+    let sender_debit = pre_sender - post_sender;
+    assert!(
+        sender_debit >= transfer_value,
+        "sender debit {} < transfer_value {} (should include gas)",
+        sender_debit, transfer_value
+    );
+    assert_eq!(
+        post_recipient,
+        pre_recipient + transfer_value,
+        "recipient should receive exactly transfer_value; pre {} post {}",
+        pre_recipient, post_recipient
+    );
+}
+
+fn sample_balances(
+    net: &TestNetwork,
+    sender: &[u8; 32],
+    recipient: &[u8; 32],
+) -> Vec<(u128, u128)> {
+    net.nodes
+        .iter()
+        .map(|n| {
+            let s = net.get_balance(n.index, sender).unwrap_or(u128::MAX);
+            let r = net.get_balance(n.index, recipient).unwrap_or(u128::MAX);
+            (s, r)
+        })
+        .collect()
+}
+
+fn assert_convergent(balances: &[(u128, u128)], context: &str) {
+    let first = balances[0];
+    for (i, b) in balances.iter().enumerate().skip(1) {
+        assert_eq!(
+            *b, first,
+            "{}: node-0 = {:?}, node-{} = {:?}",
+            context, first, i, b
+        );
+    }
+}
+
+fn per_node_dump(net: &TestNetwork) -> String {
+    net.nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "\n=== node-{} ({}, rpc {}) ===\n{}",
+                n.index,
+                n.role,
+                n.rpc_port,
+                n.output_snapshot()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}


### PR DESCRIPTION
## Summary

- `pyde testnet --full-nodes N` provisions N non-validator nodes alongside the validators. Each full node gets `node.key` + `threshold.pk` + `genesis.toml` + a `config.toml` with `role = "full"`, bootstrapping to every validator.
- New multi-node ignored test `tx_via_full_node_reaches_validator`: 3 validators + 1 full node. Client submits a transfer to the full node's RPC (node-3). The tx must reach a validator via gossip, land in a block, and every node (validators and full node) must report an identical successful receipt + matching `pyde_stateRoot`.
- Closes the remaining relay-path hop that slice 6.2 didn't exercise (slice 6.2 submitted directly to a validator's RPC).

## Harness changes

- `TestNetwork::spawn_mixed(validators, full_nodes, dev)`. Existing `spawn()` is now a thin wrapper around `spawn_mixed(_, 0, _)`.
- `TestNode.role` is tracked per-node. Indices `[0, V)` are validators, `[V, V+F)` are full nodes (same convention as `pyde testnet` output).
- `validator_indices()` / `full_node_indices()` helpers on `TestNetwork` for tests that need to pick an RPC endpoint by role.

## Verification

- Workspace: 2322 passed, 0 failed.
- Multi-node ignored suite (`cargo test -p pyde-node --test multi_node_finality --test multi_node_propagation --test multi_node_full_node_relay -- --ignored`): 3 passed, 0 failed.