### PR TITLE
fix: MEMCPY len truncation + AOT gas-parity bugs (audit item 215)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -348,11 +348,59 @@
       after 210's `#[cfg(test)]` gate). Multi-node encrypted e2e
       (`multi_node_encrypted_lifecycle` --ignored) still passes.
 
-- [ ] 215 — `⚠` **PVM `MEMCPY` + calldata u32 wrap.**
-      `crates/pvm/src/vm.rs:1265-1288` (MEMCPY no src/dst overlap
-      check) + `:364-388` (calldata `aligned_len = (len + 7) & !7`
-      can wrap `u32`). Potential heap/stack collision under
-      adversarial input. Pair with task 054 cargo-fuzz soak.
+- [x] 215 — `✓` **PVM MEMCPY + calldata u32 wrap.** Original audit
+      framing was wrong on the surface concerns — `MEMCPY` uses an
+      owned `Vec<u8>` intermediate (`checked_read_slice`) so guest
+      src/dst overlap is memmove-safe, not a memory-safety issue.
+      But investigation surfaced **three real consensus-critical
+      bugs** in the same opcode, fixed in this PR:
+      
+      1. **Interpreter MEMCPY len truncation** — `len: usize` from
+         `read_gp` flows into `checked_read_slice` → `check_access`,
+         which casts `len as u32` and silently wraps for any
+         `len > u32::MAX`. A guest passing `u64::MAX` would slip
+         past bounds checking and trigger `vec![0u8; huge_len]`
+         host-RAM DoS. Fixed by gating `len > MEMORY_SIZE → trap`
+         before the cast. Also switched gas-charge `+=` to
+         `checked_add` so a crafted len that wraps `gas_used_total`
+         past `gas_limit` cannot bypass OOG.
+      2. **AOT host_memcpy missing per-byte dynamic gas** —
+         interpreter charges `(len/8)*3` in its handler; AOT bypassed
+         it entirely (only static base gas of 5 was charged via the
+         block prologue). Same contract burned 384 vs 0 dynamic gas
+         on AOT vs interpreter validators ⇒ consensus fork on every
+         memcpy. Fixed by emitting the dynamic-gas charge in the
+         Cranelift codegen before the host call (AOT tracks gas in
+         a Cranelift SSA variable, not in `vm.gas_used_total`, so
+         charging it in `host_memcpy` would have been a no-op).
+      3. **AOT host_memcpy missing per-page allocation gas** —
+         interpreter drains `vm.memory.page_gas_used` (200 per
+         fresh page) into `gas_used_total` after every step at
+         `vm.rs:1388`. AOT bypasses that loop. `host_memcpy` now
+         packs the drained `page_gas_used` into the high 32 bits
+         of its return value; codegen folds it into `VAR_GAS_USED`
+         after the call. Plus: AOT codegen previously discarded
+         the host_memcpy fault return entirely — silently continued
+         on memory fault. Now routes through `trap_block`.
+      
+      `crates/pvm/src/vm.rs` `map_calldata` got the same defensive
+      gate (`len > MEMORY_SIZE - HEAP_START → trap`) — calldata is
+      bounded in practice by tx/block size so this is defense-in-
+      depth, not a known reachable bug.
+      
+      Tests: 4 PVM tests
+      (`memcpy_len_over_memory_size_traps_memory_fault`,
+      `memcpy_len_at_memory_size_boundary_is_accepted`,
+      `memcpy_gas_overflow_cannot_bypass_oog`,
+      `map_calldata_oversize_traps_memory_fault`) +
+      2 AOT tests
+      (`memcpy_aot_charges_dynamic_gas_parity_with_interp` —
+      asserts exact AOT/interp gas equality on a 1024-byte copy;
+      `memcpy_aot_huge_len_traps`).
+      
+      **Surfaced for follow-up: item 228 below** — the broader AOT
+      page-gas parity gap (Load/Store/wide-load/wide-store all
+      bypass the page-allocation gas the interpreter charges).
 
 - [ ] 216 — `⚠` **Poseidon2 spec-match test.**
       `crates/crypto/src/poseidon2.rs` — tests assert capacity but
@@ -410,6 +458,31 @@
       `crates/node/src/faucet.rs` is the RPC half only; no
       frontend / public API exposure.
 
+- [ ] 228 — `✓` **AOT page-gas parity across all memory ops.**
+      Surfaced while fixing 215. The interpreter drains
+      `vm.memory.page_gas_used` into `gas_used_total` at the end of
+      every step (`pvm/src/vm.rs:1388`), charging `PAGE_ALLOC_GAS`
+      (200) per fresh page touched. The AOT bypasses the step
+      loop entirely — every Load/Store/wide-load/wide-store and
+      any other memory-touching host call accumulates
+      `page_gas_used` in `vm.memory` but never folds it into the
+      AOT's SSA `VAR_GAS_USED` counter. Same contract touching
+      fresh memory pages burns different gas on AOT vs interpreter
+      validators → consensus fork on any contract with non-trivial
+      memory access. Item 215 fixed this for `MEMCPY` specifically
+      (host_memcpy now packs drained page_gas into the high 32
+      bits of its return value, codegen folds into VAR_GAS_USED).
+      Need to apply the same pattern to every other AOT memory
+      op. Scope: audit the full list of AOT-emitted memory ops,
+      either add the same pack/unpack to each host call or
+      insert a `host_drain_page_gas` drain call at the end of
+      each basic block. Consensus-critical; mainnet blocker once
+      AOT is enabled in production block-processing (currently
+      wired via `process_full_block_with_aot_and_checkpoint`).
+      Gate with an AOT-vs-interp gas-parity test harness that
+      runs every opcode through both paths and asserts gas
+      equality.
+
 - [ ] 226 — `⚠` **Plaintext RPC path: `AuthKeys::None` sig-skip
       analog.** Surfaced while closing 206.
       `crates/tx/src/validation.rs:140-149` — `validate_signature`
@@ -454,3 +527,4 @@ Fold into the relevant fix PRs above when possible:
 | 206 | 2026-04-23  | Read `rpc.rs:1117-1148` + `pool.rs:370-384` | Confirmed fall-through on no-auth_key; closed for non-devnet chain_id |
 | 207 | 2026-04-23  | Agent-traced against wire.rs compact-block encoding | Accepted; design decision needed |
 | 214 | 2026-04-23  | Read decrypt-share branch + verified `PeerInfo::invalid_messages` reuse from 014d | Fixed with spam-threshold drop + decode-Err bump |
+| 215 | 2026-04-24  | Traced interp `Memcpy` + `host_memcpy` + AOT codegen + `page_gas_used` drain; added gas-parity test that exposed 2 divergences (per-byte + per-page) | Fixed all three in one PR; surfaced 228 as follow-up |

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -999,13 +999,93 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         builder.switch_to_block(cont);
                     }
                     Opcode::Memcpy => {
-                        // Memcpy handled by VM runtime call (AOT fallback)
+                        // Memcpy handled by VM runtime call (AOT fallback).
+                        //
+                        // Audit item 215 — fixes three consensus
+                        // divergences between AOT and interpreter:
+                        //
+                        //   1. Per-byte dynamic gas (3 per 8 bytes) was
+                        //      charged by the interpreter but not by
+                        //      AOT. AOT tracks gas in `VAR_GAS_USED`,
+                        //      not in `vm.gas_used_total`, so the
+                        //      charge is emitted here in the JIT.
+                        //
+                        //   2. Per-page allocation gas (PAGE_ALLOC_GAS
+                        //      per fresh page) was charged by the
+                        //      interpreter via the post-step drain at
+                        //      `pvm/src/vm.rs:1388`. AOT bypasses that
+                        //      loop. `host_memcpy` now returns the
+                        //      drained `page_gas_used` packed into the
+                        //      high 32 bits of its result; codegen
+                        //      folds it into VAR_GAS_USED here.
+                        //
+                        //   3. The previous emission discarded the
+                        //      fault return, so AOT silently continued
+                        //      on memory fault / oversized len. Now
+                        //      routes through `trap_block`.
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let dst = gp_read!(builder, d.rd);
                         let src = gp_read!(builder, d.rs1);
                         let len_reg = (d.rs2_or_imm & 0xF) as u8;
                         let len = gp_read!(builder, len_reg);
-                        builder.ins().call(fn_memcpy_ref, &[vm_ctx, dst, src, len]);
+
+                        // Per-byte dynamic_gas = ((len + 7) >> 3) * 3
+                        let seven = builder.ins().iconst(I64, 7);
+                        let len_plus_seven = builder.ins().iadd(len, seven);
+                        let chunks = builder.ins().ushr_imm(len_plus_seven, 3);
+                        let three = builder.ins().iconst(I64, 3);
+                        let dynamic_gas = builder.ins().imul(chunks, three);
+
+                        let gas_used = builder.use_var(Variable::from_u32(VAR_GAS_USED));
+                        let new_gas = builder.ins().iadd(gas_used, dynamic_gas);
+                        builder.def_var(Variable::from_u32(VAR_GAS_USED), new_gas);
+
+                        // OOG check after dynamic charge.
+                        let gas_limit = builder.use_var(Variable::from_u32(VAR_GAS_LIMIT));
+                        let limit_nonzero = builder.ins().icmp_imm(IntCC::NotEqual, gas_limit, 0);
+                        let over =
+                            builder
+                                .ins()
+                                .icmp(IntCC::UnsignedGreaterThan, new_gas, gas_limit);
+                        let oog = builder.ins().band(limit_nonzero, over);
+                        let after_oog = builder.create_block();
+                        builder.ins().brif(oog, oog_block, &[], after_oog, &[]);
+                        builder.seal_block(after_oog);
+                        builder.switch_to_block(after_oog);
+
+                        // Call host_memcpy. Returns:
+                        //   low  32 bits: 0=success, 1=fault
+                        //   high 32 bits: page_gas to charge
+                        let call = builder.ins().call(fn_memcpy_ref, &[vm_ctx, dst, src, len]);
+                        let raw = builder.inst_results(call)[0];
+
+                        // Add page_gas (high 32) to gas counter.
+                        let page_gas = builder.ins().ushr_imm(raw, 32);
+                        let gas_used = builder.use_var(Variable::from_u32(VAR_GAS_USED));
+                        let new_gas = builder.ins().iadd(gas_used, page_gas);
+                        builder.def_var(Variable::from_u32(VAR_GAS_USED), new_gas);
+
+                        // OOG check after page-gas charge.
+                        let gas_limit = builder.use_var(Variable::from_u32(VAR_GAS_LIMIT));
+                        let limit_nonzero = builder.ins().icmp_imm(IntCC::NotEqual, gas_limit, 0);
+                        let over =
+                            builder
+                                .ins()
+                                .icmp(IntCC::UnsignedGreaterThan, new_gas, gas_limit);
+                        let oog2 = builder.ins().band(limit_nonzero, over);
+                        let after_oog2 = builder.create_block();
+                        builder.ins().brif(oog2, oog_block, &[], after_oog2, &[]);
+                        builder.seal_block(after_oog2);
+                        builder.switch_to_block(after_oog2);
+
+                        // Fault check (low 32 bits != 0).
+                        let fault_mask = builder.ins().iconst(I64, 0xFFFFFFFFi64);
+                        let fault_bits = builder.ins().band(raw, fault_mask);
+                        let is_fault = builder.ins().icmp_imm(IntCC::NotEqual, fault_bits, 0);
+                        let cont = builder.create_block();
+                        builder.ins().brif(is_fault, trap_block, &[], cont, &[]);
+                        builder.seal_block(cont);
+                        builder.switch_to_block(cont);
                     }
                     Opcode::Selfdestruct => {
                         // Selfdestruct halts execution after clearing storage

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -678,24 +678,48 @@ pub extern "C" fn host_assert(_ctx: *mut VmCtx, val: u64) -> u64 {
     }
 }
 
-/// Host: memcpy — bulk memory copy. Returns 0 on success, 1 on fault.
+/// Host: memcpy — bulk memory copy.
+///
+/// Returns a packed u64:
+///   - low  32 bits: 0 = success, 1 = fault
+///   - high 32 bits: page-allocation gas accumulated by `check_access`
+///     during this call (PAGE_ALLOC_GAS per fresh page touched)
+///
+/// The page-gas component MUST be folded into the AOT's gas counter
+/// by the codegen caller. The interpreter drains
+/// `vm.memory.page_gas_used` into `vm.gas_used_total` after every
+/// step (`pvm/src/vm.rs:1388`); the AOT bypasses that loop, so
+/// returning the drained amount here is the only way to keep AOT
+/// and interpreter gas in sync (audit item 215). Per-byte dynamic
+/// gas (3 per 8 bytes) is charged by codegen before this call.
 pub extern "C" fn host_memcpy(ctx: *mut VmCtx, dst: u64, src: u64, len: u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file). The AOT JIT's callsite emission
     // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
     // first register before calling any host_* function.
     let vm = unsafe { &mut *ctx };
-    let len = len as usize;
     if len == 0 {
         return 0;
     }
-    match vm.memory.checked_read_slice(src as u32, len) {
-        Ok(data) => match vm.memory.checked_write_slice(dst as u32, &data) {
-            Ok(()) => 0,
-            Err(_) => 1,
-        },
-        Err(_) => 1,
+    // Gate any len that doesn't fit in PVM's u32 address space — the
+    // `as u32` casts on src/dst/len below would silently truncate
+    // otherwise. Same ceiling as the interpreter (audit item 215).
+    if len > pyde_vm::memory::MEMORY_SIZE as u64 {
+        return 1; // fault, no page gas
     }
+    let len = len as usize;
+    let result = match vm.memory.checked_read_slice(src as u32, len) {
+        Ok(data) => match vm.memory.checked_write_slice(dst as u32, &data) {
+            Ok(()) => 0u64,
+            Err(_) => 1u64,
+        },
+        Err(_) => 1u64,
+    };
+    // Drain page_gas_used regardless of outcome — partial reads on
+    // the fault path may have already touched pages.
+    let page_gas = vm.memory.page_gas_used;
+    vm.memory.page_gas_used = 0;
+    (page_gas << 32) | result
 }
 
 // ============================================================================

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -140,6 +140,55 @@ mod tests {
     }
 
     #[test]
+    fn memcpy_aot_charges_dynamic_gas_parity_with_interp() {
+        // Audit item 215 — host_memcpy used to skip the per-byte
+        // dynamic-gas charge that the interpreter pays. Same contract
+        // would burn different gas on AOT vs interp validators ⇒
+        // consensus fork. This test asserts gas parity for a 1024-byte
+        // copy.
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap), // dst = HEAP_START
+            instr_ri(Opcode::Addi, 2, 0, heap), // src = HEAP_START
+            instr_ri(Opcode::Addi, 5, 0, 1024), // len = 1024
+            instr_bytes(Opcode::Memcpy, 1, 2, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+        vm.load(&code).unwrap();
+        let _ = vm.execute();
+        let interp_gas = vm.gas_used_total;
+
+        let (aot_status, aot_gas, _) = run_aot(&code, 1_000_000);
+        assert_eq!(aot_status, RESULT_SUCCESS);
+        assert_eq!(
+            aot_gas, interp_gas,
+            "AOT gas {aot_gas} != interp gas {interp_gas} — \
+             host_memcpy dynamic-gas / page-gas parity broken"
+        );
+    }
+
+    #[test]
+    fn memcpy_aot_huge_len_traps() {
+        // Audit item 215 — guest passing a huge len used to slip
+        // through `as u32` truncation in host_memcpy and either
+        // succeed silently (codegen ignored the fault return) or
+        // trigger an unbounded host allocation. Now the AOT must trap.
+        // ADDI r5, r0, -1 materialises u64::MAX in r5 by sign-extension.
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap),
+            instr_ri(Opcode::Addi, 2, 0, heap),
+            instr_ri(Opcode::Addi, 5, 0, -1), // r5 = u64::MAX
+            instr_bytes(Opcode::Memcpy, 1, 2, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let (aot_status, _, _) = run_aot(&code, 10_000_000);
+        assert_eq!(aot_status, RESULT_TRAP);
+    }
+
+    #[test]
     fn aot_add_two_numbers() {
         let code = bytecode(&[
             instr_ri(Opcode::Addi, 1, 0, 10),

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -369,6 +369,17 @@ impl Vm {
             return Ok(());
         }
 
+        // Reject calldata too large to fit in PVM's u32 address space.
+        // Without this gate the `len as u32` truncations in
+        // `checked_write_slice` and `aligned_len as u32` below would
+        // silently wrap, leaving `heap_top` pointing into already-mapped
+        // calldata bytes (audit item 215). The natural ceiling is the
+        // remaining address space above HEAP_START.
+        let max_calldata = (crate::memory::MEMORY_SIZE as u64) - (heap_start as u64);
+        if len as u64 > max_calldata {
+            return Err(Trap::MemoryFault);
+        }
+
         // Bulk write calldata into memory at HEAP_START (single bounds check)
         self.memory
             .checked_write_slice(heap_start, &self.calldata)
@@ -1268,11 +1279,27 @@ impl Vm {
                 let dst_ptr = self.cpu.read_gp(d.rd) as u32;
                 let src_ptr = self.cpu.read_gp(d.rs1) as u32;
                 let len_reg = (d.rs2_or_imm & 0xF) as u8;
-                let len = self.cpu.read_gp(len_reg) as usize;
+                let len_u64 = self.cpu.read_gp(len_reg);
+                // Gate any len that doesn't fit in PVM's u32 address space —
+                // every downstream `as u32` cast (here and in `check_access`)
+                // would silently truncate otherwise, allowing a guest to
+                // pass a len that allocates an unbounded host-side `Vec`
+                // (audit item 215). MEMORY_SIZE is the natural ceiling
+                // because no guest copy can exceed total guest memory.
+                if len_u64 > crate::memory::MEMORY_SIZE as u64 {
+                    return Err(Trap::MemoryFault);
+                }
+                let len = len_u64 as usize;
                 if len > 0 {
-                    // Charge dynamic gas: 3 per 8 bytes copied (same rate as Load/Store)
+                    // Charge dynamic gas: 3 per 8 bytes copied (same rate as
+                    // Load/Store). `checked_add` so a crafted len that wraps
+                    // `gas_used_total` past `gas_limit` cannot slip past the
+                    // OutOfGas trap below.
                     let dynamic_gas = (len as u64).div_ceil(8) * 3;
-                    self.gas_used_total += dynamic_gas;
+                    self.gas_used_total = self
+                        .gas_used_total
+                        .checked_add(dynamic_gas)
+                        .ok_or(Trap::OutOfGas)?;
                     if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                         return Err(Trap::OutOfGas);
                     }
@@ -4269,5 +4296,78 @@ mod tests {
         vm.load(&code).unwrap();
         assert_eq!(vm.run().unwrap(), ExecResult::Halt);
         assert_eq!(vm.cpu.read_gp(1), 0);
+    }
+
+    // ========== Audit item 215: MEMCPY len truncation + calldata ==========
+
+    #[test]
+    fn memcpy_len_over_memory_size_traps_memory_fault() {
+        // Loading u64::MAX into a register and using it as the MEMCPY len
+        // would, before the fix, slip through `as u32` truncations and
+        // trigger a multi-GB host-side `Vec` allocation. Now traps cleanly.
+        let mut vm = Vm::with_gas_limit(10_000_000);
+        let heap = crate::memory::HEAP_START;
+        vm.cpu.write_gp(1, heap as u64); // dst
+        vm.cpu.write_gp(2, heap as u64); // src
+        vm.cpu.write_gp(5, u64::MAX); // len register
+                                      // memcpy r1, r2, len_reg=5
+        let code = bytecode(&[
+            instr_bytes(Opcode::Memcpy, 1, 2, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap_err(), Trap::MemoryFault);
+    }
+
+    #[test]
+    fn memcpy_len_at_memory_size_boundary_is_accepted() {
+        // Exactly MEMORY_SIZE bytes is the largest legal len; anything
+        // bigger traps. Use a small src/dst inside heap to keep the
+        // copy itself bounded — the goal is to verify the gate, not
+        // exercise a real 4 MB copy in a unit test.
+        let mut vm = Vm::with_gas_limit(10_000_000);
+        let heap = crate::memory::HEAP_START;
+        vm.cpu.write_gp(1, heap as u64);
+        vm.cpu.write_gp(2, heap as u64);
+        vm.cpu.write_gp(5, 32); // small legal len
+        let code = bytecode(&[
+            instr_bytes(Opcode::Memcpy, 1, 2, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap(), ExecResult::Halt);
+    }
+
+    #[test]
+    fn memcpy_gas_overflow_cannot_bypass_oog() {
+        // With gas_used_total seeded near u64::MAX, the dynamic-gas
+        // checked_add must trap rather than wrap. Without the fix the
+        // wrap put gas_used_total below gas_limit and the copy proceeded.
+        let mut vm = Vm::with_gas_limit(u64::MAX);
+        vm.gas_used_total = u64::MAX - 10;
+        let heap = crate::memory::HEAP_START;
+        vm.cpu.write_gp(1, heap as u64);
+        vm.cpu.write_gp(2, heap as u64);
+        vm.cpu.write_gp(5, 1024); // large enough that dynamic_gas > 10
+        let code = bytecode(&[
+            instr_bytes(Opcode::Memcpy, 1, 2, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        assert_eq!(vm.run().unwrap_err(), Trap::OutOfGas);
+    }
+
+    #[test]
+    fn map_calldata_oversize_traps_memory_fault() {
+        // Calldata larger than the available address space above
+        // HEAP_START would, before the fix, silently truncate via
+        // `as u32` and leave heap_top pointing into the calldata region.
+        // Construct a Vm directly with oversized calldata and call load,
+        // which invokes map_calldata.
+        let mut vm = Vm::new();
+        let max_calldata = crate::memory::MEMORY_SIZE - (crate::memory::HEAP_START as usize);
+        vm.calldata = vec![0u8; max_calldata + 1];
+        let code = bytecode(&[instr_bytes(Opcode::Halt, 0, 0, 0)]);
+        assert_eq!(vm.load(&code).unwrap_err(), Trap::MemoryFault);
     }
 }


### PR DESCRIPTION
## Summary
Three consensus-critical bugs in MEMCPY, all fixed in one PR:

1. **Interpreter MEMCPY len truncation.** `len: usize` from
   `read_gp` silently wrapped via `as u32` in `check_access`,
   letting a guest trigger multi-GB host-side `Vec` allocation.
   Gated by `MEMORY_SIZE`. Also switched gas-charge `+=` to
   `checked_add` so a crafted len cannot wrap past `gas_limit`.

2. **AOT `host_memcpy` missing per-byte dynamic gas** (3 per 8
   bytes). Interpreter charges it; AOT skipped it entirely.
   Same contract burned different gas on AOT vs interp ⇒
   consensus fork on every memcpy. Charge now emitted in
   Cranelift codegen (AOT tracks gas in an SSA variable, not
   `vm.gas_used_total`).

3. **AOT `host_memcpy` missing per-page allocation gas** (200
   per fresh page). Interpreter drains `vm.memory.page_gas_used`
   each step (`vm.rs:1388`); AOT bypasses that loop. `host_memcpy`
   now packs drained `page_gas` into the high 32 bits of its
   return value; codegen folds it into `VAR_GAS_USED`. Plus:
   AOT codegen previously discarded `host_memcpy`'s fault
   return, silently continuing on memory fault. Now routes
   through `trap_block`.

`map_calldata` got the same defensive `len > MEMORY_SIZE - HEAP_START → trap` gate (defense-in-depth; calldata is bounded in
practice).

## Tests
- `memcpy_len_over_memory_size_traps_memory_fault`
- `memcpy_len_at_memory_size_boundary_is_accepted`
- `memcpy_gas_overflow_cannot_bypass_oog`
- `map_calldata_oversize_traps_memory_fault`
- `memcpy_aot_charges_dynamic_gas_parity_with_interp` (asserts
  exact AOT/interp gas equality for a 1024-byte copy — this is
  the test that exposed bugs #2 and #3)
- `memcpy_aot_huge_len_traps`

Multi-node encrypted e2e (`multi_node_encrypted_lifecycle`
--ignored) passes.

## Follow-up
Surfaced while fixing this: **item 228** — broader AOT page-gas
parity gap across all memory ops (Load/Store/wide-*). Same
consensus-fork risk; needs its own PR.