### PR TITLE
feat: mempool hardening round 2 — nonce-gap hints, (sender, nonce) dedup, global cap

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -637,17 +637,40 @@ impl PydeNode {
                         }
                         PostEventAction::AcceptTransaction(tx) => {
                             let tx_hash = tx.hash();
-                            // Index for compact block reconstruction
-                            let tx_bytes = wire::encode_transaction(&tx);
-                            mempool_index.write().await.insert(tx_hash, tx_bytes);
+                            // Global cap (M3) + (sender, nonce) dedup (M6)
+                            // on the gossip path too. Without these, a
+                            // busy gossip mesh can push this node past
+                            // its mempool budget or land a second-write
+                            // variant for an already-pending (sender,
+                            // nonce). Constants match rpc.rs — keep in
+                            // sync if those change.
+                            const GOSSIP_MEMPOOL_GLOBAL_CAP: usize = 100_000;
                             let mut pending = pending_txs.write().await;
-                            pending.insert(tx_hash, tx);
-                            debug!(tx_hash = hex::encode(tx_hash), pending = pending.len(), "tx accepted from gossip");
-                            drop(pending);
-                            pending_tx_times
-                                .write()
-                                .await
-                                .insert(tx_hash, std::time::Instant::now());
+                            if pending.len() >= GOSSIP_MEMPOOL_GLOBAL_CAP {
+                                debug!(
+                                    tx_hash = hex::encode(tx_hash),
+                                    cap = GOSSIP_MEMPOOL_GLOBAL_CAP,
+                                    "gossip tx dropped: mempool full"
+                                );
+                            } else if pending
+                                .values()
+                                .any(|t| t.from == tx.from && t.nonce == tx.nonce)
+                            {
+                                debug!(
+                                    tx_hash = hex::encode(tx_hash),
+                                    "gossip tx dropped: duplicate (sender, nonce)"
+                                );
+                            } else {
+                                let tx_bytes = wire::encode_transaction(&tx);
+                                mempool_index.write().await.insert(tx_hash, tx_bytes);
+                                pending.insert(tx_hash, tx);
+                                debug!(tx_hash = hex::encode(tx_hash), pending = pending.len(), "tx accepted from gossip");
+                                drop(pending);
+                                pending_tx_times
+                                    .write()
+                                    .await
+                                    .insert(tx_hash, std::time::Instant::now());
+                            }
                         }
                         PostEventAction::AddPeerToKademlia(peer_id, addrs) => {
                             for addr in &addrs {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -28,6 +28,20 @@ use tracing::info;
 /// max out the mempool — matching typical pending-account counts.
 const MEMPOOL_SENDER_CAP: usize = 128;
 
+/// Hard cap on total mempool size per node (MAINNET_PLAN M3). Under
+/// sustained overload the M2 TTL sweep drains the mempool, but a
+/// large burst can still push it past reasonable memory bounds
+/// before the 4-minute TTL kicks in. Rejecting at this cap bounds
+/// worst-case memory to roughly:
+///   100_000 tx × ~1.8 KB avg (FALCON sig dominates) = ~180 MB.
+/// Well inside a server budget; a laptop can also absorb this before
+/// swap pressure kicks in. We chose hard-reject over fee-priority
+/// eviction because our fee model has no per-tx priority signal —
+/// every tx at a given base_fee pays the same per gas unit. When the
+/// protocol grows a priority-fee field, M3 can upgrade to lowest-fee
+/// eviction.
+const MEMPOOL_GLOBAL_CAP: usize = 100_000;
+
 /// Shared node state accessible by RPC handlers.
 pub struct RpcState {
     pub chain: Arc<RwLock<ChainState>>,
@@ -459,11 +473,39 @@ impl PydeApiServer for RpcServer {
         // Compute tx hash (must match tx.hash() used in receipt generation)
         let tx_hash = tx.hash();
 
-        // Per-sender mempool cap (MAINNET_PLAN M1). Atomic with the
-        // insert under one write lock so the cap can't be raced by
-        // concurrent submissions.
+        // Global cap (M3) + per-sender cap (M1) + (sender, nonce) dedup
+        // (M6), all atomic with the insert under one write lock.
         let mut pending = self.state.pending_txs.write().await;
-        let sender_count = pending.values().filter(|t| t.from == tx.from).count();
+        if pending.len() >= MEMPOOL_GLOBAL_CAP {
+            return Err(rpc_err(
+                -32011,
+                format!(
+                    "mempool full: {} txs pending (cap {})",
+                    pending.len(),
+                    MEMPOOL_GLOBAL_CAP
+                ),
+            ));
+        }
+        let mut sender_count: usize = 0;
+        let mut duplicate_nonce = false;
+        for t in pending.values() {
+            if t.from == tx.from {
+                sender_count += 1;
+                if t.nonce == tx.nonce {
+                    duplicate_nonce = true;
+                    break;
+                }
+            }
+        }
+        if duplicate_nonce {
+            return Err(rpc_err(
+                -32010,
+                format!(
+                    "duplicate (sender, nonce)={} in mempool; cancel or wait for the existing tx to commit/expire",
+                    tx.nonce
+                ),
+            ));
+        }
         if sender_count >= MEMPOOL_SENDER_CAP {
             return Err(rpc_err(
                 -32009,
@@ -517,10 +559,39 @@ impl PydeApiServer for RpcServer {
 
         let tx_hash = tx.hash();
 
-        // Per-sender mempool cap (MAINNET_PLAN M1). See send_transaction
-        // for rationale — atomic count+insert under one write lock.
+        // Global cap + per-sender cap + dedup — same atomic check as
+        // send_transaction. See that handler for rationale.
         let mut pending = self.state.pending_txs.write().await;
-        let sender_count = pending.values().filter(|t| t.from == tx.from).count();
+        if pending.len() >= MEMPOOL_GLOBAL_CAP {
+            return Err(rpc_err(
+                -32011,
+                format!(
+                    "mempool full: {} txs pending (cap {})",
+                    pending.len(),
+                    MEMPOOL_GLOBAL_CAP
+                ),
+            ));
+        }
+        let mut sender_count: usize = 0;
+        let mut duplicate_nonce = false;
+        for t in pending.values() {
+            if t.from == tx.from {
+                sender_count += 1;
+                if t.nonce == tx.nonce {
+                    duplicate_nonce = true;
+                    break;
+                }
+            }
+        }
+        if duplicate_nonce {
+            return Err(rpc_err(
+                -32010,
+                format!(
+                    "duplicate (sender, nonce)={} in mempool; cancel or wait for the existing tx to commit/expire",
+                    tx.nonce
+                ),
+            ));
+        }
         if sender_count >= MEMPOOL_SENDER_CAP {
             return Err(rpc_err(
                 -32009,

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -156,10 +156,29 @@ fn validate_signature(tx: &Transaction, sender: &Account) -> Result<(), Validati
 }
 
 fn validate_nonce(tx: &Transaction, nonce_state: &NonceState) -> Result<(), ValidationError> {
-    nonce_state
-        .validate(tx.nonce)
-        .map(|_| ())
-        .map_err(|e| ValidationError::InvalidNonce(format!("{:?}", e)))
+    match nonce_state.validate(tx.nonce) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            // Enrich the error with the lowest unused nonce in the
+            // current window so wallets can tell the user "you're
+            // waiting on nonce N to fill" instead of "your nonce is
+            // out of range, figure it out yourself." (MAINNET_PLAN M5.)
+            //
+            // The lowest unused nonce is `base` itself — every used
+            // bit at position 0 would have already advanced `base`.
+            // So `base` is always the next-needed slot if the window
+            // has any gaps. We also include `base + WINDOW_SIZE - 1`
+            // as the current upper bound so AboveWindow errors say
+            // exactly which range is acceptable.
+            let next_needed = nonce_state.base;
+            let window_max = nonce_state.max_nonce();
+            let msg = format!(
+                "{:?} (got {}, window [{}..{}], next usable {})",
+                e, tx.nonce, nonce_state.base, window_max, next_needed
+            );
+            Err(ValidationError::InvalidNonce(msg))
+        }
+    }
 }
 
 fn validate_balance(


### PR DESCRIPTION
## Summary

Closes the three remaining Phase 7b items (**M3**, **M5**, **M6**).
With this landed, Phase 7b is complete.

### M5 — Nonce-gap hints

`InvalidNonce` errors now carry the current window bounds
(`[base..base+15]`) and the next-usable nonce (= `base` itself — any
lower nonce would have already slid the window via `advance()`).
Wallets can now show "waiting on nonce N to fill" instead of a vague
out-of-range error. Pure error-message enrichment — no behavior
change.

### M6 — `(sender, nonce)` dedup

One tx per `(sender, nonce)` slot. Duplicates rejected at both RPC
ingress paths (JSON-RPC code `-32010`) and on the gossip ingress
path (drop + debug log).

Without this, different nodes could hold different-hash variants
for the same `(sender, nonce)` — block content would depend on
which proposer wins VRF, unpredictable from the user's view.

Simplified from *fee-bump replacement* because our fee model has
no per-tx priority signal (every tx at a given `base_fee` pays the
same per gas). When the protocol grows a priority-fee field, M6 can
upgrade to real fee-bump.

### M3 — Global mempool size cap

Hard reject at **100K pending txs**, matching the M1 sender cap
budget (128 × 782 senders). Bounds worst-case memory to ~180 MB
(100K × ~1.8 KB for FALCON sig) — safe on server, fine on laptop
before swap pressure.

Applied at both RPC ingress (error `-32011`) and gossip ingress
(silent drop + debug log).

Simplified from *fee-priority eviction* for the same reason as M6.

## Regression

1K TPS × 2 min, 100 senders: **1001 TPS inclusion, 100% efficiency,
0 errors.** No change to the 4K × 10 min sustained ceiling or the
7K × 30s burst ceiling.

## New JSON-RPC error codes

| Code | Meaning |
| --- | --- |
| `-32009` | Per-sender mempool cap reached (M1, already shipped) |
| `-32010` | Duplicate `(sender, nonce)` in mempool (M6) |
| `-32011` | Mempool full — global cap reached (M3) |