### PR TITLE
chore: make workspace clippy clean under -D warnings

### DIFF
--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -1176,9 +1176,8 @@ fn extract_u64_field(body: &str, field: &str) -> Option<u64> {
     let tail = &body[start..];
     let colon = tail.find(':')? + 1;
     let rest = tail[colon..].trim_start();
-    if rest.starts_with('"') {
+    if let Some(inner) = rest.strip_prefix('"') {
         // Quoted string — look for closing quote.
-        let inner = &rest[1..];
         let end = inner.find('"')?;
         let s = &inner[..end];
         if let Some(hex) = s.strip_prefix("0x") {

--- a/crates/node/tests/loadgen_sustained.rs
+++ b/crates/node/tests/loadgen_sustained.rs
@@ -549,7 +549,7 @@ fn sustained_rate_load_test() {
         let mut gas_zero_with_txs = 0usize;
         let mut empty = 0usize;
         for l in &timing_lines {
-            let has_txs = l.contains("txs=0") == false;
+            let has_txs = !l.contains("txs=0");
             let has_gas = !l.contains("gas=0");
             if !has_txs {
                 empty += 1;

--- a/crates/node/tests/multi_node_full_node_relay.rs
+++ b/crates/node/tests/multi_node_full_node_relay.rs
@@ -45,7 +45,7 @@ fn tx_via_full_node_reaches_validator() {
         .funded_addresses()
         .unwrap_or_else(|e| panic!("read funded: {}", e));
     assert!(
-        funded.len() >= 3 + 5 + 1,
+        funded.len() > 3 + 5,
         "expected >= 9 funded addresses (3 validators + 5 test + faucet), got {}",
         funded.len()
     );

--- a/crates/state/src/jmt_store.rs
+++ b/crates/state/src/jmt_store.rs
@@ -313,7 +313,7 @@ impl TreeWriter for JmtRocksStore {
                     value_cache.put(*key_hash, Some(bytes.clone()));
                 }
                 _ => {
-                    batch.put(&key, &[]);
+                    batch.put(&key, []);
                     value_cache.put(*key_hash, None);
                 }
             }
@@ -337,7 +337,7 @@ impl TreeWriter for JmtRocksStore {
         if let Some(rm) = rightmost {
             let bytes =
                 borsh::to_vec(&rm).map_err(|e| anyhow::anyhow!("rightmost encode: {}", e))?;
-            batch.put(&Self::meta_key(META_RIGHTMOST), bytes);
+            batch.put(Self::meta_key(META_RIGHTMOST), bytes);
         }
 
         self.db


### PR DESCRIPTION
## Summary

Five lint-only fixes that `cargo clippy --workspace --all-targets
-- -D warnings` flags on the current stable toolchain. No
behavioural change — every fix is a rote clippy suggestion:

- `crates/state/src/jmt_store.rs` — drop needless `&` on two
  `AsRef<[u8]>` args to `WriteBatch::put`
  (`needless_borrows_for_generic_args`).
- `crates/node/tests/common/mod.rs` — rewrite manual prefix strip
  as `strip_prefix('"')` (`manual_strip`).
- `crates/node/tests/multi_node_full_node_relay.rs` — replace
  `>= x + 1` with `> x` (`int_plus_one`).
- `crates/node/tests/loadgen_sustained.rs` — `!contains(...)` in
  place of `contains(...) == false` (`bool_comparison`).

## Why

The Clippy / Check / Test jobs on CI have been failing on every
PR because of these lints on `main`. We've been merging past
red CI, which defeats branch protection. This PR closes the
gap so CI actually gates future work.

All 91 `pyde-state` unit tests pass; `cargo check -p pyde-node
--tests` builds every integration test target cleanly.