### PR TITLE
feat: wire format for EncryptedTxBundle (item 207 step 1/3)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -172,19 +172,82 @@
       M1/M3 caps. Not strictly a 206 fix; tracked as item **226**
       below for a follow-up PR.
 
-- [ ] 207 — `⚠` **Encrypted-tx gossip flow (074b root cause).**
-      Compact-block broadcast in `crates/node/src/node.rs` omits
-      `encrypted_txs`; full blocks only served on-demand via
-      `GET_BLOCK_TXS` (`crates/node/src/wire.rs:415`). Non-proposer
+- [~] 207 — `⚠` **Encrypted-tx gossip flow (074b root cause).**
+      Compact-block broadcast omits `encrypted_txs`; full blocks
+      only served on-demand via `GET_BLOCK_TXS`. Non-proposer
       validators never see encrypted_tx lists → decryption shares
-      arrive orphaned and queue forever. Blocks the headline
-      MEV-protection claim and 074b.
-      Fix: design doc first, choose among:
-      (A) extend compact-block protocol with encrypted_tx short IDs;
-      (B) separate gossipsub topic for encrypted_txs, published by
-      proposer alongside the block;
-      (C) proactive full-block push to committee members.
-      Then implement + add `074b` loadgen pass.
+      arrive orphaned and queue forever. Blocks the MEV headline
+      and 074b.
+
+      **Design locked in: option (D) — proposer publishes a
+      dedicated `EncryptedTxBundle{slot, block_hash,
+      encrypted_txs: Vec<Vec<u8>>}` message on the Blocks
+      channel immediately after the compact block.**
+
+      Rationale over original options:
+      - (A) compact-block extension was the audit's default but
+        costs a wire-format version bump and three new resolution
+        paths (short-ID resolve → prefill check → GET_BLOCK_TXS
+        fallback). More failure modes per PR.
+      - (B) separate channel on Consensus topic — 64 KB cap too
+        tight for an encrypted-tx bundle at useful scale.
+      - (C) proactive full-block push — burns bandwidth at scale.
+      - (D) picked: proposer→validators message on the 4 MB
+        Blocks channel. No wire-format version bump to CompactBlock,
+        no new short-ID tables, one message type. Testnet-MVP
+        scale suits simplicity over efficiency; (A) upgrade
+        remains open for later (short-ID derivation is already
+        generic — `compute_short_id` takes any `[u8; 32]`).
+
+      **Integrity anchor: existing `tx_root`.** `BlockHeader::
+      tx_root` already commits to plaintext-tx hashes ++
+      encrypted-tx hashes in order (`crates/consensus/src/
+      block.rs:198`, load-bearing for MEV). Receiver reassembles
+      the bundle, computes `EncryptedTx::hash()` per entry, calls
+      `verify_tx_root(&header.tx_root, &plaintext_txs,
+      &encrypted_tx_hashes)`. Mismatch → reject. No new sigs.
+
+      **Implementation plan (3 PRs):**
+      1. **Wire + struct.** Add `EncryptedTxBundle` to
+         `crates/net/src/propagation.rs`; add tag +
+         encode/decode in `crates/node/src/wire.rs`; round-trip
+         tests. No behaviour change — wire only.
+      2. **Proposer + receiver plumbing.** Proposer publishes
+         the bundle immediately after `encode_compact_block`;
+         receiver queues bundle alongside compact block, runs
+         `verify_tx_root` when both arrive, hands full
+         `encrypted_txs` into the existing `BlockDecryptor`
+         pipeline so queued shares can drain.
+      3. **Multi-node integration + 074b.** Spawn a testnet,
+         submit via `pyde_sendEncryptedTransaction`, assert the
+         decrypted tx commits. Unblocks 074b loadgen.
+
+      **Non-issues deliberately excluded:**
+      - No per-bundle signature. `tx_root` verifies integrity.
+      - No ordering invariant beyond the block body's own order.
+        Ordering commitment to mempool-seen txs (task 024) is
+        unchanged.
+      - No encrypted-tx gossip outside of block context.
+        Users still submit via `pyde_sendEncryptedTransaction`
+        → `tx_relay` → Transactions channel, and the proposer
+        picks from their local mempool as today. The new
+        bundle is strictly a block-time proposer→validators
+        distribution mechanism.
+
+      **Known risks:**
+      - Bundle and compact block arrive out of order. Mitigation:
+        receiver queues either arrival and resolves when both
+        are present, with a slot-bounded TTL (drop if the slot
+        is already 2+ behind head).
+      - Proposer publishes bundle but a validator never receives
+        it (gossip gap). Same mitigation as today for
+        compact-block tx resolution: fall back to `GET_BLOCK_TXS`
+        with a new tag for encrypted-tx bodies.
+      - Malicious proposer omits bundle. Receiver doesn't have
+        encrypted_tx bytes; `verify_tx_root` fails if any
+        encrypted_tx is expected (tx_root non-zero from
+        encrypted inputs). Block is rejected at the validator,
+        QC won't form. Liveness impact only.
 
 ---
 

--- a/crates/net/src/propagation.rs
+++ b/crates/net/src/propagation.rs
@@ -141,6 +141,32 @@ pub struct BlockTxsResponse {
     pub transactions: Vec<Vec<u8>>,
 }
 
+/// Encrypted-tx bundle: proposer→validators payload carrying the
+/// block's `encrypted_txs: Vec<Vec<u8>>` out-of-band from the
+/// compact block. Resolves audit item 207 / 074b: the compact block
+/// has no room for encrypted_tx bodies, so non-proposer validators
+/// would otherwise never see them and their decryption shares would
+/// orphan.
+///
+/// Integrity is anchored by the existing `BlockHeader::tx_root`
+/// commitment (see `pyde_consensus::block::compute_tx_root`):
+/// receiver hashes each `encrypted_tx` byte blob as an `EncryptedTx`
+/// and calls `verify_tx_root` against the header from the matching
+/// compact block. Mismatch → reject. No per-bundle signature is
+/// needed for authenticity.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EncryptedTxBundle {
+    /// Slot the bundle is for.
+    pub slot: u64,
+    /// Hash of the block whose `tx_root` commits to this bundle.
+    /// Lets receivers match the bundle to its compact block even if
+    /// they arrive out of order.
+    pub block_hash: [u8; 32],
+    /// Encrypted-tx byte blobs in block order, identical to
+    /// `Block::body.encrypted_txs`.
+    pub encrypted_txs: Vec<Vec<u8>>,
+}
+
 // ========== Erasure Coding ==========
 
 /// An erasure-coded chunk of a block.

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -53,6 +53,11 @@ pub mod tag {
     pub const CONSENSUS_FINALITY_CHECKPOINT: u8 = 0x19;
     pub const GET_BLOCK_TXS: u8 = 0x04;
     pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
+    /// Proposer-published bundle of encrypted_txs for a block (audit
+    /// item 207 / 074b). Published on the Blocks channel immediately
+    /// after the compact block. Integrity is anchored by the block
+    /// header's `tx_root` commitment — no per-bundle signature.
+    pub const ENCRYPTED_TX_BUNDLE: u8 = 0x06;
     pub const DECRYPTION_SHARES: u8 = 0x20;
 }
 
@@ -446,6 +451,48 @@ pub fn encode_block_txs_response(block_hash: &[u8; 32], txs: &[Vec<u8>]) -> Vec<
         enc.var_bytes(tx_bytes);
     }
     enc.finish()
+}
+
+/// Encode an `EncryptedTxBundle` for gossip on the Blocks channel.
+/// Proposer publishes immediately after `encode_compact_block`; the
+/// bundle carries the encrypted_tx byte blobs that the compact block
+/// omits. Integrity is anchored by the block header's `tx_root`
+/// commitment, verified on receive. See audit item 207.
+pub fn encode_encrypted_tx_bundle(bundle: &pyde_net::propagation::EncryptedTxBundle) -> Vec<u8> {
+    let mut enc = Encoder::new();
+    enc.u8(tag::ENCRYPTED_TX_BUNDLE);
+    enc.u64(bundle.slot);
+    enc.bytes32(&bundle.block_hash);
+    enc.u32(bundle.encrypted_txs.len() as u32);
+    for tx_bytes in &bundle.encrypted_txs {
+        enc.var_bytes(tx_bytes);
+    }
+    enc.finish()
+}
+
+/// Decode an `EncryptedTxBundle`. Rejects oversized item counts via
+/// `u32_count(MAX_DECODE_ITEMS)`; per-entry byte length is indirectly
+/// bounded by the channel's frame-size cap (4 MB for Blocks).
+pub fn decode_encrypted_tx_bundle(
+    data: &[u8],
+) -> Result<pyde_net::propagation::EncryptedTxBundle, &'static str> {
+    let mut dec = Decoder::new(data);
+    let msg_tag = dec.u8()?;
+    if msg_tag != tag::ENCRYPTED_TX_BUNDLE {
+        return Err("not an encrypted-tx bundle message");
+    }
+    let slot = dec.u64()?;
+    let block_hash = dec.bytes32()?;
+    let count = dec.u32_count(MAX_DECODE_ITEMS)?;
+    let mut encrypted_txs = Vec::with_capacity(count);
+    for _ in 0..count {
+        encrypted_txs.push(dec.var_bytes()?);
+    }
+    Ok(pyde_net::propagation::EncryptedTxBundle {
+        slot,
+        block_hash,
+        encrypted_txs,
+    })
 }
 
 pub fn encode_decryption_shares(msg: &DecryptionShareMsg) -> Vec<u8> {
@@ -1728,5 +1775,70 @@ mod tests {
         bytes.extend_from_slice(&((COMMITTEE_SIZE as u16) + 1).to_le_bytes());
         let result = decode_decryption_shares(&bytes);
         assert_eq!(result.err(), Some("decoded count exceeds max"));
+    }
+
+    // ========== EncryptedTxBundle (audit item 207) ==========
+
+    #[test]
+    fn encrypted_bundle_empty_roundtrip() {
+        let bundle = pyde_net::propagation::EncryptedTxBundle {
+            slot: 0,
+            block_hash: [0u8; 32],
+            encrypted_txs: vec![],
+        };
+        let bytes = encode_encrypted_tx_bundle(&bundle);
+        let restored = decode_encrypted_tx_bundle(&bytes).unwrap();
+        assert_eq!(restored, bundle);
+    }
+
+    #[test]
+    fn encrypted_bundle_populated_roundtrip() {
+        let bundle = pyde_net::propagation::EncryptedTxBundle {
+            slot: 42,
+            block_hash: [0xABu8; 32],
+            encrypted_txs: vec![
+                vec![0x01, 0x02, 0x03],
+                vec![0xFF; 64],
+                vec![], // empty entry is legal — var_bytes handles it
+                vec![0xDE; 1024],
+            ],
+        };
+        let bytes = encode_encrypted_tx_bundle(&bundle);
+        let restored = decode_encrypted_tx_bundle(&bytes).unwrap();
+        assert_eq!(restored, bundle);
+    }
+
+    #[test]
+    fn encrypted_bundle_wrong_tag_fails() {
+        let bundle = pyde_net::propagation::EncryptedTxBundle {
+            slot: 1,
+            block_hash: [0u8; 32],
+            encrypted_txs: vec![],
+        };
+        let mut bytes = encode_encrypted_tx_bundle(&bundle);
+        bytes[0] = tag::COMPACT_BLOCK;
+        assert_eq!(
+            decode_encrypted_tx_bundle(&bytes).err(),
+            Some("not an encrypted-tx bundle message")
+        );
+    }
+
+    #[test]
+    fn encrypted_bundle_empty_frame_fails() {
+        assert!(decode_encrypted_tx_bundle(&[]).is_err());
+    }
+
+    #[test]
+    fn encrypted_bundle_rejects_huge_count() {
+        // Hand-construct a frame whose declared count exceeds
+        // MAX_DECODE_ITEMS; decode must reject before allocating.
+        let mut bytes = vec![tag::ENCRYPTED_TX_BUNDLE];
+        bytes.extend_from_slice(&42u64.to_le_bytes()); // slot
+        bytes.extend_from_slice(&[0u8; 32]); // block_hash
+        bytes.extend_from_slice(&((MAX_DECODE_ITEMS as u32) + 1).to_le_bytes());
+        assert_eq!(
+            decode_encrypted_tx_bundle(&bytes).err(),
+            Some("decoded count exceeds max")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Audit item 207 is the root cause of 074b (encrypted-path MEV
headline): proposers broadcast compact blocks that omit the
`encrypted_txs` list, so non-proposer validators never see the
encrypted-tx bodies and their decryption shares arrive orphaned.

Design (locked in `AUDIT_FINDINGS.md`) is option (D) — proposer
publishes a dedicated `EncryptedTxBundle { slot, block_hash,
encrypted_txs: Vec<Vec<u8>> }` message on the Blocks channel
immediately after the compact block. Integrity is anchored by
the existing `BlockHeader::tx_root` commitment, so no per-bundle
signature is needed — receiver hashes each entry as an
`EncryptedTx`, calls `verify_tx_root(&header.tx_root,
&plaintext_txs, &encrypted_tx_hashes)`, rejects on mismatch.

This PR ships **only the wire format** (no behaviour change):
- `EncryptedTxBundle` struct in `pyde-net::propagation`.
- Tag `ENCRYPTED_TX_BUNDLE = 0x06` + encode / decode in
  `pyde-node::wire`.
- Count-field decode bounded via `u32_count(MAX_DECODE_ITEMS)`
  — re-uses the audit-204 helper so an over-count frame is
  rejected before allocation.
- 5 tests: empty + populated roundtrip, wrong-tag + empty-frame
  rejection, over-limit count rejection.

## Follow-ups (same branch series)

- **2/3** — proposer publish + receiver `tx_root` verify +
  decryptor plumbing.
- **3/3** — multi-node integration test; unblock 074b loadgen.

Why option (D) over the other candidates is documented in
`AUDIT_FINDINGS.md` — short version: simplest for testnet-MVP
scale, no compact-block version bump, one new message type,
existing `tx_root` is the integrity anchor. An upgrade to the
compact-block-extension variant (option A) remains possible
later without migration since `compute_short_id` is already
generic on any 32-byte hash.