### PR TITLE
fix: AOT page-gas drain across direct memory ops (audit item 228a)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -458,30 +458,50 @@
       `crates/node/src/faucet.rs` is the RPC half only; no
       frontend / public API exposure.
 
-- [ ] 228 — `✓` **AOT page-gas parity across all memory ops.**
-      Surfaced while fixing 215. The interpreter drains
-      `vm.memory.page_gas_used` into `gas_used_total` at the end of
-      every step (`pvm/src/vm.rs:1388`), charging `PAGE_ALLOC_GAS`
-      (200) per fresh page touched. The AOT bypasses the step
-      loop entirely — every Load/Store/wide-load/wide-store and
-      any other memory-touching host call accumulates
-      `page_gas_used` in `vm.memory` but never folds it into the
-      AOT's SSA `VAR_GAS_USED` counter. Same contract touching
-      fresh memory pages burns different gas on AOT vs interpreter
-      validators → consensus fork on any contract with non-trivial
-      memory access. Item 215 fixed this for `MEMCPY` specifically
-      (host_memcpy now packs drained page_gas into the high 32
-      bits of its return value, codegen folds into VAR_GAS_USED).
-      Need to apply the same pattern to every other AOT memory
-      op. Scope: audit the full list of AOT-emitted memory ops,
-      either add the same pack/unpack to each host call or
-      insert a `host_drain_page_gas` drain call at the end of
-      each basic block. Consensus-critical; mainnet blocker once
-      AOT is enabled in production block-processing (currently
-      wired via `process_full_block_with_aot_and_checkpoint`).
-      Gate with an AOT-vs-interp gas-parity test harness that
-      runs every opcode through both paths and asserts gas
-      equality.
+- [x] 228a — `✓` **AOT page-gas parity for direct memory ops.**
+      Shipped: new `host_drain_page_gas(ctx) -> u64` host function
+      that returns `vm.memory.page_gas_used` and resets to 0. New
+      `emit_drain_page_gas!` codegen macro folds the drained
+      amount into `VAR_GAS_USED` + runs the same OOG check the
+      block prologue uses. Applied after every direct memory op:
+      `Load`, `Store`, `Wload`, `Wstore`, `Push`, `Pop`,
+      `Poseidon`, `Memcpy`. Memcpy converted from 215's
+      pack-into-return-value to the uniform drain-macro pattern.
+      While writing parity tests, caught an additional divergence:
+      Poseidon charges `(len/32)*250` dynamic gas in the
+      interpreter but AOT was charging zero. Fixed by emitting
+      the dynamic charge in codegen before the host_poseidon
+      call, same pattern as memcpy's per-byte charge. Tests:
+      6 new gas-parity tests
+      (`load_aot_charges_page_gas_parity_with_interp`,
+      `store_aot_charges_page_gas_parity_with_interp`,
+      `wload_aot_charges_page_gas_parity_with_interp`,
+      `wstore_aot_charges_page_gas_parity_with_interp`,
+      `push_pop_aot_charges_page_gas_parity_with_interp`,
+      `poseidon_aot_charges_page_gas_parity_with_interp`) plus
+      the existing memcpy parity test, all asserting exact
+      AOT/interp gas equality. Multi-node encrypted e2e still
+      passes.
+
+- [ ] 228b — `✓` **AOT delegated-op gas sync** (splits from 228).
+      Surfaced while scoping 228. Complex opcodes (`CallExt`,
+      `Delegate`, `Create`, `VerifySig`, `MerkleVerify`) are
+      emitted by AOT codegen as delegations to `host_exec_opcode`,
+      which calls `vm.exec_single` → `vm.step`. `step` charges
+      gas into `vm.gas_used_total`. But the AOT's SSA
+      `VAR_GAS_USED` is **independent** of `vm.gas_used_total` —
+      nothing syncs. Result: every cross-contract call,
+      signature verify, contract create, and merkle verify
+      charges **zero gas in AOT** while interpreter charges the
+      full amount. This is a much bigger divergence than 228a
+      (affects every delegated op, not just memory). Fix:
+      modify `host_exec_opcode` ABI to return a packed
+      (result, gas_delta) so codegen can fold the gas change
+      into `VAR_GAS_USED`. Alternative: save/restore
+      `vm.gas_used_total` around the call and compute the
+      delta. Tests: gas-parity harness for each of the 5
+      delegated opcodes. Mainnet-blocker per the item-215
+      decision to ship AOT on testnet.
 
 - [ ] 226 — `⚠` **Plaintext RPC path: `AuthKeys::None` sig-skip
       analog.** Surfaced while closing 206.
@@ -528,3 +548,4 @@ Fold into the relevant fix PRs above when possible:
 | 207 | 2026-04-23  | Agent-traced against wire.rs compact-block encoding | Accepted; design decision needed |
 | 214 | 2026-04-23  | Read decrypt-share branch + verified `PeerInfo::invalid_messages` reuse from 014d | Fixed with spam-threshold drop + decode-Err bump |
 | 215 | 2026-04-24  | Traced interp `Memcpy` + `host_memcpy` + AOT codegen + `page_gas_used` drain; added gas-parity test that exposed 2 divergences (per-byte + per-page) | Fixed all three in one PR; surfaced 228 as follow-up |
+| 228a| 2026-04-24  | Enumerated AOT memory-touching host calls; gas-parity tests for each. Poseidon dynamic-gas divergence surfaced by the test harness | Fixed all 7 direct mem ops + poseidon dynamic gas; split 228b |

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -250,6 +250,13 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
         .declare_function("host_memcpy", Linkage::Import, &sig_store)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
+    // (ctx) -> u64 — returns vm.memory.page_gas_used, resets to 0.
+    // Folded into VAR_GAS_USED after every memory-touching op so AOT
+    // stays in gas lockstep with the interpreter (audit item 228a).
+    let fn_drain_page_gas = module
+        .declare_function("host_drain_page_gas", Linkage::Import, &sig_pop)
+        .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
+
     // host_wload(ctx, addr, wd) -> u64
     let fn_wload = module
         .declare_function("host_wload", Linkage::Import, &sig_sload)
@@ -369,6 +376,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
     let fn_balance_ref = module.declare_func_in_func(fn_balance, &mut ctx.func);
     let fn_assert_ref = module.declare_func_in_func(fn_assert, &mut ctx.func);
     let fn_memcpy_ref = module.declare_func_in_func(fn_memcpy, &mut ctx.func);
+    let fn_drain_page_gas_ref = module.declare_func_in_func(fn_drain_page_gas, &mut ctx.func);
     let fn_sync_gp_to_vm_ref = module.declare_func_in_func(fn_sync_gp_to_vm, &mut ctx.func);
     let fn_sync_gp_from_vm_ref = module.declare_func_in_func(fn_sync_gp_from_vm, &mut ctx.func);
 
@@ -476,6 +484,37 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                     let trapped = $builder.ins().icmp_imm(IntCC::NotEqual, flag, 0);
                     let cont = $builder.create_block();
                     $builder.ins().brif(trapped, $trap_block, &[], cont, &[]);
+                    $builder.seal_block(cont);
+                    $builder.switch_to_block(cont);
+                }};
+            }
+
+            // Helper macro: drain vm.memory.page_gas_used into
+            // VAR_GAS_USED, then run the same OOG check the block
+            // prologue uses. Call after every AOT-emitted op whose
+            // host implementation can bump `page_gas_used` through
+            // `check_access` (Load/Store/Wload/Wstore/Push/Pop/
+            // Poseidon/Memcpy). The interpreter drains after every
+            // step; AOT has to do it here per op, otherwise AOT
+            // and interp disagree on gas_used and the chain forks
+            // on any contract with non-trivial memory access
+            // (audit item 228a).
+            macro_rules! emit_drain_page_gas {
+                ($builder:expr) => {{
+                    let vm_ctx = $builder.use_var(Variable::from_u32(VAR_VM_CTX));
+                    let call = $builder.ins().call(fn_drain_page_gas_ref, &[vm_ctx]);
+                    let drained = $builder.inst_results(call)[0];
+                    let gas_used = $builder.use_var(Variable::from_u32(VAR_GAS_USED));
+                    let new_gas = $builder.ins().iadd(gas_used, drained);
+                    $builder.def_var(Variable::from_u32(VAR_GAS_USED), new_gas);
+                    let gas_limit = $builder.use_var(Variable::from_u32(VAR_GAS_LIMIT));
+                    let limit_nonzero = $builder.ins().icmp_imm(IntCC::NotEqual, gas_limit, 0);
+                    let over = $builder
+                        .ins()
+                        .icmp(IntCC::UnsignedGreaterThan, new_gas, gas_limit);
+                    let oog = $builder.ins().band(limit_nonzero, over);
+                    let cont = $builder.create_block();
+                    $builder.ins().brif(oog, oog_block, &[], cont, &[]);
                     $builder.seal_block(cont);
                     $builder.switch_to_block(cont);
                 }};
@@ -627,6 +666,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let call = builder.ins().call(fn_push_ref, &[vm_ctx, val]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -637,6 +677,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let call = builder.ins().call(fn_pop_ref, &[vm_ctx]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         // Check for fault (u64::MAX)
                         let is_err = builder.ins().icmp_imm(IntCC::Equal, result, -1i64);
                         let cont = builder.create_block();
@@ -728,6 +769,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let call = builder.ins().call(fn_wload_ref, &[vm_ctx, addr, wd]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -743,6 +785,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let call = builder.ins().call(fn_wstore_ref, &[vm_ctx, addr, ws]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -789,6 +832,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let call = builder.ins().call(fn_load_ref, &[vm_ctx, addr, w]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         gp_write!(builder, d.rd, result);
                     }
                     Opcode::Store => {
@@ -801,6 +845,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let w = builder.ins().iconst(I64, width as i64);
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         builder.ins().call(fn_store_ref, &[vm_ctx, addr, val, w]);
+                        emit_drain_page_gas!(builder);
                     }
 
                     // --- Storage operations (host calls) ---
@@ -873,15 +918,44 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
 
                     // --- Crypto (host calls) ---
                     Opcode::Poseidon => {
+                        // Audit item 228a — interpreter charges 250 gas
+                        // per 32-byte chunk (`pvm/src/vm.rs` Poseidon
+                        // handler); AOT must charge the same. Emitted
+                        // inline because host_poseidon can't reach
+                        // VAR_GAS_USED. Plus page-gas drain after the
+                        // call for the memory read inside host_poseidon.
                         let addr = gp_read!(builder, d.rs1);
                         let len_reg = (d.rs2_or_imm & 0xF) as u8;
                         let len = gp_read!(builder, len_reg);
                         let wd = builder.ins().iconst(I64, d.rd as i64);
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
+
+                        // dynamic_gas = ((len + 31) >> 5) * 250
+                        let thirty_one = builder.ins().iconst(I64, 31);
+                        let len_plus = builder.ins().iadd(len, thirty_one);
+                        let chunks = builder.ins().ushr_imm(len_plus, 5);
+                        let two_fifty = builder.ins().iconst(I64, 250);
+                        let dynamic_gas = builder.ins().imul(chunks, two_fifty);
+                        let gas_used = builder.use_var(Variable::from_u32(VAR_GAS_USED));
+                        let new_gas = builder.ins().iadd(gas_used, dynamic_gas);
+                        builder.def_var(Variable::from_u32(VAR_GAS_USED), new_gas);
+                        let gas_limit = builder.use_var(Variable::from_u32(VAR_GAS_LIMIT));
+                        let limit_nonzero = builder.ins().icmp_imm(IntCC::NotEqual, gas_limit, 0);
+                        let over =
+                            builder
+                                .ins()
+                                .icmp(IntCC::UnsignedGreaterThan, new_gas, gas_limit);
+                        let oog = builder.ins().band(limit_nonzero, over);
+                        let after_oog = builder.create_block();
+                        builder.ins().brif(oog, oog_block, &[], after_oog, &[]);
+                        builder.seal_block(after_oog);
+                        builder.switch_to_block(after_oog);
+
                         let call = builder
                             .ins()
                             .call(fn_poseidon_ref, &[vm_ctx, addr, len, wd]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -999,30 +1073,19 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         builder.switch_to_block(cont);
                     }
                     Opcode::Memcpy => {
-                        // Memcpy handled by VM runtime call (AOT fallback).
+                        // Memcpy via VM runtime call.
                         //
-                        // Audit item 215 — fixes three consensus
-                        // divergences between AOT and interpreter:
-                        //
-                        //   1. Per-byte dynamic gas (3 per 8 bytes) was
-                        //      charged by the interpreter but not by
-                        //      AOT. AOT tracks gas in `VAR_GAS_USED`,
-                        //      not in `vm.gas_used_total`, so the
-                        //      charge is emitted here in the JIT.
-                        //
-                        //   2. Per-page allocation gas (PAGE_ALLOC_GAS
-                        //      per fresh page) was charged by the
-                        //      interpreter via the post-step drain at
-                        //      `pvm/src/vm.rs:1388`. AOT bypasses that
-                        //      loop. `host_memcpy` now returns the
-                        //      drained `page_gas_used` packed into the
-                        //      high 32 bits of its result; codegen
-                        //      folds it into VAR_GAS_USED here.
-                        //
-                        //   3. The previous emission discarded the
-                        //      fault return, so AOT silently continued
-                        //      on memory fault / oversized len. Now
-                        //      routes through `trap_block`.
+                        // Gas parity with the interpreter (audit items
+                        // 215 + 228a):
+                        //   1. Per-byte dynamic gas (3 per 8 bytes)
+                        //      charged inline in the JIT before the
+                        //      host call.
+                        //   2. Per-page allocation gas drained via
+                        //      `emit_drain_page_gas!` after the host
+                        //      call, uniform with the other memory
+                        //      ops.
+                        //   3. host_memcpy fault return routed to
+                        //      `trap_block` (previously discarded).
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let dst = gp_read!(builder, d.rd);
                         let src = gp_read!(builder, d.rs1);
@@ -1053,35 +1116,13 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         builder.seal_block(after_oog);
                         builder.switch_to_block(after_oog);
 
-                        // Call host_memcpy. Returns:
-                        //   low  32 bits: 0=success, 1=fault
-                        //   high 32 bits: page_gas to charge
+                        // host_memcpy: 0=success, 1=fault.
                         let call = builder.ins().call(fn_memcpy_ref, &[vm_ctx, dst, src, len]);
-                        let raw = builder.inst_results(call)[0];
+                        let result = builder.inst_results(call)[0];
 
-                        // Add page_gas (high 32) to gas counter.
-                        let page_gas = builder.ins().ushr_imm(raw, 32);
-                        let gas_used = builder.use_var(Variable::from_u32(VAR_GAS_USED));
-                        let new_gas = builder.ins().iadd(gas_used, page_gas);
-                        builder.def_var(Variable::from_u32(VAR_GAS_USED), new_gas);
+                        emit_drain_page_gas!(builder);
 
-                        // OOG check after page-gas charge.
-                        let gas_limit = builder.use_var(Variable::from_u32(VAR_GAS_LIMIT));
-                        let limit_nonzero = builder.ins().icmp_imm(IntCC::NotEqual, gas_limit, 0);
-                        let over =
-                            builder
-                                .ins()
-                                .icmp(IntCC::UnsignedGreaterThan, new_gas, gas_limit);
-                        let oog2 = builder.ins().band(limit_nonzero, over);
-                        let after_oog2 = builder.create_block();
-                        builder.ins().brif(oog2, oog_block, &[], after_oog2, &[]);
-                        builder.seal_block(after_oog2);
-                        builder.switch_to_block(after_oog2);
-
-                        // Fault check (low 32 bits != 0).
-                        let fault_mask = builder.ins().iconst(I64, 0xFFFFFFFFi64);
-                        let fault_bits = builder.ins().band(raw, fault_mask);
-                        let is_fault = builder.ins().icmp_imm(IntCC::NotEqual, fault_bits, 0);
+                        let is_fault = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_fault, trap_block, &[], cont, &[]);
                         builder.seal_block(cont);

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -678,20 +678,13 @@ pub extern "C" fn host_assert(_ctx: *mut VmCtx, val: u64) -> u64 {
     }
 }
 
-/// Host: memcpy — bulk memory copy.
+/// Host: memcpy — bulk memory copy. Returns 0 on success, 1 on fault.
 ///
-/// Returns a packed u64:
-///   - low  32 bits: 0 = success, 1 = fault
-///   - high 32 bits: page-allocation gas accumulated by `check_access`
-///     during this call (PAGE_ALLOC_GAS per fresh page touched)
-///
-/// The page-gas component MUST be folded into the AOT's gas counter
-/// by the codegen caller. The interpreter drains
-/// `vm.memory.page_gas_used` into `vm.gas_used_total` after every
-/// step (`pvm/src/vm.rs:1388`); the AOT bypasses that loop, so
-/// returning the drained amount here is the only way to keep AOT
-/// and interpreter gas in sync (audit item 215). Per-byte dynamic
-/// gas (3 per 8 bytes) is charged by codegen before this call.
+/// Per-byte dynamic gas (3 per 8 bytes, matching `pvm/src/vm.rs`
+/// Opcode::Memcpy) is charged by the AOT codegen before this call,
+/// and per-page allocation gas is drained via `host_drain_page_gas`
+/// after — AOT tracks gas in a Cranelift SSA variable, not in
+/// `vm.gas_used_total` (audit items 215 + 228a).
 pub extern "C" fn host_memcpy(ctx: *mut VmCtx, dst: u64, src: u64, len: u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file). The AOT JIT's callsite emission
@@ -705,21 +698,40 @@ pub extern "C" fn host_memcpy(ctx: *mut VmCtx, dst: u64, src: u64, len: u64) -> 
     // `as u32` casts on src/dst/len below would silently truncate
     // otherwise. Same ceiling as the interpreter (audit item 215).
     if len > pyde_vm::memory::MEMORY_SIZE as u64 {
-        return 1; // fault, no page gas
+        return 1;
     }
     let len = len as usize;
-    let result = match vm.memory.checked_read_slice(src as u32, len) {
+    match vm.memory.checked_read_slice(src as u32, len) {
         Ok(data) => match vm.memory.checked_write_slice(dst as u32, &data) {
-            Ok(()) => 0u64,
-            Err(_) => 1u64,
+            Ok(()) => 0,
+            Err(_) => 1,
         },
-        Err(_) => 1u64,
-    };
-    // Drain page_gas_used regardless of outcome — partial reads on
-    // the fault path may have already touched pages.
-    let page_gas = vm.memory.page_gas_used;
+        Err(_) => 1,
+    }
+}
+
+/// Host: drain accumulated page-allocation gas.
+///
+/// Returns `vm.memory.page_gas_used` and resets it to 0. The
+/// interpreter folds this into `vm.gas_used_total` after every
+/// `step()` at `pvm/src/vm.rs:1388`, charging `PAGE_ALLOC_GAS` (200)
+/// per fresh page touched. The AOT tracks gas in a Cranelift SSA
+/// variable (`VAR_GAS_USED`) that is **independent** of
+/// `vm.gas_used_total`, so the drain has to be exposed as a host
+/// call and folded into the AOT's counter by codegen after every
+/// op that can bump `page_gas_used` via `check_access`
+/// (Load/Store/Wload/Wstore/Push/Pop/Poseidon/Memcpy). Without this
+/// drain, the same contract charges different gas on AOT vs
+/// interpreter validators ⇒ consensus fork (audit item 228a).
+pub extern "C" fn host_drain_page_gas(ctx: *mut VmCtx) -> u64 {
+    // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
+    // safety contract (top of file). The AOT JIT's callsite emission
+    // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
+    // first register before calling any host_* function.
+    let vm = unsafe { &mut *ctx };
+    let drained = vm.memory.page_gas_used;
     vm.memory.page_gas_used = 0;
-    (page_gas << 32) | result
+    drained
 }
 
 // ============================================================================
@@ -822,6 +834,7 @@ pub fn host_functions() -> Vec<(&'static str, *const u8)> {
         ("host_balance", host_balance as *const u8),
         ("host_assert", host_assert as *const u8),
         ("host_memcpy", host_memcpy as *const u8),
+        ("host_drain_page_gas", host_drain_page_gas as *const u8),
         ("host_checked_add", host_checked_add as *const u8),
         ("host_checked_sub", host_checked_sub as *const u8),
         ("host_checked_mul", host_checked_mul as *const u8),

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -169,6 +169,116 @@ mod tests {
         );
     }
 
+    /// Assert AOT and interpreter burn identical gas for a program
+    /// that runs to success on both paths. Used for audit item 228a
+    /// parity tests across memory-touching ops.
+    fn assert_gas_parity(code: &[u8], gas_limit: u64, label: &str) {
+        let mut vm = pyde_vm::vm::Vm::with_gas_limit(gas_limit);
+        vm.load(code).unwrap();
+        let _ = vm.execute();
+        let interp_gas = vm.gas_used_total;
+
+        let (aot_status, aot_gas, _) = run_aot(code, gas_limit);
+        assert_eq!(aot_status, RESULT_SUCCESS, "{label}: AOT did not succeed");
+        assert_eq!(
+            aot_gas, interp_gas,
+            "{label}: AOT gas {aot_gas} != interp gas {interp_gas}"
+        );
+    }
+
+    #[test]
+    fn load_aot_charges_page_gas_parity_with_interp() {
+        // Audit item 228a — host_load bumps vm.memory.page_gas_used
+        // via check_access; AOT must drain it into VAR_GAS_USED to
+        // match the interpreter's post-step drain.
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap), // r1 = HEAP_START
+            // load r2, [r1 + 0], width=64
+            instr_bytes(
+                Opcode::Load,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(0, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Load page-gas parity");
+    }
+
+    #[test]
+    fn store_aot_charges_page_gas_parity_with_interp() {
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap), // r1 = HEAP_START
+            instr_ri(Opcode::Addi, 2, 0, 42),   // r2 = value
+            // store r2, [r1 + 0], width=64
+            instr_bytes(
+                Opcode::Store,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(0, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Store page-gas parity");
+    }
+
+    #[test]
+    fn wload_aot_charges_page_gas_parity_with_interp() {
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap),
+            // wload w0, [r1 + 0] — reads 32 bytes
+            instr_ri(Opcode::Wload, 0, 1, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Wload page-gas parity");
+    }
+
+    #[test]
+    fn wstore_aot_charges_page_gas_parity_with_interp() {
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap),
+            // wstore w0, [r1 + 0] — writes 32 bytes (w0 is zero)
+            instr_ri(Opcode::Wstore, 0, 1, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Wstore page-gas parity");
+    }
+
+    #[test]
+    fn push_pop_aot_charges_page_gas_parity_with_interp() {
+        // Push writes to the stack page (fresh) → page_gas. Pop
+        // reads from the stack page (same page) → no additional
+        // page_gas since already touched. Together they exercise
+        // both host_push and host_pop drain paths.
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, 99),
+            instr_bytes(Opcode::Push, 1, 0, 0),
+            instr_bytes(Opcode::Pop, 2, 0, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Push/Pop page-gas parity");
+    }
+
+    #[test]
+    fn poseidon_aot_charges_page_gas_parity_with_interp() {
+        // host_poseidon reads `len` bytes from memory via
+        // checked_read_slice, which bumps page_gas_used for any
+        // fresh page touched. Must drain after.
+        let heap = pyde_vm::memory::HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap), // addr
+            instr_ri(Opcode::Addi, 5, 0, 64),   // len (fits in first heap page)
+            // poseidon w0 = hash(mem[r1..r1+r5])
+            instr_bytes(Opcode::Poseidon, 0, 1, 5),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity(&code, 1_000_000, "Poseidon page-gas parity");
+    }
+
     #[test]
     fn memcpy_aot_huge_len_traps() {
         // Audit item 215 — guest passing a huge len used to slip


### PR DESCRIPTION
## Summary
Interpreter drains `vm.memory.page_gas_used` into `gas_used_total`
after every step. AOT tracks gas in a separate Cranelift SSA
variable (`VAR_GAS_USED`) and never pulled the drained amount,
so any contract touching fresh memory pages burned different gas
on AOT vs interp ⇒ consensus fork.

**Fix:**
- New `host_drain_page_gas(ctx) -> u64` returns
  `vm.memory.page_gas_used` and resets to 0.
- New `emit_drain_page_gas!` codegen macro folds drained gas into
  `VAR_GAS_USED` + runs the same OOG check the block prologue uses.
- Applied after every AOT-emitted direct memory op: `Load`,
  `Store`, `Wload`, `Wstore`, `Push`, `Pop`, `Poseidon`, `Memcpy`.
- `Memcpy` converted from 215's pack-into-return-value pattern
  to the uniform drain-macro pattern.

**Bonus bug caught by the parity harness:** `Poseidon` charges
`(len/32)*250` dynamic gas in interpreter but AOT charged zero.
Same fork class as memcpy in 215. Charge now emitted in codegen
before the `host_poseidon` call.

## Tests
6 new gas-parity tests (Load, Store, Wload, Wstore, Push/Pop,
Poseidon) assert exact AOT/interp gas equality. All 32 AOT
tests + 32 node lib tests + multi-node encrypted e2e pass.

## Follow-up
**228b** — delegated ops (CallExt/Delegate/Create/VerifySig/
MerkleVerify) go through `host_exec_opcode` and charge gas in
`vm.gas_used_total`, which never syncs with AOT's `VAR_GAS_USED`.
Currently zero gas charged in AOT for these ops. Needs
`host_exec_opcode` ABI change — own PR.