### PR TITLE
fix: persist-before-memory for finality checkpoint (item 207a)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -255,20 +255,19 @@
 
 > Parallelisable with 207 once P0 trivials are in.
 
-- [ ] 207a — `✓` **Hard-finality persistence ordering.**
-      Promoted from 201. `crates/node/src/validator.rs:1560-1566,
-      1628-1630, 758-762` — three call sites update
-      `self.finality.latest_checkpoint` in-memory via
-      `record_hard_finality` / direct assignment / synthetic-anchor
-      assignment, then call `persist_finality_checkpoint` which
-      reads the value back out of `self.finality`. Crash in the
-      window reverts the WS anchor on restart (self-heals via
-      peer gossip, but a non-self-healing window exists).
-      Fix: new `persist_finality_checkpoint_direct(&cp)` that
-      takes the checkpoint explicitly; call it BEFORE the
-      in-memory mutation at each of the three sites; keep the
-      current `persist_finality_checkpoint()` as a no-longer-used
-      thin wrapper (or remove) so no new site can regress.
+- [x] 207a — `✓` **Hard-finality persistence ordering.**
+      Shipped: new `persist_finality_checkpoint_direct(&cp)` takes
+      the checkpoint explicitly and writes it to disk before
+      returning. All three call sites — `install_bootstrap_ws_
+      anchor`, `on_finality_vote` (hard-finality cert path), and
+      `ingest_finality_checkpoint` (gossip path) — now construct
+      the checkpoint, fsync it via `_direct`, and ONLY then mutate
+      `self.finality`. Persist panics on I/O failure, which aborts
+      before the memory mutation, so the invariant "on-disk ≥
+      in-memory" holds across every crash window. Kept the old
+      `persist_finality_checkpoint()` as a thin `dead_code`
+      wrapper for tests + devnet bootstrap. 65 validator tests +
+      multi-node encrypted e2e still pass.
 
 - [ ] 208 — `⚠` **Committee rotation: clear old committee keys.**
       `crates/node/src/validator.rs:828-841` — `set_committee`

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -743,7 +743,11 @@ impl ValidatorEngine {
     /// it via config.
     pub fn install_bootstrap_ws_anchor(&mut self, slot: u64) {
         use pyde_consensus::finality::{FinalityCheckpoint, HardFinalityCert};
-        self.finality.latest_checkpoint = Some(FinalityCheckpoint {
+        // Audit item 207a: persist BEFORE mutating in-memory state.
+        // If the store is attached and the write fails, persist
+        // panics — and we never touch `self.finality`, keeping the
+        // invariant that in-memory >= on-disk.
+        let cp = FinalityCheckpoint {
             slot,
             block_hash: [0u8; 32],
             state_root: [0u8; 32],
@@ -754,26 +758,50 @@ impl ValidatorEngine {
                 voter_bitmap: 0,
                 signatures: Vec::new(),
             },
-        });
+        };
+        self.persist_finality_checkpoint_direct(&cp);
+        self.finality.latest_checkpoint = Some(cp);
         if self.finality.highest_hard_slot < slot {
             self.finality.highest_hard_slot = slot;
         }
-        self.persist_finality_checkpoint();
     }
 
-    /// Persist the latest WS checkpoint to disk when a store is attached.
-    /// No-op when no store (devnet/tests) or no checkpoint yet. Panic-on-
-    /// fail because losing the WS anchor silently would re-open the
-    /// long-range-attack window after restart.
-    fn persist_finality_checkpoint(&self) {
-        let (Some(store), Some(cp)) = (
-            self.consensus_store.as_ref(),
-            self.finality.latest_checkpoint.as_ref(),
-        ) else {
+    /// Persist an explicit checkpoint to disk. Used by the three
+    /// call sites that advance the WS anchor (bootstrap install,
+    /// hard-finality vote, gossip ingest). Audit item 207a: the
+    /// previous `persist_finality_checkpoint()` read from
+    /// `self.finality.latest_checkpoint`, which forced callers to
+    /// mutate in-memory state BEFORE disk — opening a crash window
+    /// where memory said "slot N is finalized" but disk still said
+    /// "slot N-1". On restart the WS anchor would revert to N-1,
+    /// re-admitting long-range reorgs of N. Callers now pass the
+    /// cert they're about to install and invoke this FIRST, only
+    /// flipping in-memory state if the persist succeeds (panic on
+    /// failure aborts before the memory mutation).
+    fn persist_finality_checkpoint_direct(
+        &self,
+        cp: &pyde_consensus::finality::FinalityCheckpoint,
+    ) {
+        let Some(store) = self.consensus_store.as_ref() else {
             return;
         };
         if let Err(e) = store.save_finality_checkpoint(cp) {
             panic!("CRITICAL: finality checkpoint persistence failed — {}", e);
+        }
+    }
+
+    /// Persist whatever checkpoint is currently on `self.finality`.
+    /// Kept as a convenience wrapper for non-ordering-sensitive
+    /// callers (tests, and the `install_bootstrap_ws_anchor` dev-mode
+    /// path which is a bootstrap-only helper). New code on the hot
+    /// consensus path should use
+    /// `persist_finality_checkpoint_direct` and pass the cert
+    /// explicitly so the persist-before-memory invariant is visible
+    /// at the call site.
+    #[allow(dead_code)]
+    fn persist_finality_checkpoint(&self) {
+        if let Some(cp) = self.finality.latest_checkpoint.as_ref() {
+            self.persist_finality_checkpoint_direct(cp);
         }
     }
 
@@ -1592,12 +1620,21 @@ impl ValidatorEngine {
                 try_form_hard_finality(slot, block_hash, state_root, entry, &self.committee_keys)
             {
                 info!(slot, "hard finality achieved");
+                // Audit item 207a: persist BEFORE in-memory mutation.
+                // Construct the checkpoint explicitly here so we can
+                // fsync it first; if the write fails, panic aborts
+                // the process before `record_hard_finality` moves
+                // `self.finality` to a state that disk won't confirm
+                // on restart. Reverted-on-restart state was the
+                // long-range-attack re-opening the audit flagged.
+                let cp = pyde_consensus::finality::FinalityCheckpoint {
+                    slot: cert.slot,
+                    block_hash: cert.block_hash,
+                    state_root: cert.state_root,
+                    cert: cert.clone(),
+                };
+                self.persist_finality_checkpoint_direct(&cp);
                 self.finality.record_hard_finality(cert);
-                // Slice 4.3: persist the new WS checkpoint so it survives
-                // a crash. Panic-on-fail mirrors consensus_state persistence:
-                // losing the anchor silently could let a long-range chain
-                // through after restart.
-                self.persist_finality_checkpoint();
                 return true;
             }
         }
@@ -1660,8 +1697,12 @@ impl ValidatorEngine {
             }
         }
 
+        // Audit item 207a: persist BEFORE mutating in-memory state
+        // so a crash in the window can't leave in-memory ahead of
+        // disk. If the write fails, panic aborts before `latest_
+        // checkpoint` takes the new value.
+        self.persist_finality_checkpoint_direct(&cp);
         self.finality.latest_checkpoint = Some(cp);
-        self.persist_finality_checkpoint();
         true
     }
 


### PR DESCRIPTION
## Summary

Closes audit item 207a (promoted from 201). The previous
`persist_finality_checkpoint()` read the checkpoint back out of
`self.finality`, which forced callers to mutate in-memory state
BEFORE disk. A crash between those two steps reverted the WS
anchor to its on-disk (older) value on restart — re-opening
the long-range-attack window on a block the network considered
hard-finalized.

## The fix

New `persist_finality_checkpoint_direct(&cp)` takes the
checkpoint explicitly. All three hot-path sites now:

1. Construct the checkpoint locally.
2. Call the direct persist (fsync via `ConsensusStateStore`,
   panic on I/O failure — aborts before memory mutation).
3. Only then update `self.finality`.

Sites updated:
- `install_bootstrap_ws_anchor` (devnet / bootstrap).
- `on_finality_vote` (hard-finality cert formation).
- `ingest_finality_checkpoint` (gossip ingest).

Kept the old `persist_finality_checkpoint()` as a thin
`dead_code` wrapper so tests that construct checkpoints via
`self.finality` first can still persist them; new production
code on the consensus hot path should use `_direct` so the
persist-before-memory invariant is visible at the call site.

## Verification

- 65 `validator::tests::*` unit tests pass.
- `multi_node_encrypted_lifecycle` e2e (~6 s on 4-node
  testnet) still passes — confirms the refactor doesn't
  break the committed-block → decrypt → execute pipeline
  landed in #255.

Audit tracker updated: item 207a → `[x]`.