### PR TITLE
fix: view-change forwards signed message + uses dynamic quorum threshold

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -811,34 +811,58 @@
       wrong-size, zero-balance, already-registered). All 229
       pyde-tx tests + multi-node encrypted e2e pass.
 
-- [ ] 234 — **4-of-4 rolling-restart stall.** Surfaced by
-      `validator_churn` test. Killing all 4 validators of a
-      4-node committee in tight succession (one at a time, each
-      restarted before next is killed) reliably stalls the chain
-      on the 4th kill — the 3 alive nodes pin at the last
-      common slot and stop producing for ≥5s. Reproduces
-      regardless of rotation order ([0,1,2,3], [3,0,1,2] both
-      hit the stall on the 4th rotation). Likely root cause:
-      gossipsub mesh degradation after repeated peer
-      disconnect/reconnect cycles — the only never-restarted
-      node held the mesh together, and removing it leaves the
-      restarted-trio unable to form QCs (timing? mesh sparsity?
-      view-change repeatedly failing?).
+- [~] 234 — `✓` **View-change broken (empty signature + hardcoded
+      threshold) + 4-of-4 rolling-restart gossipsub mesh stall.**
+      Surfaced by `validator_churn` test then traced via
+      diagnostic instrumentation.
       
-      Mitigation in test: `validator_churn` covers 3-of-4
-      rotation (which reflects realistic operator cadence).
-      Production with 128 validators has more quorum margin
-      and slower rotation cadence, so this may not surface, but
-      worth investigating before testnet.
+      Root causes uncovered (3 separate bugs):
       
-      Investigation TODOs:
-      - Dump validator-engine logs at moment of stall: are
-        view-change messages going out? are they being
-        received? why no view-change-QC formation?
-      - Check gossipsub mesh state via metrics — peer count,
-        IHAVE/IWANT churn after multiple restarts.
-      - Try test with 7 validators (quorum 5, 2 down OK) — does
-        the stall move to N-1 of N kills?
+      1. **Empty view-change signature (FIXED).** `node.rs:2196`
+         called `engine.on_timeout(identity)` to construct a
+         properly-signed `ViewChangeMessage`, then THREW IT AWAY
+         (`_vc_msg`) and constructed a fresh `ConsensusMessage::
+         Timeout` with `signature: vec![]` for gossip. Receivers
+         verified the empty signature, rejected it, and
+         `try_form_view_change_qc` never reached quorum. Effect:
+         view-change has been entirely non-functional in
+         production code since the path was wired. Fix: forward
+         the signed `vc_msg` fields directly into the published
+         `Timeout`.
+      
+      2. **Hardcoded view-change threshold (FIXED).**
+         `view_change.rs:194` used `QUORUM_THRESHOLD as u32` (= 86,
+         the production constant) for the threshold check
+         regardless of actual `committee_keys.len()`. Devnet
+         committees of 4 validators would need 86 view-change
+         votes to form a QC — impossible. Fix: switch to
+         `quorum_for_committee(committee_keys.len())`, mirroring
+         `try_form_qc` in hotstuff.rs.
+      
+      3. **Gossipsub mesh degradation (still open).** Even with
+         #1 + #2 fixed, the 4-of-4 stall persists because
+         `gossipsub.publish` for the consensus topic returns
+         `InsufficientPeers` after the live nodes have been
+         through restart cycles. Only the never-restarted node
+         was holding the consensus-topic mesh together; removing
+         it leaves restarted peers unable to publish to each
+         other (their gossipsub state shows 0 peers in the
+         consensus mesh / 0 known subscribers). The 3-of-4
+         `validator_churn` test still passes because the chain
+         can advance via slots whose proposer is alive, with
+         view-change as the recovery path for missed-proposer
+         slots — but in 4-of-4, view-change publish itself fails.
+      
+      Open follow-ups for #3:
+      - Add periodic re-subscribe to `consensus` topic from the
+        validator side so restarted peers re-broadcast SUBSCRIBE
+        control messages to refresh peer subscriber state.
+      - Add a request-response fallback for view-change messages
+        when gossipsub publish returns `InsufficientPeers`
+        (direct point-to-point to known committee peers).
+      - Consider lowering `mesh_n_low` for small-committee
+        devnets — `mesh_n_low=4` is unsatisfiable with N=4
+        validators (max possible mesh peers = N-1 = 3).
 
 ---
 

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -8,7 +8,7 @@
 //!
 //! Liveness: guaranteed if 86+ of 128 validators are honest and online.
 
-use crate::block::{BlockHeader, QuorumCert, QUORUM_THRESHOLD};
+use crate::block::{quorum_for_committee, BlockHeader, QuorumCert, QUORUM_THRESHOLD};
 use pyde_account::address::Address;
 use pyde_crypto::falcon::{
     falcon_sign, falcon_verify, FalconPublicKey, FalconSecretKey, FalconSignature,
@@ -191,7 +191,13 @@ pub fn try_form_view_change_qc(
         }
     }
 
-    if valid_count >= QUORUM_THRESHOLD as u32 {
+    // audit 234: use the dynamic threshold so devnet committees
+    // (which are smaller than the production 128) can still form
+    // a view-change QC. Hardcoding QUORUM_THRESHOLD = 86 made
+    // view-change effectively impossible on any committee with
+    // fewer than 86 validators.
+    let threshold = quorum_for_committee(committee_keys.len());
+    if valid_count >= threshold as u32 {
         Some(ViewChangeQC {
             slot,
             highest_qc,
@@ -309,6 +315,64 @@ mod tests {
 
         let vc_qc = try_form_view_change_qc(10, &messages, &keys);
         assert!(vc_qc.is_none());
+    }
+
+    // ========== audit 234: dynamic-threshold view-change QC ==========
+
+    /// Verify view-change QC forms with the BFT threshold for a
+    /// small (devnet) committee. Pre-fix this used the hardcoded
+    /// production threshold of 86, making view-change unable to
+    /// recover any committee smaller than 86 validators.
+    #[test]
+    fn view_change_qc_dynamic_threshold_small_committee() {
+        // 4-validator committee — quorum_for_committee(4) = ceil(8/3) = 3.
+        let mut messages = Vec::new();
+        let mut keys = Vec::new();
+        for i in 0..3u8 {
+            let (pk, sk) = falcon_keygen().unwrap();
+            let pk_bytes = pk.as_bytes().to_vec();
+            let addr = derive_eoa_address(&pk_bytes);
+            let msg = create_view_change(7, &QuorumCert::empty(), i, addr, &sk).unwrap();
+            messages.push(msg);
+            keys.push(pk_bytes);
+        }
+        // Pad to a 4th key — we have 3 valid messages, 4 committee slots.
+        let (pk4, _) = falcon_keygen().unwrap();
+        keys.push(pk4.as_bytes().to_vec());
+
+        // 3 valid view-change messages, committee_size=4, threshold=3 → QC.
+        let vc_qc = try_form_view_change_qc(7, &messages, &keys);
+        assert!(
+            vc_qc.is_some(),
+            "3 valid view-change messages on a 4-validator committee should form a QC (threshold 3)"
+        );
+        assert_eq!(vc_qc.unwrap().vote_count, 3);
+    }
+
+    /// Below-threshold view-change for a small committee must NOT
+    /// form a QC.
+    #[test]
+    fn view_change_qc_dynamic_threshold_below_quorum() {
+        // 4-validator committee: 2 messages, threshold 3 → no QC.
+        let mut messages = Vec::new();
+        let mut keys = Vec::new();
+        for i in 0..2u8 {
+            let (pk, sk) = falcon_keygen().unwrap();
+            let pk_bytes = pk.as_bytes().to_vec();
+            let addr = derive_eoa_address(&pk_bytes);
+            let msg = create_view_change(7, &QuorumCert::empty(), i, addr, &sk).unwrap();
+            messages.push(msg);
+            keys.push(pk_bytes);
+        }
+        for _ in 0..2 {
+            let (pk, _) = falcon_keygen().unwrap();
+            keys.push(pk.as_bytes().to_vec());
+        }
+        let vc_qc = try_form_view_change_qc(7, &messages, &keys);
+        assert!(
+            vc_qc.is_none(),
+            "2 view-change messages on a 4-validator committee must NOT form a QC (threshold 3)"
+        );
     }
 
     // ========== Task 0494: Multiple consecutive failures ==========

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2193,14 +2193,22 @@ impl PydeNode {
                         // Check for timeout (no proposal received within 200ms)
                         if engine.is_timed_out() {
                             if let Some(identity) = validator_identity.as_ref() {
-                                if let Some(_vc_msg) = engine.on_timeout(identity) {
+                                // audit 234: forward the signed view-change
+                                // message returned by `on_timeout`. Earlier
+                                // code constructed a fresh Timeout with
+                                // `signature: vec![]`, which receivers
+                                // rejected at signature verification — so
+                                // `try_form_view_change_qc` never reached
+                                // quorum and the chain stalled on any slot
+                                // where the assigned proposer was offline.
+                                if let Some(vc_msg) = engine.on_timeout(identity) {
                                     let vc_bytes = wire::encode_consensus_message(
                                         &pyde_consensus::hotstuff::ConsensusMessage::Timeout {
-                                            slot: current_slot,
-                                            voter_index: identity.committee_index,
-                                            voter_address: identity.address,
-                                            highest_qc: engine.consensus.highest_qc.clone(),
-                                            signature: vec![],
+                                            slot: vc_msg.slot,
+                                            voter_index: vc_msg.voter_index,
+                                            voter_address: vc_msg.voter_address,
+                                            highest_qc: vc_msg.highest_qc,
+                                            signature: vc_msg.signature,
                                         }
                                     );
                                     let topic = pyde_net::node::topics::consensus();


### PR DESCRIPTION
## Summary
audit 234, parts 1+2 of 3.

Two real bugs in the view-change path that made view-change entirely non-functional in production code since wire-up. Found via diagnostic instrumentation of the `validator_churn` 4-of-4 reproducer.

### Bug 1: empty signature (`node.rs:2196`)
The runtime called `engine.on_timeout(identity)` to construct a properly-signed `ViewChangeMessage`, then **threw it away** (`_vc_msg`) and built a fresh `ConsensusMessage::Timeout` with `signature: vec![]` for gossip. Receivers verified the empty sig, rejected it, and `try_form_view_change_qc` never reached quorum.

**Effect:** any time a slot's assigned proposer was offline, the chain stalled until they came back — view-change couldn't form a fallback-proposer QC. The first 3 churn rotations passed because the chain advanced via slots whose proposer was alive; the 4th hit a slot where view-change was the only path.

**Fix:** forward `vc_msg`'s signed fields directly into the published `Timeout`.

### Bug 2: hardcoded view-change threshold (`view_change.rs:194`)
`try_form_view_change_qc` used `QUORUM_THRESHOLD as u32` (= 86, the production constant) regardless of actual `committee_keys.len()`. Devnet committees of 4 validators would need 86 view-change votes — impossible.

**Fix:** switch to `quorum_for_committee(committee_keys.len())`, mirroring `try_form_qc` in `hotstuff.rs`.

## Notes
- 3-of-4 `validator_churn` test continues to pass, strictly more correct now.
- The 4-of-4 stall persists due to a third gossipsub-mesh-degradation issue (gossip publish returns `InsufficientPeers` for the consensus topic after restart cycles). Tracked as the open `[~]` part of audit 234 with concrete follow-ups (periodic re-subscribe, request-response fallback for view-change, lower `mesh_n_low` for small committees).
- Two new unit tests verify view-change QC formation respects the dynamic threshold (3 votes on 4-validator committee → QC; 2 votes → no QC).
- 108 consensus unit + 5 prop tests still pass.