### PR TITLE
feat: per-peer rate limit on decryption shares (audit item 214)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -334,10 +334,19 @@
       selection grinding attack the agent flagged is not
       reachable.
 
-- [ ] 214 — `⚠` **Per-peer rate limit on decryption shares.**
-      `crates/node/src/node.rs` consensus handler — frame-size
-      cap bounds per-message burst but no per-peer token bucket.
-      Add same `RateLimiter` pattern used for evidence (task 014d).
+- [x] 214 — `✓` **Per-peer rate limit on decryption shares.**
+      Shipped: `crates/node/src/node.rs` decryption-share gossip
+      branch now checks `peer_manager.get_peer(propagation_source)
+      .invalid_messages` against `DECRYPT_SHARE_SPAM_THRESHOLD = 5`
+      before decode, mirroring the slash-evidence pattern from
+      task 014d. Malformed shares bump `invalid_messages` via
+      `saturating_add(1)` in the decode-Err arm, so repeat
+      offenders cross the threshold and get dropped without CPU
+      cost on the next message. Honest committee shares decode
+      cleanly and never bump the counter. Also dropped dead
+      `process_full_block_with_aot` test wrapper (zero callers
+      after 210's `#[cfg(test)]` gate). Multi-node encrypted e2e
+      (`multi_node_encrypted_lifecycle` --ignored) still passes.
 
 - [ ] 215 — `⚠` **PVM `MEMCPY` + calldata u32 wrap.**
       `crates/pvm/src/vm.rs:1265-1288` (MEMCPY no src/dst overlap
@@ -444,3 +453,4 @@ Fold into the relevant fix PRs above when possible:
 | 205 | 2026-04-23  | Read `validator.rs:1443-1466` | Confirmed: `else` persists, `if` only logs; routed through `ingest_evidence` |
 | 206 | 2026-04-23  | Read `rpc.rs:1117-1148` + `pool.rs:370-384` | Confirmed fall-through on no-auth_key; closed for non-devnet chain_id |
 | 207 | 2026-04-23  | Agent-traced against wire.rs compact-block encoding | Accepted; design decision needed |
+| 214 | 2026-04-23  | Read decrypt-share branch + verified `PeerInfo::invalid_messages` reuse from 014d | Fixed with spam-threshold drop + decode-Err bump |

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -32,18 +32,6 @@ impl BlockProcessor {
         Self::process_full_block_with_aot_and_checkpoint(chain, state, block, None, None)
     }
 
-    /// Test-only wrapper with AOT cache but no WS checkpoint. Same
-    /// `#[cfg(test)]` rationale as `process_full_block` — audit 210.
-    #[cfg(test)]
-    pub fn process_full_block_with_aot(
-        chain: &mut ChainState,
-        state: &mut StateManager,
-        block: &Block,
-        aot_cache: Option<&std::sync::Arc<crate::aot_cache::AotCache>>,
-    ) -> Result<(u64, u64, Vec<Receipt>), String> {
-        Self::process_full_block_with_aot_and_checkpoint(chain, state, block, aot_cache, None)
-    }
-
     /// Full-block processing with an explicit weak-subjectivity checkpoint
     /// slot (Phase 4 slice 4.3). Callers that have a live `FinalityTracker`
     /// should pass `tracker.latest_checkpoint.as_ref().map(|c| c.slot)` —

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2601,6 +2601,28 @@ fn handle_swarm_event(
                         if !message.data.is_empty()
                             && message.data[0] == wire::tag::DECRYPTION_SHARES
                         {
+                            // Audit item 214: rate-limit decryption share ingest
+                            // by peer-invalid-message score, same pattern as
+                            // evidence (014d). Every share costs a decode +
+                            // several DecryptionShare::from_bytes parses; a
+                            // peer that has already crossed the invalid-
+                            // message threshold on prior gossip gets dropped
+                            // here without further CPU cost. Honest committee
+                            // members stay well under the threshold because
+                            // their shares decode cleanly and bump nothing.
+                            const DECRYPT_SHARE_SPAM_THRESHOLD: u64 = 5;
+                            let propagator_invalid = peer_manager
+                                .get_peer(&propagation_source)
+                                .map(|p| p.invalid_messages)
+                                .unwrap_or(0);
+                            if propagator_invalid >= DECRYPT_SHARE_SPAM_THRESHOLD {
+                                debug!(
+                                    forwarder = %propagation_source,
+                                    invalid = propagator_invalid,
+                                    "dropping decryption shares from peer over spam threshold"
+                                );
+                                return PostEventAction::None;
+                            }
                             match wire::decode_decryption_shares(&message.data) {
                                 Ok(msg) => {
                                     debug!(
@@ -2613,6 +2635,15 @@ fn handle_swarm_event(
                                     return PostEventAction::AddDecryptionShares(msg);
                                 }
                                 Err(e) => {
+                                    // Bump peer invalid counter — repeat
+                                    // offenders cross the threshold and
+                                    // get dropped without decode next time.
+                                    if let Some(info) =
+                                        peer_manager.get_peer_mut(&propagation_source)
+                                    {
+                                        info.invalid_messages =
+                                            info.invalid_messages.saturating_add(1);
+                                    }
                                     debug!(error = e, "failed to decode decryption shares");
                                 }
                             }


### PR DESCRIPTION
## Summary
- Drop decryption-share gossip from peers already over the
  invalid-message threshold, before decode (mirrors task 014d
  slash-evidence pattern).
- Bump invalid_messages on decode failure so repeat offenders
  cross the threshold and get dropped without CPU cost next time.
- Remove dead `process_full_block_with_aot` test wrapper (zero
  callers after task 210's `#[cfg(test)]` gate).

## Impact
Honest committee shares decode cleanly and never bump the
counter, so the rate limit only kicks in for misbehaving peers.
Multi-node encrypted lifecycle e2e (`multi_node_encrypted_lifecycle`
--ignored) still passes.