### PR TITLE
fix: AOT SloadB/SstoreB mode-1 storage parity (audit item 228d)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -534,6 +534,30 @@
         of journal rollback, but the precise OOG point may
         differ. Worth a stress test.
 
+- [x] 228d — `✓` **AOT SloadB/SstoreB (mode 1, bulk-bytes
+      storage).** Shipped: new `host_sloadb` and `host_sstoreb`
+      that mirror interp's `Opcode::Sload`/`Sstore` mode-1
+      handlers (`pvm/src/vm.rs:898-914` / `:965-983`). Both
+      charge:
+      - EIP-2929 cold-access surcharge (1800) on first touch,
+      - Dynamic gas `(len/8)*3` based on bytes stored/loaded,
+      - Plus the natural memory page-gas from `checked_read_slice` /
+        `checked_write_slice`,
+      
+      all into `vm.memory.page_gas_used`; codegen drains via
+      `emit_drain_page_gas!` after the call. Codegen now wires
+      mode 1 through these new host fns instead of falling
+      through to wide mode (Sload mode 1) or trapping (Sstore
+      mode 1). 2 new parity tests
+      (`sloadb_aot_gas_parity_with_interp`,
+      `sstoreb_aot_gas_parity_with_interp`) assert exact
+      gas equality. All 40 AOT tests + multi-node encrypted e2e
+      pass.
+      
+      OOG-timing parity stress test deferred — end state is
+      identical via journal rollback, exact trap-point divergence
+      is a polish item.
+
 - [x] 228b — `✓` **AOT delegated-op gas sync.** Shipped:
       `host_exec_opcode` ABI extended to take `gas_used_in` +
       `gas_limit_in` and return `(gas_used_out << 2) | result`
@@ -613,3 +637,4 @@ Fold into the relevant fix PRs above when possible:
 | 228a| 2026-04-24  | Enumerated AOT memory-touching host calls; gas-parity tests for each. Poseidon dynamic-gas divergence surfaced by the test harness | Fixed all 7 direct mem ops + poseidon dynamic gas; split 228b |
 | 228b| 2026-04-24  | Gas-parity test on CallExt exposed 2× double-charging (static gas in both bb prologue + delegated step); ABI change routes updated gas back into VAR_GAS_USED | Fixed sync + analysis.rs double-count |
 | 228c| 2026-04-24  | Wrote `assert_gas_parity_with_state` helper; targeted tests for Sload/Sstore/Sdelete cold + Log dynamic gas all failed before fix | Fixed via `page_gas_used` accumulator pattern; 5 new parity tests pass |
+| 228d| 2026-04-24  | Added `host_sloadb` + `host_sstoreb`; rerouted Sload/Sstore mode 1 in codegen; parity tests against interp's mode-1 handler | Fixed semantic + gas divergence on bulk-bytes storage |

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -176,6 +176,16 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
         .declare_function("host_sloadg", Linkage::Import, &sig_sdel)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
+    // host_sloadb(ctx, ws_slot, ptr, rd_idx) -> u64 (4 i64 args + ptr) and
+    // host_sstoreb(ctx, ws_slot, ptr, len) -> u64 — both share `sig_store`'s
+    // (ptr_type, I64, I64, I64) -> I64 shape (audit 228d).
+    let fn_sloadb = module
+        .declare_function("host_sloadb", Linkage::Import, &sig_store)
+        .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
+    let fn_sstoreb = module
+        .declare_function("host_sstoreb", Linkage::Import, &sig_store)
+        .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
+
     // host_log(ctx, desc_ptr, num_topics) -> u64
     let fn_log = module
         .declare_function("host_log", Linkage::Import, &sig_sload)
@@ -364,6 +374,8 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
     let fn_sstore_ref = module.declare_func_in_func(fn_sstore, &mut ctx.func);
     let fn_sstoreg_ref = module.declare_func_in_func(fn_sstoreg, &mut ctx.func);
     let fn_sdelete_ref = module.declare_func_in_func(fn_sdelete, &mut ctx.func);
+    let fn_sloadb_ref = module.declare_func_in_func(fn_sloadb, &mut ctx.func);
+    let fn_sstoreb_ref = module.declare_func_in_func(fn_sstoreb, &mut ctx.func);
     let fn_sloadg_ref = module.declare_func_in_func(fn_sloadg, &mut ctx.func);
     let fn_log_ref = module.declare_func_in_func(fn_log, &mut ctx.func);
     let fn_exec_opcode_ref = module.declare_func_in_func(fn_exec_opcode, &mut ctx.func);
@@ -876,18 +888,41 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                             0 => {
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sload_ref, &[vm_ctx, ws_slot, wd]);
+                                emit_drain_page_gas!(builder);
+                            }
+                            1 => {
+                                // Memory mode (sloadb): writes raw storage
+                                // bytes to mem[ptr..ptr+len], length to
+                                // gp[rd]. Audit 228d — previously fell
+                                // through to wide mode silently. Now goes
+                                // through host_sloadb which handles cold
+                                // surcharge + dynamic gas + memory write.
+                                let ptr_reg = ((d.rs2_or_imm >> 2) & 0xF) as u8;
+                                let ptr = gp_read!(builder, ptr_reg);
+                                let rd_idx = builder.ins().iconst(I64, d.rd as i64);
+                                let call = builder
+                                    .ins()
+                                    .call(fn_sloadb_ref, &[vm_ctx, ws_slot, ptr, rd_idx]);
+                                let result = builder.inst_results(call)[0];
+                                emit_drain_page_gas!(builder);
+                                let is_err = builder.ins().icmp_imm(IntCC::NotEqual, result, 0);
+                                let cont = builder.create_block();
+                                builder.ins().brif(is_err, trap_block, &[], cont, &[]);
+                                builder.seal_block(cont);
+                                builder.switch_to_block(cont);
                             }
                             2 => {
                                 let call = builder.ins().call(fn_sloadg_ref, &[vm_ctx, ws_slot]);
                                 let result = builder.inst_results(call)[0];
                                 gp_write!(builder, d.rd, result);
+                                emit_drain_page_gas!(builder);
                             }
                             _ => {
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sload_ref, &[vm_ctx, ws_slot, wd]);
+                                emit_drain_page_gas!(builder);
                             }
                         }
-                        emit_drain_page_gas!(builder);
                     }
                     Opcode::Sstore => {
                         let mode = d.rs2_or_imm & 0x3;
@@ -897,6 +932,21 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                             0 => {
                                 let wd = builder.ins().iconst(I64, d.rd as i64);
                                 builder.ins().call(fn_sstore_ref, &[vm_ctx, ws_slot, wd])
+                            }
+                            1 => {
+                                // Memory mode (sstoreb): reads
+                                // mem[ptr..ptr+len] and writes to storage.
+                                // Audit 228d — previously trapped. Now
+                                // goes through host_sstoreb which handles
+                                // cold surcharge + dynamic gas + memory
+                                // read.
+                                let ptr_reg = ((d.rs2_or_imm >> 2) & 0xF) as u8;
+                                let len_reg = ((d.rs2_or_imm >> 6) & 0xF) as u8;
+                                let ptr = gp_read!(builder, ptr_reg);
+                                let len = gp_read!(builder, len_reg);
+                                builder
+                                    .ins()
+                                    .call(fn_sstoreb_ref, &[vm_ctx, ws_slot, ptr, len])
                             }
                             2 => {
                                 let rd_val = gp_read!(builder, d.rd);

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -301,6 +301,95 @@ pub extern "C" fn host_sstoreg(ctx: *mut VmCtx, ws_slot: u64, value: u64) -> u64
     0
 }
 
+/// Host: sloadb (Sload mode 1, memory/bulk-bytes mode).
+///
+/// Reads storage[slot_from_ws1] as raw bytes, writes them to
+/// `mem[ptr..ptr+len]`, and writes the length into gp[rd_idx].
+/// If the slot is empty, gp[rd_idx] = 0 and no memory write.
+///
+/// Audit 228d — interp at `pvm/src/vm.rs:898-914`. Charges:
+///   - EIP-2929 cold-access surcharge (1800) on first touch
+///   - dynamic gas `(len/8)*3` based on the loaded byte length
+///   - page-allocation gas for any fresh memory pages written
+/// All three are added to `vm.memory.page_gas_used`; codegen
+/// drains via `emit_drain_page_gas!` after the call.
+pub extern "C" fn host_sloadb(ctx: *mut VmCtx, ws_slot: u64, ptr: u64, rd_idx: u64) -> u64 {
+    // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
+    // safety contract (top of file). The AOT JIT's callsite emission
+    // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
+    // first register before calling any host_* function.
+    let vm = unsafe { &mut *ctx };
+    let slot = match vm.cpu.read_wide_checked(ws_slot as u8) {
+        Ok(v) => v,
+        Err(_) => return 1,
+    };
+    let key = vm.derive_storage_key(slot);
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
+    let data = vm.storage.get(&key).cloned().or_else(|| {
+        if let Some(ref backend) = vm.storage_backend {
+            let val = backend(&key);
+            if let Some(ref v) = val {
+                vm.storage.insert(key, v.clone());
+            }
+            val
+        } else {
+            None
+        }
+    });
+    if let Some(d) = data {
+        let dynamic_gas = (d.len() as u64).div_ceil(8) * 3;
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(dynamic_gas);
+        if vm.memory.checked_write_slice(ptr as u32, &d).is_err() {
+            return 1;
+        }
+        vm.cpu.write_gp(rd_idx as u8, d.len() as u64);
+    } else {
+        vm.cpu.write_gp(rd_idx as u8, 0);
+    }
+    0
+}
+
+/// Host: sstoreb (Sstore mode 1, memory/bulk-bytes mode).
+///
+/// Reads `mem[ptr..ptr+len]` and writes those bytes into
+/// storage[slot_from_ws1].
+///
+/// Audit 228d — interp at `pvm/src/vm.rs:965-983`. Same gas
+/// accumulator pattern as `host_sloadb` (cold surcharge +
+/// dynamic + memory page-gas all into `page_gas_used`).
+pub extern "C" fn host_sstoreb(ctx: *mut VmCtx, ws_slot: u64, ptr: u64, len: u64) -> u64 {
+    // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
+    // safety contract (top of file). The AOT JIT's callsite emission
+    // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
+    // first register before calling any host_* function.
+    let vm = unsafe { &mut *ctx };
+    if vm.static_mode {
+        return 1;
+    }
+    let slot = match vm.cpu.read_wide_checked(ws_slot as u8) {
+        Ok(v) => v,
+        Err(_) => return 1,
+    };
+    let key = vm.derive_storage_key(slot);
+    if !vm.warm_storage_keys.contains(&key) {
+        vm.warm_storage_keys.insert(key);
+        vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(1800);
+    }
+    vm.journal_storage_write(&key);
+    let len = len as usize;
+    let dynamic_gas = (len as u64).div_ceil(8) * 3;
+    vm.memory.page_gas_used = vm.memory.page_gas_used.saturating_add(dynamic_gas);
+    let data = match vm.memory.checked_read_slice(ptr as u32, len) {
+        Ok(d) => d,
+        Err(_) => return 1,
+    };
+    vm.storage.insert(key, data);
+    0
+}
+
 /// Host: sdelete. Clears storage[slot_from_ws1], grants refund if non-empty.
 /// Returns 0 on success, 1 if static mode violation.
 pub extern "C" fn host_sdelete(ctx: *mut VmCtx, ws_slot: u64) -> u64 {
@@ -884,6 +973,8 @@ pub fn host_functions() -> Vec<(&'static str, *const u8)> {
         ("host_sstore", host_sstore as *const u8),
         ("host_sstoreg", host_sstoreg as *const u8),
         ("host_sdelete", host_sdelete as *const u8),
+        ("host_sloadb", host_sloadb as *const u8),
+        ("host_sstoreb", host_sstoreb as *const u8),
         ("host_poseidon", host_poseidon as *const u8),
         ("host_log", host_log as *const u8),
         ("host_wide_alu", host_wide_alu as *const u8),

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -1028,6 +1028,69 @@ mod tests {
     }
 
     #[test]
+    fn sstoreb_aot_gas_parity_with_interp() {
+        // Audit 228d — Sstore mode 1 (sstoreb): reads
+        // mem[ptr..ptr+len] and writes those bytes into storage.
+        // Charges 2000 base + 1800 cold + (len/8)*3 dynamic gas.
+        // AOT used to trap on mode 1; now wired through host_sstoreb.
+        use pyde_vm::memory::HEAP_START;
+        let heap = HEAP_START as i32;
+        let code = bytecode(&[
+            // Populate mem[heap..heap+24] with some bytes
+            instr_ri(Opcode::Addi, 1, 0, heap), // r1 = HEAP_START
+            instr_ri(Opcode::Addi, 2, 0, 0xABCD), // r2 = sentinel
+            instr_bytes(
+                Opcode::Store,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(0, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_bytes(
+                Opcode::Store,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(8, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_bytes(
+                Opcode::Store,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(16, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_ri(Opcode::Addi, 3, 0, 24), // r3 = len = 24 bytes
+            // sstoreb: imm = 1 (mode) | (1 << 2) (ptr_reg=r1) | (3 << 6) (len_reg=r3)
+            instr_bytes(Opcode::Sstore, 0, 0, 1 | (1 << 2) | (3 << 6)),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Sstoreb", |vm| {
+            vm.cpu.write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+        });
+    }
+
+    #[test]
+    fn sloadb_aot_gas_parity_with_interp() {
+        // Audit 228d — Sload mode 1 (sloadb): reads raw bytes from
+        // storage[slot] into memory, writes length to gp[rd].
+        // AOT used to fall through to wide mode (silently wrong).
+        // Now wired through host_sloadb. Pre-populate storage so
+        // there's data to load + dynamic gas applies.
+        use pyde_vm::memory::HEAP_START;
+        let heap = HEAP_START as i32;
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, heap),
+            // sloadb r2, w0, ptr_reg=r1: imm = 1 (mode) | (1 << 2) (ptr_reg)
+            instr_bytes(Opcode::Sload, 2, 0, 1 | (1 << 2)),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        assert_gas_parity_with_state(&code, 1_000_000, "Sloadb", |vm| {
+            vm.cpu.write_wide(0, pyde_vm::wide::U256::from(0x1234u64));
+            // Pre-populate the storage key with 24 bytes.
+            let key = vm.derive_storage_key(pyde_vm::wide::U256::from(0x1234u64));
+            vm.storage.insert(key, vec![0xAB; 24]);
+        });
+    }
+
+    #[test]
     fn sdelete_aot_gas_parity_with_interp() {
         // Sdelete on a populated key: 2000 base + 1800 cold + 1500
         // refund (interp at `pvm/src/vm.rs:996-1004`). Tests parity


### PR DESCRIPTION
## Summary
Sload/Sstore mode 1 (bulk-bytes memory mode) used to silently
fall through to wide-mode for Sload (wrong semantics — read 32
bytes instead of variable length) and trap for Sstore (so
`sstoreb`-using contracts couldn't run on AOT at all).

**Fix:** new `host_sloadb` / `host_sstoreb` that mirror interp's
mode-1 handlers — both charge:
- EIP-2929 cold-access surcharge (1800)
- Dynamic gas `(len/8)*3` per byte
- Memory page-gas from the underlying `checked_read_slice` /
  `checked_write_slice`

into `vm.memory.page_gas_used`, which codegen drains via
`emit_drain_page_gas!` after the call.

## Tests
2 new parity tests assert exact gas equality on a 24-byte mode-1
`sstore` and the matching `sloadb`. All 40 AOT tests + multi-node
encrypted e2e pass.

## Follow-up
OOG-timing parity stress test deferred — end state is identical
via journal rollback; exact trap-point divergence is a polish
item, not a consensus issue.