### PR TITLE
feat: pyde_getThresholdPublicKey RPC (step 1/4)

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -172,6 +172,15 @@ pub trait PydeApi {
     #[method(name = "pyde_mempoolSize")]
     async fn mempool_size(&self) -> Result<String, ErrorObjectOwned>;
 
+    /// Return the committee's threshold public key (hex-encoded
+    /// wire bytes). Clients encrypt the private fields of an
+    /// `EncryptedTx` with this key locally before submitting via
+    /// `pyde_sendRawEncryptedTransaction`. Errors if the node has
+    /// no threshold committee configured (e.g. a dev node without
+    /// MEV protection wired up).
+    #[method(name = "pyde_getThresholdPublicKey")]
+    async fn get_threshold_public_key(&self) -> Result<String, ErrorObjectOwned>;
+
     /// Submit a transaction for threshold encryption and mempool inclusion.
     /// Accepts a JSON object with: from, to, value, data, gas, nonce, signature.
     /// The node encrypts it with the committee's threshold public key before adding to mempool.
@@ -1037,6 +1046,14 @@ impl PydeApiServer for RpcServer {
     async fn mempool_size(&self) -> Result<String, ErrorObjectOwned> {
         let relay = self.state.tx_relay.read().await;
         Ok(relay.mempool_size().to_string())
+    }
+
+    async fn get_threshold_public_key(&self) -> Result<String, ErrorObjectOwned> {
+        let pk =
+            self.state.threshold_pk.as_ref().ok_or_else(|| {
+                rpc_err(-32000, "threshold encryption not configured".to_string())
+            })?;
+        Ok(format!("0x{}", hex::encode(pk.to_bytes())))
     }
 
     async fn send_encrypted_transaction(


### PR DESCRIPTION
## Summary

Adds the read-only RPC a client needs before constructing an
`EncryptedTx` locally. Without this, no wallet can participate
in the MEV-protected flow — they'd have no way to know which
committee pubkey to encrypt to.

- Returns the `threshold_pk` as hex-encoded wire bytes. The
  `to_bytes` serialisation is the same format the committee
  uses internally via `ThresholdPublicKey::from_bytes`, so a
  round-trip through this RPC + the `pyde-crypto-wasm` /
  `pyde-rust-sdk` helpers (step 3/4) will give clients a live
  `ThresholdPublicKey` they can call `threshold_encrypt` on.
- Errors with `-32000 "threshold encryption not configured"`
  if the node isn't wired up with a committee (e.g. an ad-hoc
  dev node spun up without MEV protection).

## Part of a 4-PR series

Current `pyde_sendEncryptedTransaction` does server-side
encryption, which breaks the MEV model: clients can't produce
a valid FALCON signature over a ciphertext the server chose
(see `EncryptedTx::hash()` depends on `ct_hash`). The
client-side flow needs:

1. **This PR** — `pyde_getThresholdPublicKey` RPC.
2. `pyde_sendRawEncryptedTransaction` RPC (takes a pre-built
   + client-signed `EncryptedTx` wire frame; skips the server
   encrypt step).
3. `pyde-crypto-wasm` + `pyde-rust-sdk` helpers wrapping
   `threshold_encrypt` + `EncryptedTx::hash()` + FALCON sign
   + `to_bytes`.
4. Multi-node integration test using (1)–(3) to prove the
   full MEV flow end-to-end. Also unblocks 074b.

Full tracking in `AUDIT_FINDINGS.md` under item 227 (updated
at the end of the series to avoid per-step doc thrash).