### PR TITLE
feat: reorg mechanism — undo logs + revert APIs (audit 230)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -468,10 +468,36 @@
       not instrumented. Grafana dashboards under `docker/grafana/`
       are minimal.
 
-- [ ] 223 — **Reorg handling.**
-      No explicit state-rollback / chain-tip-reversal code path
-      found. Document current reorg semantics; add explicit path
-      if gaps exist.
+- [~] 223 — `✓` **Reorg handling.** Investigation found
+      structural gaps: state is committed eagerly on block
+      receive (not after QC), `chain.head_slot` is monotonic
+      (no rollback), `VersionedState` exists in
+      `crates/state/src/versioning.rs` but is unwired, and
+      sync rejects any block at `slot ≤ head_slot` so a node
+      that committed the wrong block at slot N can never
+      recover via gossip. HotStuff + multi-proposer VRF
+      makes the bug rare in practice (failures are liveness
+      not safety) but it's a real prod-readiness gap.
+      
+      Splitting into 2 PRs:
+      - **230 (this PR): mechanism**. `StateOverlay::into_writes_with_undo`
+        captures pre-block values; `StateManager::record_block_undo`
+        + `revert_to(slot)` collect + replay them; `ChainState::revert`
+        rolls header history back. Wired into BlockProcessor's
+        single-group AND multi-group paths so every block now
+        emits an undo log. Mechanism is in place but NOT yet
+        triggered — `#[allow(dead_code)]` on the revert APIs.
+        Bounded to 128 recent blocks (memory cap).
+      - **231 (next): integration**. Fork-choice rule + reorg
+        trigger in node.rs receive path + multi-node partition
+        test that produces an actual divergent chain and asserts
+        convergence after heal.
+      
+      Tests in 230: 4 ChainState revert tests (basic, no-op,
+      forward-rejected, pruned-error, genesis-clear), 4
+      StateManager revert tests (one-block undo, partial pop,
+      depth-limit-error, no-op-at-head). All 218 pyde-node
+      unit tests + multi-node encrypted e2e pass.
 
 - [ ] 224 — **Block explorer / indexer (plan 083).**
       No code. Plan tracks; listed here for visibility alongside

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -192,11 +192,16 @@ impl BlockProcessor {
                     }
                 }
             }
-            // Deferred batch commit — buffer writes, Merkle computed lazily
-            let writes = overlay.into_writes();
+            // Deferred batch commit — buffer writes, Merkle computed lazily.
+            // Audit 230: collect per-block undo entries alongside the
+            // writes so a future `state.revert_to(slot - 1)` can
+            // reverse this block when consensus picks a different
+            // chain at the same slot.
+            let (writes, undo) = overlay.into_writes_with_undo();
             if !writes.is_empty() {
                 let _ = state.update_batch_deferred(writes);
             }
+            state.record_block_undo(slot, undo);
         } else {
             // Multiple groups — TRUE PARALLEL EXECUTION via rayon + StateOverlay.
             // Each group gets a StateOverlay (reads from shared SMT, writes to local HashMap).
@@ -208,10 +213,16 @@ impl BlockProcessor {
             // Use StateManager as overlay base (reads from cache → SMT)
             let base: &dyn pyde_state::smt::StateAccess = state;
 
-            // Execute each group in parallel
-            let group_results: Vec<
+            // Execute each group in parallel.
+            // Audit 230: each group also returns its undo entries so
+            // the per-block undo log can be aggregated and recorded
+            // for `revert_to` (the multi-group path needs the same
+            // undo-collection coverage as the single-group path).
+            type GroupResults = (
                 Vec<(usize, Receipt, Vec<(sparse_merkle_tree::H256, Vec<u8>)>)>,
-            > = groups
+                Vec<pyde_state::smt::UndoEntry>,
+            );
+            let group_results: Vec<GroupResults> = groups
                 .par_iter()
                 .map(|group| {
                     let mut overlay = StateOverlay::new(base);
@@ -256,25 +267,38 @@ impl BlockProcessor {
                         }
                     }
 
-                    // Collect overlay writes
-                    let writes = overlay.into_writes();
+                    // Collect overlay writes + per-group undo (audit 230).
+                    let (writes, undo) = overlay.into_writes_with_undo();
                     // Attach writes to last result for merging
                     if let Some(last) = results.last_mut() {
                         last.2 = writes;
                     }
-                    results
+                    (results, undo)
                 })
                 .collect();
 
-            // Merge: collect all receipts (sorted by tx index) and all writes
+            // Merge: collect all receipts (sorted by tx index), all writes,
+            // and per-group undo entries (deduped — parallel groups touch
+            // disjoint keys by scheduler invariant, but defensive dedupe
+            // by key keeps things consistent if that invariant ever drifts).
             let mut all_results: Vec<(usize, Receipt)> = Vec::new();
             let mut all_writes: Vec<(sparse_merkle_tree::H256, Vec<u8>)> = Vec::new();
+            let mut undo_by_key: std::collections::HashMap<
+                pyde_state::smt::Key,
+                pyde_state::smt::UndoEntry,
+            > = std::collections::HashMap::new();
 
-            for group_result in group_results {
-                for (tx_idx, receipt, writes) in group_result {
+            for (per_tx_results, group_undo) in group_results {
+                for (tx_idx, receipt, writes) in per_tx_results {
                     total_gas += receipt.effective_gas;
                     all_results.push((tx_idx, receipt));
                     all_writes.extend(writes);
+                }
+                for entry in group_undo {
+                    // All groups read pre-block values from the same `base`,
+                    // so any duplicate-key entry has identical `old_value`.
+                    // First-write-wins is fine.
+                    undo_by_key.entry(entry.key).or_insert(entry);
                 }
             }
 
@@ -295,6 +319,10 @@ impl BlockProcessor {
                     groups.len()
                 );
             }
+
+            // Audit 230: record per-block undo log for reorg support.
+            let undo: Vec<pyde_state::smt::UndoEntry> = undo_by_key.into_values().collect();
+            state.record_block_undo(slot, undo);
         }
 
         // 4. Block reward: mint + split between service + pool shares (Phase 4 slice 4.1).

--- a/crates/node/src/chain.rs
+++ b/crates/node/src/chain.rs
@@ -77,6 +77,79 @@ impl ChainState {
     pub fn is_genesis(&self) -> bool {
         self.head_slot == 0 && self.headers.is_empty()
     }
+
+    /// Revert the chain head back to `target_slot` (audit 230).
+    ///
+    /// Drops every header at slot > target_slot from the in-memory
+    /// header map, sets `head_slot = target_slot`, and restores
+    /// `state_root` to the target slot's stored header.
+    ///
+    /// Caller is responsible for matching state-side rollback via
+    /// `StateManager::revert_to(target_slot)` — these two together
+    /// form the complete reorg rollback (chain metadata + state).
+    /// They are intentionally separate so each subsystem can be
+    /// tested in isolation; `BlockProcessor` and the receive-path
+    /// fork-choice (audit 231) call them in sequence.
+    ///
+    /// Returns the number of headers dropped, or `Err(...)` if
+    /// `target_slot > head_slot` (caller bug — only backwards
+    /// reverts are valid) or if the target's header is not in
+    /// memory (header pruned beyond the 2-epoch window).
+    ///
+    /// Audit 230 ships the mechanism; call site lights up in
+    /// 231 — `#[allow(dead_code)]` covers the gap.
+    #[allow(dead_code)]
+    pub fn revert(&mut self, target_slot: u64) -> Result<usize, String> {
+        if target_slot > self.head_slot {
+            return Err(format!(
+                "ChainState::revert: target {target_slot} > head {} (only backwards reverts valid)",
+                self.head_slot
+            ));
+        }
+        if target_slot == self.head_slot {
+            return Ok(0);
+        }
+        // Genesis case: target_slot == 0 with no header for slot 0
+        // means revert all headers and reset to genesis state.
+        // Otherwise target's header must still be in memory.
+        let target_header = if target_slot == 0 {
+            None
+        } else {
+            match self.headers.get(&target_slot) {
+                Some(h) => Some(h.clone()),
+                None => {
+                    return Err(format!(
+                        "ChainState::revert: target slot {target_slot} header not in memory \
+                         (likely pruned beyond 2-epoch window — fall back to snapshot restore)"
+                    ));
+                }
+            }
+        };
+
+        let mut dropped = 0usize;
+        let to_drop: Vec<u64> = self
+            .headers
+            .keys()
+            .copied()
+            .filter(|s| *s > target_slot)
+            .collect();
+        for slot in to_drop {
+            if let Some(header) = self.headers.remove(&slot) {
+                self.hash_to_slot.remove(&header.hash());
+                dropped += 1;
+            }
+        }
+
+        self.head_slot = target_slot;
+        self.epoch = target_slot / EPOCH_LENGTH;
+        self.state_root = match target_header {
+            Some(h) => h.state_root,
+            None => [0u8; 32], // genesis state root
+        };
+
+        debug!(target_slot, dropped, "chain head reverted to target slot");
+        Ok(dropped)
+    }
 }
 
 #[cfg(test)]
@@ -138,6 +211,80 @@ mod tests {
         assert!(chain.header(999).is_none()); // epoch 0, pruned
         assert!(chain.header(1000).is_some()); // epoch 1, kept
         assert!(chain.header(2500).is_some()); // epoch 2, kept
+    }
+
+    #[test]
+    fn revert_drops_headers_above_target() {
+        // Audit 230 — basic revert correctness.
+        let mut chain = ChainState::genesis([0; 32], 1);
+        // Build a chain of 5 headers.
+        let mut parent = [0u8; 32];
+        for slot in 1..=5 {
+            let header = dummy_header(slot, parent);
+            parent = header.hash();
+            chain.advance(header);
+        }
+        assert_eq!(chain.head_slot, 5);
+
+        // Revert to slot 3.
+        let dropped = chain.revert(3).unwrap();
+        assert_eq!(dropped, 2, "should drop slots 4 and 5");
+        assert_eq!(chain.head_slot, 3);
+        assert_eq!(chain.state_root, [3u8; 32]);
+        assert!(chain.header(4).is_none());
+        assert!(chain.header(5).is_none());
+        assert!(chain.header(3).is_some()); // target preserved
+    }
+
+    #[test]
+    fn revert_to_same_slot_is_noop() {
+        let mut chain = ChainState::genesis([0; 32], 1);
+        chain.advance(dummy_header(1, [0; 32]));
+        let dropped = chain.revert(1).unwrap();
+        assert_eq!(dropped, 0);
+        assert_eq!(chain.head_slot, 1);
+    }
+
+    #[test]
+    fn revert_forward_rejected() {
+        // Forward "reverts" are caller bugs — must error explicitly.
+        let mut chain = ChainState::genesis([0; 32], 1);
+        chain.advance(dummy_header(1, [0; 32]));
+        let err = chain.revert(5).unwrap_err();
+        assert!(err.contains("only backwards reverts"));
+    }
+
+    #[test]
+    fn revert_to_pruned_target_errors() {
+        // If the target's header has been pruned beyond the 2-epoch
+        // window, revert must refuse rather than corrupt state.
+        // EPOCH_LENGTH = 1000, so building to slot 2500 prunes
+        // anything before slot 1000.
+        let mut chain = ChainState::genesis([0; 32], 1);
+        let mut parent = [0u8; 32];
+        for slot in 1..=2500 {
+            let header = dummy_header(slot, parent);
+            parent = header.hash();
+            chain.advance(header);
+        }
+        // Attempt to revert to slot 1 (pruned).
+        let err = chain.revert(1).unwrap_err();
+        assert!(err.contains("not in memory"));
+    }
+
+    #[test]
+    fn revert_to_genesis_clears_all() {
+        let mut chain = ChainState::genesis([0; 32], 1);
+        let mut parent = [0u8; 32];
+        for slot in 1..=3 {
+            let header = dummy_header(slot, parent);
+            parent = header.hash();
+            chain.advance(header);
+        }
+        let dropped = chain.revert(0).unwrap();
+        assert_eq!(dropped, 3);
+        assert_eq!(chain.head_slot, 0);
+        assert!(chain.is_genesis());
     }
 
     #[test]

--- a/crates/node/src/state_manager.rs
+++ b/crates/node/src/state_manager.rs
@@ -1,10 +1,17 @@
 use pyde_state::jmt_store::PersistentJMT;
-use pyde_state::smt::{Key, StateAccess};
+use pyde_state::smt::{Key, StateAccess, UndoEntry};
 use sparse_merkle_tree::H256;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock as StdRwLock};
 use tracing::info;
+
+/// How many recent blocks' undo logs to keep in memory. Beyond
+/// this depth, reverts cannot be performed and the node would
+/// have to fall back to snapshot restore. 128 covers the
+/// HotStuff finality window (worst-case ~2 slots) plus generous
+/// headroom for partition-heal scenarios (audit 230).
+const MAX_UNDO_DEPTH: usize = 128;
 
 /// Pipelined state manager: separates read cache from Merkle commit.
 ///
@@ -24,6 +31,10 @@ pub struct StateManager {
     root: [u8; 32],
     tracked_keys: HashSet<Key>,
     pending_writes: Vec<(Key, Vec<u8>)>,
+    /// Per-block undo logs ordered by slot (newest last). VecDeque
+    /// for O(1) front pruning. Audit 230: drives `revert_to(slot)`
+    /// when consensus picks a different chain at the same slot.
+    block_undo_logs: VecDeque<(u64, Vec<UndoEntry>)>,
 }
 
 // SAFETY: every field of `StateManager` is already `Send`:
@@ -60,6 +71,7 @@ impl StateManager {
             root,
             tracked_keys: HashSet::new(),
             pending_writes: Vec::new(),
+            block_undo_logs: VecDeque::new(),
         })
     }
 
@@ -191,6 +203,116 @@ impl StateManager {
         self.root = root;
     }
 
+    /// Record per-block undo info (audit 230). Called by the
+    /// block processor immediately after a block's writes are
+    /// applied so a future `revert_to(slot - 1)` call can
+    /// reverse them.
+    ///
+    /// Logs older than `MAX_UNDO_DEPTH` are pruned from the front
+    /// — beyond that horizon, reverts are not possible and the
+    /// node falls back to snapshot restore.
+    pub fn record_block_undo(&mut self, slot: u64, entries: Vec<UndoEntry>) {
+        self.block_undo_logs.push_back((slot, entries));
+        while self.block_undo_logs.len() > MAX_UNDO_DEPTH {
+            self.block_undo_logs.pop_front();
+        }
+    }
+
+    /// True if the StateManager has at least one undo log
+    /// recorded for `slot` (or any later slot). Used by the
+    /// reorg path (audit 231) to verify the target depth is in
+    /// range before initiating a revert.
+    ///
+    /// Audit 230 ships the mechanism; the call site is added in
+    /// 231 — `#[allow(dead_code)]` keeps the build green while
+    /// the integration lands incrementally.
+    #[allow(dead_code)]
+    pub fn can_revert_to(&self, target_slot: u64) -> bool {
+        self.block_undo_logs
+            .front()
+            .map(|(s, _)| target_slot >= s.saturating_sub(1))
+            .unwrap_or(false)
+    }
+
+    /// Revert state to the end of `target_slot` by replaying
+    /// undo logs in reverse. Returns the number of blocks
+    /// reverted, or `Err(...)` if the target is beyond the
+    /// in-memory undo horizon.
+    ///
+    /// Walks `block_undo_logs` from the back, popping each log
+    /// whose slot is `> target_slot`, applying its old values
+    /// to the cache + scheduling them as pending SMT writes.
+    /// Stops when the next log on the back is at or before
+    /// `target_slot`.
+    ///
+    /// Audit 230 ships the mechanism; call site lights up in
+    /// 231 — `#[allow(dead_code)]` covers the gap.
+    #[allow(dead_code)]
+    pub fn revert_to(&mut self, target_slot: u64) -> Result<usize, String> {
+        // Range check: we can only revert if every slot above
+        // target is still in the in-memory log. The OLDEST log
+        // on the front represents the deepest reversible slot;
+        // anything older has been pruned.
+        if let Some((oldest_slot, _)) = self.block_undo_logs.front() {
+            if target_slot + 1 < *oldest_slot {
+                return Err(format!(
+                    "revert target {target_slot} is below oldest undo log at slot {oldest_slot}"
+                ));
+            }
+        }
+
+        let mut reverted = 0usize;
+        // Pop from the back until the back log's slot ≤ target_slot.
+        // For each popped log, apply old values to:
+        //   1. the in-memory cache (remove on None, insert otherwise)
+        //   2. the SMT (synchronously — revert must leave a coherent
+        //      view by return time, since callers expect to read
+        //      reverted state immediately)
+        while let Some((slot, _)) = self.block_undo_logs.back() {
+            if *slot <= target_slot {
+                break;
+            }
+            // Pop, then apply old values. Unwrap safe — peek was Some.
+            let (popped_slot, entries) = self.block_undo_logs.pop_back().unwrap();
+            let restore_writes: Vec<(Key, Vec<u8>)> = entries
+                .into_iter()
+                .map(|e| (e.key, e.old_value.unwrap_or_default()))
+                .collect();
+            // Cache: remove empty-value restores, insert non-empty.
+            if let Ok(mut cache) = self.cache.write() {
+                for (k, v) in &restore_writes {
+                    if v.is_empty() {
+                        cache.remove(k);
+                    } else {
+                        cache.insert(*k, v.clone());
+                    }
+                }
+            }
+            // SMT: persist the restore now so reads from the SMT
+            // tree (cache miss path) see the reverted view, and so
+            // the chain's `state_root` recomputed from this SMT
+            // matches the reverted slot's header.
+            if !restore_writes.is_empty() {
+                if let Ok(mut smt) = self.smt.lock() {
+                    if let Err(e) = smt.update_all(restore_writes) {
+                        return Err(format!("revert SMT update failed: {e}"));
+                    }
+                    // Refresh root after SMT mutation.
+                    self.root = smt.root().as_slice().try_into().unwrap_or([0u8; 32]);
+                }
+            }
+            reverted += 1;
+            tracing::debug!(slot = popped_slot, "reverted state at slot");
+        }
+        Ok(reverted)
+    }
+
+    /// Drain the in-memory undo log (testing / diagnostics).
+    #[allow(dead_code)]
+    pub fn undo_log_len(&self) -> usize {
+        self.block_undo_logs.len()
+    }
+
     pub fn is_empty(&self) -> bool {
         if let Ok(smt) = self.smt.lock() {
             smt.is_empty()
@@ -314,5 +436,208 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = StateManager::open(dir.path(), 1024).unwrap();
         assert!(state.export_snapshot().is_empty());
+    }
+
+    // ========== Audit 230: per-block undo log + revert_to ==========
+
+    fn k(seed: u8) -> Key {
+        let mut a = [0u8; 32];
+        a[0] = seed;
+        a.into()
+    }
+
+    #[test]
+    fn revert_to_undoes_one_block() {
+        // Apply one block's writes, record undo, revert, and assert
+        // the cache + pending writes restore the pre-block view.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(dir.path(), 1024).unwrap();
+
+        // Pre-block: key_a = "before". Persist it via flush so the
+        // SMT also has it (revert path schedules SMT writes).
+        let key_a = k(0xA1);
+        state
+            .update_batch(vec![(key_a, b"before".to_vec())])
+            .unwrap();
+
+        // Block at slot 1: change key_a, add key_b. Capture undo
+        // (the pre-block values) and record.
+        let key_b = k(0xB2);
+        let undo = vec![
+            UndoEntry {
+                key: key_a,
+                old_value: Some(b"before".to_vec()),
+            },
+            UndoEntry {
+                key: key_b,
+                old_value: None, // didn't exist
+            },
+        ];
+        state
+            .update_batch(vec![(key_a, b"after".to_vec()), (key_b, b"new".to_vec())])
+            .unwrap();
+        state.record_block_undo(1, undo);
+        assert_eq!(state.undo_log_len(), 1);
+
+        // Pre-revert: cache has the new values.
+        assert_eq!(state.get(&key_a).unwrap(), b"after");
+        assert_eq!(state.get(&key_b).unwrap(), b"new");
+
+        // Revert to slot 0.
+        let n = state.revert_to(0).unwrap();
+        assert_eq!(n, 1, "exactly one block should be reverted");
+        assert_eq!(state.undo_log_len(), 0);
+
+        // Post-revert: cache restored.
+        assert_eq!(state.get(&key_a).unwrap(), b"before");
+        assert_eq!(state.get(&key_b), None);
+    }
+
+    #[test]
+    fn revert_to_pops_only_above_target() {
+        // Three blocks recorded, revert to slot 1: only blocks 2 and 3
+        // are popped; block 1's undo log stays in place.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(dir.path(), 1024).unwrap();
+
+        for slot in 1..=3 {
+            let key = k(slot as u8);
+            state.update_batch(vec![(key, vec![slot as u8])]).unwrap();
+            state.record_block_undo(
+                slot,
+                vec![UndoEntry {
+                    key,
+                    old_value: None,
+                }],
+            );
+        }
+        assert_eq!(state.undo_log_len(), 3);
+
+        let n = state.revert_to(1).unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(state.undo_log_len(), 1);
+        // Block 1's write still present
+        assert_eq!(state.get(&k(1)).unwrap(), vec![1]);
+        // Blocks 2 and 3's writes reverted
+        assert_eq!(state.get(&k(2)), None);
+        assert_eq!(state.get(&k(3)), None);
+    }
+
+    #[test]
+    fn revert_to_below_oldest_log_errors() {
+        // Pruning means we can't revert past MAX_UNDO_DEPTH. Simulate
+        // by recording past the depth and asserting older logs were
+        // pruned + revert_to that depth errors.
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(dir.path(), 1024).unwrap();
+        // Write past MAX_UNDO_DEPTH (128) so the front gets pruned.
+        for slot in 1..=(MAX_UNDO_DEPTH as u64 + 5) {
+            state.record_block_undo(slot, vec![]);
+        }
+        assert_eq!(state.undo_log_len(), MAX_UNDO_DEPTH);
+        // Front log is now slot 6 (slots 1..=5 pruned).
+        // Reverting to slot 3 should be rejected.
+        let err = state.revert_to(3).unwrap_err();
+        assert!(err.contains("below oldest undo log"));
+    }
+
+    #[test]
+    fn revert_to_noop_when_target_is_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(dir.path(), 1024).unwrap();
+        state.record_block_undo(1, vec![]);
+        state.record_block_undo(2, vec![]);
+        let n = state.revert_to(2).unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(state.undo_log_len(), 2);
+    }
+
+    #[test]
+    fn revert_to_restores_smt_root_to_snapshot() {
+        // Audit 230 — root-equality test. Without this, a revert
+        // could restore values at the cache level but produce a
+        // structurally different SMT (e.g. if "empty value" doesn't
+        // collapse the same way as "key absent"), leading to a
+        // root mismatch downstream.
+        //
+        // Mirrors what BlockProcessor does in production:
+        //   update_batch_deferred(writes) → flush_pending() → record_block_undo(slot, undo)
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateManager::open(dir.path(), 1024).unwrap();
+
+        // Helper: simulate one "block" by capturing pre-block values,
+        // applying writes, flushing to SMT, recording undo. Returns
+        // the post-block root.
+        let apply_block = |s: &mut StateManager,
+                               slot: u64,
+                               writes: Vec<(Key, Vec<u8>)>|
+         -> [u8; 32] {
+            let undo: Vec<UndoEntry> = writes
+                .iter()
+                .map(|(k, _)| UndoEntry {
+                    key: *k,
+                    old_value: s.get(k),
+                })
+                .collect();
+            s.update_batch_deferred(writes).unwrap();
+            let root = s.flush_pending().unwrap();
+            s.record_block_undo(slot, undo);
+            root
+        };
+
+        // Block 1: set key_a, key_b
+        let _r1 = apply_block(
+            &mut state,
+            1,
+            vec![
+                (k(0xA1), b"a-v1".to_vec()),
+                (k(0xB2), b"b-v1".to_vec()),
+            ],
+        );
+        // Block 2: change key_a, set key_c
+        let r2_snapshot = apply_block(
+            &mut state,
+            2,
+            vec![
+                (k(0xA1), b"a-v2".to_vec()),
+                (k(0xC3), b"c-v1".to_vec()),
+            ],
+        );
+        // Block 3: change key_b, delete key_c (empty value), add key_d
+        let _r3 = apply_block(
+            &mut state,
+            3,
+            vec![
+                (k(0xB2), b"b-v2".to_vec()),
+                (k(0xC3), Vec::new()), // delete
+                (k(0xD4), b"d-v1".to_vec()),
+            ],
+        );
+
+        // Sanity: root advanced over time.
+        assert_ne!(r2_snapshot, _r1);
+        assert_ne!(_r3, r2_snapshot);
+
+        // Revert to slot 2 — root must match the slot-2 snapshot.
+        let reverted = state.revert_to(2).unwrap();
+        assert_eq!(reverted, 1);
+        assert_eq!(
+            state.root(),
+            r2_snapshot,
+            "post-revert root must equal the slot-2 snapshot"
+        );
+
+        // Cache + SMT both reflect slot-2 view.
+        assert_eq!(state.get(&k(0xA1)).unwrap(), b"a-v2"); // unchanged in block 3
+        assert_eq!(state.get(&k(0xB2)).unwrap(), b"b-v1"); // restored
+        assert_eq!(state.get(&k(0xC3)).unwrap(), b"c-v1"); // restored
+        assert_eq!(state.get(&k(0xD4)), None); // never existed before block 3
+
+        // Revert further to slot 1 — root must match block-1 root.
+        let reverted = state.revert_to(1).unwrap();
+        assert_eq!(reverted, 1);
+        assert_eq!(state.root(), _r1);
+        assert_eq!(state.get(&k(0xA1)).unwrap(), b"a-v1"); // restored
+        assert_eq!(state.get(&k(0xC3)), None); // restored to "absent"
     }
 }

--- a/crates/state/src/smt.rs
+++ b/crates/state/src/smt.rs
@@ -202,6 +202,17 @@ pub struct StateOverlay<'a> {
     writes: std::collections::HashMap<Key, Vec<u8>>,
 }
 
+/// One pre-block undo entry: the value of `key` BEFORE the block
+/// modified it. Used by `StateManager::revert_to` (audit 230) to
+/// reverse a committed block when consensus picks a different
+/// chain at the same slot.
+#[derive(Clone, Debug)]
+pub struct UndoEntry {
+    pub key: Key,
+    /// Pre-block value. `None` ⇒ key didn't exist before the block.
+    pub old_value: Option<Vec<u8>>,
+}
+
 impl<'a> StateOverlay<'a> {
     pub fn new(base: &'a dyn StateAccess) -> Self {
         Self {
@@ -213,6 +224,30 @@ impl<'a> StateOverlay<'a> {
     /// Collect all writes (for merging into the main SMT after parallel execution).
     pub fn into_writes(self) -> Vec<(Key, Vec<u8>)> {
         self.writes.into_iter().collect()
+    }
+
+    /// Like `into_writes` but ALSO returns one `UndoEntry` per write
+    /// — the value the key held in `base` BEFORE the overlay was
+    /// applied (audit 230). Reading old values requires the overlay
+    /// to be intact, so this method must run before `into_writes`
+    /// consumes `self`.
+    ///
+    /// `base` is the StateManager-or-SMT view at block-start; the
+    /// overlay's own writes are not yet in `base` (the overlay
+    /// commits in batch after execution finishes). Therefore
+    /// `base.get(key)` returns the pre-block value, which is the
+    /// correct undo target.
+    pub fn into_writes_with_undo(self) -> (Vec<(Key, Vec<u8>)>, Vec<UndoEntry>) {
+        let undo: Vec<UndoEntry> = self
+            .writes
+            .keys()
+            .map(|k| UndoEntry {
+                key: *k,
+                old_value: self.base.get(k),
+            })
+            .collect();
+        let writes: Vec<(Key, Vec<u8>)> = self.writes.into_iter().collect();
+        (writes, undo)
     }
 
     /// Number of write operations captured.


### PR DESCRIPTION
## Why
First of two PRs closing audit 223 (reorg handling). This one
ships the machinery; PR 231 wires it into the block-receive
fork-choice path.

Pyde's consensus layer (HotStuff + finality checkpoints) is
sound — finalized blocks can't be reorged. But the execution
layer commits state eagerly on block receive, and
`chain.head_slot` is monotonic with no rollback. A network
race between two competing proposals at the same slot can
leave a node committed to the loser, with no recovery path.
HotStuff + multi-proposer VRF makes this rare in practice
(failures are liveness not safety), but it's a real
prod-readiness gap.

## Mechanism
- **`StateOverlay::into_writes_with_undo`** captures
  pre-block `(key, old_value)` alongside the writes.
- **`StateManager`**: per-slot `block_undo_logs` VecDeque
  (bounded to 128), `record_block_undo`, `revert_to(slot)`,
  `can_revert_to`. `revert_to` applies restores
  synchronously to BOTH cache and SMT so callers see a
  coherent view by return time.
- **`ChainState::revert(target_slot)`** — drops headers
  above the target, rewinds `head_slot` / `epoch` /
  `state_root`. Refuses forward reverts and pruned-target
  reverts (caller-bug detection).
- **`BlockProcessor`**: single-group AND multi-group paths
  now collect undo entries and call
  `record_block_undo(slot, undo)` after writes commit.
  Multi-group dedupes by key (parallel groups touch disjoint
  keys by scheduler invariant; defensive dedupe keeps things
  consistent if the invariant ever drifts).

Revert APIs are `#[allow(dead_code)]` because **231** is
what triggers them. Splitting mechanism from integration
keeps each PR independently reviewable.

## Tests
10 new tests covering both subsystems:
- 5 `ChainState` revert tests (basic, no-op, forward-rejected,
  pruned-error, genesis-clear)
- 5 `StateManager` revert tests (one-block undo, partial pop,
  depth-limit-error, no-op-at-head, **root-equality**)

The root-equality test applies 3 blocks of writes (including a
delete and a key-not-yet-existed), captures the SMT root
mid-chain, reverts past it, and asserts `state.root()` exactly
matches the snapshot. This shakes out the "empty-value vs
key-absent" divergence risk in the SMT.

All 219 pyde-node unit tests + multi-node encrypted e2e pass.

## Next
**231** — fork-choice rule + reorg trigger in node.rs receive
path + multi-node partition test that produces an actual
divergent chain and asserts convergence after heal.