### PR TITLE
fix: AOT storage + log gas parity (audit item 228c)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -483,6 +483,57 @@
       AOT/interp gas equality. Multi-node encrypted e2e still
       passes.
 
+- [x] 228c — `✓` **AOT gas-parity harness + storage/log fixes.**
+      Shipped: new `assert_gas_parity_with_state` helper for tests
+      that need pre-prepared VM state (storage/wide-regs/contracts).
+      Used to surface and fix:
+      
+      1. **Storage cold-access surcharge (1800 gas / EIP-2929).**
+         Interp Sload/Sstore/Sdelete charge 1800 on first touch
+         of a key per-tx; AOT host functions skipped this entirely.
+         Every storage access: AOT 200 vs interp 2000. Fixed: each
+         storage host fn now adds 1800 to `vm.memory.page_gas_used`
+         on first touch + inserts key into `vm.warm_storage_keys`.
+         Codegen drains via `emit_drain_page_gas!` after the call.
+      
+      2. **Log dynamic gas (`100 + data_len*8 + num_topics*50`).**
+         Interp `Opcode::Log` charges this; AOT host_log skipped
+         it. Every log emission diverged. Fixed: `host_log` adds
+         the dynamic charge to `page_gas_used`; codegen drains.
+      
+      3. **Sdelete refund parity.** Already worked via existing
+         `vm.gas_refund += 1500` in host_sdelete. Now verified
+         by an explicit parity test that compares both
+         `gas_used_total` AND `gas_refund` between paths.
+      
+      `vm.memory.page_gas_used` now serves as the
+      AOT-drainable dynamic-gas accumulator for any host
+      function that needs to charge gas the AOT can't see.
+      Field doc updated to reflect this. Drain helper name kept
+      (`host_drain_page_gas`) for branch hygiene; rename to
+      something more general (e.g. `host_drain_dynamic_gas`)
+      can land separately.
+      
+      Tests: 5 new parity tests
+      (`sload_cold_aot_gas_parity_with_interp`,
+      `sload_warm_aot_gas_parity_with_interp`,
+      `sstore_cold_aot_gas_parity_with_interp`,
+      `sdelete_aot_gas_parity_with_interp`,
+      `log_aot_gas_parity_with_interp`).
+      All 38 AOT tests + multi-node encrypted e2e pass.
+      
+      **Gaps surfaced but NOT fixed in this PR (tracked as
+      228d):**
+      - SstoreB / SloadB (mode 1 / memory mode) dynamic gas
+        per byte stored/loaded. Interp charges `(len/8)*3`;
+        AOT codegen falls through to wide-mode for SloadB
+        (loses semantics) and traps for SstoreB. Needs full
+        mode-1 implementation in AOT host + parity tests.
+      - OOG behavior parity (interp can OOG mid-op; AOT
+        OOGs at drain time). End state is identical because
+        of journal rollback, but the precise OOG point may
+        differ. Worth a stress test.
+
 - [x] 228b — `✓` **AOT delegated-op gas sync.** Shipped:
       `host_exec_opcode` ABI extended to take `gas_used_in` +
       `gas_limit_in` and return `(gas_used_out << 2) | result`
@@ -561,3 +612,4 @@ Fold into the relevant fix PRs above when possible:
 | 215 | 2026-04-24  | Traced interp `Memcpy` + `host_memcpy` + AOT codegen + `page_gas_used` drain; added gas-parity test that exposed 2 divergences (per-byte + per-page) | Fixed all three in one PR; surfaced 228 as follow-up |
 | 228a| 2026-04-24  | Enumerated AOT memory-touching host calls; gas-parity tests for each. Poseidon dynamic-gas divergence surfaced by the test harness | Fixed all 7 direct mem ops + poseidon dynamic gas; split 228b |
 | 228b| 2026-04-24  | Gas-parity test on CallExt exposed 2× double-charging (static gas in both bb prologue + delegated step); ABI change routes updated gas back into VAR_GAS_USED | Fixed sync + analysis.rs double-count |
+| 228c| 2026-04-24  | Wrote `assert_gas_parity_with_state` helper; targeted tests for Sload/Sstore/Sdelete cold + Log dynamic gas all failed before fix | Fixed via `page_gas_used` accumulator pattern; 5 new parity tests pass |

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -864,28 +864,30 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                     }
 
                     // --- Storage operations (host calls) ---
+                    // Audit 228c: each storage host fn writes the
+                    // EIP-2929 cold-access surcharge into
+                    // `vm.memory.page_gas_used`; codegen drains it
+                    // afterwards via `emit_drain_page_gas!`.
                     Opcode::Sload => {
                         let mode = d.rs2_or_imm & 0x3;
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let ws_slot = builder.ins().iconst(I64, d.rs1 as i64);
                         match mode {
                             0 => {
-                                // Wide register mode: sload wd, ws1
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sload_ref, &[vm_ctx, ws_slot, wd]);
                             }
                             2 => {
-                                // GP register mode: sloadg rd, ws1 → returns u64
                                 let call = builder.ins().call(fn_sloadg_ref, &[vm_ctx, ws_slot]);
                                 let result = builder.inst_results(call)[0];
                                 gp_write!(builder, d.rd, result);
                             }
                             _ => {
-                                // Mode 1 (memory) and others: delegate to wide mode for now
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sload_ref, &[vm_ctx, ws_slot, wd]);
                             }
                         }
+                        emit_drain_page_gas!(builder);
                     }
                     Opcode::Sstore => {
                         let mode = d.rs2_or_imm & 0x3;
@@ -893,26 +895,23 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let ws_slot = builder.ins().iconst(I64, d.rs1 as i64);
                         let call = match mode {
                             0 => {
-                                // Wide register mode: sstore ws_slot, wd
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sstore_ref, &[vm_ctx, ws_slot, wd])
                             }
                             2 => {
-                                // GP register mode: sstoreg ws_slot, rd
                                 let rd_val = gp_read!(builder, d.rd);
                                 builder
                                     .ins()
                                     .call(fn_sstoreg_ref, &[vm_ctx, ws_slot, rd_val])
                             }
                             _ => {
-                                // Mode 1 (memory) not yet implemented → trap
                                 builder.ins().jump(trap_block, &[]);
                                 terminated = true;
                                 continue;
                             }
                         };
                         let result = builder.inst_results(call)[0];
-                        // result = 1 means static mode violation → trap
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -924,6 +923,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let ws_slot = builder.ins().iconst(I64, d.rs1 as i64);
                         let call = builder.ins().call(fn_sdelete_ref, &[vm_ctx, ws_slot]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);
@@ -1168,7 +1168,12 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         break;
                     }
 
-                    // Log: emit event via host_log(ctx, desc_ptr, num_topics)
+                    // Log: emit event via host_log(ctx, desc_ptr, num_topics).
+                    // Audit 228c: host_log writes its dynamic gas
+                    // (`100 + data_len*8 + num_topics*50`) plus the
+                    // page-gas from reading topics + data into
+                    // `vm.memory.page_gas_used`; codegen drains both
+                    // via `emit_drain_page_gas!` after the call.
                     Opcode::Log => {
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
                         let desc_ptr = gp_read!(builder, d.rs1);
@@ -1177,6 +1182,7 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                             .ins()
                             .call(fn_log_ref, &[vm_ctx, desc_ptr, num_topics]);
                         let result = builder.inst_results(call)[0];
+                        emit_drain_page_gas!(builder);
                         let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
                         let cont = builder.create_block();
                         builder.ins().brif(is_err, trap_block, &[], cont, &[]);

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -155,6 +155,14 @@ pub extern "C" fn host_pop(ctx: *mut VmCtx) -> u64 {
 
 /// Host: sload wide register mode. Reads storage[slot_from_ws1] → wd.
 /// Returns 0 on success.
+///
+/// Audit 228c — also charges the EIP-2929 cold-access surcharge
+/// (1800 gas) on first touch of a key per-tx, mirroring the
+/// interpreter's `Opcode::Sload` handler. Surcharge is added to
+/// `vm.memory.page_gas_used` so the AOT codegen drains it via
+/// `host_drain_page_gas` after the call (the field doubles as
+/// the AOT-drainable dynamic-gas accumulator, not just memory
+/// pages).
 pub extern "C" fn host_sload(ctx: *mut VmCtx, ws_slot: u64, wd: u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file). The AOT JIT's callsite emission
@@ -166,6 +174,10 @@ pub extern "C" fn host_sload(ctx: *mut VmCtx, ws_slot: u64, wd: u64) -> u64 {
         Err(_) => return 1,
     };
     let key = vm.derive_storage_key(slot);
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
     // Check overlay first, then fall back to storage backend (SMT)
     let data = vm.storage.get(&key).cloned().or_else(|| {
         if let Some(ref backend) = vm.storage_backend {
@@ -208,6 +220,11 @@ pub extern "C" fn host_sloadg(ctx: *mut VmCtx, ws_slot: u64) -> u64 {
         Err(_) => return 0,
     };
     let key = vm.derive_storage_key(slot);
+    // Audit 228c: same EIP-2929 cold-access surcharge as host_sload.
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
     // Check overlay first, then fall back to storage backend (SMT)
     let data = vm.storage.get(&key).cloned().or_else(|| {
         if let Some(ref backend) = vm.storage_backend {
@@ -244,6 +261,11 @@ pub extern "C" fn host_sstore(ctx: *mut VmCtx, ws_slot: u64, wd: u64) -> u64 {
         Err(_) => return 1,
     };
     let key = vm.derive_storage_key(slot);
+    // Audit 228c: EIP-2929 cold-access surcharge on first Sstore.
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
     vm.journal_storage_write(&key);
     let value = match vm.cpu.read_wide_checked(wd as u8) {
         Ok(v) => v,
@@ -269,6 +291,11 @@ pub extern "C" fn host_sstoreg(ctx: *mut VmCtx, ws_slot: u64, value: u64) -> u64
         Err(_) => return 1,
     };
     let key = vm.derive_storage_key(slot);
+    // Audit 228c: EIP-2929 cold-access surcharge on first Sstoreg.
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
     vm.journal_storage_write(&key);
     vm.storage.insert(key, value.to_le_bytes().to_vec());
     0
@@ -290,6 +317,11 @@ pub extern "C" fn host_sdelete(ctx: *mut VmCtx, ws_slot: u64) -> u64 {
         Err(_) => return 1,
     };
     let key = vm.derive_storage_key(slot);
+    // Audit 228c: EIP-2929 cold-access surcharge on first Sdelete.
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
     vm.journal_storage_write(&key);
     if let Some(v) = vm.storage.get(&key) {
         if !v.is_empty() {
@@ -538,6 +570,14 @@ pub extern "C" fn host_log(ctx: *mut VmCtx, desc_ptr: u64, num_topics: u64) -> u
         Ok(d) => d,
         Err(_) => return 1,
     };
+
+    // Audit 228c: dynamic gas (matching interpreter's Opcode::Log
+    // at `pvm/src/vm.rs:1063`). Folded into the AOT-drainable
+    // accumulator so codegen picks it up via host_drain_page_gas.
+    let dynamic_gas = 100u64
+        .saturating_add((data_len as u64).saturating_mul(8))
+        .saturating_add((num_topics as u64).saturating_mul(50));
+    vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(dynamic_gas);
 
     vm.logs.push(pyde_vm::vm::EventLog {
         address: vm.ctx.self_address,

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -943,6 +943,174 @@ mod tests {
         assert_eq!(return_val, 99, "r1 should hold child's return value (99)");
     }
 
+    /// Run a program on both interp and AOT against pre-prepared VM
+    /// state (storage/wide-regs/contracts), asserting exact gas
+    /// parity. The closure receives the VM right after `with_gas_limit`
+    /// and before `load`, so callers can inject wide-reg values,
+    /// storage backends, contracts, etc.
+    ///
+    /// Audit 228c — used to surface every per-opcode gas divergence
+    /// between AOT and interpreter (storage cold-access, log
+    /// dynamic, gas refund, ...).
+    fn assert_gas_parity_with_state<F: FnMut(&mut pyde_vm::vm::Vm)>(
+        code: &[u8],
+        gas_limit: u64,
+        label: &str,
+        mut prepare: F,
+    ) {
+        // Interpreter
+        let mut interp_vm = pyde_vm::vm::Vm::with_gas_limit(gas_limit);
+        prepare(&mut interp_vm);
+        interp_vm.load(code).unwrap();
+        let _ = interp_vm.execute();
+        let interp_gas = interp_vm.gas_used_total;
+
+        // AOT
+        let compiled = compile_bytecode(code).unwrap();
+        let func = compiled.as_fn();
+        let mut regs = [0u64; 16];
+        let mut aot_vm = pyde_vm::vm::Vm::with_gas_limit(gas_limit);
+        prepare(&mut aot_vm);
+        let raw = unsafe { func(regs.as_mut_ptr(), gas_limit, &mut aot_vm as *mut _) };
+        let (aot_status, aot_gas) = decode_result(raw);
+
+        assert_eq!(
+            aot_status, RESULT_SUCCESS,
+            "{label}: AOT did not succeed (status={aot_status})"
+        );
+        assert_eq!(
+            aot_gas, interp_gas,
+            "{label}: AOT gas {aot_gas} != interp gas {interp_gas}"
+        );
+    }
+
+    #[test]
+    fn sload_cold_aot_gas_parity_with_interp() {
+        // Audit 228c — interp charges 1800 cold-access surcharge on
+        // first Sload of a key per-tx (EIP-2929). AOT host_sload
+        // skips this entirely. Same contract burns Sload base only
+        // on AOT vs base+1800 on interp.
+        let code = bytecode(&[
+            instr_bytes(Opcode::Sload, 1, 0, 0), // sload w1, w0 (mode 0 = wide)
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Sload cold", |vm| {
+            // w0 = arbitrary slot (key derivation handles it)
+            vm.cpu.write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+        });
+    }
+
+    #[test]
+    fn sload_warm_aot_gas_parity_with_interp() {
+        // After the first Sload, the second (same key) should be
+        // warm: just base, no surcharge.
+        let code = bytecode(&[
+            instr_bytes(Opcode::Sload, 1, 0, 0),
+            instr_bytes(Opcode::Sload, 2, 0, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Sload warm", |vm| {
+            vm.cpu.write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+        });
+    }
+
+    #[test]
+    fn sstore_cold_aot_gas_parity_with_interp() {
+        // Cold Sstore: 2000 base + 1800 surcharge.
+        let code = bytecode(&[
+            instr_bytes(Opcode::Sstore, 1, 0, 0), // sstore w1 → slot in w0
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Sstore cold", |vm| {
+            vm.cpu.write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+            vm.cpu.write_wide(1, pyde_vm::wide::U256::from(0xCAFEu64));
+        });
+    }
+
+    #[test]
+    fn sdelete_aot_gas_parity_with_interp() {
+        // Sdelete on a populated key: 2000 base + 1800 cold + 1500
+        // refund (interp at `pvm/src/vm.rs:996-1004`). Tests parity
+        // for both gas_used_total and gas_refund.
+        let code = bytecode(&[
+            instr_bytes(Opcode::Sstore, 1, 0, 0), // populate so refund applies
+            instr_bytes(Opcode::Sdelete, 0, 0, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut interp_vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+        interp_vm
+            .cpu
+            .write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+        interp_vm
+            .cpu
+            .write_wide(1, pyde_vm::wide::U256::from(0xCAFEu64));
+        interp_vm.load(&code).unwrap();
+        let _ = interp_vm.execute();
+        let interp_gas = interp_vm.gas_used_total;
+        let interp_refund = interp_vm.gas_refund;
+
+        let compiled = compile_bytecode(&code).unwrap();
+        let func = compiled.as_fn();
+        let mut regs = [0u64; 16];
+        let mut aot_vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+        aot_vm
+            .cpu
+            .write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+        aot_vm
+            .cpu
+            .write_wide(1, pyde_vm::wide::U256::from(0xCAFEu64));
+        let raw = unsafe { func(regs.as_mut_ptr(), 1_000_000, &mut aot_vm as *mut _) };
+        let (aot_status, aot_gas) = decode_result(raw);
+        let aot_refund = aot_vm.gas_refund;
+
+        assert_eq!(aot_status, RESULT_SUCCESS);
+        assert_eq!(
+            aot_gas, interp_gas,
+            "Sdelete gas parity broken: AOT={aot_gas} interp={interp_gas}"
+        );
+        assert_eq!(
+            aot_refund, interp_refund,
+            "Sdelete refund parity broken: AOT={aot_refund} interp={interp_refund}"
+        );
+    }
+
+    #[test]
+    fn log_aot_gas_parity_with_interp() {
+        // Log charges `100 + data_len*8 + num_topics*50` dynamic gas.
+        // AOT host_log doesn't. Test with 2 topics + 16 bytes of data
+        // → expected dynamic = 100 + 16*8 + 2*50 = 328 gas extra
+        // on interp vs AOT.
+        use pyde_vm::memory::HEAP_START;
+        let heap = HEAP_START as i32;
+        let imm = 2u32; // 2 topics
+        let code = bytecode(&[
+            // Set up descriptor at HEAP_START:
+            //   topic0 (32 zero bytes), topic1 (32 zero bytes),
+            //   data_ptr (8 bytes = HEAP_START+64+16),
+            //   data_len (8 bytes = 16)
+            instr_ri(Opcode::Addi, 1, 0, heap),
+            instr_ri(Opcode::Addi, 2, 0, heap + 64 + 16), // data_ptr value
+            instr_bytes(
+                Opcode::Store,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(64, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ), // mem[heap+64] = heap+80 (data ptr)
+            instr_ri(Opcode::Addi, 3, 0, 16),             // data_len value = 16
+            instr_bytes(
+                Opcode::Store,
+                3,
+                1,
+                pyde_vm::isa::encode_mem_immediate(72, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ), // mem[heap+72] = 16
+            // log r1, 2 (descriptor at r1, 2 topics)
+            instr_bytes(Opcode::Log, 0, 1, imm),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Log dynamic", |_vm| {});
+    }
+
     #[test]
     fn callext_aot_gas_parity_with_interp() {
         // Audit item 228b — delegated ops (CallExt/Delegate/Create/


### PR DESCRIPTION
## Summary
Two more AOT/interp gas divergences fixed using the parity-test
harness as the discovery mechanism:

1. **Storage cold-access surcharge (1800 gas, EIP-2929).**
   Interp Sload/Sstore/Sdelete charge 1800 on first touch of a
   key per-tx; AOT host functions skipped this entirely. Same
   contract burned 200 vs 2000 on every storage access. Fixed:
   each storage host fn writes the surcharge into
   `vm.memory.page_gas_used` and inserts the key into
   `vm.warm_storage_keys` on cold access. Codegen drains via
   `emit_drain_page_gas!` after the call.

2. **Log dynamic gas (`100 + data_len*8 + num_topics*50`).**
   Interp `Opcode::Log` charges this; AOT `host_log` charged
   nothing. Fixed: `host_log` writes the dynamic charge into
   `page_gas_used`; codegen drains.

`vm.memory.page_gas_used` now also serves as the AOT-drainable
dynamic-gas accumulator for host functions that need to charge
gas the AOT's `VAR_GAS_USED` can't see directly. Field doc
updated to reflect the broader purpose.

## Tests
New `assert_gas_parity_with_state` helper for tests needing
pre-prepared VM state, plus 5 new parity tests covering Sload
cold/warm, Sstore cold, Sdelete (with refund), Log dynamic.
All 38 AOT tests + multi-node encrypted e2e pass.

## Follow-up (228d)
- SstoreB/SloadB (mode 1) dynamic gas — interp charges
  `(len/8)*3` per byte; AOT codegen falls through to wide-mode
  (loses semantics) for SloadB, traps for SstoreB. Needs full
  mode-1 implementation in AOT host.
- OOG-timing parity stress test — interp can OOG mid-op, AOT
  OOGs at drain time. End state same via journal rollback,
  but precise OOG point differs. Worth verifying.