### PR TITLE
audit: findings tracker + Addi parity + constant-time MAC

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -1,0 +1,301 @@
+# Pyde Audit Findings (2026-04-23)
+
+> Full-workspace audit surfaced while reviewing mainnet readiness.
+> Complements `MAINNET_PLAN.md` — items here are NEW findings not
+> already tracked as plan tasks. IDs start at 201 to avoid collision.
+>
+> Legend:
+>
+> - `[ ]` = not started
+> - `[x]` = complete
+> - `[~]` = in progress
+> - `[?]` = claim unverified; investigation required before fix
+> - `[!]` = blocked
+>
+> Verification marks:
+>
+> - `✓` self-verified against source
+> - `⚠` agent-claimed, not yet independently verified
+>
+> Ordering rationale (top of file):
+>
+> 1. **Verify-before-fix** first. One P1 finding (hard-finality race)
+>    could flip to P0 — resolve its severity before touching anything
+>    else so the queue below is actually in priority order.
+> 2. **Trivial + isolated P0s next.** Single-file, low-blast-radius,
+>    testable in isolation. Builds PR rhythm, avoids half-finished
+>    branches blocking each other.
+> 3. **Boundary-logic P0 (028 fall-through) after trivials.** Needs
+>    decision on the devnet vs mainnet split; still small.
+> 4. **Architectural P0 (074b encrypted gossip) last in the P0
+>    cluster.** Biggest design space; do it when the smaller P0s have
+>    drained so we can focus without context-switching.
+> 5. **P1 track** once P0s land.
+> 6. **P2 track** before testnet alpha, parallelisable.
+
+---
+
+## At a glance
+
+- 5 parallel audit agents + follow-up spot checks, 2026-04-23.
+- 4 P0 (mainnet blockers), 11 P1 (must-fix before audit/launch),
+  7 P2 (pre-testnet-alpha hygiene).
+- 22 fix items total. Sized for one PR each.
+- Each item carries its own file:line refs and verification mark so
+  the rework after auditor findings is smaller.
+
+---
+
+## Closed before classification
+
+- [x] 201 — `✓` **Verify hard-finality persistence race.**
+      Traced `on_finality_vote` (validator.rs:1545-1570),
+      `record_hard_finality` (finality.rs:257-281),
+      `persist_finality_checkpoint` (validator.rs:768), and
+      the two sibling call sites at 1629 and 761. Race is real
+      but NOT a classical BFT safety violation: no broadcast in
+      the window (broadcast runs after `on_finality_vote` returns,
+      see comment at validator.rs:1572-1577); self-healing via
+      peer gossip + `ingest_finality_checkpoint`; cannot produce
+      two hard-finalized blocks at the same slot. Exploitable
+      only in an esoteric combined crash + isolation + active
+      long-range-attack scenario.
+      **Verdict: not P0. Promoted to head of P1 as task 207a
+      below.** Fix approach: refactor `persist_finality_
+      checkpoint` to take cert/checkpoint directly instead of
+      reading from `self.finality`; persist before in-memory
+      update at all three call sites.
+
+---
+
+## P0 — Mainnet blockers
+
+> Order: smallest / most-isolated first.
+
+- [x] 202 — `✓` **PVM `Addi` divergence-risk parity test.**
+      Original audit framing ("trap-bypass; change to `checked_add`")
+      was wrong. Investigation found `Addi` wraps BY DESIGN — the
+      otic compiler relies on it for:
+      - constant materialisation via sign-extended negatives
+        (e.g. `REENTRANCY_SLOT = (-2i32 as u32) & 0x3FFFF`,
+        `crates/otic/src/codegen.rs:44`, emitted at `:843, :870`);
+      - two's-complement negation pattern `Not rd; Addi rd, rd, 1`
+        (`crates/otic/src/codegen.rs:1131`);
+      - loading `u64::MAX` via `Addi rN, r0, -1` (`:1615, :1639,
+        :1661, :1681, :2918, :3078`).
+      Changing to trap-on-overflow broke 3 real-contract AOT tests
+      on revert. The REAL audit concern was divergence risk between
+      interpreter and Cranelift AOT. Both wrap consistently today;
+      fix is a parity test that fails loudly if either side drifts.
+      **Shipped:** clarifying comment at
+      `crates/aot/src/codegen.rs:527` + new test
+      `addi_aot_interp_wrap_parity` in `crates/aot/src/lib.rs`
+      covering 9 adversarial `(imm1, imm2)` pairs including
+      u64::MAX roll-over in both directions.
+
+- [ ] 203 — `✓` **Constant-time MAC verification in threshold
+      decryption.** `crates/crypto/src/threshold.rs:540` — `if
+      expected_mac != ct.mac` on 32 bytes of MAC, not constant-time.
+      Workspace-wide `rg "ConstantTimeEq|ct_eq|subtle::"` against
+      `crates/crypto/` returns zero hits.
+      Fix: add `subtle` crate, use `ct_eq`; sweep crates/crypto/
+      and crates/consensus/ for other `==`/`!=` on secret material
+      (shares, keys, signatures used as dedup keys).
+
+- [ ] 204 — `✓` **Wire-decoder unbounded `Vec::with_capacity`.**
+      `crates/node/src/wire.rs:256-260, 361-370, 591-598, 760-764`
+      decode u16/u32 length fields straight into
+      `Vec::with_capacity` before validating. Gossipsub frame caps
+      (64 KB consensus / 128 KB tx) mitigate worst case, but nested
+      lists inside a legal frame can still force large allocations.
+      Fix: per-field constants (`MAX_VOTES`, `MAX_SIGS`,
+      `MAX_ACCESS`, `MAX_TIMEOUTS`) enforced after decode, before
+      any allocation.
+
+- [ ] 205 — `⚠` **Persist double-vote evidence on detection.**
+      `crates/node/src/validator.rs:1443-1449` — the equivocation
+      branch only `warn!`s; only the "new vote" branch persists
+      via `ConsensusStateStore`. Crash between detection and next
+      slot drops the evidence, loses slashing + finder's fee.
+      Fix: on detection, save evidence via the store before
+      continuing; reuse task 014c persistence schema.
+
+- [ ] 206 — `✓` **Close task 028 structural-only fall-through.**
+      `crates/node/src/rpc.rs:1117-1141` + `crates/mempool/src/
+      pool.rs:370-384`. Encrypted-tx RPC ingress only runs full
+      FALCON verify when the sender has a registered `auth_key`;
+      senders with no registered key take the length-only path.
+      Every fresh address has this window — an attacker can forge
+      encrypted txs claiming `sender = victim_new_address` until
+      the victim registers. Plan marks 028 done but the fall-through
+      is mainnet-exploitable.
+      Fix: on `chain_id != devnet`, require either a registered
+      `auth_key` OR membership in a narrow faucet allowlist.
+      Devnet keeps the fall-through for bootstrap UX.
+
+- [ ] 207 — `⚠` **Encrypted-tx gossip flow (074b root cause).**
+      Compact-block broadcast in `crates/node/src/node.rs` omits
+      `encrypted_txs`; full blocks only served on-demand via
+      `GET_BLOCK_TXS` (`crates/node/src/wire.rs:415`). Non-proposer
+      validators never see encrypted_tx lists → decryption shares
+      arrive orphaned and queue forever. Blocks the headline
+      MEV-protection claim and 074b.
+      Fix: design doc first, choose among:
+      (A) extend compact-block protocol with encrypted_tx short IDs;
+      (B) separate gossipsub topic for encrypted_txs, published by
+      proposer alongside the block;
+      (C) proactive full-block push to committee members.
+      Then implement + add `074b` loadgen pass.
+
+---
+
+## P1 — Must fix before external audit / launch
+
+> Parallelisable with 207 once P0 trivials are in.
+
+- [ ] 207a — `✓` **Hard-finality persistence ordering.**
+      Promoted from 201. `crates/node/src/validator.rs:1560-1566,
+      1628-1630, 758-762` — three call sites update
+      `self.finality.latest_checkpoint` in-memory via
+      `record_hard_finality` / direct assignment / synthetic-anchor
+      assignment, then call `persist_finality_checkpoint` which
+      reads the value back out of `self.finality`. Crash in the
+      window reverts the WS anchor on restart (self-heals via
+      peer gossip, but a non-self-healing window exists).
+      Fix: new `persist_finality_checkpoint_direct(&cp)` that
+      takes the checkpoint explicitly; call it BEFORE the
+      in-memory mutation at each of the three sites; keep the
+      current `persist_finality_checkpoint()` as a no-longer-used
+      thin wrapper (or remove) so no new site can regress.
+
+- [ ] 208 — `⚠` **Committee rotation: clear old committee keys.**
+      `crates/node/src/validator.rs:828-841` — `set_committee`
+      overwrites but if a rotation is reverted mid-reshare, an
+      isolated old member can keep signing. Not fund-loss; quorum
+      dilution + liveness risk.
+
+- [ ] 209 — `⚠` **PVM gas-metering audit.**
+      (a) verify `isa::total_gas(Opcode::Addi)` is non-zero (else
+      infinite `ADDI`-only loop is free);
+      (b) audit cold/warm storage tracking: `warm_storage_keys`
+      lives inside each `Vm`, so each parallel execution group
+      starts cold — over- or under-charging depending on group
+      merge semantics.
+
+- [ ] 210 — `⚠` **Weak-subjectivity enforcement API.**
+      `crates/node/src/block_processor.rs:45-56` —
+      `ws_checkpoint_slot` is `Option<u64>`; public variants pass
+      `None`. Easy to call a non-enforcing variant and re-open
+      long-range attack window. Make required or assert at entry.
+
+- [ ] 211 — `⚠` **Kyber ciphertext domain separation.**
+      `crates/crypto/src/kyber.rs` — encapsulation has no explicit
+      chain_id/slot binding. Sender-FALCON binding (028) covers
+      the dominant replay vector; protocol-level binding is
+      defence-in-depth and required for cross-chain replay
+      resistance.
+
+- [ ] 212 — `⚠` **FALCON signature malleability check.**
+      Any site that dedups / slashes keyed on signature bytes
+      is brittle if the upstream `falcon` crate permits multiple
+      valid sigs per `(pk, msg)`. Verify upstream; add a
+      malleability proptest; add canonicalisation if needed.
+
+- [ ] 213 — `⚠` **VRF input audit.**
+      `crates/crypto/src/vrf.rs` — confirm all VRF preimage
+      components are chain-determined (epoch, prev block hash,
+      slot). Any proposer-chooseable input opens committee
+      selection to grinding.
+
+- [ ] 214 — `⚠` **Per-peer rate limit on decryption shares.**
+      `crates/node/src/node.rs` consensus handler — frame-size
+      cap bounds per-message burst but no per-peer token bucket.
+      Add same `RateLimiter` pattern used for evidence (task 014d).
+
+- [ ] 215 — `⚠` **PVM `MEMCPY` + calldata u32 wrap.**
+      `crates/pvm/src/vm.rs:1265-1288` (MEMCPY no src/dst overlap
+      check) + `:364-388` (calldata `aligned_len = (len + 7) & !7`
+      can wrap `u32`). Potential heap/stack collision under
+      adversarial input. Pair with task 054 cargo-fuzz soak.
+
+- [ ] 216 — `⚠` **Poseidon2 spec-match test.**
+      `crates/crypto/src/poseidon2.rs` — tests assert capacity but
+      not round counts (RF=8, RI=22 for Plonky3 default). Add a
+      constants-match test pinned to the reference.
+
+- [ ] 217 — `⚠` **Witness oversize rejected without charging.**
+      `crates/state/src/witness.rs:149-173` — `verify_witnesses`
+      returns `false` on >1 MB witness with no gas charge.
+      Mitigated by the 1 MB gate; worth charging a minimum inspection
+      fee so RPC-reachable DoS is non-free.
+
+- [ ] 218 — `✓` **Validator-only consensus channel: publish-time
+      guard.** `crates/net/src/channels.rs` enforces on inbound
+      validate; no pre-publish check. Belt-and-suspenders. Add
+      assertion before any `swarm.gossipsub.publish` on the
+      consensus topic.
+
+---
+
+## P2 — Pre-testnet-alpha hygiene
+
+- [ ] 219 — **Startup guard on empty `MAINNET_BOOTSTRAP`.**
+      `crates/net/src/discovery.rs:14` — empty array, allowed by
+      task 011's config-file-injection option. Add a startup
+      refusal when `chain_id == 1` and no bootstrap peers
+      configured.
+
+- [ ] 220 — **Fast-sync / snapshot wiring.**
+      `crates/state/src/state_manager.rs:220-253` has
+      `export_snapshot` / `import_snapshot` but `crates/node/src/
+      sync.rs` never calls them. Cold-sync works; no fast-sync.
+
+- [ ] 221 — **Operator keystore / HSM design.**
+      `crates/node/src/validator.rs:40` holds raw `FalconSecretKey`
+      in memory. No encrypted-at-rest keystore, no HSM hook.
+      Mainnet operators will require this.
+
+- [ ] 222 — **Operator metrics coverage.**
+      `crates/node/src/metrics.rs` exposes a Prometheus endpoint
+      but mempool depth, block-lag, missed-proposal counters are
+      not instrumented. Grafana dashboards under `docker/grafana/`
+      are minimal.
+
+- [ ] 223 — **Reorg handling.**
+      No explicit state-rollback / chain-tip-reversal code path
+      found. Document current reorg semantics; add explicit path
+      if gaps exist.
+
+- [ ] 224 — **Block explorer / indexer (plan 083).**
+      No code. Plan tracks; listed here for visibility alongside
+      other mainnet-operator gaps.
+
+- [ ] 225 — **Faucet web UI (plan 082 partial).**
+      `crates/node/src/faucet.rs` is the RPC half only; no
+      frontend / public API exposure.
+
+---
+
+## Test-coverage follow-ups (not standalone fix items)
+
+Fold into the relevant fix PRs above when possible:
+
+- `crates/consensus/` and `crates/mempool/` have zero integration
+  tests (`tests/` dir). Add per-fix as PRs land.
+- `crates/net/` has one integration test for a whole P2P layer.
+- Multi-node gap list (tracked by plan, not repeated here).
+- Fuzz targets: 3 live, 4+ queued (plan 053, 054).
+
+---
+
+## Verification log
+
+| ID  | Verified on | How | Verdict |
+|-----|-------------|-----|---------|
+| 201 | pending     | —   | —       |
+| 202 | 2026-04-23  | Read `crates/pvm/src/vm.rs:525-575` | Confirmed asymmetry |
+| 203 | 2026-04-23  | Read `threshold.rs:530-547` + `rg ConstantTimeEq crates/crypto/` (0 hits) | Confirmed |
+| 204 | 2026-04-23  | Agent-traced; self-check pending at fix time | Accepted |
+| 205 | 2026-04-23  | Read `validator.rs:1443-1466` | Confirmed: `else` persists, `if` only logs |
+| 206 | 2026-04-23  | Read `rpc.rs:1117-1148` + `pool.rs:370-384` | Confirmed fall-through on no-auth_key |
+| 207 | 2026-04-23  | Agent-traced against wire.rs compact-block encoding | Accepted; design decision needed |

--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -93,14 +93,26 @@
       covering 9 adversarial `(imm1, imm2)` pairs including
       u64::MAX roll-over in both directions.
 
-- [ ] 203 — `✓` **Constant-time MAC verification in threshold
-      decryption.** `crates/crypto/src/threshold.rs:540` — `if
-      expected_mac != ct.mac` on 32 bytes of MAC, not constant-time.
-      Workspace-wide `rg "ConstantTimeEq|ct_eq|subtle::"` against
-      `crates/crypto/` returns zero hits.
-      Fix: add `subtle` crate, use `ct_eq`; sweep crates/crypto/
-      and crates/consensus/ for other `==`/`!=` on secret material
-      (shares, keys, signatures used as dedup keys).
+- [x] 203 — `✓` **Constant-time MAC verification in threshold
+      decryption.** Shipped: added `subtle = "2"` (no_std) as a
+      direct dep of `pyde-crypto`; `threshold.rs:540` now uses
+      `expected_mac.ct_eq(&ct.mac).unwrap_u8() == 0` instead of
+      `!=`. New regression test `tampered_mac_byte_fails_
+      verification` flips one MAC bit and asserts the mismatch
+      branch returns the generic error.
+      Sweep verdict: the other `==`/`!=` hits in `crates/crypto/`
+      and `crates/consensus/` are on public data (block hashes
+      used in slashing evidence + QC / finality lookup, share
+      indices that identify which validator contributed, length
+      comparisons on public-structure fields) — no additional
+      constant-time fixes needed today. One borderline site
+      (`threshold.rs:928` in `verify_resharing_contribution`,
+      comparing reconstructed polynomial evaluation against
+      sub-share) left alone: the compared values are destined
+      for cross-committee delivery and not secret from the new
+      committee; upgrading it is worth a look if PSS ever gets
+      a VSS commitment layer (see Deferred section of
+      `MAINNET_PLAN.md`).
 
 - [ ] 204 — `✓` **Wire-decoder unbounded `Vec::with_capacity`.**
       `crates/node/src/wire.rs:256-260, 361-370, 591-598, 760-764`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,6 +3584,7 @@ dependencies = [
  "p3-goldilocks",
  "p3-poseidon2",
  "p3-symmetric",
+ "subtle",
 ]
 
 [[package]]

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -528,7 +528,15 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let a = gp_read!(builder, d.rs1);
                         let imm = sign_extend_18(d.rs2_or_imm) as i64;
                         let b = builder.ins().iconst(I64, imm);
-                        // ADDI doesn't overflow check in interpreter (immediate is small)
+                        // Addi wraps on overflow by design — the otic
+                        // compiler relies on this for constant materialisation
+                        // (e.g. `Addi rd, r0, -2` → u64::MAX-1 for the
+                        // reentrancy-guard slot) and for two's-complement
+                        // negation (`Not rd; Addi rd, rd, 1` → -a). Changing
+                        // to checked_add would break otic codegen and
+                        // every contract's stack-frame setup. Divergence
+                        // between AOT and interpreter is guarded by
+                        // `addi_aot_interp_wrap_parity` in tests.
                         let r = builder.ins().iadd(a, b);
                         gp_write!(builder, d.rd, r);
                     }

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -112,6 +112,34 @@ mod tests {
     }
 
     #[test]
+    fn addi_aot_interp_wrap_parity() {
+        // Addi wraps on overflow by design — the otic compiler relies on
+        // this for constant materialisation and two's-complement negation.
+        // This test closes audit finding 202 (divergence risk) by asserting
+        // AOT and interpreter wrap identically across adversarial inputs.
+        // Any future edit to one side that doesn't match the other fails
+        // here before shipping.
+        for (imm1, imm2) in [
+            (-1i32, 1i32),      // u64::MAX + 1 → 0
+            (-1, -1),           // u64::MAX + -1 → u64::MAX - 1
+            (-2, 2),            // u64::MAX - 1 + 2 → 0
+            (0, -1),            // 0 + -1 → u64::MAX (sign-extend)
+            (131071, 131071),   // +max18 + +max18 (no wrap)
+            (-131072, -131072), // -max18 + -max18 (wraps into u64 top)
+            (0, 0),             // no-op
+            (1, -1),            // 1 + -1 → 0
+            (-131072, 131071),  // -min18 + max18 → -1 → u64::MAX
+        ] {
+            let code = bytecode(&[
+                instr_ri(Opcode::Addi, 1, 0, imm1),
+                instr_ri(Opcode::Addi, 2, 1, imm2),
+                instr_bytes(Opcode::Halt, 0, 0, 0),
+            ]);
+            compare_with_interpreter(&code, 0);
+        }
+    }
+
+    #[test]
     fn aot_add_two_numbers() {
         let code = bytecode(&[
             instr_ri(Opcode::Addi, 1, 0, 10),

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -11,6 +11,10 @@ p3-poseidon2 = "0.4"
 p3-symmetric = "0.4"
 falcon-rs = { version = "0.2", default-features = false, features = ["getrandom"] }
 ml-kem = { version = "0.3.0-rc.0", default-features = false, features = ["getrandom"] }
+# Constant-time comparison primitives. Used to compare MACs / secret
+# material without leaking timing side-channels. Default features
+# pull in `std`; we're no_std so turn them off.
+subtle = { version = "2", default-features = false }
 
 [[bench]]
 name = "poseidon2_bench"

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -9,6 +9,7 @@ use alloc::vec::Vec;
 
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
 use p3_goldilocks::Goldilocks;
+use subtle::ConstantTimeEq;
 
 use crate::kyber::{
     kyber_decapsulate, kyber_encapsulate, kyber_keygen, KyberCiphertext, KyberPublicKey,
@@ -535,9 +536,11 @@ pub fn combine_shares(
     // Decapsulate to get shared secret
     let ss = kyber_decapsulate(&sk, &ct.kyber_ct).map_err(|_| "Kyber-768 decapsulation failed")?;
 
-    // Verify MAC
+    // Verify MAC in constant time — a variable-time `!=` would leak
+    // per-byte match progress via timing, enabling padding-oracle-style
+    // forgery of MACs against a live validator.
     let expected_mac = compute_mac(&ss, &ct.encrypted_msg);
-    if expected_mac != ct.mac {
+    if expected_mac.ct_eq(&ct.mac).unwrap_u8() == 0 {
         return Err("MAC verification failed");
     }
 
@@ -1103,6 +1106,26 @@ mod tests {
 
         let result = combine_shares(&dec_shares, T, &ct);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn tampered_mac_byte_fails_verification() {
+        // Regression test for the constant-time MAC check. Flips one
+        // bit of the MAC on an otherwise-valid ciphertext and confirms
+        // the mismatch branch fires with the generic error. Does not
+        // measure timing (unit-test timing is too noisy); its job is
+        // to exercise the `ct_eq` code path so any future regression
+        // that broke MAC-mismatch handling fails loudly.
+        let (tpk, shares) = setup();
+        let msg = b"tampered mac test";
+        let mut ct = threshold_encrypt(&tpk, msg).unwrap();
+        ct.mac[0] ^= 0x01;
+        let dec_shares: Vec<DecryptionShare> = shares[..T]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let result = combine_shares(&dec_shares, T, &ct);
+        assert_eq!(result, Err("MAC verification failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- New `AUDIT_FINDINGS.md` tracker with 22 items from the
  2026-04-23 full-workspace audit, ordered for sequential
  fixing (verify-before-fix → smallest-isolated P0s →
  architectural P0 → P1/P2). Each item carries file:line
  refs and a verification mark.

- Fix (item 202): AOT/interpreter `Addi` wrap parity. Audit
  originally proposed changing `Addi` to trap on overflow;
  investigation showed otic deliberately uses the wrap for
  constant materialisation (`Addi rN, r0, -2` → `u64::MAX-1`
  for the reentrancy-guard slot) and two's-complement
  negation (`Not rd; Addi rd, rd, 1` → `-a`). Fix instead
  closes the real concern (AOT ↔ interpreter divergence)
  with a parity test across 9 adversarial `(imm1, imm2)`
  pairs covering `u64::MAX` roll-over in both directions.

- Fix (item 203): constant-time MAC verification in
  threshold decryption. `combine_shares` compared the
  32-byte expected MAC to the ciphertext MAC with `!=`
  (variable-time); a validator measuring decryption
  latency could forge MACs byte-by-byte (padding-oracle
  style). Now uses `subtle::ConstantTimeEq::ct_eq`; adds
  `subtle` as a direct no_std dep. Regression test
  `tampered_mac_byte_fails_verification` exercises the
  mismatch branch. Sweep of other `==`/`!=` sites in
  crates/crypto and crates/consensus confirmed they are
  on public data (block hashes, share indices, length
  checks).

- Item 201 (hard-finality persistence race) closed without
  a code change after tracing the call path; promoted to
  head of P1 as item 207a with a concrete refactor plan.
  Not a BFT safety violation — self-heals via peer gossip
  and `ingest_finality_checkpoint`.

Remaining P0s queued in `AUDIT_FINDINGS.md`: wire-decoder
length caps, double-vote evidence persistence, task 028
fall-through close, encrypted-tx gossip flow (074b root
cause). 15 P1/P2 items also tracked.