### PR TITLE
refactor: remove production .unwrap() in rpc.rs, document lock policy in state (task 060 first pass)

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1170,8 +1170,14 @@ impl PydeApiServer for RpcServer {
                     Ok(header) => {
                         // Use try_send to avoid blocking — if the WS buffer is full, skip this header.
                         // Block headers arrive every 400ms; missing one is acceptable.
-                        let msg = jsonrpsee::SubscriptionMessage::from_json(&header).unwrap();
-                        let _ = sink.try_send(msg);
+                        // The JSON serialization is infallible for `header` (a
+                        // `serde_json::Value` we constructed ourselves), but we
+                        // handle the Err arm explicitly instead of `.unwrap()`
+                        // so a tokio::spawn task can never panic on malformed
+                        // input. (MAINNET_PLAN 060.)
+                        if let Ok(msg) = jsonrpsee::SubscriptionMessage::from_json(&header) {
+                            let _ = sink.try_send(msg);
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(_) => break,
@@ -1189,11 +1195,14 @@ impl PydeApiServer for RpcServer {
         let mut rx = self.state.pending_tx_tx.subscribe();
         tokio::spawn(async move {
             while let Ok(tx_hash) = rx.recv().await {
-                if sink
-                    .send(jsonrpsee::SubscriptionMessage::from_json(&tx_hash).unwrap())
-                    .await
-                    .is_err()
-                {
+                // MAINNET_PLAN 060: graceful Err arm instead of `.unwrap()` so
+                // a malformed tx_hash (unreachable for our code paths) can't
+                // panic the spawned task.
+                let msg = match jsonrpsee::SubscriptionMessage::from_json(&tx_hash) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                if sink.send(msg).await.is_err() {
                     break;
                 }
             }
@@ -1225,11 +1234,14 @@ impl PydeApiServer for RpcServer {
                                 continue;
                             }
                         }
-                        if sink
-                            .send(jsonrpsee::SubscriptionMessage::from_json(&log).unwrap())
-                            .await
-                            .is_err()
-                        {
+                        // MAINNET_PLAN 060: graceful Err arm instead of
+                        // `.unwrap()` so a malformed log (unreachable for our
+                        // code paths) can't panic the spawned task.
+                        let msg = match jsonrpsee::SubscriptionMessage::from_json(&log) {
+                            Ok(m) => m,
+                            Err(_) => continue,
+                        };
+                        if sink.send(msg).await.is_err() {
                             break;
                         }
                     }

--- a/crates/state/src/backend.rs
+++ b/crates/state/src/backend.rs
@@ -2,6 +2,25 @@
 //!
 //! Provides a trait abstraction over key-value stores, with implementations
 //! for in-memory (testing), RocksDB (production), and LRU-cached wrappers.
+//!
+//! ## Mutex lock policy (MAINNET_PLAN 060)
+//!
+//! `CachedBackend` and `BufferedWriteBackend` use `std::sync::Mutex` for
+//! interior mutability on their LRU caches and pending-write maps. Every
+//! call site uses `.lock().unwrap()` deliberately:
+//!
+//! - A poisoned mutex means some other thread panicked while holding the
+//!   lock, which for a state-path component means the in-memory state is
+//!   potentially inconsistent. Propagating the error would force every
+//!   caller (SMT traversal, block commit, proposer) to handle a condition
+//!   that has no meaningful recovery — the right response is to fail the
+//!   node.
+//! - Phase 1 safety work (tasks 001-014) ensures on-disk consensus state
+//!   is fsync'd before a validator votes, so a panic here loses at most
+//!   un-flushed cache entries; no BFT safety violation on restart.
+//! - Consolidating all "lock or die" sites under a single documented
+//!   policy keeps the hot path readable rather than papered over with
+//!   per-site `expect()` messages that all say the same thing.
 
 use sparse_merkle_tree::merge::MergeValue;
 use sparse_merkle_tree::traits::{StoreReadOps, StoreWriteOps};

--- a/crates/state/src/jmt_store.rs
+++ b/crates/state/src/jmt_store.rs
@@ -12,6 +12,20 @@
 //! change. Keys and roots are exposed as `sparse_merkle_tree::H256`
 //! just to keep the trait surface stable; internally they roundtrip to
 //! `jmt::KeyHash` / `jmt::RootHash` (both are `[u8; 32]` newtypes).
+//!
+//! ## Mutex lock policy (MAINNET_PLAN 060)
+//!
+//! `JmtRocksStore` and `PersistentJMT` use `std::sync::Mutex` on their
+//! read-caches (`node_cache`, `value_cache`) and version/root state
+//! (`current_version`, `current_root`). Every `.lock().unwrap()` on
+//! these is deliberate: a poisoned mutex signals that some other thread
+//! panicked while holding the lock, which for a state-path component
+//! means the in-memory cache or version snapshot is potentially
+//! inconsistent. Propagating the error would force every JMT caller to
+//! handle a condition with no meaningful recovery — the right response
+//! is to fail the node. Phase 1 safety work (001-014) ensures on-disk
+//! consensus state is fsync'd before a validator votes, so a panic here
+//! loses at most un-flushed cache entries.
 
 use borsh::BorshDeserialize;
 use jmt::storage::{HasPreimage, Node, NodeBatch, NodeKey, TreeReader, TreeWriter};
@@ -117,8 +131,12 @@ impl JmtRocksStore {
         opts.set_target_file_size_base(128 * 1024 * 1024);
 
         let db = rocksdb::DB::open(&opts, path).map_err(|e| format!("rocksdb open: {}", e))?;
-        let node_cap = std::num::NonZeroUsize::new(256 * 1024).unwrap();
-        let value_cap = std::num::NonZeroUsize::new(256 * 1024).unwrap();
+        // safe (MAINNET_PLAN 060): 256 * 1024 is a non-zero compile-
+        // time constant; `NonZeroUsize::new` returning `None` is
+        // unreachable for this literal. `.expect` makes the intent
+        // explicit rather than panicking through a bare `.unwrap`.
+        let node_cap = std::num::NonZeroUsize::new(256 * 1024).expect("256 K is non-zero");
+        let value_cap = std::num::NonZeroUsize::new(256 * 1024).expect("256 K is non-zero");
         Ok(Self {
             db,
             node_cache: Mutex::new(lru::LruCache::new(node_cap)),


### PR DESCRIPTION
## Summary

First file-scoped pass on **MAINNET_PLAN task 060** (`.unwrap()` triage).
Not the whole 2,024-call backlog — just the files on the hottest
paths this session, leaving a clean pattern for future sessions.

## Changes

### `crates/node/src/rpc.rs`

Three production unwraps in WS subscription handlers wrapped
`serde_json` serialization on values we'd just constructed ourselves
(block headers, tx hashes, logs) — infallible in practice but a
panic inside a `tokio::spawn` task is still bad for observability.

Replaced with explicit `Ok(m) / Err(_) => continue` match arms. The
3 remaining unwraps are all inside `#[cfg(test)]` fixtures.

### `crates/state/src/backend.rs`

All 26 production unwraps are `self.X.lock().unwrap()` on the
`CachedBackend` / `BufferedWriteBackend` LRU + pending-write mutexes.
Added a module-level **Mutex lock policy** comment documenting why
fail-fast on poison is the correct response for this component:

- Poison → some other thread panicked while holding the lock → the
  in-memory cache is potentially inconsistent.
- Propagating the error would force every SMT caller to handle a
  condition with no meaningful recovery.
- Phase 1 fsync work (001-014) ensures no BFT safety violation on
  restart — a panic here loses at most un-flushed cache entries.

### `crates/state/src/jmt_store.rs`

Same policy applied: 13 `self.X.lock().unwrap()` sites on the JMT
read-caches + version/root snapshot state. Module-level policy
comment added. The two `NonZeroUsize::new(256 * 1024).unwrap()` sites
switched to `.expect("256 K is non-zero")` since 256 × 1024 is a
non-zero compile-time constant.

## Remaining

Task 060 backlog across the workspace is still ~**2,020** unwraps in
non-test source. Tracked for future sessions; next-hottest files are
in `pyde-rust-sdk`, `otic`, and various node subsystems.

Build: `cargo build --release --workspace` clean. `cargo fmt --all --
--check` clean.