### PR TITLE
fix: rpc ingress validation + gossipsub retry + loadgen backoff

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -540,6 +540,13 @@ impl PydeNode {
         let mut slot_interval = tokio::time::interval(std::time::Duration::from_millis(100)); // check slot every 100ms
         let mut maintenance_interval = tokio::time::interval(std::time::Duration::from_secs(10));
         let mut sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
+        // Gossip retry: re-publish uncommitted pending txs every 2 slots.
+        // Closes the window where gossipsub NoSubscribers / mesh churn /
+        // subscription timing dropped the initial broadcast — without this,
+        // a tx could sit in a single node's pending forever if its first
+        // publish missed all peers. Capped to avoid re-publish bursts.
+        let mut gossip_retry_interval = tokio::time::interval(std::time::Duration::from_millis(800));
+        const GOSSIP_RETRY_MAX_TXS: usize = 1000;
 
         loop {
             tokio::select! {
@@ -1527,6 +1534,44 @@ impl PydeNode {
                     // Try to sync if we're behind
                     if chain_sync.is_syncing() {
                         chain_sync.request_next_batch(&mut swarm);
+                    }
+                }
+                _ = gossip_retry_interval.tick() => {
+                    // Re-publish uncommitted pending txs. The initial
+                    // gossipsub publish at RPC-ingress time is
+                    // best-effort: it can silently fail with
+                    // NoSubscribers if the mesh hasn't converged yet,
+                    // and there's no retry path in libp2p's gossipsub.
+                    // Without this, a tx submitted during startup /
+                    // mesh churn / subscription re-binding can sit in
+                    // exactly one node's pending forever, orphaning
+                    // that sender's nonce window — the root cause of
+                    // the "stuck at nonce N" stalls we saw under
+                    // loadgen. Cap to avoid re-publish bursts.
+                    let pending_r = pending_txs.read().await;
+                    let to_retry: Vec<pyde_tx::types::Transaction> = pending_r
+                        .values()
+                        .take(GOSSIP_RETRY_MAX_TXS)
+                        .cloned()
+                        .collect();
+                    drop(pending_r);
+                    if !to_retry.is_empty() {
+                        let topic = pyde_net::node::topics::transactions();
+                        let mut ok = 0;
+                        let mut nosub = 0;
+                        for tx in &to_retry {
+                            let bytes = wire::encode_transaction(tx);
+                            match swarm.behaviour_mut().gossipsub.publish(topic.clone(), bytes) {
+                                Ok(_) => ok += 1,
+                                Err(_) => nosub += 1,
+                            }
+                        }
+                        debug!(
+                            total = to_retry.len(),
+                            ok,
+                            nosub,
+                            "gossip retry"
+                        );
                     }
                 }
                 _ = maintenance_interval.tick() => {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -12,6 +12,8 @@ use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use pyde_tx::execution::Receipt;
 use pyde_tx::pipeline::BlockContext;
+use pyde_tx::types::Transaction;
+use pyde_tx::validation::{validate_transaction, ValidationContext, ValidationError};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -421,6 +423,11 @@ impl PydeApiServer for RpcServer {
             tx_type,
         };
 
+        // Ingress validation — same canonical validator as `send_raw_transaction`.
+        // Dev-mode unsigned txs pass because `dev_skip_signature` is driven
+        // by chain_id == 31337 inside `ingress_validate`.
+        ingress_validate(&self.state.state, &self.state.chain, &tx).await?;
+
         // Compute tx hash (must match tx.hash() used in receipt generation)
         let tx_hash = tx.hash();
 
@@ -458,6 +465,11 @@ impl PydeApiServer for RpcServer {
                 pyde_tx::types::Transaction::from_bytes(&tx_bytes).ok_or("invalid tx encoding")
             })
             .map_err(|e| rpc_err(-32602, format!("invalid tx encoding: {}", e)))?;
+
+        // Ingress validation — reject invalid txs BEFORE polluting the
+        // mempool + gossip network. See `ingress_validate` docs.
+        ingress_validate(&self.state.state, &self.state.chain, &tx).await?;
+
         let tx_hash = tx.hash();
 
         let mut pending = self.state.pending_txs.write().await;
@@ -1096,6 +1108,64 @@ pub async fn start_rpc_server(
 // ============================================================
 // Helpers
 // ============================================================
+
+/// Validate a transaction at RPC ingress using the canonical
+/// `pyde_tx::validation` pipeline. Reads the sender's on-chain
+/// account + nonce + vesting lock + current chain state, feeds them
+/// to `validate_transaction`. Reject here = no pollution of the
+/// local mempool, no wasted gossip, no wasted proposer slot-budget.
+///
+/// The only intentional relaxation vs block-execution validation is
+/// the sig-skip rule: on chain_id==31337 (devnet) we skip FALCON
+/// verification so the `--dev` `pyde_sendTransaction` path (unsigned
+/// txs from pre-funded accounts) still works. Any other chain_id
+/// enforces sigs.
+async fn ingress_validate(
+    state: &Arc<RwLock<StateManager>>,
+    chain: &Arc<RwLock<ChainState>>,
+    tx: &Transaction,
+) -> Result<(), ErrorObjectOwned> {
+    let chain_r = chain.read().await;
+    let chain_id = chain_r.chain_id;
+    let base_fee = chain_r.base_fee;
+    let head_slot = chain_r.head_slot;
+    drop(chain_r);
+
+    let state_r = state.read().await;
+    let sender = pyde_tx::pipeline::load_account(&*state_r, &tx.from);
+    let nonce_state = pyde_tx::pipeline::load_nonce(&*state_r, &tx.from);
+    let sender_locked = pyde_tx::pipeline::read_vesting_schedule(&*state_r, &tx.from)
+        .map(|s| s.locked_at(head_slot))
+        .unwrap_or(0);
+    drop(state_r);
+
+    let ctx = ValidationContext {
+        block_height: head_slot,
+        base_fee,
+        block_gas_limit: pyde_tx::fee::GAS_CEILING,
+        chain_id,
+        dev_skip_signature: chain_id == 31337,
+        sender_locked,
+    };
+
+    validate_transaction(tx, &sender, &nonce_state, &ctx).map_err(|e| {
+        let code = match e {
+            ValidationError::InvalidSignature => -32001,
+            ValidationError::InvalidNonce(_) => -32002,
+            ValidationError::InsufficientBalance { .. } => -32003,
+            ValidationError::WrongChainId { .. } => -32004,
+            ValidationError::GasLimitTooLow { .. }
+            | ValidationError::GasLimitTooHigh { .. } => -32005,
+            ValidationError::DeadlineExpired { .. } => -32006,
+            ValidationError::TxTooLarge { .. } | ValidationError::CalldataTooLarge { .. } => {
+                -32007
+            }
+            ValidationError::InvalidAccessList(_) => -32008,
+            _ => -32000,
+        };
+        rpc_err(code, format!("ingress validation: {:?}", e))
+    })
+}
 
 fn rpc_err(code: i32, msg: String) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, msg, None::<()>)

--- a/crates/node/tests/loadgen_sustained.rs
+++ b/crates/node/tests/loadgen_sustained.rs
@@ -286,6 +286,14 @@ fn sustained_rate_load_test() {
                         }
                         Err(_) => {
                             err.fetch_add(1, Ordering::Relaxed);
+                            // Back off a full slot on rejection. Usually an
+                            // InvalidNonce "too far ahead" — we've submitted
+                            // nonces faster than the chain can commit them
+                            // to advance `base`. Waiting a slot lets the
+                            // chain commit a block (or two), advancing the
+                            // window so the same tx validates on retry.
+                            tokio::time::sleep(Duration::from_millis(400)).await;
+                            next_submit = Instant::now();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Three related mempool/ingress bugs.

- `send_raw_transaction` / `send_transaction` now run the canonical
  `validate_transaction` (chain state + sender account + nonce
  window + vesting lock) before inserting into the mempool or
  gossiping. Previously, invalid txs polluted both.
- Gossipsub best-effort publish silently dropped txs on
  `NoSubscribers` during mesh convergence. An 800 ms retry tick
  re-publishes uncommitted pending txs (cap 1000/tick).
- Sustained loadgen now backs off 400 ms on RPC rejection so a
  transient window-full doesn't cascade into a hot reject loop.