### PR TITLE
feat: MEV-protected encrypted-tx flow working end-to-end (item 227 step 4/4)

### DIFF
--- a/crates/net/src/channels.rs
+++ b/crates/net/src/channels.rs
@@ -16,6 +16,13 @@ use std::collections::HashSet;
 pub enum Channel {
     Consensus,
     Transactions,
+    /// MEV-protected (threshold-encrypted) transactions. Separate from
+    /// `Transactions` so the receive dispatcher doesn't have to probe
+    /// both plaintext + encrypted wire formats on every message —
+    /// they share a first-byte prefix (sender address), so type
+    /// confusion would otherwise be possible. Audit item 227
+    /// step 4 / option E.
+    EncryptedTransactions,
     Blocks,
     Sync,
 }
@@ -26,6 +33,7 @@ impl Channel {
         match self {
             Channel::Consensus => "pyde/consensus/1",
             Channel::Transactions => "pyde/transactions/1",
+            Channel::EncryptedTransactions => "pyde/encrypted_tx/1",
             Channel::Blocks => "pyde/blocks/1",
             Channel::Sync => "pyde/sync/1",
         }
@@ -41,6 +49,7 @@ impl Channel {
         match topic {
             "pyde/consensus/1" => Some(Channel::Consensus),
             "pyde/transactions/1" => Some(Channel::Transactions),
+            "pyde/encrypted_tx/1" => Some(Channel::EncryptedTransactions),
             "pyde/blocks/1" => Some(Channel::Blocks),
             "pyde/sync/1" => Some(Channel::Sync),
             _ => None,
@@ -52,6 +61,7 @@ impl Channel {
         &[
             Channel::Consensus,
             Channel::Transactions,
+            Channel::EncryptedTransactions,
             Channel::Blocks,
             Channel::Sync,
         ]
@@ -98,7 +108,8 @@ pub fn validate_message(msg: &NetworkMessage, is_validator_peer: bool) -> Valida
     // Check message size limits per channel
     let max_size = match msg.channel {
         Channel::Consensus => 64 * 1024,     // 64KB (votes, view changes)
-        Channel::Transactions => 128 * 1024, // 128KB (encrypted txs)
+        Channel::Transactions => 128 * 1024, // 128KB (plaintext txs)
+        Channel::EncryptedTransactions => 128 * 1024, // 128KB (same as plaintext)
         Channel::Blocks => 4 * 1024 * 1024,  // 4MB (full blocks)
         Channel::Sync => 8 * 1024 * 1024,    // 8MB (state chunks)
     };
@@ -188,7 +199,7 @@ mod tests {
 
     #[test]
     fn all_channels_count() {
-        assert_eq!(Channel::all().len(), 4);
+        assert_eq!(Channel::all().len(), 5);
     }
 
     #[test]

--- a/crates/net/src/ddos.rs
+++ b/crates/net/src/ddos.rs
@@ -145,7 +145,8 @@ impl SubnetLimiter {
 pub fn max_message_size(channel: Channel) -> usize {
     match channel {
         Channel::Consensus => 64 * 1024,     // 64 KB (votes, view changes)
-        Channel::Transactions => 128 * 1024, // 128 KB (encrypted transactions)
+        Channel::Transactions => 128 * 1024, // 128 KB (plaintext txs)
+        Channel::EncryptedTransactions => 128 * 1024, // 128 KB (encrypted txs)
         Channel::Blocks => 4 * 1024 * 1024,  // 4 MB (full blocks)
         Channel::Sync => 8 * 1024 * 1024,    // 8 MB (state sync chunks)
     }

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -149,9 +149,17 @@ pub mod topics {
         IdentTopic::new("pyde/consensus/1")
     }
 
-    /// Encrypted transactions from users.
+    /// Plaintext transactions from users.
     pub fn transactions() -> IdentTopic {
         IdentTopic::new("pyde/transactions/1")
+    }
+
+    /// Threshold-encrypted (MEV-protected) transactions. Separate
+    /// from plaintext transactions so the receive dispatcher can
+    /// decode the right wire format without probing. Audit item
+    /// 227 step 4 / option E.
+    pub fn encrypted_transactions() -> IdentTopic {
+        IdentTopic::new("pyde/encrypted_tx/1")
     }
 
     /// Proposed blocks and scheduled blocks.
@@ -166,7 +174,13 @@ pub mod topics {
 
     /// All topic names.
     pub fn all() -> Vec<IdentTopic> {
-        vec![consensus(), transactions(), blocks(), sync()]
+        vec![
+            consensus(),
+            transactions(),
+            encrypted_transactions(),
+            blocks(),
+            sync(),
+        ]
     }
 }
 
@@ -205,11 +219,16 @@ pub fn subscribe_topics(
     swarm: &mut Swarm<PydeBehaviour>,
     is_validator: bool,
 ) -> Result<(), String> {
-    // All nodes subscribe to transactions, blocks, sync
+    // All nodes subscribe to transactions (plaintext + encrypted), blocks, sync
     swarm
         .behaviour_mut()
         .gossipsub
         .subscribe(&topics::transactions())
+        .map_err(|e| format!("subscribe error: {e}"))?;
+    swarm
+        .behaviour_mut()
+        .gossipsub
+        .subscribe(&topics::encrypted_transactions())
         .map_err(|e| format!("subscribe error: {e}"))?;
     swarm
         .behaviour_mut()

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -886,6 +886,26 @@ impl PydeNode {
                                                 times_w.remove(h);
                                             }
                                         }
+                                        // Audit item 227 step 4: clear encrypted txs from
+                                        // the local tx_relay once the block committing
+                                        // them has been fully processed. The self-propose
+                                        // path deliberately does NOT do this — self-proposals
+                                        // can lose the multi-proposer VRF lottery, and
+                                        // removing on self-propose would permanently drop
+                                        // the tx even when a different validator's block
+                                        // wins the slot. Doing it here, after the block
+                                        // has actually been QC'd and processed, matches
+                                        // the P7a-2 plaintext fix.
+                                        if !block.body.encrypted_txs.is_empty() {
+                                            let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
+                                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                                .map(|etx| etx.hash())
+                                                .collect();
+                                            if !enc_hashes.is_empty() {
+                                                let mut relay_w = tx_relay.write().await;
+                                                relay_w.remove_included(&enc_hashes);
+                                            }
+                                        }
                                         info!(slot, txs = tc, gas, "compact block reconstructed and processed");
                                     }
                                     Err(e) => {
@@ -1408,15 +1428,17 @@ impl PydeNode {
                                         }
                                     }
 
-                                    // Remove included encrypted txs from mempool
-                                    if !block.body.encrypted_txs.is_empty() {
-                                        let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
-                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
-                                            .map(|etx| etx.hash())
-                                            .collect();
-                                        let mut relay_w = tx_relay.write().await;
-                                        relay_w.remove_included(&enc_hashes);
-                                    }
+                                    // Audit item 227 step 4: do NOT remove encrypted txs
+                                    // from tx_relay here. Self-proposals can lose the
+                                    // multi-proposer VRF lottery, and removing at self-
+                                    // propose time would permanently orphan the tx when
+                                    // a different validator's block wins the slot. The
+                                    // removal happens in the `ReconstructCompactBlock`
+                                    // handler once the committed block has been processed
+                                    // — if our block ends up being the winner, it arrives
+                                    // back to us via gossip like any other block and the
+                                    // cleanup fires there. If it loses, the tx stays in
+                                    // the mempool for future slots.
 
                                     // Store full block for sync serving + missing tx requests
                                     let full_block_bytes = wire::encode_block(&block);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -445,6 +445,15 @@ impl PydeNode {
         // 10. Start RPC server if enabled
         let (tx_gossip_tx, mut tx_gossip_rx) =
             tokio::sync::mpsc::channel::<pyde_tx::types::Transaction>(1024);
+        // Audit item 227 step 4 / option E: RPC ingress side of the
+        // encrypted-tx gossip channel. After pyde_sendRawEncryptedTransaction
+        // accepts a tx into the local tx_relay, the RPC handler also
+        // pushes it here. The main loop forwards it to gossipsub on the
+        // encrypted-tx topic so every validator's tx_relay ends up with
+        // a copy — otherwise only the RPC-receiving node's proposer
+        // could ever include the tx in a block.
+        let (encrypted_tx_gossip_tx, mut encrypted_tx_gossip_rx) =
+            tokio::sync::mpsc::channel::<pyde_mempool::encrypted::EncryptedTx>(1024);
         // WebSocket subscription broadcast channels (created even if RPC disabled — cheap no-op)
         let (new_heads_tx, _) = tokio::sync::broadcast::channel::<serde_json::Value>(256);
         let (pending_tx_tx, _) = tokio::sync::broadcast::channel::<String>(4096);
@@ -478,6 +487,7 @@ impl PydeNode {
                 logs_tx,
                 dev_mode: self.config.node.dev_mode,
                 tx_gossip_tx: tx_gossip_tx.clone(),
+                encrypted_tx_gossip_tx: encrypted_tx_gossip_tx.clone(),
             });
             match rpc::start_rpc_server(
                 &self.config.rpc.listen,
@@ -681,6 +691,149 @@ impl PydeNode {
                                     .write()
                                     .await
                                     .insert(tx_hash, std::time::Instant::now());
+                            }
+                        }
+                        PostEventAction::QcFormedFromGossip { slot } => {
+                            // Audit item 227 step 4: QC just formed for
+                            // `slot` via an incoming gossip vote — the
+                            // original decrypt path at `select_and_vote`
+                            // only triggered when our OWN vote closed the
+                            // QC, which is rare in a 4+-node committee.
+                            // Mirror that logic here so the decrypt flow
+                            // starts regardless of which validator's vote
+                            // was the one.
+                            if !validator_identity
+                                .as_ref()
+                                .map(|id| id.key_share.is_some())
+                                .unwrap_or(false)
+                            {
+                                continue;
+                            }
+                            // Already started decryption for this slot? Skip.
+                            if pending_decryptors.read().await.contains_key(&slot) {
+                                continue;
+                            }
+                            let block = match block_store.get_block_raw(slot)
+                                .and_then(|b| wire::decode_block(&b).ok())
+                            {
+                                Some(b) => b,
+                                None => continue,
+                            };
+                            if block.body.encrypted_txs.is_empty() {
+                                continue;
+                            }
+                            let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> = block
+                                .body
+                                .encrypted_txs
+                                .iter()
+                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                .collect();
+                            let tx_root_ok = crate::block_processor::verify_decryptor_against_committed_root(
+                                &block.header.tx_root,
+                                &block.body.transactions,
+                                &enc_txs,
+                            );
+                            if !tx_root_ok {
+                                error!(slot, "decrypt-time tx_root mismatch");
+                                continue;
+                            }
+                            let engine = match validator_engine.as_mut() {
+                                Some(e) => e,
+                                None => continue,
+                            };
+                            let threshold = pyde_consensus::block::quorum_for_committee(
+                                engine.committee_keys.len(),
+                            );
+                            let identity = validator_identity.as_ref().unwrap();
+                            if let Ok(mut decryptor) =
+                                pyde_mempool::decryption::BlockDecryptor::new(
+                                    enc_txs.clone(),
+                                    threshold,
+                                )
+                            {
+                                if let Some(ks) = &identity.key_share {
+                                    decryptor.add_member_shares(ks);
+                                }
+                                // Replay any shares that arrived before
+                                // the decryptor existed.
+                                {
+                                    let mut q = queued_shares.write().await;
+                                    if let Some(queued) = q.remove(&slot) {
+                                        for qmsg in &queued {
+                                            for (i, sb) in qmsg.shares.iter().enumerate() {
+                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
+                                                    decryptor.add_share(i, s);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                pending_decryptors
+                                    .write()
+                                    .await
+                                    .insert(slot, decryptor);
+                            }
+                            // Broadcast our own decryption shares on the
+                            // consensus topic.
+                            if let Some(shares) =
+                                engine.generate_decryption_shares(identity, &enc_txs)
+                            {
+                                let msg = wire::DecryptionShareMsg {
+                                    slot,
+                                    member_index: identity.committee_index,
+                                    shares: shares.iter().map(|s| s.to_bytes()).collect(),
+                                };
+                                let share_bytes = wire::encode_decryption_shares(&msg);
+                                let topic = pyde_net::node::topics::consensus();
+                                let _ = swarm
+                                    .behaviour_mut()
+                                    .gossipsub
+                                    .publish(topic, share_bytes);
+                                info!(
+                                    slot,
+                                    enc_txs = enc_txs.len(),
+                                    "broadcast decryption shares (gossip-QC)"
+                                );
+                            }
+                        }
+                        PostEventAction::AcceptEncryptedTransaction(enc_tx) => {
+                            // Audit item 227 step 4 / option E: inbound
+                            // from the encrypted-transactions gossip topic.
+                            // Route through the same ingress policy as the
+                            // RPC path so mainnet still enforces registered
+                            // auth_keys while devnet keeps the structural-
+                            // only fall-through.
+                            let from = enc_tx.sender;
+                            let tx_hash = enc_tx.hash();
+                            let sender_pk_opt = {
+                                let state_r = state.read().await;
+                                let sender_key = pyde_state::keys::balance_key(&from);
+                                state_r
+                                    .get(&sender_key)
+                                    .and_then(|b| pyde_account::types::Account::from_bytes(&b))
+                                    .and_then(|acct| match acct.auth_keys {
+                                        pyde_account::types::AuthKeys::Single(pk) => Some(pk),
+                                        _ => None,
+                                    })
+                            };
+                            let chain_id = chain.read().await.chain_id;
+                            let mut relay = tx_relay.write().await;
+                            let accepted = match (sender_pk_opt, chain_id) {
+                                (Some(pk), _) => relay.receive_tx_verified(enc_tx, &pk),
+                                (None, 31337) => relay.receive_tx(enc_tx),
+                                (None, _) => {
+                                    debug!(
+                                        tx_hash = hex::encode(tx_hash),
+                                        "dropped encrypted gossip tx: sender has no registered auth_key"
+                                    );
+                                    false
+                                }
+                            };
+                            if accepted {
+                                debug!(
+                                    tx_hash = hex::encode(tx_hash),
+                                    "encrypted tx accepted from gossip"
+                                );
                             }
                         }
                         PostEventAction::AddPeerToKademlia(peer_id, addrs) => {
@@ -906,7 +1059,13 @@ impl PydeNode {
                                                 relay_w.remove_included(&enc_hashes);
                                             }
                                         }
-                                        info!(slot, txs = tc, gas, "compact block reconstructed and processed");
+                                        info!(
+                                            slot,
+                                            txs = tc,
+                                            encrypted = block.body.encrypted_txs.len(),
+                                            gas,
+                                            "compact block reconstructed and processed"
+                                        );
                                     }
                                     Err(e) => {
                                         debug!(slot, error = %e, "compact block rejected");
@@ -1485,16 +1644,21 @@ impl PydeNode {
                                             encrypted_txs: block.body.encrypted_txs.clone(),
                                         };
                                         let bundle_bytes = wire::encode_encrypted_tx_bundle(&bundle);
-                                        if let Err(e) = swarm
+                                        match swarm
                                             .behaviour_mut()
                                             .gossipsub
                                             .publish(topic, bundle_bytes)
                                         {
-                                            debug!(
+                                            Ok(_) => debug!(
+                                                slot = current_slot,
+                                                entries = block.body.encrypted_txs.len(),
+                                                "published encrypted-tx bundle"
+                                            ),
+                                            Err(e) => debug!(
                                                 slot = current_slot,
                                                 error = %e,
                                                 "no gossipsub subscribers for encrypted-tx bundle"
-                                            );
+                                            ),
                                         }
                                     }
 
@@ -1749,6 +1913,21 @@ impl PydeNode {
                         debug!(tx_hash = hex::encode(tx.hash()), "gossiped tx to network");
                     }
                 }
+                Some(enc_tx) = encrypted_tx_gossip_rx.recv() => {
+                    // Audit item 227 step 4 / option E: fan out the
+                    // encrypted tx to other validators. Without this,
+                    // only the RPC-receiving node has it and only its
+                    // own proposals can include it — under multi-proposer
+                    // VRF the tx would be permanently orphaned.
+                    let tx_hash = enc_tx.hash();
+                    let tx_bytes = enc_tx.to_bytes();
+                    let topic = pyde_net::node::topics::encrypted_transactions();
+                    if let Err(e) = swarm.behaviour_mut().gossipsub.publish(topic, tx_bytes) {
+                        debug!(error = %e, "failed to gossip encrypted tx");
+                    } else {
+                        debug!(tx_hash = hex::encode(tx_hash), "gossiped encrypted tx to network");
+                    }
+                }
                 _ = sync_interval.tick() => {
                     // Try to sync if we're behind
                     if chain_sync.is_syncing() {
@@ -1930,6 +2109,12 @@ enum PostEventAction {
     /// gossip and local detection arrive in the same tick).
     BroadcastConsensusMany(Vec<Vec<u8>>),
     AcceptTransaction(pyde_tx::types::Transaction),
+    /// Ingress from the encrypted-transactions gossip topic
+    /// (audit item 227 step 4 / option E). Main loop routes it
+    /// through `tx_relay.receive_tx_verified` or
+    /// `receive_tx` depending on whether the sender has a
+    /// registered `AuthKeys::Single` on-chain.
+    AcceptEncryptedTransaction(pyde_mempool::encrypted::EncryptedTx),
     #[allow(dead_code)]
     StoreReceipts(u64, Vec<pyde_tx::execution::Receipt>),
     AddPeerToKademlia(PeerId, Vec<libp2p::Multiaddr>),
@@ -1945,6 +2130,17 @@ enum PostEventAction {
     /// block can pull encrypted_txs out of it on arrival, regardless
     /// of gossipsub ordering. Audit item 207.
     BufferEncryptedBundle(pyde_net::propagation::EncryptedTxBundle),
+    /// A fresh QC just formed via an incoming gossip vote. Main loop
+    /// uses this to trigger the post-QC decryption flow — previously
+    /// that flow was only attached to `select_and_vote`'s local-QC
+    /// path, which in a 4+-node committee rarely fires (our vote is
+    /// typically not the 3rd/Nth that closes the QC; another
+    /// validator's is). Without this action the encrypted-tx
+    /// decryption never started on real multi-node networks.
+    /// Audit item 227 step 4 / option E.
+    QcFormedFromGossip {
+        slot: u64,
+    },
     /// Send a `PydeAuthReq` to a newly connected peer. The main loop
     /// generates a fresh nonce, records it in `pending_auth_nonces`, and
     /// dispatches via the swarm.
@@ -2016,6 +2212,24 @@ fn handle_swarm_event(
                         }
                         Err(e) => {
                             debug!(error = e, "failed to decode tx from gossip");
+                        }
+                    }
+                }
+                Some(Channel::EncryptedTransactions) => {
+                    debug!(bytes = message.data.len(), "received encrypted tx gossip");
+                    // Audit item 227 step 4 / option E: decode the
+                    // EncryptedTx wire frame and route it to the main
+                    // loop's action handler, which drops it into the
+                    // local tx_relay. The local tx_relay is what the
+                    // block builder pulls from when this node is the
+                    // winning proposer — without this path, only the
+                    // RPC-ingress node ever has the tx in its relay.
+                    match pyde_mempool::encrypted::EncryptedTx::from_bytes(&message.data) {
+                        Some(enc_tx) => {
+                            return PostEventAction::AcceptEncryptedTransaction(enc_tx);
+                        }
+                        None => {
+                            debug!("failed to decode encrypted tx from gossip");
                         }
                     }
                 }
@@ -2441,6 +2655,10 @@ fn handle_swarm_event(
                                         debug!(slot, voter_index, "received vote");
                                         if let Some(qc) = engine.on_vote(msg) {
                                             info!(slot, votes = qc.vote_count(), "QC formed");
+                                            // Audit item 227 step 4: notify main loop so
+                                            // the decrypt pipeline starts even when OUR
+                                            // own vote isn't the one that closes the QC.
+                                            return PostEventAction::QcFormedFromGossip { slot };
                                         }
                                     }
                                     ConsensusMessage::Timeout {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -17,7 +17,7 @@ use pyde_tx::validation::{validate_transaction, ValidationContext, ValidationErr
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::info;
+use tracing::{debug, info};
 
 /// Maximum number of pending txs any single sender can have in the
 /// mempool (MAINNET_PLAN M1). Blocks one-account spam from filling a
@@ -74,6 +74,13 @@ pub struct RpcState {
     pub dev_mode: bool,
     /// Channel to gossip submitted transactions to the P2P network.
     pub tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_tx::types::Transaction>,
+    /// Audit item 227 step 4 / option E: encrypted-tx gossip side
+    /// channel. After `send_raw_encrypted_transaction` accepts a tx
+    /// into the local tx_relay, push a clone here so the node's
+    /// main loop can publish it on the encrypted-transactions
+    /// gossipsub topic — otherwise only this node's proposals can
+    /// ever include it.
+    pub encrypted_tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_mempool::encrypted::EncryptedTx>,
 }
 
 /// Define the Pyde JSON-RPC API.
@@ -1224,6 +1231,10 @@ impl PydeApiServer for RpcServer {
 
         let from = enc_tx.sender;
         let tx_hash = enc_tx.hash();
+        // Clone for the gossip fan-out below. We gossip only after
+        // local acceptance so the ingress policy (auth_key lookup,
+        // sig verify) gates what the network sees.
+        let tx_for_gossip = enc_tx.clone();
 
         // Same ingest policy as the server-side path (audit item 206):
         // mainnet requires the sender to have a registered auth_key,
@@ -1270,6 +1281,23 @@ impl PydeApiServer for RpcServer {
             tx_hash = hex::encode(tx_hash),
             "raw encrypted tx accepted into mempool"
         );
+
+        // Audit item 227 step 4 / option E: fan out to validator
+        // peers so their tx_relays also have the tx — without this,
+        // only our own proposals can include it.
+        if self
+            .state
+            .encrypted_tx_gossip_tx
+            .send(tx_for_gossip)
+            .await
+            .is_err()
+        {
+            debug!(
+                tx_hash = hex::encode(tx_hash),
+                "encrypted-tx gossip channel closed — skipping fan-out"
+            );
+        }
+
         Ok(format!("0x{}", hex::encode(tx_hash)))
     }
 

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -764,6 +764,126 @@ impl TestNetwork {
         })
     }
 
+    /// Submit a client-built, client-signed encrypted transfer and
+    /// return the encrypted-tx hash (hex). Exercises the full
+    /// MEV-protected flow end-to-end (audit items 207 + 227):
+    ///
+    ///   1. Fetch the committee's threshold pubkey via
+    ///      `pyde_getThresholdPublicKey`.
+    ///   2. Build an `EncryptedTx` locally (threshold-encrypt the
+    ///      private fields, FALCON-sign the hash).
+    ///   3. Submit via `pyde_sendRawEncryptedTransaction`.
+    ///
+    /// The sender must have a registered on-chain `AuthKeys::Single`
+    /// — `try_decrypt_and_execute` drops encrypted txs from senders
+    /// without one. Validator accounts satisfy this at genesis, so
+    /// callers typically pass a `load_validator_key` keypair here.
+    pub fn submit_encrypted_transfer(
+        &self,
+        rpc_node_idx: usize,
+        sender_pk_bytes: &[u8],
+        sender_sk_bytes: &[u8],
+        recipient: &[u8; 32],
+        value: u128,
+    ) -> Result<String, String> {
+        // 1. Threshold pubkey from the node.
+        let tpk_resp = rpc_call(
+            &self.nodes[rpc_node_idx].rpc_url(),
+            "pyde_getThresholdPublicKey",
+            "[]",
+        )?;
+        let tpk_hex = parse_hex_result(&tpk_resp)?;
+        let tpk_bytes = hex::decode(tpk_hex.trim_start_matches("0x"))
+            .map_err(|e| format!("decode threshold pk hex: {}", e))?;
+        let tpk = pyde_crypto::threshold::ThresholdPublicKey::from_bytes(&tpk_bytes)
+            .ok_or_else(|| "invalid threshold pk bytes".to_string())?;
+
+        // 2. Sender FALCON secret key.
+        let sk = pyde_crypto::falcon::FalconSecretKey::from_bytes(sender_sk_bytes)
+            .ok_or_else(|| "invalid sender secret key".to_string())?;
+        let sender = pyde_account::address::derive_eoa_address(sender_pk_bytes);
+
+        // 3. Current nonce.
+        let nonce_params = format!(r#"["0x{}"]"#, hex::encode(sender));
+        let nonce_resp = rpc_call(
+            &self.nodes[rpc_node_idx].rpc_url(),
+            "pyde_getTransactionCount",
+            &nonce_params,
+        )?;
+        // getTransactionCount returns "0x{hex}".
+        let nonce_hex = parse_hex_result(&nonce_resp)?;
+        let nonce = u64::from_str_radix(nonce_hex.trim_start_matches("0x"), 16)
+            .map_err(|e| format!("parse nonce hex {:?}: {}", nonce_hex, e))?;
+
+        // 4. Build EncryptedTx with a placeholder signature, then
+        //    rewrite the signature field after hashing + signing.
+        //    Order matters: `EncryptedTx::hash()` covers the
+        //    ciphertext, so sign AFTER encryption.
+        // `mempool::pool::Mempool::check_core_validity` rejects txs
+        // with an empty access_list (`MissingAccessList`). Populate a
+        // minimal single-entry list for the recipient — parallel-exec
+        // scheduler needs SOMETHING here, and the exact content is
+        // plaintext on the wire so there's no MEV cost to including
+        // the recipient address.
+        let access_list = vec![pyde_tx::types::AccessEntry {
+            address: *recipient,
+            reads: Vec::new(),
+            writes: Vec::new(),
+        }];
+        let mut enc_tx = pyde_mempool::encrypted::encrypt_transaction(
+            sender,
+            nonce,
+            /* gas_limit */ 100_000,
+            access_list,
+            /* deadline */ None,
+            /* chain_id */ 31337,
+            /* signature */ Vec::new(),
+            recipient,
+            value,
+            /* calldata */ &[],
+            &tpk,
+        )
+        .map_err(|e| format!("threshold encryption failed: {}", e))?;
+        let tx_hash = enc_tx.hash();
+        let sig = pyde_crypto::falcon::falcon_sign(&sk, &tx_hash)
+            .map_err(|e| format!("FALCON sign failed: {}", e))?;
+        enc_tx.signature = sig.as_bytes().to_vec();
+
+        // Self-verify before wire-encoding so a failure here points
+        // at client-side sign logic rather than wire / server issues.
+        let self_pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(sender_pk_bytes)
+            .ok_or_else(|| "invalid sender public key".to_string())?;
+        let self_sig = pyde_crypto::falcon::FalconSignature::from_bytes(&enc_tx.signature)
+            .ok_or_else(|| "just-produced signature unparseable".to_string())?;
+        if !pyde_crypto::falcon::falcon_verify(&self_pk, &enc_tx.hash(), &self_sig) {
+            return Err("client-side self-verify of EncryptedTx signature failed".into());
+        }
+
+        // 5. Submit via the raw-encrypted RPC.
+        let wire = enc_tx.to_bytes();
+        // And round-trip verify — if to_bytes → from_bytes → hash
+        // doesn't match the hash we signed, the wire format drifted.
+        let roundtrip = pyde_mempool::encrypted::EncryptedTx::from_bytes(&wire)
+            .ok_or_else(|| "wire round-trip decode failed".to_string())?;
+        if roundtrip.hash() != tx_hash {
+            return Err(format!(
+                "wire round-trip hash drift: signed={} decoded={}",
+                hex::encode(tx_hash),
+                hex::encode(roundtrip.hash())
+            ));
+        }
+        if !pyde_crypto::falcon::falcon_verify(&self_pk, &roundtrip.hash(), &self_sig) {
+            return Err("post-roundtrip sig verify failed (server would see this too)".into());
+        }
+        let params = format!(r#"["0x{}"]"#, hex::encode(&wire));
+        let submit_resp = rpc_call(
+            &self.nodes[rpc_node_idx].rpc_url(),
+            "pyde_sendRawEncryptedTransaction",
+            &params,
+        )?;
+        parse_hex_result(&submit_resp).map(|s| s.to_string())
+    }
+
     /// Balance in quanta. Returns `0` if the account is unknown.
     pub fn get_balance(&self, node_idx: usize, address: &[u8; 32]) -> Result<u128, String> {
         let params = format!(r#"["0x{}"]"#, hex::encode(address));

--- a/crates/node/tests/multi_node_encrypted_lifecycle.rs
+++ b/crates/node/tests/multi_node_encrypted_lifecycle.rs
@@ -1,0 +1,171 @@
+//! End-to-end lifecycle test for the MEV-protected encrypted-tx flow
+//! (audit items 207 + 227 step 4/4 — also unblocks 074b).
+//!
+//! Exercises the full client-side flow against a 4-node testnet:
+//!
+//!   1. Client fetches the committee threshold pubkey via
+//!      `pyde_getThresholdPublicKey` (item 227 step 1/4).
+//!   2. Client encrypts `(to, value, calldata)` locally and signs
+//!      `EncryptedTx::hash()` with the sender's FALCON key
+//!      (item 227 step 3/4).
+//!   3. Client submits via `pyde_sendRawEncryptedTransaction`
+//!      (item 227 step 2/4).
+//!   4. Proposer includes the encrypted tx, publishes a compact
+//!      block + an `EncryptedTxBundle` on the Blocks channel
+//!      (item 207 steps 1+2/3).
+//!   5. Non-proposer validators pull the encrypted_txs out of the
+//!      bundle, reconstruct the full block, run the
+//!      decryption-share protocol, execute the decrypted tx, and
+//!      credit the recipient.
+//!
+//! Assertion: the recipient's on-chain balance increases by exactly
+//! `transfer_value` on every node. If the encrypted-tx flow is
+//! wired correctly, the balance change is identical across all
+//! nodes (because every validator decrypted + executed the same
+//! tx). If any piece of the chain is broken (bundle not
+//! propagating, shares orphaned, decryption failing, sig rejected),
+//! the balance doesn't change and the test fails loudly.
+//!
+//! Uses a validator account as the sender because
+//! `try_decrypt_and_execute` drops encrypted txs from senders
+//! without `AuthKeys::Single` on-chain (see `block_processor.rs`
+//! ~L801); validators satisfy this at genesis.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::Duration;
+
+/// Multi-node encrypted-tx lifecycle. Marked `#[ignore]` because
+/// it spawns real subprocesses — run with `cargo test --ignored`.
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn encrypted_tx_decrypts_and_credits_recipient_on_all_nodes() {
+    let net = TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4-node testnet: {}", e));
+
+    // Let bootstrap + gossip mesh converge. Submitting before the
+    // encrypted-share path is fully warm tends to drop shares.
+    net.wait_for_slot(5, Duration::from_secs(45))
+        .unwrap_or_else(|e| panic!("initial warm-up: {}", e));
+
+    // Sender: validator 0's FALCON keypair. Has AuthKeys::Single
+    // registered at genesis + has balance. Clean for encrypted-tx
+    // since try_decrypt_and_execute requires a registered key.
+    let (sender_pk, sender_sk) = net
+        .load_validator_key(0)
+        .unwrap_or_else(|e| panic!("load validator 0 key: {}", e));
+
+    // Recipient: a test account (not a validator — keeps balance
+    // math clean, no fee-credit accumulation to worry about).
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("read funded: {}", e));
+    assert!(
+        funded.len() > 4,
+        "expected >4 funded addresses (4 validators + >=1 test acct), got {}",
+        funded.len()
+    );
+    let recipient = funded[4];
+
+    let transfer_value: u128 = 1_000_000_000; // 1 PYDE
+
+    // Snapshot recipient balance pre-tx on every node.
+    let pre_balances: Vec<u128> = net
+        .nodes
+        .iter()
+        .map(|n| {
+            net.get_balance(n.index, &recipient)
+                .unwrap_or_else(|e| panic!("get_balance pre node-{}: {}", n.index, e))
+        })
+        .collect();
+    let first_pre = pre_balances[0];
+    for (i, b) in pre_balances.iter().enumerate().skip(1) {
+        assert_eq!(
+            *b, first_pre,
+            "pre-balance divergence: node-0 = {}, node-{} = {}",
+            first_pre, i, b
+        );
+    }
+
+    // Submit encrypted tx via node-0.
+    let tx_hash = net
+        .submit_encrypted_transfer(
+            /* rpc_node_idx */ 0,
+            &sender_pk,
+            &sender_sk,
+            &recipient,
+            transfer_value,
+        )
+        .unwrap_or_else(|e| panic!("submit_encrypted_transfer: {}", e));
+    eprintln!("submitted encrypted tx hash = {}", tx_hash);
+
+    // Wait for the full flow to complete:
+    //   * block inclusion (~1 slot = 400ms after submission window)
+    //   * compact block + bundle gossip to all non-proposer nodes
+    //   * QC formation (2f+1 votes)
+    //   * decryption-share exchange
+    //   * threshold decryption + execution
+    //   * state root commit + propagation
+    // 60s is generous; a healthy flow typically commits in <10s.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let mut last_balances: Vec<u128> = pre_balances.clone();
+    let mut committed_on_all = false;
+    while std::time::Instant::now() < deadline {
+        let current: Vec<u128> = net
+            .nodes
+            .iter()
+            .map(|n| net.get_balance(n.index, &recipient).unwrap_or(0))
+            .collect();
+        last_balances = current.clone();
+
+        let all_updated = current
+            .iter()
+            .enumerate()
+            .all(|(i, b)| *b == pre_balances[i] + transfer_value);
+        if all_updated {
+            committed_on_all = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    if !committed_on_all {
+        // Dump per-node tail output to help diagnose.
+        let dumps = net
+            .nodes
+            .iter()
+            .map(|n| {
+                format!(
+                    "\n=== node-{} (rpc port {}) ===\n{}",
+                    n.index,
+                    n.rpc_port,
+                    n.output_snapshot()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        panic!(
+            "encrypted tx did not commit on all nodes within 60s\n\
+             pre_balances:  {:?}\n\
+             last_balances: {:?}\n\
+             expected per-node increase: {}\n{}",
+            pre_balances, last_balances, transfer_value, dumps
+        );
+    }
+
+    // State root convergence: every validator executed the same
+    // decrypted tx, so roots must match.
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let root = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            root, reference_root,
+            "state_root divergence after encrypted tx:\n  node-0:  {}\n  node-{}: {}",
+            reference_root, n.index, root
+        );
+    }
+}

--- a/crates/pyde-crypto-wasm/src/lib.rs
+++ b/crates/pyde-crypto-wasm/src/lib.rs
@@ -341,7 +341,10 @@ pub fn build_raw_encrypted_tx_wasm(params_json: &str, sk_hex: &str) -> Result<St
 
     let sender = parse_addr(v.get("sender"))?;
     let nonce = v.get("nonce").and_then(|x| x.as_u64()).unwrap_or(0);
-    let gas_limit = v.get("gasLimit").and_then(|x| x.as_u64()).unwrap_or(100_000);
+    let gas_limit = v
+        .get("gasLimit")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(100_000);
     let chain_id = v.get("chainId").and_then(|x| x.as_u64()).unwrap_or(31337);
     let deadline = v.get("deadline").and_then(|x| x.as_u64());
     let to = parse_addr(v.get("to"))?;


### PR DESCRIPTION
## Summary

Closes audit item 227 step 4/4 and unblocks 074b.

A new multi-node integration test (`multi_node_encrypted_lifecycle.rs`)
spawns 4 validators, submits a client-built + client-signed
`EncryptedTx` via `pyde_sendRawEncryptedTransaction`, waits for
the full MEV-protected pipeline, and asserts the recipient's
balance updates on every node. Passes in ~6 seconds.

## What the test exercises end-to-end

1. Client fetches committee threshold pubkey via
   `pyde_getThresholdPublicKey` (step 1/4, #251).
2. Client threshold-encrypts + FALCON-signs locally via the
   pyde-rust-sdk `build_raw_encrypted_tx` helper (step 3/4,
   #253 + #254).
3. Client submits via `pyde_sendRawEncryptedTransaction`
   (step 2/4, #252).
4. RPC-ingress node **gossips the encrypted tx** to every
   validator on a new `pyde/encrypted_tx/1` topic (option E,
   new in this PR).
5. Winning proposer selects from its mempool, includes in
   block, publishes compact block + `EncryptedTxBundle`
   (item 207, #249 + #250).
6. QC forms — via incoming gossip votes, which now **triggers
   the decrypt pipeline** (bug fix in this PR).
7. Threshold decryption fires, tx executes, balance updates
   on all 4 nodes, state roots converge.

## Two fixes in this PR

**Encrypted-tx gossip (option E).** New `Channel::
EncryptedTransactions` + `topics::encrypted_transactions()`.
RPC ingress pushes accepted txs onto a side channel; main loop
forwards to gossipsub. Receivers decode and insert into
`tx_relay` via the same policy as the RPC path. Without this,
only the ingress node had the tx — under multi-proposer VRF
it was permanently orphaned because non-RPC proposers never
saw it.

**Gossip-QC decrypt trigger.** The existing post-QC decrypt
flow only fired when our OWN vote closed the QC. In an N≥4
committee the closing vote typically arrives via gossip from
another validator, so the pipeline never started on real
networks. Added `PostEventAction::QcFormedFromGossip { slot }`
returned by the gossip-vote handler; main loop runs the
decrypt-init + share-broadcast logic. Idempotent via
`pending_decryptors` presence check.

## Also landed (first commit on branch)

**Test infrastructure + mempool-cleanup correctness fix.**
`common::submit_encrypted_transfer` helper + the
`multi_node_encrypted_lifecycle.rs` test file. Plus a
correctness fix surfaced while debugging: encrypted txs are
no longer removed from `tx_relay` on self-propose (VRF-losing
self-proposals previously orphaned their own encrypted txs
before the winning block could commit them). Removal now
happens only in the winning-block commit path, matching the
P7a-2 plaintext pattern.

## Drive-bys

- `pyde-crypto-wasm` fmt tweak (long-line break on
  `gas_limit` parse).