### PR TITLE
fix: reject unauth'd encrypted-tx senders on production chain_id

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -148,18 +148,29 @@
       the evidence lands in both queues with the correct sigs +
       hashes + signer.
 
-- [ ] 206 — `✓` **Close task 028 structural-only fall-through.**
-      `crates/node/src/rpc.rs:1117-1141` + `crates/mempool/src/
-      pool.rs:370-384`. Encrypted-tx RPC ingress only runs full
-      FALCON verify when the sender has a registered `auth_key`;
-      senders with no registered key take the length-only path.
-      Every fresh address has this window — an attacker can forge
-      encrypted txs claiming `sender = victim_new_address` until
-      the victim registers. Plan marks 028 done but the fall-through
-      is mainnet-exploitable.
-      Fix: on `chain_id != devnet`, require either a registered
-      `auth_key` OR membership in a narrow faucet allowlist.
-      Devnet keeps the fall-through for bootstrap UX.
+- [x] 206 — `✓` **Close task 028 structural-only fall-through.**
+      `crates/node/src/rpc.rs` `send_encrypted_transaction` now
+      routes through a new `encrypted_tx_ingest_policy` helper with
+      three arms: `Verify(pk)` when sender has a registered
+      `Single` auth_key; `StructuralOnly` only on `chain_id ==
+      31337` (devnet) for faucet / bootstrap UX; `Reject` on every
+      other chain_id with RPC error `-32001`. 3 new unit tests
+      cover all three branches across representative chain_ids
+      (1, 2, 7, 1337, 1_000_000).
+
+      Follow-up flagged while investigating: the PLAINTEXT path
+      has an analogous issue — `validate_signature` in
+      `crates/tx/src/validation.rs:140-149` accepts any tx whose
+      sender account has `AuthKeys::None` without a signature
+      check ("System/contract accounts — no signature check at
+      this level"), and `load_account` at
+      `crates/tx/src/pipeline.rs:148-158` returns a default EOA
+      with `AuthKeys::None` for any address not yet in state.
+      Balance-check gates the fund-loss exploit (a fresh
+      attacker-chosen `from` has 0 balance, can't cover gas) but
+      DoS-style mempool pollution is still possible within the
+      M1/M3 caps. Not strictly a 206 fix; tracked as item **226**
+      below for a follow-up PR.
 
 - [ ] 207 — `⚠` **Encrypted-tx gossip flow (074b root cause).**
       Compact-block broadcast in `crates/node/src/node.rs` omits
@@ -302,6 +313,24 @@
       `crates/node/src/faucet.rs` is the RPC half only; no
       frontend / public API exposure.
 
+- [ ] 226 — `⚠` **Plaintext RPC path: `AuthKeys::None` sig-skip
+      analog.** Surfaced while closing 206.
+      `crates/tx/src/validation.rs:140-149` — `validate_signature`
+      accepts any tx whose sender account has `AuthKeys::None`
+      without a FALCON check (comment: "System/contract accounts
+      — no signature check at this level"). `load_account` at
+      `crates/tx/src/pipeline.rs:148-158` returns a default EOA
+      with `AuthKeys::None` for any address not yet in state, so
+      an attacker can submit `send_raw_transaction` with
+      `from = victim_fresh_address` and no signature and clear
+      `validate_signature`. Balance-check gates fund-loss (fresh
+      account has 0 balance) but the mempool pollution surface is
+      still non-zero within M1/M3 caps. Fix: at RPC ingress on
+      production chain_id, require the sender account to exist
+      with a registered auth_key (OR take a narrow
+      faucet-allowlist path), mirroring the 206 policy. Keep the
+      internal contract-to-contract path unaffected.
+
 ---
 
 ## Test-coverage follow-ups (not standalone fix items)
@@ -320,10 +349,10 @@ Fold into the relevant fix PRs above when possible:
 
 | ID  | Verified on | How | Verdict |
 |-----|-------------|-----|---------|
-| 201 | pending     | —   | —       |
-| 202 | 2026-04-23  | Read `crates/pvm/src/vm.rs:525-575` | Confirmed asymmetry |
-| 203 | 2026-04-23  | Read `threshold.rs:530-547` + `rg ConstantTimeEq crates/crypto/` (0 hits) | Confirmed |
-| 204 | 2026-04-23  | Agent-traced; self-check pending at fix time | Accepted |
-| 205 | 2026-04-23  | Read `validator.rs:1443-1466` | Confirmed: `else` persists, `if` only logs |
-| 206 | 2026-04-23  | Read `rpc.rs:1117-1148` + `pool.rs:370-384` | Confirmed fall-through on no-auth_key |
+| 201 | 2026-04-23  | Traced `on_finality_vote` + `persist_finality_checkpoint` call order | Real race but not BFT-critical; P1 (207a) |
+| 202 | 2026-04-23  | Read `crates/pvm/src/vm.rs:525-575` | Wrapping is by-design; shipped parity test |
+| 203 | 2026-04-23  | Read `threshold.rs:530-547` + `rg ConstantTimeEq crates/crypto/` (0 hits) | Confirmed; fixed with `ct_eq` |
+| 204 | 2026-04-23  | Full sweep of `wire.rs` decoders (18 sites) | Fixed with `u16/u32_count(max)` helpers |
+| 205 | 2026-04-23  | Read `validator.rs:1443-1466` | Confirmed: `else` persists, `if` only logs; routed through `ingest_evidence` |
+| 206 | 2026-04-23  | Read `rpc.rs:1117-1148` + `pool.rs:370-384` | Confirmed fall-through on no-auth_key; closed for non-devnet chain_id |
 | 207 | 2026-04-23  | Agent-traced against wire.rs compact-block encoding | Accepted; design decision needed |

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1116,11 +1116,15 @@ impl PydeApiServer for RpcServer {
 
         // Task 028: bind ciphertext to sender's on-chain FALCON pubkey.
         // Look up the sender's account; if a Single auth_key is registered,
-        // enforce full FALCON verification (receive_tx_verified). Accounts
-        // with no registered key (fresh / faucet / system) fall back to
-        // the structural-only path so devnet bootstrap still works. Mainnet
-        // users are expected to have an auth_key set, putting them on the
-        // verified path by default.
+        // enforce full FALCON verification (receive_tx_verified).
+        //
+        // Audit item 206: on production chain_ids the fall-through to the
+        // structural-only path is closed — accounts with no registered
+        // auth_key are REJECTED, because structural-only accepts any
+        // 500-1000 byte blob as a "signature" and lets an attacker spoof
+        // `sender = victim_address` for every fresh address. Devnet
+        // (chain_id == 31337) keeps the fall-through so faucet / bootstrap
+        // accounts can transact before their first key registration.
         let sender_pk_opt = {
             let state_r = self.state.state.read().await;
             let sender_key = pyde_state::keys::balance_key(&from);
@@ -1134,10 +1138,18 @@ impl PydeApiServer for RpcServer {
         };
 
         let mut relay = self.state.tx_relay.write().await;
-        let accepted = if let Some(sender_pk) = sender_pk_opt {
-            relay.receive_tx_verified(enc_tx, &sender_pk)
-        } else {
-            relay.receive_tx(enc_tx)
+        let accepted = match encrypted_tx_ingest_policy(sender_pk_opt, self.chain_id) {
+            EncryptedTxIngestPolicy::Verify(sender_pk) => {
+                relay.receive_tx_verified(enc_tx, &sender_pk)
+            }
+            EncryptedTxIngestPolicy::StructuralOnly => relay.receive_tx(enc_tx),
+            EncryptedTxIngestPolicy::Reject => {
+                return Err(rpc_err(
+                    -32001,
+                    "encrypted-tx sender has no registered auth_key; register one before submitting"
+                        .to_string(),
+                ));
+            }
         };
         if !accepted {
             return Err(rpc_err(
@@ -1352,6 +1364,40 @@ fn rpc_err(code: i32, msg: String) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(code, msg, None::<()>)
 }
 
+/// Policy choice for how to gate encrypted-tx RPC ingress against
+/// `send_encrypted_transaction`'s sender-FALCON binding (audit item
+/// 206). Split out as a pure function so the devnet/production
+/// branch is unit-testable without spinning up an `RpcServer`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum EncryptedTxIngestPolicy {
+    /// Sender has an on-chain `Single` auth_key; route through full
+    /// FALCON verification against it.
+    Verify(Vec<u8>),
+    /// Devnet-only: sender has no registered key yet (faucet /
+    /// bootstrap account). Accept via structural-only — signature
+    /// length is sanity-checked, FALCON is not.
+    StructuralOnly,
+    /// Production: sender has no registered key. Reject so attackers
+    /// can't spoof `from = victim_fresh_address` through the
+    /// length-only path.
+    Reject,
+}
+
+/// See `EncryptedTxIngestPolicy`. `sender_pk` comes from the
+/// sender's on-chain account (`None` means either no account or an
+/// account with `AuthKeys::None`). `chain_id == 31337` identifies
+/// devnet; any other chain_id is treated as production.
+fn encrypted_tx_ingest_policy(
+    sender_pk: Option<Vec<u8>>,
+    chain_id: u64,
+) -> EncryptedTxIngestPolicy {
+    match sender_pk {
+        Some(pk) => EncryptedTxIngestPolicy::Verify(pk),
+        None if chain_id == 31337 => EncryptedTxIngestPolicy::StructuralOnly,
+        None => EncryptedTxIngestPolicy::Reject,
+    }
+}
+
 fn parse_address(input: &str) -> Result<[u8; 32], ErrorObjectOwned> {
     let hex_str = input.strip_prefix("0x").unwrap_or(input);
     let bytes =
@@ -1543,6 +1589,44 @@ mod tests {
     #[test]
     fn decode_u128_short_returns_zero() {
         assert_eq!(decode_u128(&[1, 2, 3]), 0);
+    }
+
+    #[test]
+    fn ingest_policy_verifies_when_auth_key_registered() {
+        let pk = vec![0x11u8; 900];
+        assert_eq!(
+            encrypted_tx_ingest_policy(Some(pk.clone()), 1),
+            EncryptedTxIngestPolicy::Verify(pk.clone())
+        );
+        // Devnet with a registered key still verifies — the
+        // structural-only branch is only for the no-key case.
+        assert_eq!(
+            encrypted_tx_ingest_policy(Some(pk.clone()), 31337),
+            EncryptedTxIngestPolicy::Verify(pk)
+        );
+    }
+
+    #[test]
+    fn ingest_policy_devnet_falls_through_without_key() {
+        assert_eq!(
+            encrypted_tx_ingest_policy(None, 31337),
+            EncryptedTxIngestPolicy::StructuralOnly
+        );
+    }
+
+    #[test]
+    fn ingest_policy_production_rejects_without_key() {
+        // Mainnet and any non-devnet chain_id must reject — otherwise
+        // an attacker can spoof `from = victim_fresh_address` through
+        // the length-only path.
+        for chain_id in [1u64, 2, 7, 1337, 1_000_000] {
+            assert_eq!(
+                encrypted_tx_ingest_policy(None, chain_id),
+                EncryptedTxIngestPolicy::Reject,
+                "chain_id {} must reject no-key encrypted tx",
+                chain_id
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`send_encrypted_transaction`'s fall-through to `receive_tx`
(pool.rs structural-only verify — accepts any 500–1000 byte
signature blob, no FALCON check) fired whenever the sender had
no on-chain `auth_key`. Every fresh address hits that case, so
an attacker could spoof `from = victim_fresh_address` and
pollute the encrypted mempool until the victim registered a key.

- New `encrypted_tx_ingest_policy` helper returns one of three
  decisions: `Verify(pk)` when a `Single` auth_key is registered;
  `StructuralOnly` only on `chain_id == 31337` (devnet, for
  faucet / bootstrap accounts); `Reject` with RPC error `-32001`
  on every other chain_id.
- The RPC method matches on the enum; devnet behaviour is
  unchanged.
- 3 unit tests cover all three branches across representative
  chain_ids (1, 2, 7, 1337, 1_000_000).

Closes item 206 in `AUDIT_FINDINGS.md`.

## Follow-up surfaced during investigation (not this PR)

`validate_signature` in `crates/tx/src/validation.rs:140-149`
accepts any tx whose sender account has `AuthKeys::None` without
a FALCON check, and `load_account` returns a default EOA with
`AuthKeys::None` for any address not yet in state. Balance-check
gates fund-loss (fresh account has 0 balance) but mempool
pollution is still possible within M1/M3 caps. Tracked as item
226 in `AUDIT_FINDINGS.md` for a dedicated follow-up.