### PR TITLE
fix: reject AuthKeys::None plaintext senders on production (audit 226)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -612,23 +612,33 @@
       `aot_real_counter_contract`) all still pass. Multi-node
       encrypted e2e still passes.
 
-- [ ] 226 — `⚠` **Plaintext RPC path: `AuthKeys::None` sig-skip
-      analog.** Surfaced while closing 206.
-      `crates/tx/src/validation.rs:140-149` — `validate_signature`
-      accepts any tx whose sender account has `AuthKeys::None`
-      without a FALCON check (comment: "System/contract accounts
-      — no signature check at this level"). `load_account` at
-      `crates/tx/src/pipeline.rs:148-158` returns a default EOA
-      with `AuthKeys::None` for any address not yet in state, so
-      an attacker can submit `send_raw_transaction` with
-      `from = victim_fresh_address` and no signature and clear
-      `validate_signature`. Balance-check gates fund-loss (fresh
-      account has 0 balance) but the mempool pollution surface is
-      still non-zero within M1/M3 caps. Fix: at RPC ingress on
-      production chain_id, require the sender account to exist
-      with a registered auth_key (OR take a narrow
-      faucet-allowlist path), mirroring the 206 policy. Keep the
-      internal contract-to-contract path unaffected.
+- [x] 226 — `✓` **Plaintext RPC path: `AuthKeys::None` sig-skip
+      analog.** Surfaced while closing 206. Shipped at two layers:
+      
+      1. **RPC ingress gate** (`crates/node/src/rpc.rs`
+         `ingress_validate`) — new `plaintext_tx_ingest_policy`
+         helper rejects txs with `sender.auth_keys == None` on any
+         chain_id != 31337. Returns clear `-32001` error with
+         "audit 226" tag. Devnet keeps the relaxed faucet/bootstrap
+         UX. Mirrors the 206 policy (`encrypted_tx_ingest_policy`).
+      
+      2. **Validation defense-in-depth**
+         (`crates/tx/src/validation.rs` `validate_transaction`) —
+         same gate added BEFORE the existing
+         `dev_skip_signature` / `sig_pre_verified` branch so any
+         caller (RPC ingress, block-execution pipeline,
+         `sig_pre_verified` fast path) sees the same enforcement.
+         Closes a malicious-block-builder bypass: a validator
+         could otherwise include a `from = victim_fresh_address`
+         tx with `fee_payer = Paymaster(...)` in their proposed
+         block, slipping past both the signature short-circuit
+         AND the balance gate.
+      
+      Tests: 3 unit tests on `plaintext_tx_ingest_policy` covering
+      Single / MultiSig / None across devnet and mainnet
+      chain_ids; 2 integration tests on `validate_transaction`
+      asserting AuthKeys::None rejects on production and accepts
+      on devnet. Multi-node encrypted e2e still passes.
 
 ---
 
@@ -663,3 +673,4 @@ Fold into the relevant fix PRs above when possible:
 | 228d| 2026-04-24  | Added `host_sloadb` + `host_sstoreb`; rerouted Sload/Sstore mode 1 in codegen; parity tests against interp's mode-1 handler | Fixed semantic + gas divergence on bulk-bytes storage |
 | 217 | 2026-04-24  | Searched every caller of `verify_witnesses`; only tests/benches. No production path verifies witnesses today | Not a bug; re-open if stateless validation wires into production |
 | 218 | 2026-04-24  | Wrapped BroadcastConsensus / BroadcastConsensusMany / maybe_rebroadcast_reshare in `is_validator` gates | Belt-and-suspenders egress guard added |
+| 226 | 2026-04-25  | New `plaintext_tx_ingest_policy` mirrors 206 + same gate added in `validate_transaction` for defense-in-depth at block-validation | Closed at both RPC ingress and validation layers |

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1466,6 +1466,11 @@ async fn ingress_validate(
         .unwrap_or(0);
     drop(state_r);
 
+    // Audit 226: gate the sender's auth_keys at ingress.
+    if let Err(msg) = plaintext_tx_ingest_policy(&sender.auth_keys, chain_id) {
+        return Err(rpc_err(-32001, format!("ingress validation: {msg}")));
+    }
+
     let ctx = ValidationContext {
         block_height: head_slot,
         base_fee,
@@ -1530,6 +1535,35 @@ fn encrypted_tx_ingest_policy(
         Some(pk) => EncryptedTxIngestPolicy::Verify(pk),
         None if chain_id == 31337 => EncryptedTxIngestPolicy::StructuralOnly,
         None => EncryptedTxIngestPolicy::Reject,
+    }
+}
+
+/// Plaintext-tx ingress policy, mirroring `encrypted_tx_ingest_policy`
+/// (audit 206) for the legacy plaintext path (audit 226).
+///
+/// `pyde_tx::validation::validate_signature` short-circuits FALCON
+/// verification when the sender account has `AuthKeys::None`
+/// ("System/contract accounts — no signature check at this level"),
+/// and `pyde_tx::pipeline::load_account` returns a default EOA with
+/// `AuthKeys::None` for any address that has never been seen on chain.
+/// The combination lets an attacker spoof `from = victim_fresh_address`
+/// past the signature check; balance gates fund-loss but a Paymaster
+/// fee_payer slips past balance too, polluting the mempool.
+///
+/// Policy:
+///   - Single / MultiSig: allow (validate_signature handles it).
+///   - None on devnet (chain_id == 31337): allow — the faucet /
+///     bootstrap UX needs unsigned txs from unregistered accounts.
+///   - None on any other chain_id: reject at ingress.
+fn plaintext_tx_ingest_policy(
+    auth_keys: &pyde_account::types::AuthKeys,
+    chain_id: u64,
+) -> Result<(), &'static str> {
+    match auth_keys {
+        pyde_account::types::AuthKeys::Single(_)
+        | pyde_account::types::AuthKeys::MultiSig { .. } => Ok(()),
+        pyde_account::types::AuthKeys::None if chain_id == 31337 => Ok(()),
+        pyde_account::types::AuthKeys::None => Err("sender has no registered auth_key (audit 226)"),
     }
 }
 
@@ -1760,6 +1794,47 @@ mod tests {
                 EncryptedTxIngestPolicy::Reject,
                 "chain_id {} must reject no-key encrypted tx",
                 chain_id
+            );
+        }
+    }
+
+    #[test]
+    fn plaintext_ingest_policy_allows_registered_keys() {
+        // Single auth_key allowed on every chain_id.
+        let pk = vec![0x11u8; 900];
+        for chain_id in [1u64, 7, 31337, 1_000_000] {
+            assert!(plaintext_tx_ingest_policy(
+                &pyde_account::types::AuthKeys::Single(pk.clone()),
+                chain_id,
+            )
+            .is_ok());
+        }
+        // MultiSig also allowed on every chain_id.
+        let multi = pyde_account::types::AuthKeys::MultiSig {
+            keys: vec![pk.clone()],
+            threshold: 1,
+        };
+        for chain_id in [1u64, 31337] {
+            assert!(plaintext_tx_ingest_policy(&multi, chain_id).is_ok());
+        }
+    }
+
+    #[test]
+    fn plaintext_ingest_policy_devnet_allows_no_auth_key() {
+        // chain_id == 31337 keeps the relaxed faucet/bootstrap UX.
+        assert!(plaintext_tx_ingest_policy(&pyde_account::types::AuthKeys::None, 31337).is_ok());
+    }
+
+    #[test]
+    fn plaintext_ingest_policy_production_rejects_no_auth_key() {
+        // Every non-devnet chain_id must reject so an attacker
+        // can't spoof `from = victim_fresh_address` past the
+        // sig-skip in validate_signature.
+        for chain_id in [1u64, 2, 7, 1337, 1_000_000] {
+            let err = plaintext_tx_ingest_policy(&pyde_account::types::AuthKeys::None, chain_id);
+            assert!(
+                err.is_err(),
+                "chain_id {chain_id} must reject AuthKeys::None"
             );
         }
     }

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -96,6 +96,25 @@ pub fn validate_transaction(
     // 1. Chain ID
     validate_chain_id(tx, ctx)?;
 
+    // 1.5 Audit 226 — reject AuthKeys::None senders on non-devnet
+    // chain_id. `validate_signature` short-circuits FALCON
+    // verification when the sender has `AuthKeys::None`, and
+    // `pyde_tx::pipeline::load_account` returns a default EOA with
+    // `AuthKeys::None` for any address never seen on chain. The gap
+    // lets an attacker submit a tx with `from = victim_fresh_address`
+    // that bypasses the signature check entirely. Balance gates
+    // direct fund-loss but a Paymaster fee_payer slips past balance
+    // and the tx pollutes the mempool / can land in a block.
+    //
+    // Gating here (not just at the RPC ingress in `rpc.rs`) makes the
+    // check a defense-in-depth invariant: any caller of
+    // `validate_transaction` — RPC, block validation, gossip — sees
+    // the same enforcement. Devnet (chain_id == 31337) keeps the
+    // relaxed behaviour for the faucet / bootstrap UX.
+    if ctx.chain_id != 31337 && matches!(sender.auth_keys, pyde_account::types::AuthKeys::None) {
+        return Err(ValidationError::InvalidSignature);
+    }
+
     // 2. Signature. Skipping is allowed only when the caller explicitly
     // sets `dev_skip_signature` (test-only) or `sig_pre_verified`
     // (production fast path where the block processor already ran a
@@ -629,5 +648,53 @@ mod tests {
         tx.data = vec![0u8; MAX_CALLDATA * 10];
         let err = validate_size(&tx).unwrap_err();
         assert!(matches!(err, ValidationError::CalldataTooLarge { .. }));
+    }
+
+    // ========== Audit 226: AuthKeys::None production reject ==========
+
+    #[test]
+    fn validate_transaction_rejects_authkeys_none_on_production() {
+        // A fresh (or contract / system) account has AuthKeys::None.
+        // On non-devnet chain_id this should be rejected at
+        // validate_transaction time so it can't slip past the
+        // signature short-circuit ("System/contract accounts — no
+        // signature check at this level"). Defense-in-depth alongside
+        // the rpc.rs ingress gate (audit 226).
+        let (tx, _, nonce_state) = make_valid_tx_and_account();
+        let mut victim_account = Account::new_eoa(&[]);
+        victim_account.address = tx.from;
+        victim_account.auth_keys = pyde_account::types::AuthKeys::None;
+        victim_account.balance = 1_000_000_000_000;
+        let ctx = ValidationContext {
+            chain_id: 1, // production
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &victim_account, &nonce_state, &ctx).unwrap_err();
+        assert!(
+            matches!(err, ValidationError::InvalidSignature),
+            "expected InvalidSignature for AuthKeys::None on production, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_transaction_allows_authkeys_none_on_devnet() {
+        // chain_id == 31337 keeps the relaxed faucet/bootstrap UX:
+        // an unregistered account can still send unsigned txs.
+        let (mut tx, _, nonce_state) = make_valid_tx_and_account();
+        tx.chain_id = 31337;
+        let mut victim_account = Account::new_eoa(&[]);
+        victim_account.address = tx.from;
+        victim_account.auth_keys = pyde_account::types::AuthKeys::None;
+        victim_account.balance = 1_000_000_000_000;
+        let ctx = ValidationContext {
+            chain_id: 31337,
+            dev_skip_signature: true,
+            ..default_ctx()
+        };
+        // Should pass all the audit-226-related checks. Other rules
+        // may still apply (this just asserts 226 doesn't reject).
+        validate_transaction(&tx, &victim_account, &nonce_state, &ctx)
+            .expect("devnet must allow AuthKeys::None senders");
     }
 }


### PR DESCRIPTION
## Bug
`validate_signature` short-circuits FALCON verification for any
sender whose account has `AuthKeys::None` ("System/contract
accounts — no signature check at this level"). `load_account`
returns a default EOA with `AuthKeys::None` for any address
never seen on chain. Combined: an attacker submits a tx with
`from = victim_fresh_address` that bypasses signature
validation. Balance gates direct fund-loss, but a `Paymaster`
fee_payer slips past balance and pollutes the mempool / can
land in a malicious block.

## Fix at two layers
1. **RPC ingress** (`rpc.rs`) — new `plaintext_tx_ingest_policy`
   helper rejects `AuthKeys::None` on `chain_id != 31337` with
   a clear `-32001` error. Mirrors 206's
   `encrypted_tx_ingest_policy`.
2. **Validation defense-in-depth** (`validation.rs`) — same gate
   in `validate_transaction` (before the
   `dev_skip_signature` / `sig_pre_verified` branch) so any
   caller — RPC, block-execution, gossip — enforces the policy.
   Closes the malicious-block-builder bypass.

Devnet (`chain_id == 31337`) keeps the relaxed
faucet/bootstrap UX so unregistered accounts can still send
unsigned txs.

## Tests
- 3 unit tests on `plaintext_tx_ingest_policy` covering
  Single / MultiSig / None across devnet and mainnet chain_ids
- 2 integration tests on `validate_transaction` asserting
  AuthKeys::None rejects on production and accepts on devnet

Multi-node encrypted e2e passes; clippy clean.