### PR TITLE
style: cargo fmt --all across workspace (task 052)

### DIFF
--- a/crates/node/src/fast_tx.rs
+++ b/crates/node/src/fast_tx.rs
@@ -24,9 +24,7 @@ pub async fn start_fast_tx_listener(
     listen: &str,
     port: u16,
     pending_txs: Arc<RwLock<std::collections::HashMap<[u8; 32], pyde_tx::types::Transaction>>>,
-    pending_tx_times: Arc<
-        RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>,
-    >,
+    pending_tx_times: Arc<RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_tx::types::Transaction>,
 ) -> Result<std::net::SocketAddr, String> {
     let addr = format!("{}:{}", listen, port);
@@ -62,9 +60,7 @@ async fn handle_connection(
     mut stream: tokio::net::TcpStream,
     peer: std::net::SocketAddr,
     pending_txs: Arc<RwLock<std::collections::HashMap<[u8; 32], pyde_tx::types::Transaction>>>,
-    pending_tx_times: Arc<
-        RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>,
-    >,
+    pending_tx_times: Arc<RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_tx::types::Transaction>,
 ) {
     let mut accepted = 0u64;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -221,9 +221,8 @@ impl PydeNode {
         // periodically by the maintenance tick so a tx that never
         // commits (under sustained overload) doesn't live in memory
         // forever.
-        let pending_tx_times: Arc<
-            RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>,
-        > = Arc::new(RwLock::new(std::collections::HashMap::new()));
+        let pending_tx_times: Arc<RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>> =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
 
         // Mempool tx index for compact block reconstruction: tx_hash → wire-encoded bytes
         let mempool_index: Arc<RwLock<std::collections::HashMap<[u8; 32], Vec<u8>>>> =
@@ -556,7 +555,8 @@ impl PydeNode {
         // subscription timing dropped the initial broadcast — without this,
         // a tx could sit in a single node's pending forever if its first
         // publish missed all peers. Capped to avoid re-publish bursts.
-        let mut gossip_retry_interval = tokio::time::interval(std::time::Duration::from_millis(800));
+        let mut gossip_retry_interval =
+            tokio::time::interval(std::time::Duration::from_millis(800));
         const GOSSIP_RETRY_MAX_TXS: usize = 1000;
 
         loop {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -61,8 +61,7 @@ pub struct RpcState {
     /// (block builder, gossip handler, fast_tx ingress) don't have
     /// to change. Drift is tolerated — an entry missing from one map
     /// is just skipped by the eviction loop, not a correctness bug.
-    pub pending_tx_times:
-        Arc<RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    pub pending_tx_times: Arc<RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
     /// Committee threshold public key for encrypting transactions (MEV protection).
     pub threshold_pk: Option<pyde_crypto::threshold::ThresholdPublicKey>,
     /// Broadcast channel for new block headers (WebSocket subscriptions).
@@ -1325,12 +1324,11 @@ async fn ingress_validate(
             ValidationError::InvalidNonce(_) => -32002,
             ValidationError::InsufficientBalance { .. } => -32003,
             ValidationError::WrongChainId { .. } => -32004,
-            ValidationError::GasLimitTooLow { .. }
-            | ValidationError::GasLimitTooHigh { .. } => -32005,
-            ValidationError::DeadlineExpired { .. } => -32006,
-            ValidationError::TxTooLarge { .. } | ValidationError::CalldataTooLarge { .. } => {
-                -32007
+            ValidationError::GasLimitTooLow { .. } | ValidationError::GasLimitTooHigh { .. } => {
+                -32005
             }
+            ValidationError::DeadlineExpired { .. } => -32006,
+            ValidationError::TxTooLarge { .. } | ValidationError::CalldataTooLarge { .. } => -32007,
             ValidationError::InvalidAccessList(_) => -32008,
             _ => -32000,
         };

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -97,12 +97,15 @@ impl TestNetwork {
 
     /// Spawn V validators + F full nodes. Full nodes bootstrap to every
     /// validator and relay txs but don't participate in consensus.
-    pub fn spawn_mixed(
-        validators: usize,
-        full_nodes: usize,
-        dev: bool,
-    ) -> Result<Self, String> {
-        Self::spawn_mixed_inner(validators, full_nodes, 0, dev, Self::DEFAULT_BLOCK_TIME_MS, None)
+    pub fn spawn_mixed(validators: usize, full_nodes: usize, dev: bool) -> Result<Self, String> {
+        Self::spawn_mixed_inner(
+            validators,
+            full_nodes,
+            0,
+            dev,
+            Self::DEFAULT_BLOCK_TIME_MS,
+            None,
+        )
     }
 
     /// Same as `spawn_mixed`, but the last `deferred` full nodes have
@@ -189,8 +192,8 @@ impl TestNetwork {
 
         let tempdir = tempfile::tempdir().map_err(|e| format!("create tempdir: {}", e))?;
         let net_dir = tempdir.path().join("net");
-        let chain_id = chain_id_override
-            .unwrap_or_else(|| if dev { 31337 } else { rand_chain_id() });
+        let chain_id =
+            chain_id_override.unwrap_or_else(|| if dev { 31337 } else { rand_chain_id() });
         let pyde_bin = pyde_binary_path();
 
         // Find contiguous free port ranges for p2p (UDP — used by QUIC)
@@ -251,7 +254,13 @@ impl TestNetwork {
                 start_node(&mut n, &pyde_bin, dev)?;
             } else {
                 // Keep them reserved until start_deferred() is called.
-                deferred_port_holders.insert(i, DeferredPortHolder { _udp: udp, _tcp: tcp });
+                deferred_port_holders.insert(
+                    i,
+                    DeferredPortHolder {
+                        _udp: udp,
+                        _tcp: tcp,
+                    },
+                );
             }
             nodes.push(n);
         }
@@ -372,10 +381,7 @@ impl TestNetwork {
             .ok_or_else(|| format!("no epoch field in response: {}", resp))?
             + key.len();
         let tail = &resp[start..];
-        let end = tail
-            .bytes()
-            .take_while(|b| b.is_ascii_digit())
-            .count();
+        let end = tail.bytes().take_while(|b| b.is_ascii_digit()).count();
         if end == 0 {
             return Err(format!("couldn't parse epoch from {}", tail));
         }
@@ -388,11 +394,7 @@ impl TestNetwork {
     /// Read the proposer address for a block at `slot` from `node_idx`'s
     /// `pyde_getBlockByNumber`. Returns `Ok(None)` if the node has not
     /// committed that slot yet (gap or pre-produced).
-    pub fn proposer_of(
-        &self,
-        node_idx: usize,
-        slot: u64,
-    ) -> Result<Option<[u8; 32]>, String> {
+    pub fn proposer_of(&self, node_idx: usize, slot: u64) -> Result<Option<[u8; 32]>, String> {
         let params = format!("[{}]", slot);
         let resp = rpc_call(
             &self.nodes[node_idx].rpc_url(),
@@ -405,17 +407,22 @@ impl TestNetwork {
         // Response has `"proposer":"0x<64 hex>"`. Extract it.
         let key = r#""proposer":"0x"#;
         let start = resp.find(key).ok_or_else(|| {
-            format!("no proposer in getBlockByNumber({}) response: {}", slot, resp)
+            format!(
+                "no proposer in getBlockByNumber({}) response: {}",
+                slot, resp
+            )
         })?;
         let tail = &resp[start + key.len()..];
         let end = tail
             .find('"')
             .ok_or_else(|| format!("unterminated proposer: {}", resp))?;
         let hex = &tail[..end];
-        let bytes = hex::decode(hex)
-            .map_err(|e| format!("decode proposer {}: {}", hex, e))?;
+        let bytes = hex::decode(hex).map_err(|e| format!("decode proposer {}: {}", hex, e))?;
         if bytes.len() != 32 {
-            return Err(format!("proposer address is {} bytes, expected 32", bytes.len()));
+            return Err(format!(
+                "proposer address is {} bytes, expected 32",
+                bytes.len()
+            ));
         }
         let mut addr = [0u8; 32];
         addr.copy_from_slice(&bytes);
@@ -514,11 +521,7 @@ impl TestNetwork {
     /// The tx must be wire-encoded via `Transaction::to_bytes()` and
     /// correctly signed by the FALCON key installed as `AuthKeys::Single`
     /// for its `from` address. Returns the submitted tx hash.
-    pub fn submit_raw_tx(
-        &self,
-        node_idx: usize,
-        tx_bytes: &[u8],
-    ) -> Result<String, String> {
+    pub fn submit_raw_tx(&self, node_idx: usize, tx_bytes: &[u8]) -> Result<String, String> {
         let hex = hex::encode(tx_bytes);
         let params = format!(r#"["0x{}"]"#, hex);
         let resp = rpc_call(
@@ -540,11 +543,7 @@ impl TestNetwork {
     /// hex string WITHOUT the `0x` prefix; empty string if no code.
     pub fn get_code(&self, node_idx: usize, address: &[u8; 32]) -> Result<String, String> {
         let params = format!(r#"["0x{}"]"#, hex::encode(address));
-        let resp = rpc_call(
-            &self.nodes[node_idx].rpc_url(),
-            "pyde_getCode",
-            &params,
-        )?;
+        let resp = rpc_call(&self.nodes[node_idx].rpc_url(), "pyde_getCode", &params)?;
         let hex = parse_hex_result(&resp)?;
         Ok(hex.trim_start_matches("0x").to_string())
     }
@@ -564,11 +563,7 @@ impl TestNetwork {
             hex::encode(to),
             hex::encode(calldata),
         );
-        let resp = rpc_call(
-            &self.nodes[node_idx].rpc_url(),
-            "pyde_call",
-            &params,
-        )?;
+        let resp = rpc_call(&self.nodes[node_idx].rpc_url(), "pyde_call", &params)?;
         let hex = parse_hex_result(&resp)?;
         Ok(hex.trim_start_matches("0x").to_string())
     }
@@ -593,13 +588,9 @@ impl TestNetwork {
     /// Read a validator's FALCON keypair from its datadir. Layout is
     /// the one `generate_testnet` writes: `pk_len u32 LE || pk || sk`.
     /// Returns `(pk_bytes, sk_bytes)`.
-    pub fn load_validator_key(
-        &self,
-        node_idx: usize,
-    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+    pub fn load_validator_key(&self, node_idx: usize) -> Result<(Vec<u8>, Vec<u8>), String> {
         let path = self.nodes[node_idx].datadir.join("validator.key");
-        let raw = std::fs::read(&path)
-            .map_err(|e| format!("read {}: {}", path.display(), e))?;
+        let raw = std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
         if raw.len() < 4 {
             return Err(format!("validator.key too short: {}", raw.len()));
         }
@@ -623,11 +614,7 @@ impl TestNetwork {
         &self,
         node_idx: usize,
     ) -> Result<Vec<(String, u128, String)>, String> {
-        let resp = rpc_call(
-            &self.nodes[node_idx].rpc_url(),
-            "pyde_getValidators",
-            "[]",
-        )?;
+        let resp = rpc_call(&self.nodes[node_idx].rpc_url(), "pyde_getValidators", "[]")?;
         parse_validator_set(&resp)
     }
 
@@ -780,11 +767,7 @@ impl TestNetwork {
     /// Balance in quanta. Returns `0` if the account is unknown.
     pub fn get_balance(&self, node_idx: usize, address: &[u8; 32]) -> Result<u128, String> {
         let params = format!(r#"["0x{}"]"#, hex::encode(address));
-        let resp = rpc_call(
-            &self.nodes[node_idx].rpc_url(),
-            "pyde_getBalance",
-            &params,
-        )?;
+        let resp = rpc_call(&self.nodes[node_idx].rpc_url(), "pyde_getBalance", &params)?;
         // `pyde_getBalance` returns the balance as a decimal string
         // (see `balance.to_string()` in `rpc.rs::get_balance`). Not
         // hex, despite the `0x`-ish feel of the sibling RPCs.
@@ -816,8 +799,8 @@ impl TestNetwork {
         let success = extract_bool_field(body, "status")
             .or_else(|| extract_bool_field(body, "success"))
             .unwrap_or(false);
-        let block_slot = extract_u64_field(body, "blockNumber")
-            .or_else(|| extract_u64_field(body, "slot"));
+        let block_slot =
+            extract_u64_field(body, "blockNumber").or_else(|| extract_u64_field(body, "slot"));
         Ok(Some(ReceiptView {
             raw: body.to_string(),
             success,
@@ -1122,12 +1105,16 @@ fn parse_validator_set(resp: &str) -> Result<Vec<(String, u128, String)>, String
             .find(key_stake)
             .ok_or("no stake field after address")?;
         let stake_start = after_addr + stake_start_rel + key_stake.len();
-        let stake_end_rel = resp[stake_start..]
-            .find('"')
-            .ok_or("unterminated stake")?;
+        let stake_end_rel = resp[stake_start..].find('"').ok_or("unterminated stake")?;
         let stake: u128 = resp[stake_start..stake_start + stake_end_rel]
             .parse()
-            .map_err(|e| format!("parse stake {}: {}", &resp[stake_start..stake_start + stake_end_rel], e))?;
+            .map_err(|e| {
+                format!(
+                    "parse stake {}: {}",
+                    &resp[stake_start..stake_start + stake_end_rel],
+                    e
+                )
+            })?;
 
         let after_stake = stake_start + stake_end_rel;
         let status_start_rel = resp[after_stake..]
@@ -1201,10 +1188,7 @@ fn extract_u64_field(body: &str, field: &str) -> Option<u64> {
         }
     } else {
         // Bare number — read until a non-digit.
-        let end = rest
-            .bytes()
-            .take_while(|b| b.is_ascii_digit())
-            .count();
+        let end = rest.bytes().take_while(|b| b.is_ascii_digit()).count();
         rest[..end].parse().ok()
     }
 }

--- a/crates/node/tests/loadgen_sustained.rs
+++ b/crates/node/tests/loadgen_sustained.rs
@@ -102,8 +102,14 @@ fn sustained_rate_load_test() {
     println!("║  Pyde Phase 7 — Sustained-Rate Load Test            ║");
     println!("╠══════════════════════════════════════════════════════╣");
     println!("  Target TPS:   {}", target_tps);
-    println!("  Duration:     {} s  (+ {} s warm-up, not measured)", duration_s, warmup_s);
-    println!("  Senders:      {} (per-account rate: {:.1} tx/s)", num_senders, per_acct_rate);
+    println!(
+        "  Duration:     {} s  (+ {} s warm-up, not measured)",
+        duration_s, warmup_s
+    );
+    println!(
+        "  Senders:      {} (per-account rate: {:.1} tx/s)",
+        num_senders, per_acct_rate
+    );
     println!("  chain_id:     {} (FALCON sig verification ON)", CHAIN_ID);
     println!("  Recipient:    0x{}", hex::encode(RECIPIENT));
     println!("╚══════════════════════════════════════════════════════╝");
@@ -120,8 +126,8 @@ fn sustained_rate_load_test() {
     let (faucet_pk_bytes, faucet_sk_bytes) = net
         .load_faucet_key()
         .unwrap_or_else(|e| panic!("load faucet.key: {}", e));
-    let faucet_sk = FalconSecretKey::from_bytes(&faucet_sk_bytes)
-        .expect("invalid FALCON secret key");
+    let faucet_sk =
+        FalconSecretKey::from_bytes(&faucet_sk_bytes).expect("invalid FALCON secret key");
     let faucet_addr = derive_eoa_address(&faucet_pk_bytes);
     println!("  faucet: 0x{}", hex::encode(faucet_addr));
 
@@ -129,7 +135,10 @@ fn sustained_rate_load_test() {
     println!("  nodes:  {:?}", rpc_urls);
 
     // --- Phase 1: fund N sender wallets from faucet ---
-    println!("\n[1/3] Funding {} sender wallets from faucet…", num_senders);
+    println!(
+        "\n[1/3] Funding {} sender wallets from faucet…",
+        num_senders
+    );
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -350,9 +359,7 @@ fn sustained_rate_load_test() {
                                 let resp = rpc_send_raw(&cli, &url, &hex_tx).await;
                                 eprintln!(
                                     "  [sender 0] nonce={} rejection #{}: {}",
-                                    nonce,
-                                    prev_err,
-                                    resp
+                                    nonce, prev_err, resp
                                 );
                             }
                             // Back off a full slot on rejection. Usually an
@@ -383,7 +390,11 @@ fn sustained_rate_load_test() {
                 let cur = progress_sub.load(Ordering::Relaxed);
                 let dt = (now - last_time).as_secs_f64();
                 let rate = (cur - last_count) as f64 / dt;
-                let phase = if now < progress_measure_at { "warmup" } else { "measure" };
+                let phase = if now < progress_measure_at {
+                    "warmup"
+                } else {
+                    "measure"
+                };
                 println!(
                     "  [{:>7}] +{} submits in {:.1}s → {:.0} tx/s (total: {}, errors: {})",
                     phase,
@@ -435,8 +446,7 @@ fn sustained_rate_load_test() {
     let total_submit_elapsed = total_run_s as f64;
     let submit_tps_overall = total_submits as f64 / total_submit_elapsed;
     let warmup_submits = total_submits.saturating_sub(measure_submits);
-    let confirmed_measurement =
-        confirmed_after_settle.saturating_sub(warmup_submits as u128);
+    let confirmed_measurement = confirmed_after_settle.saturating_sub(warmup_submits as u128);
     let inclusion_tps_steady = confirmed_measurement as f64 / measurement_elapsed;
     let inclusion_efficiency = if measure_submits > 0 {
         confirmed_measurement as f64 / measure_submits as f64
@@ -447,14 +457,32 @@ fn sustained_rate_load_test() {
     println!("\n╔══════════════════════════════════════════════════════╗");
     println!("║  RESULTS                                             ║");
     println!("╠══════════════════════════════════════════════════════╣");
-    println!("  Target:                 {} TPS for {} s", target_tps, duration_s);
-    println!("  Submitted (total):      {} txs over {:.0} s", total_submits, total_submit_elapsed);
-    println!("  Submitted (measured):   {} txs over {} s ({:.0} tx/s)", measure_submits, duration_s, submit_tps_measure);
+    println!(
+        "  Target:                 {} TPS for {} s",
+        target_tps, duration_s
+    );
+    println!(
+        "  Submitted (total):      {} txs over {:.0} s",
+        total_submits, total_submit_elapsed
+    );
+    println!(
+        "  Submitted (measured):   {} txs over {} s ({:.0} tx/s)",
+        measure_submits, duration_s, submit_tps_measure
+    );
     println!("  Submit errors:          {}", err_count);
-    println!("  Confirmed @ submit-end: {} txs", confirmed_at_end_of_submit);
+    println!(
+        "  Confirmed @ submit-end: {} txs",
+        confirmed_at_end_of_submit
+    );
     println!("  Confirmed @ +20 s:      {} txs", confirmed_after_settle);
-    println!("  Inclusion TPS steady:   {:.0} (measured window only)", inclusion_tps_steady);
-    println!("  Inclusion efficiency:   {:.1}%", inclusion_efficiency * 100.0);
+    println!(
+        "  Inclusion TPS steady:   {:.0} (measured window only)",
+        inclusion_tps_steady
+    );
+    println!(
+        "  Inclusion efficiency:   {:.1}%",
+        inclusion_efficiency * 100.0
+    );
     println!("  Submit TPS overall:     {:.0}", submit_tps_overall);
     println!("╚══════════════════════════════════════════════════════╝");
 
@@ -499,7 +527,8 @@ fn sustained_rate_load_test() {
         let timing_lines: Vec<&str> = snap
             .lines()
             .filter(|l| {
-                l.contains("proposed and processed") && !l.contains("pending=0 ")
+                l.contains("proposed and processed")
+                    && !l.contains("pending=0 ")
                     && !l.contains("pending=0\n")
             })
             .collect();
@@ -543,8 +572,7 @@ fn sustained_rate_load_test() {
             .lines()
             .filter(|l| l.contains(" WARN ") || l.contains(" ERROR "))
             .collect();
-        let warn_tail: Vec<&str> =
-            warn_lines.iter().rev().take(30).rev().copied().collect();
+        let warn_tail: Vec<&str> = warn_lines.iter().rev().take(30).rev().copied().collect();
         eprintln!(
             "=== node 0 WARN/ERROR (last {}) ===\n{}\n",
             warn_tail.len(),
@@ -623,11 +651,7 @@ async fn rpc_send_raw(client: &reqwest::Client, url: &str, tx_hex: &str) -> serd
 /// `"error"`. jsonrpsee returns HTTP 200 with an error body for
 /// nonce-too-high, mempool-full, invalid-sig — a bare status check
 /// would overcount successful submits.
-async fn rpc_send_raw_fast(
-    client: &reqwest::Client,
-    url: &str,
-    tx_hex: &str,
-) -> Result<(), ()> {
+async fn rpc_send_raw_fast(client: &reqwest::Client, url: &str, tx_hex: &str) -> Result<(), ()> {
     let body = format!(
         r#"{{"jsonrpc":"2.0","id":1,"method":"pyde_sendRawTransaction","params":["0x{}"]}}"#,
         tx_hex
@@ -650,11 +674,7 @@ async fn rpc_send_raw_fast(
     Ok(())
 }
 
-async fn fetch_nonce(
-    client: &reqwest::Client,
-    url: &str,
-    addr: &[u8; 32],
-) -> Option<u64> {
+async fn fetch_nonce(client: &reqwest::Client, url: &str, addr: &[u8; 32]) -> Option<u64> {
     let resp = rpc_call(
         client,
         url,
@@ -670,11 +690,7 @@ async fn fetch_nonce(
     }
 }
 
-async fn fetch_balance(
-    client: &reqwest::Client,
-    url: &str,
-    addr: &[u8; 32],
-) -> Option<u128> {
+async fn fetch_balance(client: &reqwest::Client, url: &str, addr: &[u8; 32]) -> Option<u128> {
     let resp = rpc_call(
         client,
         url,

--- a/crates/node/tests/multi_node_contract_sigs.rs
+++ b/crates/node/tests/multi_node_contract_sigs.rs
@@ -154,14 +154,18 @@ fn contract_deploy_and_call_with_real_sigs() {
     );
     for (i, c) in &codes[1..] {
         assert_eq!(
-            c, &reference_code,
+            c,
+            &reference_code,
             "code mismatch node-0 vs node-{}: {} vs {}",
             i,
             reference_code.len(),
             c.len()
         );
     }
-    eprintln!("code agreement: {} bytes on all 4 nodes", reference_code.len() / 2);
+    eprintln!(
+        "code agreement: {} bytes on all 4 nodes",
+        reference_code.len() / 2
+    );
 
     // ── 6. Build + sign + submit set_count(42) ──────────────────
     let selector = otic::codegen::compute_selector("set_count");
@@ -256,9 +260,7 @@ fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
 fn compile_deploy_payload(src: &str) -> Vec<u8> {
     let c = otic::compile_all(src);
     let (_, cc) = &c[0];
-    let mut out = Vec::with_capacity(
-        8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len(),
-    );
+    let mut out = Vec::with_capacity(8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len());
     out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());
     out.extend_from_slice(&(cc.runtime_bytecode.len() as u32).to_le_bytes());
     out.extend_from_slice(&cc.constructor_bytecode);

--- a/crates/node/tests/multi_node_double_sign_slash.rs
+++ b/crates/node/tests/multi_node_double_sign_slash.rs
@@ -26,8 +26,7 @@ use std::time::Duration;
 #[test]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn double_sign_debits_stake() {
-    let net = TestNetwork::spawn(4, true)
-        .unwrap_or_else(|e| panic!("spawn 4v testnet: {}", e));
+    let net = TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4v testnet: {}", e));
 
     // Chain needs to be alive and advancing for the slash tx to land.
     net.wait_for_slot(5, Duration::from_secs(45))

--- a/crates/node/tests/multi_node_epoch_rotation.rs
+++ b/crates/node/tests/multi_node_epoch_rotation.rs
@@ -63,7 +63,8 @@ fn epoch_rotation_crosses_boundary() {
         .unwrap_or_else(|e| panic!("epoch of slot {}: {}", EPOCH_LENGTH - 1, e))
         .unwrap_or_else(|| panic!("node-0 missing block at slot {}", EPOCH_LENGTH - 1));
     assert_eq!(
-        e0, 0,
+        e0,
+        0,
         "slot {} should be epoch 0, got {}",
         EPOCH_LENGTH - 1,
         e0
@@ -74,11 +75,7 @@ fn epoch_rotation_crosses_boundary() {
         .epoch_of(0, EPOCH_LENGTH)
         .unwrap_or_else(|e| panic!("epoch of slot {}: {}", EPOCH_LENGTH, e))
         .unwrap_or_else(|| panic!("node-0 missing block at slot {}", EPOCH_LENGTH));
-    assert_eq!(
-        e1, 1,
-        "slot {} should be epoch 1, got {}",
-        EPOCH_LENGTH, e1
-    );
+    assert_eq!(e1, 1, "slot {} should be epoch 1, got {}", EPOCH_LENGTH, e1);
 
     // Block at slot target_slot (deep in epoch 1) matches too.
     let e_deep = net
@@ -116,7 +113,11 @@ fn epoch_rotation_crosses_boundary() {
         rotated_count,
         net.nodes.len()
     );
-    eprintln!("rotation log observed on {}/{} nodes", rotated_count, net.nodes.len());
+    eprintln!(
+        "rotation log observed on {}/{} nodes",
+        rotated_count,
+        net.nodes.len()
+    );
 }
 
 fn per_node_dump(net: &TestNetwork) -> String {

--- a/crates/node/tests/multi_node_full_node_relay.rs
+++ b/crates/node/tests/multi_node_full_node_relay.rs
@@ -126,19 +126,22 @@ fn tx_via_full_node_reaches_validator() {
     assert!(
         post_sender < pre_sender,
         "sender balance did not decrease: pre {} post {}",
-        pre_sender, post_sender
+        pre_sender,
+        post_sender
     );
     let sender_debit = pre_sender - post_sender;
     assert!(
         sender_debit >= transfer_value,
         "sender debit {} < transfer_value {} (should include gas)",
-        sender_debit, transfer_value
+        sender_debit,
+        transfer_value
     );
     assert_eq!(
         post_recipient,
         pre_recipient + transfer_value,
         "recipient should receive exactly transfer_value; pre {} post {}",
-        pre_recipient, post_recipient
+        pre_recipient,
+        post_recipient
     );
 }
 

--- a/crates/node/tests/multi_node_larger_failure.rs
+++ b/crates/node/tests/multi_node_larger_failure.rs
@@ -19,8 +19,7 @@ use std::time::{Duration, Instant};
 #[test]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn two_of_seven_offline_keeps_chain_live() {
-    let mut net = TestNetwork::spawn(7, true)
-        .unwrap_or_else(|e| panic!("spawn 7v: {}", e));
+    let mut net = TestNetwork::spawn(7, true).unwrap_or_else(|e| panic!("spawn 7v: {}", e));
 
     // Warm up to a healthy depth. 90s accommodates the contended-host
     // case where multiple multi-node binaries run in parallel.
@@ -40,8 +39,8 @@ fn two_of_seven_offline_keeps_chain_live() {
     let killed_addrs: Vec<[u8; 32]> = killed_indices.iter().map(|&i| funded[i]).collect();
     let survivors: Vec<usize> = (2..7).collect();
 
-    let kill_slot = min_slot_over(&net, &survivors)
-        .unwrap_or_else(|e| panic!("snapshot slot: {}", e));
+    let kill_slot =
+        min_slot_over(&net, &survivors).unwrap_or_else(|e| panic!("snapshot slot: {}", e));
     eprintln!(
         "killing {:?} at slot {} (survivors: {:?})",
         killed_indices, kill_slot, survivors
@@ -55,11 +54,12 @@ fn two_of_seven_offline_keeps_chain_live() {
     // live validators and quorum = 5, this is tight: every live
     // validator MUST vote on every slot. 90s is plenty.
     let target_slot = kill_slot + 10;
-    wait_for_slot_on_nodes(&net, &survivors, target_slot, Duration::from_secs(90))
-        .unwrap_or_else(|e| {
+    wait_for_slot_on_nodes(&net, &survivors, target_slot, Duration::from_secs(90)).unwrap_or_else(
+        |e| {
             let dumps = per_node_dump(&net);
             panic!("{}\n{}", e, dumps);
-        });
+        },
+    );
 
     // State roots must agree among the 5 survivors.
     let mut roots: Vec<(usize, String)> = Vec::new();
@@ -89,7 +89,8 @@ fn two_of_seven_offline_keeps_chain_live() {
                 inspected += 1;
                 for (idx, killed) in killed_indices.iter().zip(killed_addrs.iter()) {
                     assert_ne!(
-                        &p, killed,
+                        &p,
+                        killed,
                         "slot {} proposer is killed node-{} (0x{})",
                         slot,
                         idx,
@@ -119,7 +120,10 @@ fn min_slot_over(net: &TestNetwork, indices: &[usize]) -> Result<u64, String> {
         .filter(|(i, _)| indices.contains(i))
         .map(|(_, s)| s.ok_or_else(|| "missing slot on a node".to_string()))
         .collect::<Result<Vec<_>, _>>()?;
-    slots.into_iter().min().ok_or_else(|| "empty indices".into())
+    slots
+        .into_iter()
+        .min()
+        .ok_or_else(|| "empty indices".into())
 }
 
 fn wait_for_slot_on_nodes(

--- a/crates/node/tests/multi_node_leader_failure.rs
+++ b/crates/node/tests/multi_node_leader_failure.rs
@@ -23,8 +23,8 @@ use std::time::{Duration, Instant};
 #[test]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn validator_failure_keeps_chain_live() {
-    let mut net = TestNetwork::spawn(4, true)
-        .unwrap_or_else(|e| panic!("spawn 4-validator testnet: {}", e));
+    let mut net =
+        TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4-validator testnet: {}", e));
 
     // Let consensus warm up to a healthy depth. Generous timeout
     // because this test often runs concurrently with other
@@ -47,25 +47,27 @@ fn validator_failure_keeps_chain_live() {
     // funded_addresses dedupes). Node-i's validator key produces
     // address `funded[i]`.
     let killed_addr = funded[0];
-    let kill_slot = min_slot_over(&net, &[1, 2, 3])
-        .unwrap_or_else(|e| panic!("snapshot slot: {}", e));
+    let kill_slot =
+        min_slot_over(&net, &[1, 2, 3]).unwrap_or_else(|e| panic!("snapshot slot: {}", e));
     eprintln!(
         "about to kill node-0 (addr 0x{}) at slot {}",
         hex::encode(killed_addr),
         kill_slot
     );
 
-    net.kill_node(0).unwrap_or_else(|e| panic!("kill node-0: {}", e));
+    net.kill_node(0)
+        .unwrap_or_else(|e| panic!("kill node-0: {}", e));
 
     // Give the survivors a fresh 15 s to make progress. At 400 ms
     // block time, that's ~35 slots of headroom; we only require
     // slot to grow by >= 10 to call it "live".
     let target_slot = kill_slot + 10;
-    wait_for_slot_on_nodes(&net, &[1, 2, 3], target_slot, Duration::from_secs(60))
-        .unwrap_or_else(|e| {
+    wait_for_slot_on_nodes(&net, &[1, 2, 3], target_slot, Duration::from_secs(60)).unwrap_or_else(
+        |e| {
             let dumps = per_node_dump(&net);
             panic!("{}\n{}", e, dumps);
-        });
+        },
+    );
 
     // State roots must agree across the 3 survivors.
     let mut roots: Vec<(usize, String)> = Vec::new();
@@ -97,7 +99,8 @@ fn validator_failure_keeps_chain_live() {
             Ok(Some(p)) => {
                 inspected += 1;
                 assert_ne!(
-                    p, killed_addr,
+                    p,
+                    killed_addr,
                     "slot {} proposer is the killed node-0 (0x{})",
                     slot,
                     hex::encode(p)
@@ -125,7 +128,10 @@ fn min_slot_over(net: &TestNetwork, indices: &[usize]) -> Result<u64, String> {
         .filter(|(i, _)| indices.contains(i))
         .map(|(_, s)| s.ok_or_else(|| "missing slot on a node".to_string()))
         .collect::<Result<Vec<_>, _>>()?;
-    slots.into_iter().min().ok_or_else(|| "empty indices".into())
+    slots
+        .into_iter()
+        .min()
+        .ok_or_else(|| "empty indices".into())
 }
 
 fn wait_for_slot_on_nodes(

--- a/crates/node/tests/multi_node_partition_heal.rs
+++ b/crates/node/tests/multi_node_partition_heal.rs
@@ -30,8 +30,7 @@ use std::time::{Duration, Instant};
 #[test]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn partitioned_validator_heals_without_fork() {
-    let mut net = TestNetwork::spawn(4, true)
-        .unwrap_or_else(|e| panic!("spawn 4v: {}", e));
+    let mut net = TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4v: {}", e));
 
     // Warm up: every node agrees on some history before we disrupt.
     net.wait_for_slot(20, Duration::from_secs(60))
@@ -62,8 +61,8 @@ fn partitioned_validator_heals_without_fork() {
 
     // Let the majority advance by at least 15 slots while node-3 is
     // gone, so the heal has something non-trivial to sync.
-    let kill_slot = min_slot_over(&net, &[0, 1, 2])
-        .unwrap_or_else(|e| panic!("snapshot slot: {}", e));
+    let kill_slot =
+        min_slot_over(&net, &[0, 1, 2]).unwrap_or_else(|e| panic!("snapshot slot: {}", e));
     let majority_target = kill_slot + 15;
     wait_for_slot_on_nodes(&net, &[0, 1, 2], majority_target, Duration::from_secs(60))
         .unwrap_or_else(|e| {
@@ -71,8 +70,8 @@ fn partitioned_validator_heals_without_fork() {
             panic!("majority progress: {}\n{}", e, dumps);
         });
 
-    let majority_head_at_heal = min_slot_over(&net, &[0, 1, 2])
-        .unwrap_or_else(|e| panic!("majority head: {}", e));
+    let majority_head_at_heal =
+        min_slot_over(&net, &[0, 1, 2]).unwrap_or_else(|e| panic!("majority head: {}", e));
     let majority_root_at_heal = net
         .state_root(0)
         .unwrap_or_else(|e| panic!("majority root: {}", e));
@@ -92,19 +91,15 @@ fn partitioned_validator_heals_without_fork() {
     // Wait for node-3 to catch up. The majority is still producing
     // blocks while node-3 syncs, so we target the head-at-heal slot,
     // not a higher moving target.
-    wait_for_node_to_reach(
-        &net,
-        3,
-        majority_head_at_heal,
-        Duration::from_secs(60),
-    )
-    .unwrap_or_else(|e| {
-        let dumps = per_node_dump(&net);
-        panic!("node-3 catch-up: {}\n{}", e, dumps);
-    });
+    wait_for_node_to_reach(&net, 3, majority_head_at_heal, Duration::from_secs(60)).unwrap_or_else(
+        |e| {
+            let dumps = per_node_dump(&net);
+            panic!("node-3 catch-up: {}\n{}", e, dumps);
+        },
+    );
 
-    let node3_head_after_heal = slot_of(&net, 3)
-        .unwrap_or_else(|e| panic!("node-3 post-heal head: {}", e));
+    let node3_head_after_heal =
+        slot_of(&net, 3).unwrap_or_else(|e| panic!("node-3 post-heal head: {}", e));
     eprintln!(
         "node-3 caught up to slot {} (majority-at-heal was {})",
         node3_head_after_heal, majority_head_at_heal
@@ -193,7 +188,10 @@ fn min_slot_over(net: &TestNetwork, indices: &[usize]) -> Result<u64, String> {
         .filter(|(i, _)| indices.contains(i))
         .map(|(_, s)| s.ok_or_else(|| "missing slot on a node".to_string()))
         .collect::<Result<Vec<_>, _>>()?;
-    slots.into_iter().min().ok_or_else(|| "empty indices".into())
+    slots
+        .into_iter()
+        .min()
+        .ok_or_else(|| "empty indices".into())
 }
 
 fn wait_for_slot_on_nodes(

--- a/crates/node/tests/multi_node_propagation.rs
+++ b/crates/node/tests/multi_node_propagation.rs
@@ -129,9 +129,11 @@ fn transfer_propagates_and_balances_match() {
     );
 
     assert_eq!(
-        post_recipient, pre_recipient + transfer_value,
+        post_recipient,
+        pre_recipient + transfer_value,
         "recipient should receive exactly transfer_value; pre {} post {}",
-        pre_recipient, post_recipient
+        pre_recipient,
+        post_recipient
     );
 }
 

--- a/crates/node/tests/multi_node_sync.rs
+++ b/crates/node/tests/multi_node_sync.rs
@@ -26,7 +26,12 @@ fn new_node_syncs_from_network() {
         .unwrap_or_else(|e| panic!("spawn 3v+1 deferred: {}", e));
 
     let fulls = net.full_node_indices();
-    assert_eq!(fulls.len(), 1, "expected exactly 1 full node, got {}", fulls.len());
+    assert_eq!(
+        fulls.len(),
+        1,
+        "expected exactly 1 full node, got {}",
+        fulls.len()
+    );
     let late_joiner = fulls[0];
 
     // Confirm the deferred node really is cold — no process attached.
@@ -45,8 +50,8 @@ fn new_node_syncs_from_network() {
     // Grab the validators' head before starting the joiner. The
     // joiner should at least reach this slot; it will likely go
     // further since blocks keep being produced.
-    let validator_head_at_join = min_validator_slot(&net)
-        .unwrap_or_else(|e| panic!("read validator head: {}", e));
+    let validator_head_at_join =
+        min_validator_slot(&net).unwrap_or_else(|e| panic!("read validator head: {}", e));
     eprintln!(
         "validator head at join: slot {} — starting node-{}",
         validator_head_at_join, late_joiner
@@ -59,18 +64,23 @@ fn new_node_syncs_from_network() {
     // Wait for the late joiner to reach at least the validator head
     // captured above. 60s is generous — validators make ~2 blocks/s
     // and block-sync requests are batched.
-    wait_for_node_to_reach(&net, late_joiner, validator_head_at_join, Duration::from_secs(60))
-        .unwrap_or_else(|e| {
-            let dumps = per_node_dump(&net);
-            panic!("{}\n{}", e, dumps);
-        });
+    wait_for_node_to_reach(
+        &net,
+        late_joiner,
+        validator_head_at_join,
+        Duration::from_secs(60),
+    )
+    .unwrap_or_else(|e| {
+        let dumps = per_node_dump(&net);
+        panic!("{}\n{}", e, dumps);
+    });
 
     // Catch-up done. Validate consistency at whatever slot the
     // joiner is now at. State root must match at least one validator
     // at the joiner's current head slot (the validators may be a few
     // slots ahead because the chain keeps moving).
-    let joiner_head = slot_of(&net, late_joiner)
-        .unwrap_or_else(|e| panic!("read joiner head: {}", e));
+    let joiner_head =
+        slot_of(&net, late_joiner).unwrap_or_else(|e| panic!("read joiner head: {}", e));
     eprintln!("joiner caught up to slot {}", joiner_head);
     assert!(
         joiner_head >= validator_head_at_join,
@@ -128,7 +138,9 @@ fn new_node_syncs_from_network() {
         assert!(
             gap <= 5,
             "validators raced too far past joiner: joiner slot {}, max validator slot {}, gap {}",
-            joiner_slot, max_val_slot, gap
+            joiner_slot,
+            max_val_slot,
+            gap
         );
         eprintln!(
             "no exact slot match (validators raced ahead by {} slots) — acceptable",
@@ -146,17 +158,15 @@ fn wait_for_slot_on_validators(
     let deadline = Instant::now() + timeout;
     let vids = net.validator_indices();
     loop {
-        let all_ok = vids.iter().all(|&i| {
-            slot_of(net, i).map(|s| s >= target_slot).unwrap_or(false)
-        });
+        let all_ok = vids
+            .iter()
+            .all(|&i| slot_of(net, i).map(|s| s >= target_slot).unwrap_or(false));
         if all_ok {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            let per_node: Vec<(usize, Option<u64>)> = vids
-                .iter()
-                .map(|&i| (i, slot_of(net, i).ok()))
-                .collect();
+            let per_node: Vec<(usize, Option<u64>)> =
+                vids.iter().map(|&i| (i, slot_of(net, i).ok())).collect();
             return Err(format!(
                 "wait_for_slot_on_validators({}) timed out: {:?}",
                 target_slot, per_node

--- a/crates/node/tests/stress_077.rs
+++ b/crates/node/tests/stress_077.rs
@@ -66,11 +66,8 @@ fn fund_account(smt: &mut pyde_state::smt::PydeSMT, idx: u64) -> [u8; 32] {
         gas_tank: 0,
         key_nonce: 0,
     };
-    smt.insert(
-        pyde_state::keys::balance_key(&address),
-        account.to_bytes(),
-    )
-    .unwrap();
+    smt.insert(pyde_state::keys::balance_key(&address), account.to_bytes())
+        .unwrap();
     smt.insert(
         pyde_state::keys::nonce_key(&address),
         pyde_account::nonce::NonceState::new().to_bytes().to_vec(),
@@ -97,11 +94,8 @@ fn fund_recipient_only(smt: &mut pyde_state::smt::PydeSMT, idx: u64) -> [u8; 32]
         gas_tank: 0,
         key_nonce: 0,
     };
-    smt.insert(
-        pyde_state::keys::balance_key(&address),
-        account.to_bytes(),
-    )
-    .unwrap();
+    smt.insert(pyde_state::keys::balance_key(&address), account.to_bytes())
+        .unwrap();
     address
 }
 
@@ -219,10 +213,10 @@ fn task_077_wide_parallel_1000_transfers() {
     for r_addr in &recipients {
         let bal_key = pyde_state::keys::balance_key(r_addr);
         let bytes = smt.get(&bal_key).expect("recipient account exists");
-        let account = pyde_account::types::Account::from_bytes(&bytes)
-            .expect("account decodes");
+        let account = pyde_account::types::Account::from_bytes(&bytes).expect("account decodes");
         assert_eq!(
-            account.balance, 1_000,
+            account.balance,
+            1_000,
             "recipient {:?} should have received exactly 1000 quanta",
             hex::encode(r_addr)
         );

--- a/crates/state/src/backend.rs
+++ b/crates/state/src/backend.rs
@@ -462,7 +462,10 @@ impl<S: StoreReadOps<SmtValue>> StoreReadOps<SmtValue> for CachedBackend<S> {
         }
         *self.misses.lock().unwrap() += 1;
         let result = self.inner.get_leaf(leaf_key)?;
-        self.leaf_cache.lock().unwrap().put(*leaf_key, result.clone());
+        self.leaf_cache
+            .lock()
+            .unwrap()
+            .put(*leaf_key, result.clone());
         Ok(result)
     }
 }
@@ -547,12 +550,7 @@ impl BufferedWriteBackend {
 
     /// Flush all pending writes as a single RocksDB WriteBatch.
     pub fn flush(&self) -> Result<(), BackendError> {
-        let branches: Vec<_> = self
-            .pending_branches
-            .lock()
-            .unwrap()
-            .drain()
-            .collect();
+        let branches: Vec<_> = self.pending_branches.lock().unwrap().drain().collect();
         let leaves: Vec<_> = self.pending_leaves.lock().unwrap().drain().collect();
         if branches.is_empty() && leaves.is_empty() {
             return Ok(());
@@ -643,10 +641,7 @@ impl StoreWriteOps<SmtValue> for BufferedWriteBackend {
     }
 
     fn remove_leaf(&mut self, leaf_key: &H256) -> Result<(), sparse_merkle_tree::error::Error> {
-        self.pending_leaves
-            .lock()
-            .unwrap()
-            .insert(*leaf_key, None);
+        self.pending_leaves.lock().unwrap().insert(*leaf_key, None);
         Ok(())
     }
 }

--- a/crates/state/src/jmt_store.rs
+++ b/crates/state/src/jmt_store.rs
@@ -129,9 +129,7 @@ impl JmtRocksStore {
     pub fn open_tmp() -> Result<Self, String> {
         let dir = tempfile::tempdir().map_err(|e| format!("tempdir: {}", e))?;
         let path = dir.keep();
-        let path_str = path
-            .to_str()
-            .ok_or("invalid UTF-8 in temp path")?;
+        let path_str = path.to_str().ok_or("invalid UTF-8 in temp path")?;
         Self::open(path_str)
     }
 
@@ -239,13 +237,14 @@ impl TreeReader for JmtRocksStore {
         } else {
             None
         };
-        self.value_cache.lock().unwrap().put(key_hash, result.clone());
+        self.value_cache
+            .lock()
+            .unwrap()
+            .put(key_hash, result.clone());
         Ok(result)
     }
 
-    fn get_rightmost_leaf(
-        &self,
-    ) -> anyhow::Result<Option<(NodeKey, jmt::storage::LeafNode)>> {
+    fn get_rightmost_leaf(&self) -> anyhow::Result<Option<(NodeKey, jmt::storage::LeafNode)>> {
         // Used during restore-from-snapshot. We persist rightmost on
         // every write_node_batch call; read it back here.
         let key = Self::meta_key(META_RIGHTMOST);
@@ -318,7 +317,8 @@ impl TreeWriter for JmtRocksStore {
             }
         }
         if let Some(rm) = rightmost {
-            let bytes = borsh::to_vec(&rm).map_err(|e| anyhow::anyhow!("rightmost encode: {}", e))?;
+            let bytes =
+                borsh::to_vec(&rm).map_err(|e| anyhow::anyhow!("rightmost encode: {}", e))?;
             batch.put(&Self::meta_key(META_RIGHTMOST), bytes);
         }
 
@@ -364,7 +364,9 @@ impl PersistentJMT {
                 tree.get_root_hash(v)
                     .map_err(|e| format!("recover root: {}", e))?
             }
-            None => RootHash(JellyfishMerkleTree::<JmtRocksStore, Poseidon2JmtHasher>::EMPTY_ROOT.0),
+            None => {
+                RootHash(JellyfishMerkleTree::<JmtRocksStore, Poseidon2JmtHasher>::EMPTY_ROOT.0)
+            }
         };
 
         // When no version exists, we haven't committed anything yet.
@@ -439,9 +441,7 @@ impl PersistentJMT {
         let value_set: Vec<(KeyHash, Option<OwnedValue>)> = entries
             .into_iter()
             .map(|(k, v)| {
-                let kh = KeyHash(
-                    <[u8; 32]>::try_from(k.as_slice()).expect("H256 is 32 bytes"),
-                );
+                let kh = KeyHash(<[u8; 32]>::try_from(k.as_slice()).expect("H256 is 32 bytes"));
                 // Empty value → tombstone (None); matches SMT::zero() semantics.
                 let val = if v.is_empty() { None } else { Some(v) };
                 (kh, val)

--- a/crates/state/src/smt.rs
+++ b/crates/state/src/smt.rs
@@ -296,10 +296,7 @@ impl PersistentSMT {
         self.inner
             .update(key, SmtValue(value))
             .map_err(|_| "SMT update failed")?;
-        self.inner
-            .store()
-            .flush()
-            .map_err(|_| "SMT flush failed")?;
+        self.inner.store().flush().map_err(|_| "SMT flush failed")?;
         Ok(self.root())
     }
 
@@ -309,10 +306,7 @@ impl PersistentSMT {
             self.inner
                 .update(*key, SmtValue::zero())
                 .map_err(|_| "SMT delete failed")?;
-            self.inner
-                .store()
-                .flush()
-                .map_err(|_| "SMT flush failed")?;
+            self.inner.store().flush().map_err(|_| "SMT flush failed")?;
         }
         Ok(existed)
     }
@@ -323,10 +317,7 @@ impl PersistentSMT {
         self.inner
             .update_all(leaves)
             .map_err(|_| "SMT batch update failed")?;
-        self.inner
-            .store()
-            .flush()
-            .map_err(|_| "SMT flush failed")?;
+        self.inner.store().flush().map_err(|_| "SMT flush failed")?;
         Ok(self.root())
     }
 

--- a/crates/tx/src/parallel.rs
+++ b/crates/tx/src/parallel.rs
@@ -720,10 +720,10 @@ mod tests {
 
         assert_eq!(sched.total_txs, 50_000);
         assert_eq!(sched.group_count(), 50_000); // all independent
-        // The O(n^2) regression baseline was 341_000 ms for 50K txs.
-        // A 5 s ceiling keeps the regression signal (700× margin) while
-        // tolerating contended CI runs / laptops under concurrent
-        // workspace load, where the strict 500 ms bar flaked.
+                                                 // The O(n^2) regression baseline was 341_000 ms for 50K txs.
+                                                 // A 5 s ceiling keeps the regression signal (700× margin) while
+                                                 // tolerating contended CI runs / laptops under concurrent
+                                                 // workspace load, where the strict 500 ms bar flaked.
         assert!(
             elapsed.as_millis() < 5_000,
             "50K scheduling took {}ms, must be <5000ms (was 341,000ms with O(n^2))",


### PR DESCRIPTION
## Summary

MAINNET_PLAN task 052 was listed as "stale formatting diff in
`production_sigs.rs`" but an audit during this session found
`cargo fmt --check` fails across **19 files** spanning
`crates/node/src`, `crates/node/tests`, `crates/state/src`, and
`crates/tx/src/parallel.rs`.

The fmt CI job (task 049, `.github/workflows/ci.yml:21`) exists but
hasn't been gating merges in practice — this PR rebases everything
to what rustfmt produces today.

## Contents

Pure `cargo fmt --all` pass. Zero semantic changes — diff is
whitespace and line-wrap only. `cargo build --release` passes.
`cargo fmt --check` is now clean.

## Files

All fmt-only:
- `crates/node/src/{fast_tx,node,rpc}.rs`
- `crates/node/tests/{common/mod,loadgen_sustained,multi_node_*,stress_077}.rs`
- `crates/state/src/{backend,jmt_store,smt}.rs`
- `crates/tx/src/parallel.rs`

## Plan follow-up

Once this lands, CI should start failing any new fmt drift. If it
doesn't, the branch-protection rule needs `Rustfmt` added to the
required-checks list.