### PR TITLE
feat: epoch rotation + 2/7 fault tolerance tests (+ block_time_ms config actually takes effect)

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -90,6 +90,13 @@ pub enum Command {
         /// Chain ID (31337 = devnet, skips signature validation).
         #[arg(long, default_value = "31337")]
         chain_id: u64,
+
+        /// Block time in milliseconds (controls slot rate). Default 400
+        /// matches mainnet target. Lower values (e.g. 50-100) are
+        /// useful for tests that need to cross multi-slot boundaries
+        /// quickly — epoch rotation at slot 1000, finality depth, etc.
+        #[arg(long, default_value = "400")]
+        block_time_ms: u64,
     },
 
     /// Start a public faucet server.

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -755,6 +755,7 @@ pub fn generate_testnet(
     base_rpc_port: u16,
     dev_mode: bool,
     chain_id: u64,
+    block_time_ms: u64,
 ) -> Result<(), String> {
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::falcon_keygen;
@@ -964,7 +965,7 @@ rate_limit_per_ip = 5
 bootstrap_peers = {bootstrap}
 
 [consensus]
-block_time_ms = 400
+block_time_ms = {block_time_ms}
 gas_target = 400000000
 gas_ceiling = 1600000000
 
@@ -991,6 +992,7 @@ json = false
             rpc_port = rpc_port,
             metrics_port = metrics_port,
             bootstrap = bootstrap,
+            block_time_ms = block_time_ms,
         );
 
         fs::write(node_dir.join("config.toml"), config_toml)
@@ -1053,7 +1055,7 @@ rate_limit_per_ip = 5
 bootstrap_peers = {bootstrap}
 
 [consensus]
-block_time_ms = 400
+block_time_ms = {block_time_ms}
 gas_target = 400000000
 gas_ceiling = 1600000000
 
@@ -1080,6 +1082,7 @@ json = false
             rpc_port = rpc_port,
             metrics_port = metrics_port,
             bootstrap = bootstrap,
+            block_time_ms = block_time_ms,
         );
 
         fs::write(node_dir.join("config.toml"), config_toml)

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -48,6 +48,7 @@ fn main() {
             base_rpc_port,
             dev,
             chain_id,
+            block_time_ms,
         } => {
             if let Err(e) = genesis::generate_testnet(
                 &out,
@@ -57,6 +58,7 @@ fn main() {
                 base_rpc_port,
                 dev,
                 chain_id,
+                block_time_ms,
             ) {
                 eprintln!("error: {}", e);
                 std::process::exit(1);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -515,18 +515,20 @@ impl PydeNode {
         // --- Main event loop ---
         let mut shutdown_rx = self.shutdown.subscribe();
 
-        // Slot clock for block timing
-        // Slot clock: if resuming from persisted head, backdate genesis
-        // so current_slot() picks up where we left off.
+        // Slot clock for block timing. If resuming from persisted head,
+        // backdate genesis so current_slot() picks up where we left off.
+        // Block time comes from `[consensus].block_time_ms` (default
+        // 400); `with_block_time` clamps out-of-range values.
+        let block_time_ms = self.config.consensus.block_time_ms;
         let slot_clock = if saved_head > 0 {
-            let backdate_ms = saved_head * pyde_consensus::block::BLOCK_TIME_MS;
+            let backdate_ms = saved_head * block_time_ms;
             let now_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis() as u64;
-            SlotClock::new(now_ms.saturating_sub(backdate_ms))
+            SlotClock::with_block_time(now_ms.saturating_sub(backdate_ms), block_time_ms)
         } else {
-            SlotClock::new(0)
+            SlotClock::with_block_time(0, block_time_ms)
         };
         let mut last_slot = slot_clock.current_slot();
 

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -1,8 +1,11 @@
 //! Slot clock: tracks the current slot based on wall clock time.
 //!
-//! Slot 0 starts at genesis timestamp. Each slot is 400ms.
+//! Slot 0 starts at genesis timestamp. Each slot defaults to 400ms
+//! but is configurable via `[consensus].block_time_ms` so tests can
+//! cross large slot counts (epoch boundaries) quickly.
 //! The slot clock determines when to propose, vote, and advance.
 
+#[cfg(test)]
 use pyde_consensus::block::BLOCK_TIME_MS;
 use std::time::{Duration, Instant};
 
@@ -12,14 +15,27 @@ pub struct SlotClock {
     genesis_instant: Instant,
     /// Genesis Unix timestamp in ms (for absolute time reference).
     genesis_timestamp_ms: u64,
-    /// Slot duration.
-    #[allow(dead_code)]
-    slot_duration: Duration,
+    /// Slot duration in ms — configurable via `[consensus].block_time_ms`.
+    block_time_ms: u64,
 }
 
 impl SlotClock {
-    /// Create a new slot clock. If genesis_timestamp_ms is 0, use current time.
+    /// Create a new slot clock at the default block time
+    /// (`BLOCK_TIME_MS` = 400 ms). If `genesis_timestamp_ms` is 0,
+    /// use the current wall clock. Kept for the in-module tests;
+    /// production code goes through `with_block_time` so the config
+    /// value actually takes effect.
+    #[cfg(test)]
     pub fn new(genesis_timestamp_ms: u64) -> Self {
+        Self::with_block_time(genesis_timestamp_ms, BLOCK_TIME_MS)
+    }
+
+    /// Create a new slot clock with a caller-supplied slot duration.
+    /// Values outside 10..=10_000 are clamped to 10 ms / 10 s — sub-
+    /// 10ms rates destabilize consensus on laptops and > 10s rates
+    /// are clearly a config error.
+    pub fn with_block_time(genesis_timestamp_ms: u64, block_time_ms: u64) -> Self {
+        let block_time_ms = block_time_ms.clamp(10, 10_000);
         let now_ms = current_time_ms();
         let genesis_instant = if genesis_timestamp_ms == 0 || genesis_timestamp_ms >= now_ms {
             // Genesis is now or in the future — start from current instant
@@ -37,14 +53,14 @@ impl SlotClock {
             } else {
                 genesis_timestamp_ms
             },
-            slot_duration: Duration::from_millis(BLOCK_TIME_MS),
+            block_time_ms,
         }
     }
 
     /// Current slot number based on elapsed time since genesis.
     pub fn current_slot(&self) -> u64 {
         let elapsed = self.genesis_instant.elapsed();
-        (elapsed.as_millis() as u64) / BLOCK_TIME_MS
+        (elapsed.as_millis() as u64) / self.block_time_ms
     }
 
     /// Time remaining in the current slot.
@@ -52,7 +68,7 @@ impl SlotClock {
     pub fn time_remaining(&self) -> Duration {
         let elapsed = self.genesis_instant.elapsed();
         let elapsed_ms = elapsed.as_millis() as u64;
-        let slot_end_ms = (self.current_slot() + 1) * BLOCK_TIME_MS;
+        let slot_end_ms = (self.current_slot() + 1) * self.block_time_ms;
         let remaining = slot_end_ms.saturating_sub(elapsed_ms);
         Duration::from_millis(remaining)
     }
@@ -60,7 +76,7 @@ impl SlotClock {
     /// Duration until a specific slot starts.
     #[allow(dead_code)]
     pub fn duration_until_slot(&self, slot: u64) -> Duration {
-        let slot_start_ms = slot * BLOCK_TIME_MS;
+        let slot_start_ms = slot * self.block_time_ms;
         let elapsed_ms = self.genesis_instant.elapsed().as_millis() as u64;
         if slot_start_ms > elapsed_ms {
             Duration::from_millis(slot_start_ms - elapsed_ms)
@@ -71,19 +87,19 @@ impl SlotClock {
 
     /// Timestamp (Unix ms) for a given slot.
     pub fn slot_timestamp(&self, slot: u64) -> u64 {
-        self.genesis_timestamp_ms + slot * BLOCK_TIME_MS
+        self.genesis_timestamp_ms + slot * self.block_time_ms
     }
 
     /// Slot duration.
     #[allow(dead_code)]
     pub fn slot_duration(&self) -> Duration {
-        self.slot_duration
+        Duration::from_millis(self.block_time_ms)
     }
 
     /// Milliseconds elapsed within the current slot (0..400).
     pub fn ms_into_slot(&self) -> u64 {
         let elapsed_ms = self.genesis_instant.elapsed().as_millis() as u64;
-        elapsed_ms % BLOCK_TIME_MS
+        elapsed_ms % self.block_time_ms
     }
 }
 

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -86,6 +86,9 @@ struct DeferredPortHolder {
 }
 
 impl TestNetwork {
+    /// Default block time (400 ms/slot) — mainnet target.
+    const DEFAULT_BLOCK_TIME_MS: u64 = 400;
+
     /// Spawn an N-validator testnet. `dev=true` uses `chain_id=31337`
     /// and skips signature validation (required for ad-hoc devnets).
     pub fn spawn(validators: usize, dev: bool) -> Result<Self, String> {
@@ -99,7 +102,7 @@ impl TestNetwork {
         full_nodes: usize,
         dev: bool,
     ) -> Result<Self, String> {
-        Self::spawn_mixed_inner(validators, full_nodes, 0, dev)
+        Self::spawn_mixed_inner(validators, full_nodes, 0, dev, Self::DEFAULT_BLOCK_TIME_MS)
     }
 
     /// Same as `spawn_mixed`, but the last `deferred` full nodes have
@@ -119,7 +122,25 @@ impl TestNetwork {
                 deferred, full_nodes
             ));
         }
-        Self::spawn_mixed_inner(validators, full_nodes, deferred, dev)
+        Self::spawn_mixed_inner(
+            validators,
+            full_nodes,
+            deferred,
+            dev,
+            Self::DEFAULT_BLOCK_TIME_MS,
+        )
+    }
+
+    /// Spawn V validators at a custom block time (ms/slot). 400 is the
+    /// production default; 50-100 is useful for tests that need to
+    /// cross epoch boundaries (1000 slots) quickly. Block times < 50
+    /// tend to destabilize consensus on laptops under 4-subprocess load.
+    pub fn spawn_with_block_time(
+        validators: usize,
+        dev: bool,
+        block_time_ms: u64,
+    ) -> Result<Self, String> {
+        Self::spawn_mixed_inner(validators, 0, 0, dev, block_time_ms)
     }
 
     fn spawn_mixed_inner(
@@ -127,6 +148,7 @@ impl TestNetwork {
         full_nodes: usize,
         deferred: usize,
         dev: bool,
+        block_time_ms: u64,
     ) -> Result<Self, String> {
         if !(2..=8).contains(&validators) {
             return Err(format!(
@@ -159,7 +181,15 @@ impl TestNetwork {
 
         // Run `pyde testnet` to set up genesis + per-node configs.
         run_testnet_cli(
-            &pyde_bin, validators, full_nodes, &net_dir, dev, chain_id, p2p_base, rpc_base,
+            &pyde_bin,
+            validators,
+            full_nodes,
+            &net_dir,
+            dev,
+            chain_id,
+            p2p_base,
+            rpc_base,
+            block_time_ms,
         )?;
 
         // Port-holder strategy:
@@ -277,6 +307,37 @@ impl TestNetwork {
         }
         node.kill();
         Ok(())
+    }
+
+    /// Read the `epoch` field from a committed block. Returns
+    /// `Ok(None)` if the node hasn't committed that slot yet.
+    pub fn epoch_of(&self, node_idx: usize, slot: u64) -> Result<Option<u64>, String> {
+        let params = format!("[{}]", slot);
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getBlockByNumber",
+            &params,
+        )?;
+        if resp.contains(r#""result":null"#) {
+            return Ok(None);
+        }
+        let key = r#""epoch":"#;
+        let start = resp
+            .find(key)
+            .ok_or_else(|| format!("no epoch field in response: {}", resp))?
+            + key.len();
+        let tail = &resp[start..];
+        let end = tail
+            .bytes()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        if end == 0 {
+            return Err(format!("couldn't parse epoch from {}", tail));
+        }
+        let v: u64 = tail[..end]
+            .parse()
+            .map_err(|e| format!("parse epoch {}: {}", &tail[..end], e))?;
+        Ok(Some(v))
     }
 
     /// Read the proposer address for a block at `slot` from `node_idx`'s
@@ -727,6 +788,7 @@ fn run_testnet_cli(
     chain_id: u64,
     base_port: u16,
     base_rpc_port: u16,
+    block_time_ms: u64,
 ) -> Result<(), String> {
     let mut cmd = Command::new(pyde);
     cmd.arg("testnet")
@@ -741,7 +803,9 @@ fn run_testnet_cli(
         .arg("--base-rpc-port")
         .arg(base_rpc_port.to_string())
         .arg("--chain-id")
-        .arg(chain_id.to_string());
+        .arg(chain_id.to_string())
+        .arg("--block-time-ms")
+        .arg(block_time_ms.to_string());
     if dev {
         cmd.arg("--dev");
     }

--- a/crates/node/tests/multi_node_epoch_rotation.rs
+++ b/crates/node/tests/multi_node_epoch_rotation.rs
@@ -1,0 +1,136 @@
+//! Epoch rotation test (slice 6.7, plan task 069).
+//!
+//! 4 validators at block_time_ms=100 (fast mode; default is 400).
+//! Runs the chain past slot 1000 (one EPOCH_LENGTH) and verifies:
+//!   - every node's `pyde_getBlockByNumber` reports `epoch == 1` for
+//!     slots 1000..=1005 and `epoch == 0` for slots 999 and below;
+//!   - state_root converges across all 4 nodes;
+//!   - at least one validator's log contains
+//!     "committee rotated at epoch boundary" (proof the rotation
+//!     code path actually fired, not just that the epoch field got
+//!     computed at the block-header level).
+//!
+//! With EPOCH_LENGTH = 1000 and 100 ms/slot, an epoch boundary is
+//! ~100 s after genesis. Bumping to slot 1005 gives a small margin
+//! for the rotation handler to run on every node before we sample.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::Duration;
+
+const EPOCH_LENGTH: u64 = 1000;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn epoch_rotation_crosses_boundary() {
+    // 100 ms/slot crosses the 1000-slot boundary in ~100 s. Pyde
+    // consensus stays stable at this rate on a laptop under the
+    // 4-subprocess load (libp2p QUIC handshake + gossipsub).
+    let net = TestNetwork::spawn_with_block_time(4, true, 100)
+        .unwrap_or_else(|e| panic!("spawn 4v at 100ms: {}", e));
+
+    // Target = epoch boundary + a few slots of headroom so the
+    // rotation handler has processed on every node before we poll.
+    let target_slot = EPOCH_LENGTH + 5;
+    eprintln!("waiting for slot {}...", target_slot);
+    net.wait_for_slot(target_slot, Duration::from_secs(240))
+        .unwrap_or_else(|e| {
+            let dumps = per_node_dump(&net);
+            panic!("cross-epoch wait: {}\n{}", e, dumps);
+        });
+    eprintln!("all nodes reached slot {}", target_slot);
+
+    // Every node's state_root must match at this point — no fork
+    // across the epoch boundary.
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let root = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            root, reference_root,
+            "state_root divergence across epoch boundary:\n  node-0:  {}\n  node-{}: {}",
+            reference_root, n.index, root
+        );
+    }
+
+    // Block at slot 999 (last of epoch 0) must report epoch=0.
+    let e0 = net
+        .epoch_of(0, EPOCH_LENGTH - 1)
+        .unwrap_or_else(|e| panic!("epoch of slot {}: {}", EPOCH_LENGTH - 1, e))
+        .unwrap_or_else(|| panic!("node-0 missing block at slot {}", EPOCH_LENGTH - 1));
+    assert_eq!(
+        e0, 0,
+        "slot {} should be epoch 0, got {}",
+        EPOCH_LENGTH - 1,
+        e0
+    );
+
+    // Block at slot 1000 (first of epoch 1) must report epoch=1.
+    let e1 = net
+        .epoch_of(0, EPOCH_LENGTH)
+        .unwrap_or_else(|e| panic!("epoch of slot {}: {}", EPOCH_LENGTH, e))
+        .unwrap_or_else(|| panic!("node-0 missing block at slot {}", EPOCH_LENGTH));
+    assert_eq!(
+        e1, 1,
+        "slot {} should be epoch 1, got {}",
+        EPOCH_LENGTH, e1
+    );
+
+    // Block at slot target_slot (deep in epoch 1) matches too.
+    let e_deep = net
+        .epoch_of(0, target_slot)
+        .unwrap_or_else(|e| panic!("epoch of slot {}: {}", target_slot, e))
+        .unwrap_or_else(|| panic!("node-0 missing block at slot {}", target_slot));
+    assert_eq!(
+        e_deep, 1,
+        "slot {} should be epoch 1, got {}",
+        target_slot, e_deep
+    );
+    eprintln!(
+        "epoch field: slot {} → {}, slot {} → {}, slot {} → {}",
+        EPOCH_LENGTH - 1,
+        e0,
+        EPOCH_LENGTH,
+        e1,
+        target_slot,
+        e_deep
+    );
+
+    // Observable rotation: every validator should have logged
+    // "committee rotated at epoch boundary" exactly once as they
+    // crossed slot 1000.
+    let mut rotated_count = 0;
+    for n in &net.nodes {
+        let snapshot = n.output_snapshot();
+        if snapshot.contains("committee rotated at epoch boundary") {
+            rotated_count += 1;
+        }
+    }
+    assert!(
+        rotated_count >= net.nodes.len(),
+        "only {}/{} validators logged 'committee rotated at epoch boundary' — rotation path didn't fire on some node",
+        rotated_count,
+        net.nodes.len()
+    );
+    eprintln!("rotation log observed on {}/{} nodes", rotated_count, net.nodes.len());
+}
+
+fn per_node_dump(net: &TestNetwork) -> String {
+    net.nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "\n=== node-{} ({}, rpc {}) ===\n{}",
+                n.index,
+                n.role,
+                n.rpc_port,
+                n.output_snapshot()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}

--- a/crates/node/tests/multi_node_larger_failure.rs
+++ b/crates/node/tests/multi_node_larger_failure.rs
@@ -1,0 +1,168 @@
+//! Fault tolerance at larger committee size (slice 6.9, plan task 071).
+//!
+//! The plan targets "42/128 validators offline" — which would need a
+//! cluster, not a laptop. The invariant being tested is simply that
+//! Pyde tolerates up to f = floor((n-1)/3) offline validators and
+//! keeps making progress. This test proves the invariant at N=7, f=2
+//! (~28.6% offline) — a strict subset of a committee where quorum is
+//! ceil(2n/3) = 5; with 2 down, 5 remain alive, quorum still holds.
+//!
+//! Slice 6.5 already proved 1/4. This extends to 2/7 — the smallest
+//! multi-kill that stays under BFT's fault budget AND runs within the
+//! harness's 8-validator cap.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::{Duration, Instant};
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn two_of_seven_offline_keeps_chain_live() {
+    let mut net = TestNetwork::spawn(7, true)
+        .unwrap_or_else(|e| panic!("spawn 7v: {}", e));
+
+    // Warm up to a healthy depth. 90s accommodates the contended-host
+    // case where multiple multi-node binaries run in parallel.
+    net.wait_for_slot(20, Duration::from_secs(90))
+        .unwrap_or_else(|e| panic!("warm-up: {}", e));
+
+    // Record the validators we're about to kill + the survivors.
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("funded: {}", e));
+    assert!(
+        funded.len() >= 7,
+        "expected >= 7 funded addresses, got {}",
+        funded.len()
+    );
+    let killed_indices = [0usize, 1];
+    let killed_addrs: Vec<[u8; 32]> = killed_indices.iter().map(|&i| funded[i]).collect();
+    let survivors: Vec<usize> = (2..7).collect();
+
+    let kill_slot = min_slot_over(&net, &survivors)
+        .unwrap_or_else(|e| panic!("snapshot slot: {}", e));
+    eprintln!(
+        "killing {:?} at slot {} (survivors: {:?})",
+        killed_indices, kill_slot, survivors
+    );
+    for &idx in &killed_indices {
+        net.kill_node(idx)
+            .unwrap_or_else(|e| panic!("kill node-{}: {}", idx, e));
+    }
+
+    // Survivors must advance by at least 10 slots post-kill. With 5
+    // live validators and quorum = 5, this is tight: every live
+    // validator MUST vote on every slot. 90s is plenty.
+    let target_slot = kill_slot + 10;
+    wait_for_slot_on_nodes(&net, &survivors, target_slot, Duration::from_secs(90))
+        .unwrap_or_else(|e| {
+            let dumps = per_node_dump(&net);
+            panic!("{}\n{}", e, dumps);
+        });
+
+    // State roots must agree among the 5 survivors.
+    let mut roots: Vec<(usize, String)> = Vec::new();
+    for &i in &survivors {
+        let r = net
+            .state_root(i)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", i, e));
+        roots.push((i, r));
+    }
+    let reference = roots[0].1.clone();
+    for (i, r) in roots.iter().skip(1) {
+        assert_eq!(
+            r, &reference,
+            "state_root divergence among survivors: node-{} = {}, node-{} = {}",
+            roots[0].0, reference, i, r
+        );
+    }
+
+    // No block in the post-kill window may name either killed
+    // validator as proposer. Read headers from node-2 (first alive).
+    let window_start = kill_slot + 3;
+    let window_end = target_slot;
+    let mut inspected = 0usize;
+    for slot in window_start..=window_end {
+        match net.proposer_of(survivors[0], slot) {
+            Ok(Some(p)) => {
+                inspected += 1;
+                for (idx, killed) in killed_indices.iter().zip(killed_addrs.iter()) {
+                    assert_ne!(
+                        &p, killed,
+                        "slot {} proposer is killed node-{} (0x{})",
+                        slot,
+                        idx,
+                        hex::encode(p)
+                    );
+                }
+            }
+            Ok(None) => {}
+            Err(e) => eprintln!("getBlockByNumber({}) failed: {}", slot, e),
+        }
+    }
+    assert!(
+        inspected >= 5,
+        "expected >= 5 post-kill blocks, got {}",
+        inspected
+    );
+    eprintln!(
+        "verified {} post-kill blocks in slots {}..={} — no killed validators as proposer",
+        inspected, window_start, window_end
+    );
+}
+
+fn min_slot_over(net: &TestNetwork, indices: &[usize]) -> Result<u64, String> {
+    let slots: Vec<u64> = net
+        .current_slots()
+        .into_iter()
+        .filter(|(i, _)| indices.contains(i))
+        .map(|(_, s)| s.ok_or_else(|| "missing slot on a node".to_string()))
+        .collect::<Result<Vec<_>, _>>()?;
+    slots.into_iter().min().ok_or_else(|| "empty indices".into())
+}
+
+fn wait_for_slot_on_nodes(
+    net: &TestNetwork,
+    indices: &[usize],
+    target: u64,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let slots: Vec<(usize, Option<u64>)> = net
+            .current_slots()
+            .into_iter()
+            .filter(|(i, _)| indices.contains(i))
+            .collect();
+        if slots
+            .iter()
+            .all(|(_, s)| s.map(|v| v >= target).unwrap_or(false))
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "wait_for_slot_on_nodes({:?}, {}) timed out — {:?}",
+                indices, target, slots
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+fn per_node_dump(net: &TestNetwork) -> String {
+    net.nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "\n=== node-{} ({}, rpc {}) ===\n{}",
+                n.index,
+                n.role,
+                n.rpc_port,
+                n.output_snapshot()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}


### PR DESCRIPTION
## Summary

Two multi-node ignored tests:
- **6.7 — committee rotation** (`multi_node_epoch_rotation.rs`): 4 validators at `block_time=100 ms`; run past slot 1005. Asserts `pyde_getBlockByNumber(999).epoch == 0`, `(1000).epoch == 1`, convergent state roots, and that every validator's log contains `"committee rotated at epoch boundary"`.
- **6.9 — N/M offline** (`multi_node_larger_failure.rs`): plan targets 42/128 offline but that's cluster-scale. Invariant (`tolerate floor((n-1)/3) offline`) tested at N=7, f=2 — the largest mid-run kill still under BFT's fault budget within the harness's 8-validator cap. Kills node-0 + node-1 mid-run; survivors advance 10 slots and converge.

## Config bug fix

`[consensus].block_time_ms` was parsed from `config.toml` but **not honored** — `SlotClock::new()` hardcoded `BLOCK_TIME_MS` from the consensus crate. Written-but-ignored, which would have confused operators trying to configure slot pace.

- `SlotClock::with_block_time` now takes the config value, clamped to `[10, 10_000]` ms.
- Without this fix, slice 6.7 would need ~7 min wall clock to cross 1000 slots; with it, ~100 s.

## CLI + harness additions

- `pyde testnet --block-time-ms N` (default 400) plumbed through `generate_testnet` into each node's `config.toml`.
- `TestNetwork::spawn_with_block_time(validators, dev, ms)`.
- `TestNetwork::epoch_of(node_idx, slot)` → pulls `epoch` from `pyde_getBlockByNumber`.

## Verification

- Workspace: 2322 passed, 0 failed.
- 6.7 epoch test: 1 passed in ~100 s.
- 6.9 fault test: 1 passed in ~15 s.
- All 8 multi-node ignored tests pass individually.