### PR TITLE
test: wire_transaction fuzz target + expose pyde-node lib (task 053 follow-up)

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -1,0 +1,19 @@
+//! Library surface of the node crate.
+//!
+//! `pyde-node` is primarily a binary (`src/main.rs` → the `pyde` CLI).
+//! This `lib.rs` exists so a small set of bin-internal modules can also
+//! be used by out-of-workspace consumers — today that means the
+//! `fuzz/` crate (task 053) which needs to hand arbitrary bytes to the
+//! wire decoders without reconstructing the bin's module tree.
+//!
+//! Modules listed here are **additionally** compiled into the library
+//! target; the binary declares its own `mod wire;` in `main.rs` and
+//! keeps using it via `crate::wire::`. The doubled compilation is
+//! negligible and means we don't have to refactor the binary's module
+//! tree to expose anything.
+//!
+//! Keep this surface small. If a module has internal-only state or
+//! needs to share a global with the binary (channels, runtime
+//! handles), it stays out of here.
+
+pub mod wire;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 #   cargo +nightly install cargo-fuzz         # one-time
 #   cargo +nightly fuzz run pvm_interpreter
 #   cargo +nightly fuzz run tx_decoder
+#   cargo +nightly fuzz run wire_transaction
 
 [package.metadata]
 cargo-fuzz = true
@@ -22,6 +23,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 pyde-vm = { path = "../crates/pvm" }
 pyde-tx = { path = "../crates/tx" }
+pyde-node = { path = "../crates/node" }
 
 [[bin]]
 name = "pvm_interpreter"
@@ -33,6 +35,13 @@ bench = false
 [[bin]]
 name = "tx_decoder"
 path = "fuzz_targets/tx_decoder.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_transaction"
+path = "fuzz_targets/wire_transaction.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -7,17 +7,16 @@ would poison the stable-toolchain build.
 
 ## Targets
 
-| Target            | What it fuzzes                                    | Why it matters                                                                                |
-| ----------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `pvm_interpreter` | `Vm::load` + `Vm::execute` on arbitrary bytecode  | Contract-deploy bytecode is attacker-supplied; a panic here crashes validators post-deploy.   |
-| `tx_decoder`      | `pyde_tx::types::Transaction::from_bytes`         | RPC-ingress + gossip bytes hit this before validation. Must return `Option`, never panic.     |
+| Target              | What it fuzzes                                    | Why it matters                                                                                 |
+| ------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `pvm_interpreter`   | `Vm::load` + `Vm::execute` on arbitrary bytecode  | Contract-deploy bytecode is attacker-supplied; a panic here crashes validators post-deploy.    |
+| `tx_decoder`        | `pyde_tx::types::Transaction::from_bytes`         | RPC-ingress + gossip bytes hit this before validation. Must return `Option`, never panic.      |
+| `wire_transaction`  | `pyde_node::wire::decode_transaction`             | Compact-block + gossip decoder; distinct from `from_bytes`. Reached via `pyde-node`'s lib target. |
 
 ## Planned follow-up targets
 
-- `wire_transaction` / `wire_block` / `wire_consensus_message` —
-  blocked on exposing a lib target from `crates/node` (currently
-  bin-only). Once `pyde-node` has a `src/lib.rs` re-exporting
-  `wire`, these are one-liners.
+- `wire_block` / `wire_consensus_message` — the lib target now
+  exists, so these are one-liner additions once we want them.
 - `otic_parser` — fuzz `.oti` source parsing.
 - `falcon_verify` / `kyber_decrypt` — fuzz PQ crypto deserialisers
   (likely thin wrappers; real coverage comes from upstream fuzzing).
@@ -33,6 +32,7 @@ cargo +nightly install cargo-fuzz
 cd fuzz
 cargo +nightly fuzz run pvm_interpreter
 cargo +nightly fuzz run tx_decoder
+cargo +nightly fuzz run wire_transaction
 ```
 
 By default libfuzzer runs forever, discovering new inputs + storing

--- a/fuzz/fuzz_targets/wire_transaction.rs
+++ b/fuzz/fuzz_targets/wire_transaction.rs
@@ -1,0 +1,17 @@
+//! Fuzz target: `pyde_node::wire::decode_transaction` on arbitrary bytes.
+//!
+//! The node's compact-block + gossip tx path uses the `wire` decoder
+//! (distinct from `Transaction::from_bytes` — see `tx_decoder.rs`).
+//! Both paths see untrusted peer bytes; both need to return a
+//! `Result`, not panic.
+//!
+//! Reached via the lib target added to `crates/node/src/lib.rs`
+//! alongside this target.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_transaction(data);
+});


### PR DESCRIPTION
## Summary

Closes the gap left by #242 — the `wire_transaction` fuzz target was
blocked on `crates/node` being bin-only. Adds a 21-line
`crates/node/src/lib.rs` that re-exposes the `wire` module as a
library item, and wires the target into the fuzz crate.

## `crates/node/src/lib.rs`

The binary (`main.rs`) keeps its own `mod wire;` and `crate::wire::`
references, so this is purely additive — `wire.rs` compiles into
both the bin and lib units. The doubled compilation is negligible
and the alternative (refactoring `main.rs`'s entire module tree) was
way out of scope.

Doc comment in `lib.rs` spells out the policy explicitly:

> Keep this surface small. If a module has internal-only state or
> needs to share a global with the binary (channels, runtime
> handles), it stays out of here.

Happy to expose `chain` / `wire::consensus` / etc. later the moment
another consumer needs them.

## `fuzz/`

Adds `pyde-node = { path = "../crates/node" }` to `fuzz/Cargo.toml`,
wires the `wire_transaction` `[[bin]]` target, and updates
`fuzz/README.md`'s target table. `wire_block` and
`wire_consensus_message` are now one-liners; left out of this commit
to keep the PR scoped to closing the specific gap.

## Verified

- `cargo build --release --workspace` — clean.
- `cd fuzz && cargo check` — clean (pyde-node dep resolves via the
  new lib target).
- `cargo fmt --all -- --check` — clean.