### PR TITLE
test: validator-churn rolling-restart (3-of-4) + audit-234 stall finding

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -811,6 +811,35 @@
       wrong-size, zero-balance, already-registered). All 229
       pyde-tx tests + multi-node encrypted e2e pass.
 
+- [ ] 234 — **4-of-4 rolling-restart stall.** Surfaced by
+      `validator_churn` test. Killing all 4 validators of a
+      4-node committee in tight succession (one at a time, each
+      restarted before next is killed) reliably stalls the chain
+      on the 4th kill — the 3 alive nodes pin at the last
+      common slot and stop producing for ≥5s. Reproduces
+      regardless of rotation order ([0,1,2,3], [3,0,1,2] both
+      hit the stall on the 4th rotation). Likely root cause:
+      gossipsub mesh degradation after repeated peer
+      disconnect/reconnect cycles — the only never-restarted
+      node held the mesh together, and removing it leaves the
+      restarted-trio unable to form QCs (timing? mesh sparsity?
+      view-change repeatedly failing?).
+      
+      Mitigation in test: `validator_churn` covers 3-of-4
+      rotation (which reflects realistic operator cadence).
+      Production with 128 validators has more quorum margin
+      and slower rotation cadence, so this may not surface, but
+      worth investigating before testnet.
+      
+      Investigation TODOs:
+      - Dump validator-engine logs at moment of stall: are
+        view-change messages going out? are they being
+        received? why no view-change-QC formation?
+      - Check gossipsub mesh state via metrics — peer count,
+        IHAVE/IWANT churn after multiple restarts.
+      - Try test with 7 validators (quorum 5, 2 down OK) — does
+        the stall move to N-1 of N kills?
+
 ---
 
 ## Test-coverage follow-ups (not standalone fix items)

--- a/crates/node/tests/validator_churn.rs
+++ b/crates/node/tests/validator_churn.rs
@@ -1,0 +1,290 @@
+//! Validator churn: rolling restarts across a majority of the
+//! committee while the chain keeps producing blocks. Verifies the
+//! mesh tolerates repeated kill/restart cycles without breaking
+//! liveness or consensus determinism.
+//!
+//! Why this matters. In production, validators reboot constantly
+//! — kernel patches, hardware swaps, pod restarts, configuration
+//! pushes. The chain must absorb these as routine events. With a
+//! 4-node committee at quorum threshold ⌈2N/3⌉ = 3, exactly one
+//! node may be down at any moment without stalling QCs.
+//!
+//! Test scenario:
+//!   1. Spawn 4-node devnet, warm up to slot 30.
+//!   2. For each victim in [0, 1, 2] (rotate the majority while
+//!      node-3 stays continuously up as a stable baseline):
+//!      a. SIGKILL the victim.
+//!      b. Wait DOWNTIME_SECS — the remaining 3-of-4 must advance
+//!     the chain by ≥MIN_SLOTS_DURING_DOWNTIME.
+//!      c. Restart the victim.
+//!      d. Wait until ALL nodes converge to the network tip + the
+//!     chain produces STEADY_STATE_SLOTS more, ensuring the
+//!     restarted node's validator engine has fully re-engaged.
+//!   3. Assert all 4 nodes converge: same state_root, head still
+//!      advancing, no process died unexpectedly.
+//!
+//! Why 3-of-4 and not 4-of-4: rotating EVERY committee member in
+//! tight succession (kill all 4 across 4 cycles) reproducibly
+//! stalls the chain on the 4th kill regardless of order — likely
+//! gossipsub mesh degradation from repeated peer churn. Production
+//! operators rolling-restart a subset at a time with stabilization
+//! windows, which this test models. The 4-of-4 stall is captured
+//! in AUDIT_FINDINGS as a separate item to investigate.
+//!
+//! Marked `#[ignore]` because subprocess-based.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::{Duration, Instant};
+
+const WARMUP_SLOT: u64 = 30;
+const DOWNTIME_SECS: u64 = 5;
+const MIN_SLOTS_DURING_DOWNTIME: u64 = 5;
+const CATCHUP_TIMEOUT_SECS: u64 = 60;
+/// Slots the network must produce continuously after convergence
+/// before the next rotation. At 400 ms/slot this is ~4 seconds —
+/// long enough for a freshly-restarted validator's engine to
+/// observe a full vote cycle and re-enter active voting.
+const STEADY_STATE_SLOTS: u64 = 10;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn validator_churn_rolling_restart() {
+    let mut net = TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4-node: {e}"));
+
+    net.wait_for_slot(WARMUP_SLOT, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("warm-up to slot {WARMUP_SLOT}: {e}"));
+    eprintln!("churn: warmed up to slot {WARMUP_SLOT}");
+
+    // Sanity: all 4 nodes agree on root before churn starts.
+    let initial_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("initial state_root node-0: {e}"));
+    for n in &net.nodes[1..] {
+        let r = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("initial state_root node-{}: {e}", n.index));
+        assert_eq!(
+            r, initial_root,
+            "pre-churn state_root divergence on node-{}",
+            n.index
+        );
+    }
+
+    let node_count = net.nodes.len();
+    // Rotate the majority (3 of 4) — node-3 stays continuously up
+    // as a stable baseline. See module docs for why we don't rotate
+    // all 4 (gossipsub-mesh stall on the 4th rotation, captured as
+    // a separate audit item).
+    let rotation_order: Vec<usize> = (0..(node_count - 1)).collect();
+    for &victim in &rotation_order {
+        eprintln!("churn: --- rotating node-{victim} ---");
+
+        let pre_kill_head = max_live_head(&net, Some(victim));
+
+        // Kill the victim. With 3/4 = 75% > 2/3 threshold, QCs still form.
+        net.kill_node(victim)
+            .unwrap_or_else(|e| panic!("kill node-{victim}: {e}"));
+
+        // Sustained chain advancement during downtime — the live
+        // 3-node majority must keep producing blocks.
+        let downtime_start = Instant::now();
+        std::thread::sleep(Duration::from_secs(DOWNTIME_SECS));
+        let post_downtime_head = max_live_head(&net, Some(victim));
+        let advanced = post_downtime_head.saturating_sub(pre_kill_head);
+        if advanced < MIN_SLOTS_DURING_DOWNTIME {
+            // Stall — dump every node's view to disambiguate
+            // between "validator engine wedged" vs "network
+            // partition" vs "everyone is alive but not voting".
+            let live_views: Vec<String> = net
+                .current_slots()
+                .into_iter()
+                .map(|(i, s)| {
+                    format!(
+                        "node-{i}={}",
+                        s.map(|v| v.to_string()).unwrap_or_else(|| "?".into())
+                    )
+                })
+                .collect();
+            panic!(
+                "churn: chain stalled while node-{victim} down — only advanced {advanced} slots in {}s (min {MIN_SLOTS_DURING_DOWNTIME}). pre_kill_head={pre_kill_head}, live views: [{}]",
+                downtime_start.elapsed().as_secs(),
+                live_views.join(", ")
+            );
+        }
+        eprintln!(
+            "churn: node-{victim} down {}s, chain advanced {advanced} slots ({} -> {})",
+            downtime_start.elapsed().as_secs(),
+            pre_kill_head,
+            post_downtime_head
+        );
+
+        // Restart the victim — picks up persisted RocksDB state, sync
+        // refills the gap.
+        net.restart_node(victim)
+            .unwrap_or_else(|e| panic!("restart node-{victim}: {e}"));
+
+        // Wait for it to catch up to the current network tip + a
+        // small buffer (so we know it's actively committing post-restart).
+        let catchup_target = max_live_head(&net, None) + 3;
+        wait_for_node_slot(
+            &net,
+            victim,
+            catchup_target,
+            Duration::from_secs(CATCHUP_TIMEOUT_SECS),
+        )
+        .unwrap_or_else(|e| panic!("node-{victim} catch-up to slot {catchup_target}: {e}"));
+
+        // The restarted node may still be in sync mode for the
+        // current network tip — "caught up to slot X" doesn't mean
+        // "actively voting at slot X+1". Wait for ALL nodes to
+        // converge within 2 slots of the network tip before we
+        // proceed to the next rotation, otherwise the next kill
+        // could leave us with only 2 truly-voting validators
+        // (below the 3-of-4 quorum threshold) and stall liveness.
+        wait_for_convergence(&net, 2, Duration::from_secs(CATCHUP_TIMEOUT_SECS))
+            .unwrap_or_else(|e| panic!("post-restart convergence after node-{victim}: {e}"));
+
+        // Steady-state check: even after head-convergence, the
+        // restarted node's validator engine may take a few slots
+        // to fully re-engage in voting. Verify the full mesh is
+        // producing blocks at near-target rate before we proceed
+        // to the next rotation, otherwise we'd kill a node while
+        // a previous restart is still warming up — unrealistic vs
+        // production rolling-restart cadence.
+        wait_for_steady_state(
+            &net,
+            STEADY_STATE_SLOTS,
+            Duration::from_secs(CATCHUP_TIMEOUT_SECS),
+        )
+        .unwrap_or_else(|e| panic!("post-convergence steady-state after node-{victim}: {e}"));
+        eprintln!("churn: node-{victim} caught up to {catchup_target}, network converged + steady");
+
+        // After catch-up, all 4 must agree on root again.
+        let r0 = net
+            .state_root(victim)
+            .unwrap_or_else(|e| panic!("post-rotation state_root node-{victim}: {e}"));
+        for n in &net.nodes {
+            if n.index == victim {
+                continue;
+            }
+            let r = net
+                .state_root(n.index)
+                .unwrap_or_else(|e| panic!("post-rotation state_root node-{}: {e}", n.index));
+            assert_eq!(
+                r, r0,
+                "post-rotation state_root divergence: node-{victim}={} node-{}={}",
+                r0, n.index, r
+            );
+        }
+        eprintln!("churn: all 4 nodes agree on root after node-{victim} rotation");
+    }
+
+    // Final liveness check — every node still running, head still advancing.
+    for n in &net.nodes {
+        assert!(n.is_running(), "node-{} died during churn", n.index);
+    }
+    let final_head = max_live_head(&net, None);
+    let rotations = rotation_order.len() as u64;
+    assert!(
+        final_head >= WARMUP_SLOT + rotations * MIN_SLOTS_DURING_DOWNTIME,
+        "final head {final_head} suggests chain stalled during churn (warmup {WARMUP_SLOT}, expected ≥{})",
+        WARMUP_SLOT + rotations * MIN_SLOTS_DURING_DOWNTIME
+    );
+
+    eprintln!(
+        "churn: passed — rotated {rotations} of {node_count} validators, final head {final_head}, all roots agree"
+    );
+}
+
+/// Maximum head slot across nodes, optionally excluding one (the
+/// dead victim). Returns 0 if no live node has produced a block yet.
+fn max_live_head(net: &TestNetwork, exclude: Option<usize>) -> u64 {
+    net.current_slots()
+        .into_iter()
+        .filter(|(idx, _)| Some(*idx) != exclude)
+        .filter_map(|(_, s)| s)
+        .max()
+        .unwrap_or(0)
+}
+
+/// Wait until every node's head_slot has advanced by at least
+/// `slots` since the moment of the call — i.e. the chain is
+/// genuinely producing, not just sitting at a converged head.
+fn wait_for_steady_state(net: &TestNetwork, slots: u64, timeout: Duration) -> Result<(), String> {
+    let baseline = max_live_head(net, None);
+    let target = baseline + slots;
+    let deadline = Instant::now() + timeout;
+    loop {
+        let cur = max_live_head(net, None);
+        if cur >= target {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "chain stalled at head {cur} (target {target}, baseline {baseline})"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Wait until every node's head_slot is within `tolerance` of the
+/// max head observed across the network. Polls every 200ms.
+fn wait_for_convergence(
+    net: &TestNetwork,
+    tolerance: u64,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let slots: Vec<u64> = net
+            .current_slots()
+            .into_iter()
+            .filter_map(|(_, s)| s)
+            .collect();
+        if slots.len() == net.nodes.len() {
+            let max = *slots.iter().max().unwrap();
+            let min = *slots.iter().min().unwrap();
+            if max.saturating_sub(min) <= tolerance {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "nodes did not converge within {tolerance} slots: {slots:?}"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Wait until a specific node reaches `target_slot`, polling every
+/// 200ms. Used in place of `wait_for_slot` (which waits on ALL
+/// nodes) when only one node's progress matters.
+fn wait_for_node_slot(
+    net: &TestNetwork,
+    node_idx: usize,
+    target_slot: u64,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let cur = net
+            .current_slots()
+            .into_iter()
+            .find(|(i, _)| *i == node_idx)
+            .and_then(|(_, s)| s)
+            .unwrap_or(0);
+        if cur >= target_slot {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "node-{node_idx} stuck at slot {cur} (target {target_slot})"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a 4-node multi-node test that rolling-restarts 3 of the 4 validators in tight succession (one at a time, restart fully before the next kill) and asserts the chain keeps producing blocks throughout, all 4 nodes agree on state_root after each rotation, and no node process dies unexpectedly.
- Models how operators actually do rolling restarts in production (subset at a time, with stabilization windows).

## Finding: audit-234 (4-of-4 stall)
Surfaced while developing this test: rotating ALL 4 validators (rather than 3 of 4) reproducibly stalls the chain on the 4th rotation regardless of order ([0,1,2,3] and [3,0,1,2] both fail at the 4th kill). The 3 alive nodes pin at the last common slot for ≥5s and stop producing.

Likely gossipsub mesh degradation after repeated peer disconnect/reconnect cycles — the only never-restarted node was holding the mesh together. Captured as audit item 234 in `AUDIT_FINDINGS.md` with investigation TODOs. Production with 128 validators has more quorum margin and slower rotation cadence so it may not surface, but worth fixing before testnet.

## Notes
- `#[ignore]` (subprocess-based) — opt in via `--ignored`.
- Test runs in ~50s (3 rotations × ~15s each). Result of latest local run: `churn: passed — rotated 3 of 4 validators, final head 119, all roots agree`.