### PR TITLE
test: contract deploy+call + real FALCON sigs across 4-node network (chain_id=1)

### DIFF
--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -102,7 +102,7 @@ impl TestNetwork {
         full_nodes: usize,
         dev: bool,
     ) -> Result<Self, String> {
-        Self::spawn_mixed_inner(validators, full_nodes, 0, dev, Self::DEFAULT_BLOCK_TIME_MS)
+        Self::spawn_mixed_inner(validators, full_nodes, 0, dev, Self::DEFAULT_BLOCK_TIME_MS, None)
     }
 
     /// Same as `spawn_mixed`, but the last `deferred` full nodes have
@@ -128,6 +128,7 @@ impl TestNetwork {
             deferred,
             dev,
             Self::DEFAULT_BLOCK_TIME_MS,
+            None,
         )
     }
 
@@ -140,7 +141,26 @@ impl TestNetwork {
         dev: bool,
         block_time_ms: u64,
     ) -> Result<Self, String> {
-        Self::spawn_mixed_inner(validators, 0, 0, dev, block_time_ms)
+        Self::spawn_mixed_inner(validators, 0, 0, dev, block_time_ms, None)
+    }
+
+    /// Spawn V validators with a caller-supplied `chain_id`. Any value
+    /// other than 31337 causes the block processor to ENFORCE FALCON
+    /// signature verification on every tx (see `block_processor.rs`
+    /// and `validation.rs`). Use with signed txs via
+    /// `pyde_sendRawTransaction`; `pyde_sendTransaction` (dev-mode
+    /// unsigned) is rejected because chain_id != 31337 doesn't unlock
+    /// the sig-skip. Dev flag is still true so other dev ergonomics
+    /// (auto-fund, log format) behave normally.
+    pub fn spawn_with_chain_id(validators: usize, chain_id: u64) -> Result<Self, String> {
+        Self::spawn_mixed_inner(
+            validators,
+            0,
+            0,
+            true,
+            Self::DEFAULT_BLOCK_TIME_MS,
+            Some(chain_id),
+        )
     }
 
     fn spawn_mixed_inner(
@@ -149,6 +169,7 @@ impl TestNetwork {
         deferred: usize,
         dev: bool,
         block_time_ms: u64,
+        chain_id_override: Option<u64>,
     ) -> Result<Self, String> {
         if !(2..=8).contains(&validators) {
             return Err(format!(
@@ -168,7 +189,8 @@ impl TestNetwork {
 
         let tempdir = tempfile::tempdir().map_err(|e| format!("create tempdir: {}", e))?;
         let net_dir = tempdir.path().join("net");
-        let chain_id = if dev { 31337 } else { rand_chain_id() };
+        let chain_id = chain_id_override
+            .unwrap_or_else(|| if dev { 31337 } else { rand_chain_id() });
         let pyde_bin = pyde_binary_path();
 
         // Find contiguous free port ranges for p2p (UDP — used by QUIC)
@@ -454,6 +476,119 @@ impl TestNetwork {
     // --------------------------------------------------------------
     // Slashing helpers (slice 6.6)
     // --------------------------------------------------------------
+
+    /// Read the faucet's FALCON keypair. `generate_testnet` writes
+    /// it to `<net_dir>/faucet.key` in the same layout as
+    /// `validator.key` (pk_len u32 LE || pk || sk). The faucet holds
+    /// 1T PYDE at genesis — plenty for deploy + call gas — and has
+    /// its pubkey installed as `AuthKeys::Single`, so signed txs
+    /// from it verify cleanly on any chain_id.
+    pub fn load_faucet_key(&self) -> Result<(Vec<u8>, Vec<u8>), String> {
+        // Any node's datadir sits at `<net_dir>/node-<i>`, and the
+        // faucet key lives at `<net_dir>/faucet.key`. Walk up from
+        // node-0's datadir.
+        let faucet_path = self.nodes[0]
+            .datadir
+            .parent()
+            .ok_or("node-0 datadir has no parent")?
+            .join("faucet.key");
+        let raw = std::fs::read(&faucet_path)
+            .map_err(|e| format!("read {}: {}", faucet_path.display(), e))?;
+        if raw.len() < 4 {
+            return Err(format!("faucet.key too short: {}", raw.len()));
+        }
+        let pk_len = u32::from_le_bytes(raw[..4].try_into().unwrap()) as usize;
+        if raw.len() < 4 + pk_len {
+            return Err(format!(
+                "faucet.key truncated: expected >= {} bytes, got {}",
+                4 + pk_len,
+                raw.len()
+            ));
+        }
+        let pk = raw[4..4 + pk_len].to_vec();
+        let sk = raw[4 + pk_len..].to_vec();
+        Ok((pk, sk))
+    }
+
+    /// Submit a pre-signed `Transaction` via `pyde_sendRawTransaction`.
+    /// The tx must be wire-encoded via `Transaction::to_bytes()` and
+    /// correctly signed by the FALCON key installed as `AuthKeys::Single`
+    /// for its `from` address. Returns the submitted tx hash.
+    pub fn submit_raw_tx(
+        &self,
+        node_idx: usize,
+        tx_bytes: &[u8],
+    ) -> Result<String, String> {
+        let hex = hex::encode(tx_bytes);
+        let params = format!(r#"["0x{}"]"#, hex);
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_sendRawTransaction",
+            &params,
+        )?;
+        // Handler returns the tx hash as a plain hex string result
+        // (no JSON-stringified wrapper like pyde_sendTransaction).
+        parse_hex_result(&resp).map_err(|e| {
+            format!(
+                "pyde_sendRawTransaction parse failed: {}; raw response:\n{}",
+                e, resp
+            )
+        })
+    }
+
+    /// Read deployed contract code via `pyde_getCode`. Returns the
+    /// hex string WITHOUT the `0x` prefix; empty string if no code.
+    pub fn get_code(&self, node_idx: usize, address: &[u8; 32]) -> Result<String, String> {
+        let params = format!(r#"["0x{}"]"#, hex::encode(address));
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getCode",
+            &params,
+        )?;
+        let hex = parse_hex_result(&resp)?;
+        Ok(hex.trim_start_matches("0x").to_string())
+    }
+
+    /// Execute a read-only call against a deployed contract via
+    /// `pyde_call`. `calldata` is the full calldata bytes (4-byte
+    /// selector + ABI-encoded args). Returns the result hex string
+    /// (WITHOUT `0x` prefix).
+    pub fn pyde_call_view(
+        &self,
+        node_idx: usize,
+        to: &[u8; 32],
+        calldata: &[u8],
+    ) -> Result<String, String> {
+        let params = format!(
+            r#"[{{"to":"0x{}","data":"0x{}","gas":10000000}}]"#,
+            hex::encode(to),
+            hex::encode(calldata),
+        );
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_call",
+            &params,
+        )?;
+        let hex = parse_hex_result(&resp)?;
+        Ok(hex.trim_start_matches("0x").to_string())
+    }
+
+    /// Extract the `returnData` field from a receipt's raw JSON.
+    /// Returns the decoded bytes (stripping the `0x` prefix).
+    /// For Deploy receipts, this is the contract address (32 bytes).
+    pub fn decode_return_data(raw: &str) -> Result<Vec<u8>, String> {
+        let key = r#""returnData":"0x"#;
+        let start = raw
+            .find(key)
+            .ok_or_else(|| format!("no returnData in receipt: {}", raw))?
+            + key.len();
+        let tail = &raw[start..];
+        let end = tail
+            .find('"')
+            .ok_or_else(|| format!("unterminated returnData: {}", raw))?;
+        hex::decode(&tail[..end])
+            .map_err(|e| format!("decode returnData hex {:?}: {}", &tail[..end], e))
+    }
 
     /// Read a validator's FALCON keypair from its datadir. Layout is
     /// the one `generate_testnet` writes: `pk_len u32 LE || pk || sk`.

--- a/crates/node/tests/multi_node_contract_sigs.rs
+++ b/crates/node/tests/multi_node_contract_sigs.rs
@@ -1,0 +1,267 @@
+//! Production-sigs + smart-contract lifecycle across a 4-node
+//! network (plan backlog — closes the two biggest coverage gaps
+//! in Phase 6).
+//!
+//! This single test covers two invariants that previously only
+//! held at the in-memory / single-node level:
+//!
+//!  1. Real FALCON-512 signature verification across consensus.
+//!     Every tx in every block is re-verified by every validator
+//!     under `chain_id != 31337`. The devnet-chain tests skip
+//!     FALCON entirely; this one does not.
+//!
+//!  2. Smart contract deploy + call propagates identically across
+//!     the network. Code bytes are written at `code_key(addr)` on
+//!     every node; a subsequent state-changing call via
+//!     `pyde_sendRawTransaction` must reach every validator, land
+//!     in a block, and update contract storage deterministically
+//!     — `pyde_call(get_count)` from every node must return 42.
+//!
+//! Flow:
+//!  - 4 validators at chain_id=1 (production mode).
+//!  - Compile the on-chain `Counter` contract (same source used by
+//!    `production_sigs.rs` — has `init()`, `set_count(n)`,
+//!    `get_count()`).
+//!  - Faucet (1T PYDE at genesis, pubkey pre-installed) signs a
+//!    Deploy tx, submits via `pyde_sendRawTransaction`.
+//!  - Wait for the deploy receipt; extract contract address from
+//!    `returnData`.
+//!  - Assert `pyde_getCode(contract)` agrees across all 4 nodes.
+//!  - Faucet signs + submits `set_count(42)`. Wait for the call
+//!    receipt to land on every node with `success = true`.
+//!  - Query `pyde_call(get_count)` on each of the 4 nodes; all
+//!    must return the same 8-byte LE encoding of 42.
+//!  - Assert `pyde_stateRoot` matches across the 4 nodes.
+
+mod common;
+
+use common::TestNetwork;
+use pyde_crypto::falcon::{falcon_sign, FalconSecretKey};
+use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+use std::time::Duration;
+
+const COUNTER_SRC: &str = r#"
+contract Counter {
+    storage { count: u64, }
+    #[constructor] pub fn init() { self.count = 0; }
+    pub fn increment() { self.count = self.count + 1; }
+    pub fn set_count(n: u64) { self.count = n; }
+    #[view] pub fn get_count() -> u64 { return self.count; }
+}
+"#;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn contract_deploy_and_call_with_real_sigs() {
+    // chain_id=1 → block processor enforces FALCON sig verification
+    // on every tx. See `crates/node/src/block_processor.rs` — the
+    // `dev_skip_signature` flag is false for any chain_id != 31337.
+    let net = TestNetwork::spawn_with_chain_id(4, 1)
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+
+    // Wait for chain to advance so the first tx has somewhere to land.
+    net.wait_for_slot(3, Duration::from_secs(30))
+        .unwrap_or_else(|e| panic!("warm-up: {}", e));
+
+    // Faucet: 1T PYDE allocation at genesis, AuthKeys::Single with
+    // the pubkey from the .key file. Good for ~200 txs of deploy-
+    // class gas before we'd have to think about nonce/balance.
+    let (faucet_pk_bytes, faucet_sk_bytes) = net
+        .load_faucet_key()
+        .unwrap_or_else(|e| panic!("load faucet.key: {}", e));
+    let faucet_sk = FalconSecretKey::from_bytes(&faucet_sk_bytes)
+        .expect("faucet.key produced invalid FALCON secret key");
+    let faucet_addr = pyde_account::address::derive_eoa_address(&faucet_pk_bytes);
+    eprintln!("faucet address: 0x{}", hex::encode(faucet_addr));
+
+    // Sanity: all 4 nodes see the faucet's genesis balance.
+    let faucet_balance = net
+        .get_balance(0, &faucet_addr)
+        .unwrap_or_else(|e| panic!("faucet balance: {}", e));
+    assert!(
+        faucet_balance > 10_000_000_000_000_000, // > 10k PYDE minimum for ~200 deploys
+        "faucet balance too low for test: {}",
+        faucet_balance
+    );
+
+    // ── 1. Compile Counter contract ─────────────────────────────
+    let deploy_payload = compile_deploy_payload(COUNTER_SRC);
+    eprintln!("compiled deploy payload: {} bytes", deploy_payload.len());
+
+    // ── 2. Build + sign + submit Deploy tx ──────────────────────
+    let mut deploy_tx = Transaction {
+        from: faucet_addr,
+        to: [0u8; 32], // Deploy targets zero address
+        value: 0,
+        data: deploy_payload,
+        gas_limit: 100_000_000, // Counter is tiny, but ctor + storage writes need headroom
+        nonce: 0,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::Deploy,
+    };
+    sign_tx(&mut deploy_tx, &faucet_sk);
+    let deploy_hash = net
+        .submit_raw_tx(0, &deploy_tx.to_bytes())
+        .unwrap_or_else(|e| panic!("submit deploy: {}", e));
+    eprintln!("deploy tx_hash: {}", deploy_hash);
+
+    // ── 3. Wait for deploy receipt on every node ────────────────
+    let deploy_receipts = net
+        .wait_for_receipt_on_all(&deploy_hash, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("deploy receipt wait: {}", e));
+    for (i, r) in deploy_receipts.iter().enumerate() {
+        eprintln!("node-{} deploy receipt: success={}", i, r.success);
+        assert!(
+            r.success,
+            "node-{} reports failed deploy receipt:\n{}",
+            i, r.raw
+        );
+    }
+
+    // ── 4. Extract contract address from receipt returnData ─────
+    let return_bytes = TestNetwork::decode_return_data(&deploy_receipts[0].raw)
+        .unwrap_or_else(|e| panic!("decode deploy returnData: {}", e));
+    assert_eq!(
+        return_bytes.len(),
+        32,
+        "deploy returnData should be a 32-byte address, got {} bytes",
+        return_bytes.len()
+    );
+    let mut contract_addr = [0u8; 32];
+    contract_addr.copy_from_slice(&return_bytes);
+    eprintln!("deployed at: 0x{}", hex::encode(contract_addr));
+
+    // ── 5. Code present + identical on every node ───────────────
+    let codes: Vec<(usize, String)> = net
+        .nodes
+        .iter()
+        .map(|n| {
+            let c = net
+                .get_code(n.index, &contract_addr)
+                .unwrap_or_else(|e| panic!("get_code node-{}: {}", n.index, e));
+            (n.index, c)
+        })
+        .collect();
+    let reference_code = codes[0].1.clone();
+    assert!(
+        !reference_code.is_empty(),
+        "node-0 has no code at {:?} — deploy didn't install bytecode",
+        contract_addr
+    );
+    for (i, c) in &codes[1..] {
+        assert_eq!(
+            c, &reference_code,
+            "code mismatch node-0 vs node-{}: {} vs {}",
+            i,
+            reference_code.len(),
+            c.len()
+        );
+    }
+    eprintln!("code agreement: {} bytes on all 4 nodes", reference_code.len() / 2);
+
+    // ── 6. Build + sign + submit set_count(42) ──────────────────
+    let selector = otic::codegen::compute_selector("set_count");
+    let mut call_data = selector.to_be_bytes().to_vec();
+    call_data.extend_from_slice(&42u64.to_le_bytes());
+
+    let mut call_tx = Transaction {
+        from: faucet_addr,
+        to: contract_addr,
+        value: 0,
+        data: call_data.clone(),
+        gas_limit: 5_000_000,
+        nonce: 1,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: 1,
+        tx_type: TransactionType::Standard,
+    };
+    sign_tx(&mut call_tx, &faucet_sk);
+    let call_hash = net
+        .submit_raw_tx(0, &call_tx.to_bytes())
+        .unwrap_or_else(|e| panic!("submit set_count: {}", e));
+    eprintln!("set_count tx_hash: {}", call_hash);
+
+    let call_receipts = net
+        .wait_for_receipt_on_all(&call_hash, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("call receipt wait: {}", e));
+    for (i, r) in call_receipts.iter().enumerate() {
+        eprintln!("node-{} set_count receipt: success={}", i, r.success);
+        assert!(
+            r.success,
+            "node-{} reports failed set_count receipt:\n{}",
+            i, r.raw
+        );
+    }
+
+    // ── 7. get_count() via pyde_call on every node ──────────────
+    let get_selector = otic::codegen::compute_selector("get_count");
+    let view_calldata = get_selector.to_be_bytes().to_vec();
+    let mut view_results: Vec<(usize, String)> = Vec::new();
+    for n in &net.nodes {
+        let r = net
+            .pyde_call_view(n.index, &contract_addr, &view_calldata)
+            .unwrap_or_else(|e| panic!("pyde_call node-{}: {}", n.index, e));
+        view_results.push((n.index, r));
+    }
+    eprintln!("view results: {:?}", view_results);
+    // pyde_call returns the GP return as 8 bytes LE hex — r1 = 42
+    // for our set_count. Expected: 2a00000000000000 (LE u64 of 42).
+    let expected = hex::encode(42u64.to_le_bytes());
+    for (i, v) in &view_results {
+        assert_eq!(
+            v, &expected,
+            "node-{} pyde_call(get_count) returned {:?}, expected {:?}",
+            i, v, expected
+        );
+    }
+
+    // ── 8. state_root converges ─────────────────────────────────
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let r = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            r, reference_root,
+            "state_root divergence after deploy+call:\n  node-0: {}\n  node-{}: {}",
+            reference_root, n.index, r
+        );
+    }
+    eprintln!("state_root match across all 4 nodes: {}", reference_root);
+}
+
+/// FALCON-sign a transaction in place. Matches the convention in
+/// `production_sigs.rs`: the signature binds `tx.hash()`, which is
+/// the Poseidon2 hash over the tx fields MINUS the signature slot.
+fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
+    tx.signature = falcon_sign(sk, &tx.hash())
+        .expect("FALCON sign")
+        .as_bytes()
+        .to_vec();
+}
+
+/// Compile `src` with otic and pack into the Deploy-tx `data`
+/// pipeline format: `[clen u32 LE][rlen u32 LE][constructor][runtime]`.
+/// Mirrors `production_sigs.rs::compile` — this is the canonical
+/// on-chain deploy envelope.
+fn compile_deploy_payload(src: &str) -> Vec<u8> {
+    let c = otic::compile_all(src);
+    let (_, cc) = &c[0];
+    let mut out = Vec::with_capacity(
+        8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len(),
+    );
+    out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(cc.runtime_bytecode.len() as u32).to_le_bytes());
+    out.extend_from_slice(&cc.constructor_bytecode);
+    out.extend_from_slice(&cc.runtime_bytecode);
+    out
+}


### PR DESCRIPTION
## Summary

Closes the two biggest Phase 6 coverage gaps in a single test:

- **Real FALCON-512 signature verification across consensus.** All prior multi-node tests used `chain_id == 31337` which skips sigs. This one uses `chain_id = 1`, so the block processor's `dev_skip_signature` stays `false` and every tx in every block is re-verified by every validator.
- **Smart-contract deploy + call across the network.** Contract code propagates to every node's `code_key(addr)`; a state-changing call via `pyde_sendRawTransaction` reaches every validator, lands in a block, and updates contract storage deterministically.

## Test flow

1. 4 validators at `chain_id=1` (production mode).
2. Faucet (1T PYDE, `AuthKeys::Single` installed) signs + submits a Deploy tx for `Counter`.
3. Extract contract address from `receipt.returnData`.
4. `pyde_getCode(addr)` returns identical 440 bytes on all 4 nodes.
5. Faucet signs + submits `set_count(42)` at nonce=1.
6. `pyde_call(get_count)` on each of the 4 nodes returns `2a00000000000000` (LE hex of 42).
7. `pyde_stateRoot` matches across all 4 nodes.

## Harness additions

- `TestNetwork::spawn_with_chain_id(validators, chain_id)` — any `chain_id != 31337` enforces FALCON verification.
- `load_faucet_key()` — reads `<net_dir>/faucet.key`.
- `submit_raw_tx(node_idx, tx_bytes)` — `pyde_sendRawTransaction`.
- `get_code(node_idx, addr)` — `pyde_getCode`.
- `pyde_call_view(node_idx, to, calldata)` — static call via `pyde_call`, returns hex result.
- `decode_return_data(receipt_raw)` — pulls `returnData` bytes from a receipt JSON blob.
- `spawn_mixed_inner` threads `chain_id_override: Option<u64>` so the dev-mode default of 31337 can be overridden.

## Verification

- Solo: 1 passed in ~5 s. Code match on all 4 nodes. Views return 42 on all 4 nodes. Identical state_root.
- Workspace: 2322 passed, 0 failed.