### PR TITLE
feat: RegisterPubkey tx type for pubkey bootstrap (audit 229)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -640,6 +640,48 @@
       asserting AuthKeys::None rejects on production and accepts
       on devnet. Multi-node encrypted e2e still passes.
 
+- [x] 229 — `✓` **`RegisterPubkey` tx type — bootstrap path for
+      pubkey registration.** Surfaced while shipping 226. Without
+      this, a fresh address that received funds had no way to
+      ever submit a tx because `validate_transaction` rejected
+      AuthKeys::None senders on production (the 226 fix), and
+      no protocol path could upgrade the account from
+      AuthKeys::None to AuthKeys::Single(pk).
+      
+      Shipped: new `TransactionType::RegisterPubkey = 13`. The
+      pubkey holder submits an unsigned tx with their FALCON
+      pubkey in `tx.data`; protocol verifies
+      `tx.from == Poseidon2(tx.data)` and registers
+      `auth_keys = Single(tx.data)`. Rules:
+      
+      - **No signature** — the address-derivation check is the
+        proof of pubkey ownership; only the keypair holder can
+        produce a pubkey that hashes to a given address.
+      - **No gas, no value** — fresh accounts have no balance
+        to spend; charging gas creates a chicken-and-egg.
+      - **Anyone can submit** — registering YOUR pubkey on YOUR
+        address is harmless (only the legit pubkey passes the
+        hash check; same-pubkey re-registration is a no-op;
+        different-pubkey rejected).
+      - **One-time only** — refuse if `auth_keys != None`. Key
+        rotation goes through the existing `pyde_account::auth::
+        rotate` flow which requires a current-key signature.
+      - **Balance > 0 required** — without this gate, an attacker
+        could spam-register from millions of locally-generated
+        keypairs and bloat state cheaply. Funding a recipient
+        first costs PYDE per address, naturally rate-limiting.
+      
+      Validation routed through `validate_register_pubkey` BEFORE
+      the audit-226 AuthKeys::None gate fires (otherwise the tx
+      type couldn't exist). Pipeline dispatch executes by setting
+      `sender.auth_keys = AuthKeys::Single(tx.data)` and returns
+      a zero-cost successful receipt.
+      
+      Tests: 7 unit tests covering happy path + every reject
+      branch (with-signature, with-value, with-gas, wrong-pubkey,
+      wrong-size, zero-balance, already-registered). All 229
+      pyde-tx tests + multi-node encrypted e2e pass.
+
 ---
 
 ## Test-coverage follow-ups (not standalone fix items)
@@ -674,3 +716,4 @@ Fold into the relevant fix PRs above when possible:
 | 217 | 2026-04-24  | Searched every caller of `verify_witnesses`; only tests/benches. No production path verifies witnesses today | Not a bug; re-open if stateless validation wires into production |
 | 218 | 2026-04-24  | Wrapped BroadcastConsensus / BroadcastConsensusMany / maybe_rebroadcast_reshare in `is_validator` gates | Belt-and-suspenders egress guard added |
 | 226 | 2026-04-25  | New `plaintext_tx_ingest_policy` mirrors 206 + same gate added in `validate_transaction` for defense-in-depth at block-validation | Closed at both RPC ingress and validation layers |
+| 229 | 2026-04-25  | New `TransactionType::RegisterPubkey`; address-derivation check (`from == Poseidon2(data)`) is the proof; gated by funded + unregistered + one-time | Bootstrap path for pubkey registration shipped |

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -506,6 +506,13 @@ fn execute_transaction_inner(
                 ),
             }
         }
+        TransactionType::RegisterPubkey => {
+            // Audit 229: validate_register_pubkey already enforced
+            // tx.from == Poseidon2(tx.data), sender.balance > 0, and
+            // sender.auth_keys == None. Just commit the registration.
+            sender.auth_keys = pyde_account::types::AuthKeys::Single(tx.data.clone());
+            (true, 0u64, 0u64, Vec::new(), Vec::new())
+        }
         TransactionType::Slash => execute_slash(tx, smt, &mut sender.balance),
         TransactionType::ClaimAirdrop => {
             execute_claim_airdrop(tx, smt, block_ctx, &mut sender.balance)

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -66,6 +66,17 @@ pub enum TransactionType {
     /// Resume normal block processing (Phase 4 slice 4.6). Clears the
     /// pause flag. Same multisig-signed blob format as `EmergencyPause`.
     EmergencyResume = 12,
+    /// First-time pubkey registration (audit 229). `tx.data` carries
+    /// the FALCON-512 public key whose Poseidon2 hash equals
+    /// `tx.from`. No signature, no gas, no value. Allowed only when
+    /// the sender account exists with `balance > 0` and
+    /// `auth_keys == AuthKeys::None` (i.e. funded but never
+    /// registered). The address-derivation check is the proof of
+    /// pubkey ownership — only the keypair holder can produce a
+    /// pubkey that hashes to a given address. After execution,
+    /// `sender.auth_keys = AuthKeys::Single(tx.data)` and the
+    /// account can sign normal txs from then on.
+    RegisterPubkey = 13,
 }
 
 impl TransactionType {
@@ -84,6 +95,7 @@ impl TransactionType {
             10 => Some(Self::RotateMultisig),
             11 => Some(Self::EmergencyPause),
             12 => Some(Self::EmergencyResume),
+            13 => Some(Self::RegisterPubkey),
             _ => None,
         }
     }
@@ -516,6 +528,7 @@ mod tests {
             TransactionType::RotateMultisig,
             TransactionType::EmergencyPause,
             TransactionType::EmergencyResume,
+            TransactionType::RegisterPubkey,
         ];
         for ty in all {
             let tag = ty as u8;

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -96,6 +96,15 @@ pub fn validate_transaction(
     // 1. Chain ID
     validate_chain_id(tx, ctx)?;
 
+    // RegisterPubkey (audit 229) takes a separate validation path:
+    // no signature, no gas, no balance check, AuthKeys::None is the
+    // pre-condition (not a rejection). Routing it here keeps the
+    // 226 gate, signature check, and balance check below from
+    // tripping on its intentionally-unsigned shape.
+    if tx.tx_type == crate::types::TransactionType::RegisterPubkey {
+        return validate_register_pubkey(tx, sender, nonce_state);
+    }
+
     // 1.5 Audit 226 — reject AuthKeys::None senders on non-devnet
     // chain_id. `validate_signature` short-circuits FALCON
     // verification when the sender has `AuthKeys::None`, and
@@ -143,6 +152,63 @@ pub fn validate_transaction(
     // 8. Size
     validate_size(tx)?;
 
+    Ok(())
+}
+
+/// Validate a `TransactionType::RegisterPubkey` (audit 229).
+///
+/// Rules:
+///   - `tx.signature` is empty (the address-derivation check is
+///     the proof of pubkey ownership, no FALCON sig needed).
+///   - `tx.value == 0`, `tx.gas_limit == 0`: no transfer, no gas.
+///   - `tx.data.len() == FALCON_PUBLIC_KEY_LEN` (897 bytes).
+///   - `tx.from == Poseidon2(tx.data)`: the address derives from
+///     this pubkey, so only the keypair holder can produce it.
+///   - `sender.balance > 0`: account must have been funded already.
+///     Without this, an attacker can spam-register from millions of
+///     locally-generated keypairs and bloat state without spending
+///     anything.
+///   - `sender.auth_keys == AuthKeys::None`: one-time registration.
+///     Re-registration (or upgrading auth) goes through
+///     `pyde_account::auth::rotate` with a current-key signature.
+///   - Nonce check still applies — `tx.nonce` must be valid.
+fn validate_register_pubkey(
+    tx: &Transaction,
+    sender: &Account,
+    nonce_state: &NonceState,
+) -> Result<(), ValidationError> {
+    if !tx.signature.is_empty() {
+        return Err(ValidationError::InvalidSignature);
+    }
+    if tx.value != 0 {
+        return Err(ValidationError::InvalidPaymaster); // misuse — register tx must not transfer
+    }
+    if tx.gas_limit != 0 {
+        return Err(ValidationError::GasLimitTooHigh {
+            limit: tx.gas_limit,
+            max: 0,
+        });
+    }
+    if tx.data.len() != pyde_crypto::falcon::FalconPublicKey::SIZE {
+        return Err(ValidationError::InvalidSignature);
+    }
+    let derived = pyde_crypto::poseidon2::poseidon2_hash(&tx.data).to_bytes();
+    if derived != tx.from {
+        return Err(ValidationError::InvalidSignature);
+    }
+    if sender.balance == 0 {
+        return Err(ValidationError::InsufficientBalance {
+            required: 1,
+            available: 0,
+        });
+    }
+    if !matches!(sender.auth_keys, pyde_account::types::AuthKeys::None) {
+        // Already registered — refuse to re-register. Use the
+        // key-rotation flow (`pyde_account::auth::rotate`) instead.
+        return Err(ValidationError::InvalidSignature);
+    }
+    validate_nonce(tx, nonce_state)?;
+    validate_size(tx)?;
     Ok(())
 }
 
@@ -696,5 +762,150 @@ mod tests {
         // may still apply (this just asserts 226 doesn't reject).
         validate_transaction(&tx, &victim_account, &nonce_state, &ctx)
             .expect("devnet must allow AuthKeys::None senders");
+    }
+
+    // ========== Audit 229: RegisterPubkey tx type ==========
+
+    fn make_register_pubkey_tx_and_account() -> (Transaction, Account, NonceState) {
+        let (pk, _sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let address = derive_eoa_address(&pk_bytes);
+        // Build an account in the "funded but unregistered" state.
+        // Account::new_eoa(&[]) would set auth_keys = Single(empty),
+        // not None — start from the empty_account default instead.
+        let account = Account {
+            address,
+            nonce: 0,
+            balance: 1_000_000,
+            code_hash: sparse_merkle_tree::H256::zero(),
+            storage_root: sparse_merkle_tree::H256::zero(),
+            account_type: pyde_account::types::AccountType::EOA,
+            auth_keys: pyde_account::types::AuthKeys::None,
+            gas_tank: 0,
+            key_nonce: 0,
+        };
+        let tx = Transaction {
+            from: address,
+            to: ZERO_ADDRESS,
+            value: 0,
+            data: pk_bytes,
+            gas_limit: 0,
+            nonce: 0,
+            signature: vec![], // unsigned
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::RegisterPubkey,
+        };
+        (tx, account, NonceState::new())
+    }
+
+    #[test]
+    fn register_pubkey_happy_path_accepted() {
+        let (tx, account, nonce_state) = make_register_pubkey_tx_and_account();
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        validate_transaction(&tx, &account, &nonce_state, &ctx)
+            .expect("happy-path RegisterPubkey must pass validation");
+    }
+
+    #[test]
+    fn register_pubkey_with_signature_rejected() {
+        // The whole point is the address-derivation check is the proof
+        // — no FALCON sig is needed. A non-empty signature signals
+        // confused intent; reject so we don't accidentally let an
+        // alternative auth flow slip in.
+        let (mut tx, account, nonce_state) = make_register_pubkey_tx_and_account();
+        tx.signature = vec![0xAB; 666];
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::InvalidSignature));
+    }
+
+    #[test]
+    fn register_pubkey_with_value_or_gas_rejected() {
+        let (mut tx, account, nonce_state) = make_register_pubkey_tx_and_account();
+        tx.value = 100;
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        assert!(validate_transaction(&tx, &account, &nonce_state, &ctx).is_err());
+
+        tx.value = 0;
+        tx.gas_limit = 21_000;
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::GasLimitTooHigh { .. }));
+    }
+
+    #[test]
+    fn register_pubkey_wrong_pubkey_for_address_rejected() {
+        // Attacker tries to register a pubkey that does NOT hash to
+        // tx.from. Address-derivation check rejects.
+        let (mut tx, account, nonce_state) = make_register_pubkey_tx_and_account();
+        let (other_pk, _) = falcon_keygen().unwrap();
+        tx.data = other_pk.as_bytes().to_vec();
+        // tx.from is still the original address (Poseidon2 of the original pk)
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::InvalidSignature));
+    }
+
+    #[test]
+    fn register_pubkey_wrong_data_size_rejected() {
+        let (mut tx, account, nonce_state) = make_register_pubkey_tx_and_account();
+        tx.data = vec![0xAB; 100]; // not 897 bytes
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::InvalidSignature));
+    }
+
+    #[test]
+    fn register_pubkey_zero_balance_rejected() {
+        // Account must have been funded already — otherwise an
+        // attacker can spam-register from millions of locally-generated
+        // keypairs and bloat state without spending anything.
+        let (tx, mut account, nonce_state) = make_register_pubkey_tx_and_account();
+        account.balance = 0;
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::InsufficientBalance { .. }));
+    }
+
+    #[test]
+    fn register_pubkey_already_registered_rejected() {
+        // One-time only. Re-registration goes through the
+        // key-rotation flow (`pyde_account::auth::rotate`) which
+        // requires a sig from the current key.
+        let (tx, mut account, nonce_state) = make_register_pubkey_tx_and_account();
+        account.auth_keys = pyde_account::types::AuthKeys::Single(vec![0xCD; 897]);
+        let ctx = ValidationContext {
+            chain_id: 1,
+            dev_skip_signature: false,
+            ..default_ctx()
+        };
+        let err = validate_transaction(&tx, &account, &nonce_state, &ctx).unwrap_err();
+        assert!(matches!(err, ValidationError::InvalidSignature));
     }
 }


### PR DESCRIPTION
## The gap
After 226 (which rejects `AuthKeys::None` senders on production
to close the fresh-victim spoof), a fresh address that
received funds had no way to ever submit a tx. The chain
created the account with `AuthKeys::None`, and no protocol
path upgraded it to `Single(pk)`.

## The fix
New `TransactionType::RegisterPubkey = 13`. The pubkey holder
submits an unsigned tx with their FALCON pubkey in `tx.data`;
protocol verifies `tx.from == Poseidon2(tx.data)` and registers
`auth_keys = Single(tx.data)`.

**Rules:**
- **No signature** — the address-derivation check IS the proof
  of pubkey ownership; only the keypair holder can produce a
  pubkey that hashes to a given address.
- **No gas, no value** — fresh accounts have no balance to
  spend; charging gas creates a chicken-and-egg.
- **Anyone can submit** — same-pubkey re-registration is a
  no-op; different-pubkey rejected by hash check.
- **One-time only** — refuse if `auth_keys != None`. Key
  rotation uses the existing `pyde_account::auth::rotate` flow.
- **Balance > 0 required** — without this, an attacker could
  spam-register from locally-generated keypairs and bloat
  state cheaply. Funding a recipient first costs PYDE per
  address, naturally rate-limiting.

Validation routed through `validate_register_pubkey` BEFORE
the audit-226 AuthKeys::None gate fires (otherwise the tx type
couldn't exist). Pipeline dispatch sets
`sender.auth_keys = Single(tx.data)` and returns a zero-cost
successful receipt.

## Tests
7 unit tests covering happy path + every reject branch:
signature, value, gas, wrong-pubkey, wrong-size, zero-balance,
already-registered. All 229 pyde-tx tests + multi-node
encrypted e2e pass.

## Follow-up
- `TransactionType::Batch` is currently a placeholder (default
  arm returns "ok, 21k gas, no-op"). Worth either implementing
  or removing the variant — separate PR.
- Lift always-applicable checks (chain_id / nonce / size) above
  the type-specific dispatch in `validate_transaction` to
  remove the duplicate `validate_nonce` / `validate_size`
  calls. Code-smell only; not a bug.