### PR TITLE
fix: double-sign slashing end-to-end + genesis validator-entry format

### DIFF
--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -445,8 +445,11 @@ pub fn initialize_genesis(
     }
 
     // 3. Write validator registry entries (for epoch committee selection).
-    // Each validator stored at validator_key(address) with serialized public key + stake.
-    // Format: [pk_len:4 LE][pk_bytes][stake:16 LE][status:1]
+    // Use `ValidatorEntry::encode()` so the wire format stays aligned
+    // with whatever `decode()` expects — the hand-rolled encoder here
+    // previously omitted the `last_claimed_at` field, which meant
+    // every decode() on a genesis entry returned None and the RPC
+    // + slash + stake paths silently saw an empty validator set.
     let mut val_count: u64 = 0;
     for val in &config.validators {
         let address = parse_hex_address(&val.address)?;
@@ -455,14 +458,16 @@ pub fn initialize_genesis(
             hex::decode(pk_hex).map_err(|e| format!("invalid validator pk for registry: {}", e))?;
         let stake = val.stake_u128()?;
 
-        let mut val_data = Vec::with_capacity(4 + pk_bytes.len() + 16 + 1);
-        val_data.extend_from_slice(&(pk_bytes.len() as u32).to_le_bytes());
-        val_data.extend_from_slice(&pk_bytes);
-        val_data.extend_from_slice(&stake.to_le_bytes());
-        val_data.push(0x00); // 0x00 = Active status
+        let entry = pyde_tx::pipeline::ValidatorEntry {
+            pk: pk_bytes,
+            stake,
+            status: 0x00, // Active
+            last_claimed_at: 0,
+            exit_block: None,
+        };
 
         let key = pyde_state::keys::validator_key(&address);
-        entries.push((key, val_data));
+        entries.push((key, entry.encode()));
 
         // Store address at index for enumeration
         let idx_key = pyde_state::keys::validator_index_key(val_count);

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -382,6 +382,12 @@ impl PydeApiServer for RpcServer {
             Some("stakeDeposit") => pyde_tx::types::TransactionType::StakeDeposit,
             Some("stakeWithdraw") => pyde_tx::types::TransactionType::StakeWithdraw,
             Some("deploy") => pyde_tx::types::TransactionType::Deploy,
+            // Slash txs carry double-sign evidence in the `data` field;
+            // the pipeline re-verifies both FALCON signatures against the
+            // accused validator's on-chain pubkey before debiting stake.
+            // Dev mode exposes this path so multi-node harness tests can
+            // submit forged evidence without routing through a proposer.
+            Some("slash") => pyde_tx::types::TransactionType::Slash,
             _ => {
                 if to == [0u8; 32] {
                     pyde_tx::types::TransactionType::Deploy

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -368,6 +368,118 @@ impl TestNetwork {
     }
 
     // --------------------------------------------------------------
+    // Slashing helpers (slice 6.6)
+    // --------------------------------------------------------------
+
+    /// Read a validator's FALCON keypair from its datadir. Layout is
+    /// the one `generate_testnet` writes: `pk_len u32 LE || pk || sk`.
+    /// Returns `(pk_bytes, sk_bytes)`.
+    pub fn load_validator_key(
+        &self,
+        node_idx: usize,
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        let path = self.nodes[node_idx].datadir.join("validator.key");
+        let raw = std::fs::read(&path)
+            .map_err(|e| format!("read {}: {}", path.display(), e))?;
+        if raw.len() < 4 {
+            return Err(format!("validator.key too short: {}", raw.len()));
+        }
+        let pk_len = u32::from_le_bytes(raw[..4].try_into().unwrap()) as usize;
+        if raw.len() < 4 + pk_len {
+            return Err(format!(
+                "validator.key truncated: expected >= {} bytes, got {}",
+                4 + pk_len,
+                raw.len()
+            ));
+        }
+        let pk = raw[4..4 + pk_len].to_vec();
+        let sk = raw[4 + pk_len..].to_vec();
+        Ok((pk, sk))
+    }
+
+    /// Read the on-chain validator set via `pyde_getValidators`. Returns
+    /// a vec of (address, stake, status) tuples. `status` is "active",
+    /// "unbonding", or "exited".
+    pub fn get_validator_set(
+        &self,
+        node_idx: usize,
+    ) -> Result<Vec<(String, u128, String)>, String> {
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getValidators",
+            "[]",
+        )?;
+        parse_validator_set(&resp)
+    }
+
+    /// Build the wire-format bytes for a `DoubleSignEvidence`.
+    /// Mirrors `pyde_node::wire::encode_double_sign_evidence` — kept
+    /// here rather than imported because `pyde_node` is a binary-only
+    /// crate (no `[lib]` target) and integration tests can't reach
+    /// into its modules.
+    ///
+    /// Layout (EVIDENCE_VERSION = 1):
+    ///   u8 version | u64 slot | [u8;32] hash1 | u32 len | sig1 bytes
+    ///             | [u8;32] hash2 | u32 len | sig2 bytes
+    ///             | [u8;32] signer | [u8;32] submitter
+    pub fn encode_double_sign_evidence_bytes(
+        slot: u64,
+        hash_1: &[u8; 32],
+        signature_1: &[u8],
+        hash_2: &[u8; 32],
+        signature_2: &[u8],
+        signer: &[u8; 32],
+        submitter: &[u8; 32],
+    ) -> Vec<u8> {
+        let mut out = Vec::with_capacity(
+            1 + 8 + 32 + 4 + signature_1.len() + 32 + 4 + signature_2.len() + 32 + 32,
+        );
+        out.push(1u8); // version
+        out.extend_from_slice(&slot.to_le_bytes());
+        out.extend_from_slice(hash_1);
+        out.extend_from_slice(&(signature_1.len() as u32).to_le_bytes());
+        out.extend_from_slice(signature_1);
+        out.extend_from_slice(hash_2);
+        out.extend_from_slice(&(signature_2.len() as u32).to_le_bytes());
+        out.extend_from_slice(signature_2);
+        out.extend_from_slice(signer);
+        out.extend_from_slice(submitter);
+        out
+    }
+
+    /// Submit a double-sign Slash tx via `pyde_sendTransaction`.
+    /// `evidence_hex` is the output of `encode_double_sign_evidence`,
+    /// hex-encoded without the `0x` prefix. `submitter` is the address
+    /// that pays gas and receives the finder's fee.
+    pub fn submit_slash_tx(
+        &self,
+        node_idx: usize,
+        submitter: &[u8; 32],
+        evidence_hex: &str,
+    ) -> Result<String, String> {
+        // to = zero address; slash txs have no recipient. tx_type =
+        // "slash" triggers the TransactionType::Slash path added to
+        // the RPC handler for this slice.
+        let params = format!(
+            r#"[{{"from":"0x{}","to":"0x{}","value":"0","gas":500000,"data":"0x{}","txType":"slash"}}]"#,
+            hex::encode(submitter),
+            hex::encode([0u8; 32]),
+            evidence_hex,
+        );
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_sendTransaction",
+            &params,
+        )?;
+        parse_escaped_tx_hash(&resp).map_err(|e| {
+            format!(
+                "pyde_sendTransaction(slash) parse failed: {}; raw response:\n{}",
+                e, resp
+            )
+        })
+    }
+
+    // --------------------------------------------------------------
     // Tx lifecycle helpers (slice 6.2)
     // --------------------------------------------------------------
 
@@ -760,6 +872,55 @@ fn parse_hex_result(resp: &str) -> Result<String, String> {
         .find('"')
         .ok_or_else(|| format!("unterminated result in {:?}", resp))?;
     Ok(tail[..end].to_string())
+}
+
+/// Extract every validator (address, stake, status) from a
+/// `pyde_getValidators` response. Handler returns a real JSON object
+/// (not a stringified one), so the wire layout is
+///   `"result":{"count":N,"validators":[{"address":"0x..","stake":"N","status":"..","index":i},...]}`
+/// Uses simple string scanning to avoid pulling serde into the harness.
+fn parse_validator_set(resp: &str) -> Result<Vec<(String, u128, String)>, String> {
+    // Leave the `0x` prefix in the captured address so callers can
+    // compare against `format!("0x{}", hex::encode(addr))` directly.
+    let key_addr = r#""address":""#;
+    let key_stake = r#""stake":""#;
+    let key_status = r#""status":""#;
+    let mut out = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(addr_start_rel) = resp[cursor..].find(key_addr) {
+        let addr_start = cursor + addr_start_rel + key_addr.len();
+        let addr_end_rel = resp[addr_start..]
+            .find('"')
+            .ok_or_else(|| format!("unterminated address in {:?}", &resp[addr_start..]))?;
+        let addr = resp[addr_start..addr_start + addr_end_rel].to_string();
+
+        // stake and status follow the address for the same validator object.
+        let after_addr = addr_start + addr_end_rel;
+        let stake_start_rel = resp[after_addr..]
+            .find(key_stake)
+            .ok_or("no stake field after address")?;
+        let stake_start = after_addr + stake_start_rel + key_stake.len();
+        let stake_end_rel = resp[stake_start..]
+            .find('"')
+            .ok_or("unterminated stake")?;
+        let stake: u128 = resp[stake_start..stake_start + stake_end_rel]
+            .parse()
+            .map_err(|e| format!("parse stake {}: {}", &resp[stake_start..stake_start + stake_end_rel], e))?;
+
+        let after_stake = stake_start + stake_end_rel;
+        let status_start_rel = resp[after_stake..]
+            .find(key_status)
+            .ok_or("no status field after stake")?;
+        let status_start = after_stake + status_start_rel + key_status.len();
+        let status_end_rel = resp[status_start..]
+            .find('"')
+            .ok_or("unterminated status")?;
+        let status = resp[status_start..status_start + status_end_rel].to_string();
+
+        out.push((addr, stake, status));
+        cursor = status_start + status_end_rel;
+    }
+    Ok(out)
 }
 
 /// Extract the `txHash` from a `pyde_sendTransaction` response.

--- a/crates/node/tests/multi_node_double_sign_slash.rs
+++ b/crates/node/tests/multi_node_double_sign_slash.rs
@@ -1,0 +1,197 @@
+//! Double-sign slashing end-to-end test (slice 6.6, plan task 068).
+//!
+//! Validates the Phase 1 slashing fix across the network:
+//!   - A forged `DoubleSignEvidence` with two REAL FALCON signatures
+//!     from node-0's validator key (loaded from disk) is submitted
+//!     as a `TransactionType::Slash` by node-1 via RPC.
+//!   - The pipeline's `execute_slash` path runs, re-verifies both
+//!     signatures against node-0's on-chain public key, zeroes its
+//!     stake, marks it Ejected, and credits node-1 with the 10%
+//!     finder's fee.
+//!
+//! The evidence is forged in the sense that the two block hashes
+//! (`[0x11;32]` and `[0x22;32]`) don't correspond to real blocks —
+//! but they don't need to. The slashing invariant is "this validator
+//! FALCON-signed two different `(slot, hash)` pairs under the
+//! proposer-sign protocol", and that invariant holds here because
+//! we used node-0's real secret key to produce both signatures.
+
+mod common;
+
+use common::TestNetwork;
+use pyde_consensus::hotstuff::proposer_sign_message;
+use pyde_crypto::falcon::{falcon_sign, FalconSecretKey};
+use std::time::Duration;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn double_sign_debits_stake() {
+    let net = TestNetwork::spawn(4, true)
+        .unwrap_or_else(|e| panic!("spawn 4v testnet: {}", e));
+
+    // Chain needs to be alive and advancing for the slash tx to land.
+    net.wait_for_slot(5, Duration::from_secs(45))
+        .unwrap_or_else(|e| panic!("warm-up: {}", e));
+
+    // Load node-0's FALCON keypair. This is the signer being framed;
+    // we use its REAL private key so the signatures genuinely verify.
+    let (pk_bytes, sk_bytes) = net
+        .load_validator_key(0)
+        .unwrap_or_else(|e| panic!("load_validator_key(0): {}", e));
+    let sk = FalconSecretKey::from_bytes(&sk_bytes)
+        .expect("validator.key produced invalid FALCON secret key");
+
+    // Addresses. funded[0..4] are the 4 validators in index order
+    // (see slice 6.5 commit note for the dedup guarantee).
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("funded: {}", e));
+    let offender = funded[0]; // node-0
+    let submitter = funded[1]; // node-1 — pays gas, earns finder's fee
+
+    // Sanity: on-chain state confirms node-0 is active and staked.
+    let pre_validators = net
+        .get_validator_set(1)
+        .unwrap_or_else(|e| panic!("pre-slash validators: {}", e));
+    eprintln!("pre-slash validator set:");
+    for (addr, stake, status) in &pre_validators {
+        eprintln!("  {}  stake={}  status={}", addr, stake, status);
+    }
+    let offender_pre = find_validator(&pre_validators, &offender)
+        .unwrap_or_else(|| panic!("offender 0x{} not in validator set", hex::encode(offender)));
+    assert_eq!(
+        offender_pre.2, "active",
+        "offender should be active pre-slash; got {}",
+        offender_pre.2
+    );
+    assert!(
+        offender_pre.1 > 0,
+        "offender should have stake pre-slash; got {}",
+        offender_pre.1
+    );
+    let pre_submitter_balance = net
+        .get_balance(1, &submitter)
+        .unwrap_or_else(|e| panic!("submitter balance pre: {}", e));
+
+    // Build forged-but-valid double-sign evidence. Slot is arbitrary;
+    // the pipeline doesn't cross-check slot against actual block
+    // history, only that the signatures verify over
+    // `proposer_sign_message(slot, hash)`.
+    let slot: u64 = 100;
+    let block_hash_1 = [0x11u8; 32];
+    let block_hash_2 = [0x22u8; 32];
+    let msg_1 = proposer_sign_message(slot, &block_hash_1);
+    let msg_2 = proposer_sign_message(slot, &block_hash_2);
+    let sig_1 = falcon_sign(&sk, &msg_1).expect("FALCON sign msg_1");
+    let sig_2 = falcon_sign(&sk, &msg_2).expect("FALCON sign msg_2");
+
+    // Sanity: confirm the sigs we just produced verify against the
+    // pubkey on file. Cheap local check; catches key-format bugs
+    // before we spend 60s waiting for an RPC round-trip.
+    let pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(&pk_bytes)
+        .expect("validator.key produced invalid FALCON public key");
+    assert!(
+        pyde_crypto::falcon::falcon_verify(&pk, &msg_1, &sig_1),
+        "local sig_1 verify failed — key-load is wrong"
+    );
+    assert!(
+        pyde_crypto::falcon::falcon_verify(&pk, &msg_2, &sig_2),
+        "local sig_2 verify failed — key-load is wrong"
+    );
+
+    let evidence_bytes = TestNetwork::encode_double_sign_evidence_bytes(
+        slot,
+        &block_hash_1,
+        sig_1.as_bytes(),
+        &block_hash_2,
+        sig_2.as_bytes(),
+        &offender,
+        &submitter,
+    );
+    let evidence_hex = hex::encode(&evidence_bytes);
+    eprintln!(
+        "evidence size: {} bytes ({} hex chars)",
+        evidence_bytes.len(),
+        evidence_hex.len()
+    );
+
+    // Submit via node-1 (the submitter / finder).
+    let tx_hash = net
+        .submit_slash_tx(1, &submitter, &evidence_hex)
+        .unwrap_or_else(|e| panic!("submit_slash_tx: {}", e));
+    eprintln!("slash tx_hash: {}", tx_hash);
+
+    // Wait for the slash to land on every validator. If the evidence
+    // were invalid the tx would still land — just with success=false.
+    let receipts = net
+        .wait_for_receipt_on_all(&tx_hash, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("receipt wait: {}", e));
+    for (i, r) in receipts.iter().enumerate() {
+        eprintln!("node-{} receipt: success={} raw={}", i, r.success, r.raw);
+        assert!(
+            r.success,
+            "node-{} reported a failed slash receipt:\nraw: {}",
+            i, r.raw
+        );
+    }
+
+    // Post-slash state: offender stake debited by VALIDATOR_STAKE,
+    // status = exited. The Phase 1 slash is a fixed 10,000 PYDE
+    // (10^13 quanta) per double-sign offense — not "100% of all
+    // staked tokens" — so a validator staking more than that will
+    // still have some balance left in their validator entry, but is
+    // ejected from the active set regardless.
+    //
+    // SLASH_VALIDATOR_STAKE is re-exported from `pyde-slashing`.
+    const VALIDATOR_SLASH_AMOUNT: u128 = 10_000_000_000_000;
+
+    let post_validators = net
+        .get_validator_set(1)
+        .unwrap_or_else(|e| panic!("post-slash validators: {}", e));
+    eprintln!("post-slash validator set:");
+    for (addr, stake, status) in &post_validators {
+        eprintln!("  {}  stake={}  status={}", addr, stake, status);
+    }
+    let offender_post = find_validator(&post_validators, &offender)
+        .unwrap_or_else(|| panic!("offender 0x{} missing post-slash", hex::encode(offender)));
+
+    let expected_post_stake = offender_pre.1.saturating_sub(VALIDATOR_SLASH_AMOUNT);
+    assert_eq!(
+        offender_post.1, expected_post_stake,
+        "offender stake: pre {} - slash {} should give {}, got {}",
+        offender_pre.1, VALIDATOR_SLASH_AMOUNT, expected_post_stake, offender_post.1
+    );
+    assert_eq!(
+        offender_post.2, "exited",
+        "offender status should be exited post-slash; got {}",
+        offender_post.2
+    );
+
+    // The finder's fee and gas charges interleave with proposer
+    // rewards + validator-subsidy accrual that the submitter is
+    // also accumulating (node-1 is itself an active validator
+    // producing blocks during the test). Disentangling those flows
+    // would need RPC access to the accumulator fields that aren't
+    // exposed yet, so we log the delta for visibility but don't
+    // assert an exact value here. The finder-fee arithmetic is
+    // unit-tested in `crates/tx/src/pipeline.rs` slash tests; this
+    // test's load-bearing invariants are the stake decrement + the
+    // ejection on-chain, both checked above.
+    let post_submitter_balance = net
+        .get_balance(1, &submitter)
+        .unwrap_or_else(|e| panic!("submitter balance post: {}", e));
+    let expected_fee = VALIDATOR_SLASH_AMOUNT / 10;
+    let actual_delta = post_submitter_balance as i128 - pre_submitter_balance as i128;
+    eprintln!(
+        "submitter balance: pre={} post={} delta={} (expected fee component: {})",
+        pre_submitter_balance, post_submitter_balance, actual_delta, expected_fee
+    );
+}
+
+fn find_validator<'a>(
+    set: &'a [(String, u128, String)],
+    addr: &[u8; 32],
+) -> Option<&'a (String, u128, String)> {
+    let needle = format!("0x{}", hex::encode(addr));
+    set.iter().find(|(a, _, _)| a == &needle)
+}


### PR DESCRIPTION
## Summary

- End-to-end multi-node test for the Phase 1 slashing fix: forge `DoubleSignEvidence` with two real FALCON signatures from node-0's validator key (loaded from its datadir), submit as a `Slash` tx from node-1 via RPC, and verify on-chain that node-0's stake drops by `VALIDATOR_STAKE` (10,000 PYDE) and its status becomes Ejected.
- **Bug fix:** `genesis.rs::initialize_genesis` was writing validator registry entries in a 918-byte format missing `last_claimed_at u128`. `ValidatorEntry::decode` expects 934 bytes and returned `None` on every genesis validator, which made `pyde_getValidators` return `{"count":4,"validators":[]}`, broke the slash-tx path, and would have broken the first epoch rotation that tried to load validators from state. Fixed by routing through `ValidatorEntry::encode()` so genesis tracks the unified serialization.
- `pyde_sendTransaction` now accepts `txType: "slash"` (dev-mode only, same gate as the rest of the handler). Production clients continue via `pyde_sendRawTransaction`.

## Harness additions

- `load_validator_key(node_idx)` — reads `node-i/validator.key` (`pk_len | pk | sk`), returns `(pk_bytes, sk_bytes)`.
- `get_validator_set(node_idx)` — parser for `pyde_getValidators` returning `Vec<(addr_hex, stake, status)>`. Addresses keep the `0x` prefix so callers match against `format!("0x{}", hex::encode(a))`.
- `submit_slash_tx(node_idx, submitter, evidence_hex)` — correct RPC envelope for a Slash tx (to = zero, txType = "slash", value = 0, gas = 500k).
- `encode_double_sign_evidence_bytes(...)` — inline replica of `pyde_node::wire::encode_double_sign_evidence`. Can't import directly because `pyde-node` has no `[lib]` target.

## Test strategy

1. Spawn 4 validators; wait for slot 5.
2. Read node-0's FALCON keypair from disk.
3. Locally FALCON-sign `proposer_sign_message(slot=100, [0x11;32])` and the same for `[0x22;32]`. Self-verify both before spending RPC time.
4. Submit the Slash tx from node-1 (finder).
5. Assert receipt success on every node, matching block_slot, and offender's stake dropped by exactly 10^13 quanta (10,000 PYDE) with status `"exited"`.
6. Submitter balance delta is logged but not asserted — tangles with proposer rewards + validator subsidy accrual during the test run. Finder-fee arithmetic is unit-tested in `pipeline.rs`.

## Verification

- Workspace: 2322 passed, 0 failed.
- Multi-node ignored (6 tests total): all pass individually.