### PR TITLE
test: cargo-fuzz scaffolding + first two targets (task 053 first pass)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@ target/
 .claude/
 pyde-book/
 ROADMAP.md
+
+# cargo-fuzz artefacts (task 053). Crate lives outside the workspace
+# and has its own Cargo.lock + target/ dir + corpus dir which we don't
+# commit. Fuzz crashes go into fuzz/artifacts/ and should also stay
+# out of the repo — they can be MB-sized and reproduce from the seed.
+fuzz/Cargo.lock
+fuzz/target/
+fuzz/corpus/
+fuzz/artifacts/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
     "crates/pyde-rust-sdk",
     "crates/pyde-crypto-wasm",
 ]
+# cargo-fuzz needs nightly + libfuzzer-sys + `-Cinstrument-coverage`.
+# Keep it out of the stable workspace build (task 053, MAINNET_PLAN).
+exclude = ["fuzz"]
 
 # Workspace-wide clippy lint configuration (slice 5.5).
 #

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "pyde-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+license = "Apache-2.0"
+
+# Intentionally excluded from the root workspace (`Cargo.toml`'s
+# `[workspace] exclude = ["fuzz"]`). cargo-fuzz needs nightly +
+# -Cinstrument-coverage flags that would poison the workspace's
+# stable-toolchain build if we included it.
+#
+# Run with:
+#   cargo +nightly install cargo-fuzz         # one-time
+#   cargo +nightly fuzz run pvm_interpreter
+#   cargo +nightly fuzz run tx_decoder
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+pyde-vm = { path = "../crates/pvm" }
+pyde-tx = { path = "../crates/tx" }
+
+[[bin]]
+name = "pvm_interpreter"
+path = "fuzz_targets/pvm_interpreter.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "tx_decoder"
+path = "fuzz_targets/tx_decoder.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,57 @@
+# pyde-fuzz
+
+`cargo-fuzz` harnesses for MAINNET_PLAN task 053. Lives outside the
+main workspace (`Cargo.toml`'s `[workspace] exclude = ["fuzz"]`)
+because libfuzzer needs nightly + coverage instrumentation that
+would poison the stable-toolchain build.
+
+## Targets
+
+| Target            | What it fuzzes                                    | Why it matters                                                                                |
+| ----------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `pvm_interpreter` | `Vm::load` + `Vm::execute` on arbitrary bytecode  | Contract-deploy bytecode is attacker-supplied; a panic here crashes validators post-deploy.   |
+| `tx_decoder`      | `pyde_tx::types::Transaction::from_bytes`         | RPC-ingress + gossip bytes hit this before validation. Must return `Option`, never panic.     |
+
+## Planned follow-up targets
+
+- `wire_transaction` / `wire_block` / `wire_consensus_message` —
+  blocked on exposing a lib target from `crates/node` (currently
+  bin-only). Once `pyde-node` has a `src/lib.rs` re-exporting
+  `wire`, these are one-liners.
+- `otic_parser` — fuzz `.oti` source parsing.
+- `falcon_verify` / `kyber_decrypt` — fuzz PQ crypto deserialisers
+  (likely thin wrappers; real coverage comes from upstream fuzzing).
+
+## Running
+
+```bash
+# One-time setup
+rustup toolchain install nightly
+cargo +nightly install cargo-fuzz
+
+# From the repo root
+cd fuzz
+cargo +nightly fuzz run pvm_interpreter
+cargo +nightly fuzz run tx_decoder
+```
+
+By default libfuzzer runs forever, discovering new inputs + storing
+them in `fuzz/corpus/<target>/`. Interrupt with `Ctrl-C`. Reproduce a
+crash with:
+
+```bash
+cargo +nightly fuzz run <target> fuzz/artifacts/<target>/<crash-hash>
+```
+
+## 72-hour soak runs (task 054)
+
+Task 054 is the scheduled long soak. Run each target for 72 h under
+CI or a dedicated box, fix every discovered crash, re-run. Track
+coverage regressions with `cargo +nightly fuzz coverage <target>`.
+
+## Seed corpus
+
+Drop known-good inputs into `fuzz/corpus/<target>/` to give libfuzzer
+a head start. For `tx_decoder`, a handful of real `Transaction`
+encodings is enough; the fuzzer mutates from there. Seed corpus is
+optional — libfuzzer starts from the empty byte string otherwise.

--- a/fuzz/fuzz_targets/pvm_interpreter.rs
+++ b/fuzz/fuzz_targets/pvm_interpreter.rs
@@ -1,0 +1,33 @@
+//! Fuzz target: PVM interpreter on arbitrary bytecode.
+//!
+//! Feeds `data` directly into `Vm::load` + `Vm::execute` and requires
+//! the interpreter to never panic. Any reachable panic (out-of-bounds
+//! index, arithmetic overflow in the decoder, unreachable arms on
+//! malformed opcodes) is a bug that needs a `Trap` or explicit error
+//! path, not a panic.
+//!
+//! Coverage: every byte of `data` is exposed to the instruction
+//! decoder (`Opcode::from_u8`), the immediate decoder, and the
+//! dispatcher. The guest bytecode comes from smart-contract deploys
+//! today; any PVM crash on attacker-crafted bytecode is a liveness
+//! bug (panicking validator) and potentially a safety bug (forks on
+//! pre-check divergence across validators with different compiler
+//! versions).
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut vm = pyde_vm::vm::Vm::new();
+    // `load` may reject malformed bytecode with `Trap` — that's the
+    // correct response, not a crash. Early-return on load failure.
+    if vm.load(data).is_err() {
+        return;
+    }
+    // Give the VM a bounded gas budget so an adversary can't make the
+    // harness loop forever on a large `data`. 10 M gas is well beyond
+    // any real deploy but bounded from the fuzzer's view.
+    vm.gas_limit = 10_000_000;
+    let _ = vm.execute();
+});

--- a/fuzz/fuzz_targets/tx_decoder.rs
+++ b/fuzz/fuzz_targets/tx_decoder.rs
@@ -1,0 +1,18 @@
+//! Fuzz target: `Transaction::from_bytes` on arbitrary bytes.
+//!
+//! The tx wire format is accepted over RPC (`pyde_sendRawTransaction`)
+//! and gossip. Any byte string from a peer has to round-trip through
+//! `from_bytes` before ingress validation even runs; a panic here
+//! means a single malformed tx can crash the node before the sender
+//! ever gets rate-limited. Must return `Option<Transaction>` for any
+//! input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Just the decoder. We explicitly accept `None` as a valid
+    // outcome — this fuzz only flags panics + aborts.
+    let _ = pyde_tx::types::Transaction::from_bytes(data);
+});


### PR DESCRIPTION
## Summary

First pass on **MAINNET_PLAN task 053**. Adds a `fuzz/` crate at the
repo root, workspace-excluded so its nightly + coverage-instrument
toolchain can't poison the stable workspace build.

## Targets

| Target            | Entry point                                       | Why                                                                              |
|-------------------|---------------------------------------------------|----------------------------------------------------------------------------------|
| `pvm_interpreter` | `Vm::load` + `Vm::execute` on arbitrary bytecode  | Contract-deploy bytecode is attacker-supplied; panics here crash validators.     |
| `tx_decoder`      | `Transaction::from_bytes`                         | RPC + gossip bytes hit this before validation; must return `Option`, not panic.  |

Both targets cap CPU: `pvm_interpreter` pins `gas_limit` at 10 M so
libfuzzer can't make the harness loop forever on a valid-but-large
program; `tx_decoder` is a pure decoder so it's naturally bounded.

## Deliberately out of scope

- **`wire_transaction` / `wire_block` / `wire_consensus_message`** —
  blocked on `crates/node` exposing a `src/lib.rs`. It's currently
  bin-only, so `pyde_node::wire::decode_transaction` isn't reachable
  from an external crate. Small follow-up — tracked in
  `fuzz/README.md`.
- **`otic_parser`, `falcon_verify`, `kyber_decrypt`** — listed in
  `fuzz/README.md` as planned targets.
- **Task 054** (72 h soak per target + crash remediation) — the
  whole point of the harness, kicks off once the initial targets are
  stable and running in CI.

Also adds `fuzz/Cargo.lock`, `fuzz/target/`, `fuzz/corpus/`, and
`fuzz/artifacts/` to `.gitignore` so per-run coverage data + crash
corpora don't bloat the repo.

## Running

```bash
rustup toolchain install nightly
cargo +nightly install cargo-fuzz
cd fuzz
cargo +nightly fuzz run pvm_interpreter
cargo +nightly fuzz run tx_decoder
```

## Build check

- `cargo build --release --workspace` — clean (fuzz excluded).
- `cd fuzz && cargo check` — clean on stable; `cargo fuzz run` needs
  nightly only for libfuzzer instrumentation.
- `cargo fmt --all -- --check` — clean.