### PR TITLE
feat(consensus): (height, view) state machine + single-leader fallback

### DIFF
--- a/crates/consensus/CONSENSUS_INVARIANTS.md
+++ b/crates/consensus/CONSENSUS_INVARIANTS.md
@@ -1,0 +1,167 @@
+# Pyde Consensus — State Machine Invariants
+
+Written 2026-04-26 as the design contract for the audit-234 follow-up
+refactor (decouple `target_height` from `current_slot`,
+single-leader-per-view fallback, RR fallback for liveness messages).
+
+The invariants below are what the new state machine MUST hold. Each
+characterization and regression test in `crates/consensus/tests/` and
+`crates/node/tests/` should map to one of these.
+
+---
+
+## State
+
+The validator's consensus state is keyed on `(height, view)`:
+
+- `height: u64` — the position in the chain we are currently trying to
+  commit. Monotonically non-decreasing; only advances when a block at
+  `height` reaches a vote-QC AND is applied locally.
+- `view: u64` — the recovery attempt within `height`. Starts at 0 for
+  every fresh height; increments on view-change-QC formation.
+- `current_slot: u64` — wall-clock slot, advanced by the engine tick
+  every `SLOT_DURATION_MS`. Used for **timing decisions only**
+  (when to time out, when to refresh randomness). Never used as the
+  recovery target.
+
+The relationship `height ≤ current_slot` always holds. They diverge
+during recovery — the chain falls behind wall-clock until view-change
+recovers, then catches up.
+
+---
+
+## Invariants
+
+### Safety (must not be violated under any execution)
+
+**S1 — Single-block-per-height.**
+For every height `H`, the chain commits at most one block. Two
+distinct blocks at the same `H` is a safety violation.
+
+**S2 — No double-vote across views.**
+For a given `(H, V)`, a validator votes for at most one block. A
+validator MAY vote for different blocks at `(H, V1)` and `(H, V2)`
+where `V1 ≠ V2` (this is what view-change is for), but only if it
+locked on no QC at the lower view.
+
+**S3 — Locked-QC monotonicity.**
+A validator's `locked_qc.height` only increases. A vote for `(H, V)`
+where `H ≤ locked_qc.height` is rejected at the create-vote layer.
+
+**S4 — Persist-before-broadcast.**
+For every state mutation that establishes `(H, V)` participation
+(vote, view-change message, lock-bump), the change is fsync'd to
+`ConsensusStateStore` BEFORE the corresponding wire message is
+broadcast. A crash between persist and broadcast is recoverable; a
+crash between broadcast and persist breaks S2.
+
+### Liveness (must hold under partial-synchrony)
+
+**L1 — Oldest-unresolved-height invariant.**
+View-change always operates on the OLDEST `H` for which no block
+has been committed locally, regardless of `current_slot`. If
+`height = 145` and the wall-clock is now at slot 150, view-change
+messages still target `(145, V)`, not `(150, *)`. The chain does
+not skip past unresolved heights.
+
+**L2 — Single deterministic leader per (H, V).**
+For a given `(H, V)`, there is exactly one designated proposer:
+`committee[fallback_index(H, V, committee_keys.len())]`. All
+honest validators compute the same answer. Multiple
+fallback-proposal candidates per `(H, V)` are NOT permitted.
+
+> Note: the happy-path proposer (V=0) is selected by VRF as today.
+> This invariant only applies to recovery views (V ≥ 1).
+
+**L3 — View advancement.**
+A validator advances `view` for height `H` when EITHER:
+- it receives a `ViewChangeQC(H, V)` (advances to `V+1`), OR
+- its view-change timeout for `(H, V)` expires AND it has not
+  observed a vote-QC for `(H, V)` (advances to `V+1` and broadcasts
+  a new view-change message).
+
+`view` only increases. There is no "view 2 then view 1 again."
+
+**L4 — At-least-once delivery for liveness messages.**
+For each `(H, V)` recovery, the messages
+`{ViewChange(H, V), Vote(H, V), Proposal(H, V)}` are delivered to
+the designated leader (and to all validators for vote messages) via
+**either** gossipsub OR the request-response fallback transport,
+within `RECOVERY_DELIVERY_TIMEOUT_MS`. If gossipsub returns
+`InsufficientPeers` OR a per-message deadline elapses, the sender
+falls back to direct RR delivery to all known committee peers.
+
+**L5 — Recovery progress.**
+If `(H, V)` fails to commit within `VIEW_TIMEOUT_MS` (a function
+of `V` — typically exponential backoff: `200ms * 2^V`), the
+validator broadcasts `ViewChange(H, V+1)`. There is no upper bound
+on `V`; recovery continues until 2f+1 validators are online and
+mutually reachable.
+
+### State-machine ordering
+
+**O1 — Lock-then-vote.**
+On receiving a valid proposal for `(H, V)`, the validator FIRST
+updates its `locked_qc` if the proposal extends a higher QC, THEN
+persists, THEN signs the vote, THEN broadcasts. Out-of-order writes
+risk S3.
+
+**O2 — Apply-then-advance.**
+A block at height `H` is applied to local state only after a vote-QC
+is formed AND the block matches the QC's `block_hash`. After apply,
+`height` advances to `H+1` and `view` resets to 0.
+
+**O3 — `current_slot` is timing-only.**
+No safety or liveness decision reads `current_slot` directly. Only
+`height` and `view` drive the state machine. `current_slot` is read
+exclusively by:
+- the timeout-firing predicate (`now_ms - slot_start_ms ≥ T`)
+- the proposer-VRF input (which slot to compute candidacy for at V=0)
+- epoch-randomness scheduling
+
+---
+
+## Failure modes the new design must close
+
+These are what audit 234 surfaced. Each maps to an invariant above:
+
+| Failure mode | Invariant violated today | New invariant that closes it |
+|---|---|---|
+| Slot-sync drift (VC msg targets wrong slot) | L1 | L1 (operate on oldest unresolved H) |
+| Vote splitting (multiple fallback proposals per slot) | L2 | L2 (single deterministic leader per (H,V)) |
+| Mesh inconsistency (gossipsub drops VC/votes) | L4 | L4 (RR fallback for liveness msgs) |
+| `timeout` tracker reset on `advance_slot` (recovery state lost) | L1 + O3 | O3 (current_slot is timing-only) |
+
+---
+
+## Non-invariants (deliberate design choices, NOT properties to enforce)
+
+- **The happy-path proposer is multi-proposer (lowest VRF score).**
+  This is the latency-optimization that makes the chain fast on the
+  happy path. Only the recovery (V≥1) leader is single-proposer.
+- **Wall-clock fairness.** Different validators may observe slot
+  boundaries at slightly different `now_ms`. The state machine is
+  resilient to this skew via L3 and L5.
+- **Equivalence between `height` and on-chain block slot.** They are
+  the same number, but conceptually distinct: `height` is "what
+  position am I trying to commit", which equals the block's `slot`
+  field once the block exists.
+
+---
+
+## Testing matrix (what the regression tests cover)
+
+| Test | Invariant under test |
+|---|---|
+| `slot_drift_does_not_advance_target_height` | L1, O3 |
+| `view_change_targets_oldest_unresolved_height` | L1 |
+| `single_fallback_leader_per_view` | L2 |
+| `vote_split_recovers_via_view_advancement` | L3 |
+| `gossip_drop_recovers_via_rr_fallback` | L4 |
+| `repeated_view_failures_eventually_commit` | L5 |
+| `persist_before_broadcast_holds_under_crash` | S4 |
+| `locked_qc_never_decreases` | S3 |
+| `single_block_per_height_under_partition` | S1 |
+
+The first three are the failing tests in step 1c/1d of this PR
+sequence; the rest land alongside steps 2-4 of the audit-234 fix.

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -62,9 +62,29 @@ pub enum ConsensusMessage {
 }
 
 /// The state machine for a single validator's consensus participation.
+///
+/// Two distinct slot-like quantities live here. They are intentionally
+/// separate (audit-234 part 4 — see `crates/consensus/CONSENSUS_INVARIANTS.md`):
+///
+/// - `current_slot` is the wall-clock slot. Advanced by the engine tick
+///   every `SLOT_DURATION_MS`. Used for **timing decisions only**
+///   (when to time out, proposer-VRF input at view 0, epoch scheduling).
+///   It must NEVER be used as the recovery target: when recovery takes
+///   longer than a slot, `current_slot` drifts past the height we are
+///   actually trying to commit.
+///
+/// - `target_height` is the position in the chain we are currently
+///   trying to commit. Monotonically non-decreasing; only advances when
+///   a block at `target_height` reaches a vote-QC. View-change
+///   messages, fallback proposals, and timeout-tracker keys ALL use
+///   `target_height`, never `current_slot`.
+///
+/// `current_view` is the recovery attempt within `target_height`.
+/// 0 = happy-path proposer (VRF). ≥1 = view-change-driven fallback
+/// proposer. Resets to 0 every time `target_height` advances.
 #[derive(Clone, Debug)]
 pub struct ConsensusState {
-    /// Current slot.
+    /// Wall-clock slot (timing only — see struct doc).
     pub current_slot: u64,
     /// Current epoch.
     pub current_epoch: u64,
@@ -76,6 +96,12 @@ pub struct ConsensusState {
     pub last_committed_hash: [u8; 32],
     /// Last committed slot.
     pub last_committed_slot: u64,
+    /// The chain height we are currently trying to commit
+    /// (audit-234 part 4). See struct doc.
+    pub target_height: u64,
+    /// Recovery attempt within `target_height` (audit-234 part 4).
+    /// 0 = happy-path; ≥1 = view-change-driven fallback.
+    pub current_view: u64,
     /// Votes collected for current slot (if we're the next proposer).
     pub pending_votes: Vec<ConsensusMessage>,
     /// Timeout votes collected.
@@ -91,16 +117,46 @@ impl ConsensusState {
             last_voted_slot: 0,
             last_committed_hash: [0u8; 32],
             last_committed_slot: 0,
+            // Genesis is at slot 0; the first slot we try to commit is 1.
+            target_height: 1,
+            current_view: 0,
             pending_votes: Vec::new(),
             pending_timeouts: Vec::new(),
         }
     }
 
-    /// Advance to next slot.
+    /// Advance the wall-clock slot by one. Does NOT touch
+    /// `target_height` or `current_view` — those advance only when a
+    /// vote-QC forms (target_height) or a view-change-QC forms
+    /// (current_view).
     pub fn advance_slot(&mut self) {
         self.current_slot += 1;
         self.pending_votes.clear();
         self.pending_timeouts.clear();
+    }
+
+    /// Advance `target_height` to `new_height` and reset
+    /// `current_view` to 0. No-op if `new_height <= target_height`
+    /// (target is monotonic). Returns true iff the target advanced.
+    ///
+    /// Called by the engine after a vote-QC forms, signalling that
+    /// the current target has been certified and we are ready to
+    /// move on to the next height.
+    pub fn advance_target_height(&mut self, new_height: u64) -> bool {
+        if new_height > self.target_height {
+            self.target_height = new_height;
+            self.current_view = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Bump `current_view` by one, signalling a recovery attempt for
+    /// the current `target_height`. Called by the engine when a
+    /// view-change-QC forms.
+    pub fn bump_view(&mut self) {
+        self.current_view += 1;
     }
 }
 

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -17,6 +17,15 @@ use pyde_crypto::falcon::{
 /// Timeout duration before declaring proposer failure (milliseconds).
 pub const PROPOSAL_TIMEOUT_MS: u64 = 200;
 
+/// Audit 234 part 3: secondary timeout. After voting for a proposal,
+/// if no QC for the slot is observed within this window, the
+/// validator triggers view-change as a liveness fallback. Set well
+/// above the 400ms slot time so a healthy chain never trips it
+/// (a slot that gets its QC promptly clears the validator's
+/// state before this fires), but low enough that gossip-mesh
+/// inconsistency is recovered within a few seconds.
+pub const PROGRESS_TIMEOUT_MS: u64 = 2_000;
+
 /// Slot duration (milliseconds).
 pub const SLOT_DURATION_MS: u64 = 400;
 
@@ -212,8 +221,102 @@ pub fn try_form_view_change_qc(
 /// Determine the fallback proposer for a slot.
 /// The fallback is the committee member with the 2nd lowest VRF score.
 /// `sorted_scores` should be (address, score) sorted by score ascending.
+///
+/// Note: superseded by `fallback_leader_index((H, V), n)` for the
+/// audit-234 part 4 single-leader-per-view design. Kept for tests.
+#[allow(dead_code)]
 pub fn fallback_proposer(sorted_scores: &[(Address, u64)]) -> Option<Address> {
     sorted_scores.get(1).map(|(addr, _)| *addr)
+}
+
+/// Marker prefix in a `BlockHeader.vrf_proof` field signalling
+/// "this is a view-change fallback proposal, validate against the
+/// view-change-QC rather than VRF". The marker is followed by:
+///   - u64 LE: VC-QC slot (target_height the fallback is for)
+///   - u64 LE: view number the fallback was built at
+/// Total: 8 (marker) + 8 (slot) + 8 (view) = 24 bytes.
+pub const FALLBACK_PROPOSAL_MARKER: &[u8; 8] = b"FALLBACK";
+
+/// Audit-234 part 4 (CONSENSUS_INVARIANTS.md L2): deterministic
+/// fallback leader for the recovery view at `(height, view)`.
+/// All honest validators compute the same answer regardless of
+/// which view-change messages they observed, so the fallback
+/// proposer is unanimous without depending on the gossip mesh
+/// having delivered identical VC-message subsets to every peer.
+///
+/// The mapping `(H + V) mod n` is intentionally simple:
+///   - deterministic and cheap (no hashing)
+///   - rotates within a height: each failing view picks a different
+///     committee member, so a stuck leader is bypassed within at
+///     most n-1 view bumps
+///   - rotates across heights: even if every view-0 leader is
+///     honest-but-unreachable, the V≥1 fallback for the next height
+///     picks a different member
+///
+/// Pre-mainnet: if grinding-resistance becomes a concern (committee
+/// members predicting future leadership and timing out strategically),
+/// upgrade to `Poseidon2(epoch_randomness || H || V) mod n`. For now
+/// the simple modular sum is sufficient — V advances only on quorum
+/// timeout, not on individual proposer choice.
+pub fn fallback_leader_index(height: u64, view: u64, committee_size: usize) -> usize {
+    if committee_size == 0 {
+        return 0;
+    }
+    (height.wrapping_add(view) as usize) % committee_size
+}
+
+/// Deterministically pick the fallback proposer's committee index
+/// from a view-change-QC's voter bitmap: the lowest-indexed bit
+/// that is set.
+///
+/// Note: superseded by `fallback_leader_index((H, V), n)` for the
+/// audit-234 part 4 single-leader-per-view design. Bitmap-based
+/// selection failed under mesh inconsistency because different
+/// validators observed different VC-message subsets and computed
+/// different fallback leaders, splitting votes across the
+/// candidates. Kept dead for now; remove with the next view_change
+/// cleanup pass.
+#[allow(dead_code)]
+pub fn deterministic_fallback_index(voter_bitmap: u128) -> Option<u8> {
+    if voter_bitmap == 0 {
+        return None;
+    }
+    Some(voter_bitmap.trailing_zeros() as u8)
+}
+
+/// Build a `vrf_proof` field carrying the fallback marker + the
+/// view-change-QC's slot + the recovery view number. Receivers
+/// recognize this prefix and validate the proposer against
+/// `fallback_leader_index(slot, view, committee_size)` instead of
+/// running VRF verification.
+pub fn encode_fallback_proof(vc_qc_slot: u64, view: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(FALLBACK_PROPOSAL_MARKER.len() + 16);
+    buf.extend_from_slice(FALLBACK_PROPOSAL_MARKER);
+    buf.extend_from_slice(&vc_qc_slot.to_le_bytes());
+    buf.extend_from_slice(&view.to_le_bytes());
+    buf
+}
+
+/// True iff `vrf_proof` was produced by `encode_fallback_proof`.
+pub fn is_fallback_proof(vrf_proof: &[u8]) -> bool {
+    vrf_proof.len() >= FALLBACK_PROPOSAL_MARKER.len()
+        && &vrf_proof[..FALLBACK_PROPOSAL_MARKER.len()] == FALLBACK_PROPOSAL_MARKER
+}
+
+/// Decode a fallback proof produced by `encode_fallback_proof`,
+/// returning `(vc_qc_slot, view)`. Returns None if the buffer is
+/// not a fallback proof or is truncated.
+pub fn decode_fallback_proof(vrf_proof: &[u8]) -> Option<(u64, u64)> {
+    if !is_fallback_proof(vrf_proof) {
+        return None;
+    }
+    let after_marker = &vrf_proof[FALLBACK_PROPOSAL_MARKER.len()..];
+    if after_marker.len() < 16 {
+        return None;
+    }
+    let slot = u64::from_le_bytes(after_marker[0..8].try_into().ok()?);
+    let view = u64::from_le_bytes(after_marker[8..16].try_into().ok()?);
+    Some((slot, view))
 }
 
 /// Create an empty block header for when both primary and fallback fail.
@@ -382,6 +485,70 @@ mod tests {
         let scores = vec![([0x01; 32], 100), ([0x02; 32], 200), ([0x03; 32], 300)];
         let fallback = fallback_proposer(&scores).unwrap();
         assert_eq!(fallback, [0x02; 32]); // 2nd lowest
+    }
+
+    // ===== audit-234 part 4: (height, view) leader + fallback proof =====
+
+    #[test]
+    fn fallback_leader_index_deterministic_per_height_view() {
+        // Same (H, V) → same leader, regardless of call order.
+        for n in [3usize, 4, 7, 16, 128] {
+            for h in [0u64, 1, 5, 145, 1_000_000] {
+                for v in [0u64, 1, 2, 5] {
+                    let a = fallback_leader_index(h, v, n);
+                    let b = fallback_leader_index(h, v, n);
+                    assert_eq!(a, b, "non-deterministic at (H={h}, V={v}, n={n})");
+                    assert!(a < n, "leader index out of range at (H={h}, V={v}, n={n})");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fallback_leader_index_rotates_within_height() {
+        // Different views for the same height pick different leaders
+        // (within one full rotation). After n bumps the cycle repeats,
+        // which is fine — the chain only needs at most f failed views
+        // to reach an honest leader.
+        let n = 4;
+        let h = 145;
+        let leaders: std::collections::HashSet<usize> =
+            (0..(n as u64)).map(|v| fallback_leader_index(h, v, n)).collect();
+        assert_eq!(
+            leaders.len(),
+            n,
+            "n consecutive views should cover every committee slot exactly once"
+        );
+    }
+
+    #[test]
+    fn fallback_leader_index_zero_committee_safe() {
+        // Defensive: no panic on degenerate committee.
+        assert_eq!(fallback_leader_index(5, 0, 0), 0);
+    }
+
+    #[test]
+    fn fallback_proof_roundtrip() {
+        let proof = encode_fallback_proof(145, 3);
+        assert!(is_fallback_proof(&proof));
+        let decoded = decode_fallback_proof(&proof).expect("must decode");
+        assert_eq!(decoded, (145, 3));
+    }
+
+    #[test]
+    fn decode_fallback_proof_rejects_non_fallback() {
+        // VRF-shaped data (no fallback marker) returns None.
+        let vrf_like = vec![0xAB; 96];
+        assert!(decode_fallback_proof(&vrf_like).is_none());
+    }
+
+    #[test]
+    fn decode_fallback_proof_rejects_truncated() {
+        // Marker present but missing the view u64.
+        let mut truncated = FALLBACK_PROPOSAL_MARKER.to_vec();
+        truncated.extend_from_slice(&145u64.to_le_bytes()); // slot only, no view
+        assert!(is_fallback_proof(&truncated));
+        assert!(decode_fallback_proof(&truncated).is_none());
     }
 
     #[test]

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -499,6 +499,8 @@ mod tests {
             last_voted_slot: 100,
             last_committed_hash: [0xCD; 32],
             last_committed_slot: 98,
+            target_height: 100,
+            current_view: 0,
             pending_votes: Vec::new(),
             pending_timeouts: Vec::new(),
         }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -314,16 +314,37 @@ pub struct ValidatorEngine {
     /// validator will not vote on the selected proposal for that slot.
     /// Soft enforcement — a 1/128 false positive just costs one vote.
     inclusion_violated_slots: std::collections::HashSet<u64>,
+    /// Audit 234 part 3: wall-clock timestamp (Unix ms) of the
+    /// most recent forward movement of `consensus.highest_qc.slot`,
+    /// AND the slot value at that moment. `is_timed_out` lazily
+    /// detects QC progress (current `highest_qc.slot` > the cached
+    /// one), updates both fields, then checks the
+    /// `PROGRESS_TIMEOUT_MS` deadline. Powers the
+    /// "no-progress" liveness fallback: if the chain hasn't
+    /// produced a new QC for `PROGRESS_TIMEOUT_MS`, the validator
+    /// triggers view-change regardless of whether a proposal was
+    /// received for the current slot. Without this, gossip-mesh
+    /// degradation can wedge the chain indefinitely — validators
+    /// that received the proposal vote and don't time out,
+    /// validators that didn't time out and view-change, and
+    /// neither path reaches quorum.
+    last_qc_progress_ms: u64,
+    last_seen_qc_slot: u64,
 }
 
 impl ValidatorEngine {
     /// Create a new validator engine at genesis.
     pub fn new(epoch_randomness: [u8; 32]) -> Self {
         let now_ms = current_time_ms();
+        let consensus = ConsensusState::new();
+        // audit-234 part 4: TimeoutTracker is keyed on `target_height`,
+        // not the wall-clock slot. ConsensusState::new() initializes
+        // target_height to 1 (the first slot we want to commit).
+        let initial_target = consensus.target_height;
         Self {
-            consensus: ConsensusState::new(),
+            consensus,
             finality: FinalityTracker::new(),
-            timeout: TimeoutTracker::new(0, now_ms),
+            timeout: TimeoutTracker::new(initial_target, now_ms),
             committee_keys: Vec::new(),
             epoch_randomness,
             votes: HashMap::new(),
@@ -337,6 +358,8 @@ impl ValidatorEngine {
             broadcast_evidence: Vec::new(),
             seen_evidence: std::collections::HashSet::new(),
             inclusion_violated_slots: std::collections::HashSet::new(),
+            last_qc_progress_ms: now_ms,
+            last_seen_qc_slot: 0,
             randomness_collector: None,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
@@ -1124,6 +1147,15 @@ impl ValidatorEngine {
             return false;
         }
 
+        // Audit 234 part 3: fallback proposals (built by the
+        // deterministic fallback proposer after a view-change-QC
+        // forms) carry a marker in vrf_proof instead of VRF data.
+        // Validate the proposer against our local view-change-QC
+        // rather than running VRF verification.
+        if pyde_consensus::view_change::is_fallback_proof(&header.vrf_proof) {
+            return self.buffer_fallback_proposal(header, proposer_signature);
+        }
+
         // VRF data must be at least 32 bytes (output) + some proof bytes
         if header.vrf_proof.len() < 33 {
             warn!(slot, "proposal has missing or truncated VRF data");
@@ -1347,6 +1379,240 @@ impl ValidatorEngine {
         vote
     }
 
+    /// Validate + buffer a fallback proposal (audit 234 part 3).
+    /// Uses the local view-change-QC rather than VRF for proposer
+    /// authority. Returns true iff the proposal was buffered.
+    fn buffer_fallback_proposal(
+        &mut self,
+        header: &BlockHeader,
+        proposer_signature: &[u8],
+    ) -> bool {
+        let slot = header.slot;
+
+        // Local view-change-QC for this slot is required to
+        // recognize the legitimate fallback proposer. Without it,
+        // we have no way to validate the proposal; reject and let
+        // our own view-change-QC formation catch up.
+        if self.timeout.slot != slot || self.timeout.view_change_qc.is_none() {
+            debug!(slot, "fallback proposal received without local view-change-QC; deferring");
+            return false;
+        }
+        let vc_qc = self.timeout.view_change_qc.as_ref().unwrap();
+
+        // Verify the proposer is a committee member.
+        let proposer_idx = match self.committee_keys.iter().position(|k| {
+            pyde_account::address::derive_eoa_address(k) == header.proposer
+        }) {
+            Some(i) => i,
+            None => {
+                warn!(
+                    slot,
+                    proposer = hex::encode(header.proposer),
+                    "fallback proposal from non-committee member"
+                );
+                return false;
+            }
+        };
+        let _ = vc_qc;
+
+        // audit-234 part 4 (CONSENSUS_INVARIANTS.md L2): the proposer
+        // MUST be the deterministic leader for the view encoded in
+        // the proposal's fallback proof. The view comes from the
+        // proof, not from the receiver's local `current_view`,
+        // because honest validators may be ahead/behind on view
+        // bumps under partial connectivity. Computing the leader
+        // against the proposer-asserted view lets a receiver accept
+        // a valid fallback for a view it hasn't installed yet
+        // (it'll catch up when more VC messages arrive); rejecting
+        // mismatches still blocks attacker-built proposals at the
+        // wrong index.
+        let (proof_slot, proof_view) =
+            match pyde_consensus::view_change::decode_fallback_proof(&header.vrf_proof) {
+                Some(decoded) => decoded,
+                None => {
+                    warn!(slot, "fallback proposal has malformed fallback proof");
+                    return false;
+                }
+            };
+        if proof_slot != slot {
+            warn!(
+                slot,
+                proof_slot, "fallback proposal: proof slot does not match header slot"
+            );
+            return false;
+        }
+        let expected_leader = pyde_consensus::view_change::fallback_leader_index(
+            slot,
+            proof_view,
+            self.committee_keys.len(),
+        );
+        if proposer_idx != expected_leader {
+            warn!(
+                slot,
+                view = proof_view,
+                proposer = proposer_idx,
+                expected = expected_leader,
+                "fallback proposal: proposer is not the deterministic leader for this view"
+            );
+            return false;
+        }
+
+        // Verify proposer signature on the block header (same
+        // canonical message format as the regular path).
+        if proposer_signature.is_empty() {
+            warn!(slot, "fallback proposal missing proposer signature");
+            return false;
+        }
+        let pk = match pyde_crypto::falcon::FalconPublicKey::from_bytes(
+            &self.committee_keys[proposer_idx],
+        ) {
+            Some(pk) => pk,
+            None => {
+                warn!(slot, "fallback proposer pk decode failed");
+                return false;
+            }
+        };
+        let sig = match pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature) {
+            Some(s) => s,
+            None => {
+                warn!(slot, "fallback proposer signature decode failed");
+                return false;
+            }
+        };
+        let block_hash = header.hash();
+        let sign_msg = proposer_sign_message(slot, &block_hash);
+        if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
+            warn!(slot, "fallback proposer signature verification failed");
+            return false;
+        }
+
+        // Buffer with vrf_score = committee_index. When multiple
+        // alive validators each broadcast a fallback proposal,
+        // receivers' existing min-by-vrf_score selection picks the
+        // lowest committee_index — deterministic across all
+        // receivers without requiring identical view-change-QC
+        // bitmaps. Real proposals (if they arrive) have full
+        // 64-bit VRF scores from a hash, so a u8 committee_index
+        // never beats a real proposal in the rare race.
+        let entry = self.buffered_proposals.entry(slot).or_default();
+        entry.push(BufferedProposal {
+            header: header.clone(),
+            proposer_signature: proposer_signature.to_vec(),
+            vrf_score: proposer_idx as u64,
+        });
+        info!(slot, proposer_idx, "buffered fallback proposal");
+        true
+    }
+
+    /// If a view-change-QC has formed for the current slot AND we
+    /// are the deterministic fallback proposer (audit 234 part 3),
+    /// build the empty fallback block and return it for broadcast.
+    /// Otherwise returns None.
+    pub fn try_build_fallback_proposal(
+        &mut self,
+        identity: &ValidatorIdentity,
+        parent_hash: [u8; 32],
+        state_root: [u8; 32],
+    ) -> Option<Block> {
+        // audit-234 part 4 (CONSENSUS_INVARIANTS.md L1, O3): fallback
+        // proposals target `target_height`, not `current_slot`.
+        // Wall-clock drift during recovery would otherwise cause the
+        // fallback to be built for a slot the chain has already moved
+        // past.
+        let slot = self.consensus.target_height;
+        info!(mine = identity.committee_index, target_height = slot, current_slot = self.consensus.current_slot, "DBG try_build_fallback_proposal entered");
+        // NOTE: previously voting for slot does NOT disqualify us from
+        // being the fallback proposer (audit 234 part 3). The whole
+        // reason a view-change-QC exists at this slot is that the
+        // earlier vote-QC failed to reach quorum — we need a fresh
+        // proposal to break the wedge. The voted-slot dedup matters
+        // only against double-voting on the SAME proposal, which is
+        // enforced by HotStuff safety in `create_vote`.
+        if self.timeout.slot != slot {
+            info!(slot, timeout_slot = self.timeout.slot, "DBG fallback skip: timeout.slot != target_height");
+            return None;
+        }
+        if self.timeout.view_change_qc.is_none() {
+            return None;
+        }
+        // audit-234 part 4 (CONSENSUS_INVARIANTS.md L2): only the
+        // deterministic leader for `(target_height, current_view)`
+        // builds a fallback. Other validators return None. This
+        // collapses the multi-proposer fallback that was splitting
+        // votes under asymmetric gossip delivery — every honest
+        // receiver computes the same `fallback_leader_index`
+        // independently of which view-change messages it observed,
+        // so the only candidate proposal carries a single committee
+        // index that all receivers agree on.
+        let view = self.consensus.current_view;
+        let leader_idx = pyde_consensus::view_change::fallback_leader_index(
+            slot,
+            view,
+            self.committee_keys.len(),
+        );
+        if (identity.committee_index as usize) != leader_idx {
+            debug!(
+                slot,
+                view,
+                mine = identity.committee_index,
+                leader = leader_idx,
+                "fallback skip: not the deterministic leader for this view"
+            );
+            return None;
+        }
+        info!(
+            slot,
+            view,
+            mine = identity.committee_index,
+            "DBG fallback: I am the deterministic leader for (target_height, current_view); building"
+        );
+        // Don't double-build.
+        if self
+            .buffered_proposals
+            .get(&slot)
+            .is_some_and(|v| v.iter().any(|p| p.header.proposer == identity.address))
+        {
+            return None;
+        }
+
+        let vrf_proof = pyde_consensus::view_change::encode_fallback_proof(slot, view);
+        let header = BlockHeader {
+            slot,
+            epoch: slot / EPOCH_LENGTH,
+            parent_hash,
+            proposer: identity.address,
+            vrf_proof,
+            qc_previous: self.consensus.highest_qc.clone(),
+            tx_root: [0u8; 32],
+            state_root,
+            timestamp: current_time_ms(),
+        };
+
+        let block_hash = header.hash();
+        let sign_msg = proposer_sign_message(slot, &block_hash);
+        let proposer_signature = match pyde_crypto::falcon::falcon_sign(&identity.secret_key, &sign_msg) {
+            Ok(sig) => sig.to_vec(),
+            Err(_) => {
+                warn!(slot, "failed to sign fallback proposal");
+                return None;
+            }
+        };
+
+        info!(slot, "built fallback proposal as deterministic view-change fallback proposer");
+        Some(Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: vec![],
+                execution_schedule: ExecutionSchedule {
+                    groups: vec![],
+                    total_txs: 0,
+                },
+            },
+            proposer_signature,
+        })
+    }
+
     /// Build a block proposal for the current slot.
     /// Called when this validator is the proposer.
     pub fn build_proposal(
@@ -1551,6 +1817,15 @@ impl ValidatorEngine {
                 if mutated {
                     self.persist_consensus();
                 }
+                // audit-234 part 4 (CONSENSUS_INVARIANTS.md O2): a QC
+                // for slot `slot` certifies the block at that height.
+                // Advance `target_height` to `slot + 1` so subsequent
+                // recovery (view-change, fallback) targets the next
+                // height we need to commit, not the one we just
+                // certified. `advance_target_height` is monotonic
+                // (no-op if a later QC already advanced past us) and
+                // resets the timeout tracker for the new target.
+                self.advance_target_height(slot + 1);
                 // Record soft finality
                 self.finality
                     .record_soft_finality(slot, block_hash, qc.clone());
@@ -1564,7 +1839,15 @@ impl ValidatorEngine {
     /// Handle a slot timeout: create view change message.
     /// Returns the message to broadcast.
     pub fn on_timeout(&mut self, identity: &ValidatorIdentity) -> Option<ViewChangeMessage> {
-        let slot = self.consensus.current_slot;
+        // audit-234 part 4 (CONSENSUS_INVARIANTS.md L1, O3): the
+        // view-change message MUST target `target_height` — the
+        // oldest height we still need to commit — not the
+        // wall-clock `current_slot`. When recovery takes longer
+        // than `SLOT_DURATION_MS`, `current_slot` drifts and a
+        // VC msg keyed on it would target a slot the chain has
+        // already moved past, leaving the original failed slot
+        // permanently uncommitted.
+        let slot = self.consensus.target_height;
         match create_view_change(
             slot,
             &self.consensus.highest_qc,
@@ -1584,16 +1867,70 @@ impl ValidatorEngine {
     }
 
     /// Handle an incoming view change message.
-    /// Returns the ViewChangeQC if quorum is reached.
+    /// Returns true when a view-change-QC is installed in `self.timeout`.
+    ///
+    /// audit-234 part 4 (CONSENSUS_INVARIANTS.md L3): on the first
+    /// formation of a VC-QC for the current view, bump
+    /// `consensus.current_view`. The deterministic leader for the
+    /// new view (V+1) is then `fallback_leader_index(target_height,
+    /// current_view, n)`. The timeout tracker is reset so the new
+    /// view's leader gets a fresh proposal window — the VC-QC is
+    /// preserved on the new tracker so receivers know recovery is
+    /// in progress.
     pub fn on_view_change(&mut self, msg: ViewChangeMessage) -> bool {
         let slot = msg.slot;
+
+        // audit-234 part 4: ignore late VC messages for slots the
+        // chain has already moved past. Without this guard, a VC
+        // msg arriving after target_height advanced would re-form
+        // a VC-QC for the stale slot and clobber the current
+        // target's timeout tracker (since the first-formation
+        // check sees vc_qc=None and would install a fresh tracker
+        // keyed on the stale slot). target_height monotonicity
+        // means msg.slot < target_height is always stale; equal
+        // is the current target; greater is future and we accept
+        // it (the chain hasn't reached it yet but we'll need the
+        // VC state by the time it does).
+        if slot < self.consensus.target_height {
+            debug!(
+                slot,
+                target_height = self.consensus.target_height,
+                "ignoring stale view-change message"
+            );
+            return false;
+        }
+
         let entry = self.view_changes.entry(slot).or_default();
         entry.push(msg);
 
         // Try to form view change QC
         if let Some(vc_qc) = try_form_view_change_qc(slot, entry, &self.committee_keys) {
-            info!(slot, votes = vc_qc.vote_count, "view change QC formed");
-            self.timeout.view_change_qc = Some(vc_qc);
+            let first_formation = self.timeout.view_change_qc.is_none();
+            if first_formation {
+                self.consensus.bump_view();
+                self.persist_consensus();
+                info!(
+                    slot,
+                    votes = vc_qc.vote_count,
+                    new_view = self.consensus.current_view,
+                    "view change QC formed; bumped to view {}",
+                    self.consensus.current_view
+                );
+                // Fresh tracker for the new view so the leader has a
+                // full proposal window. Preserve the VC-QC so the
+                // receive-side gate in `buffer_fallback_proposal`
+                // and the build-side gate in
+                // `try_build_fallback_proposal` recognize that
+                // recovery is in progress.
+                let now_ms = current_time_ms();
+                let mut new_tracker = TimeoutTracker::new(slot, now_ms);
+                new_tracker.view_change_qc = Some(vc_qc);
+                self.timeout = new_tracker;
+            } else {
+                // VC-QC already installed — idempotent late-arriving
+                // VC messages just refresh the QC contents.
+                self.timeout.view_change_qc = Some(vc_qc);
+            }
             true
         } else {
             false
@@ -1873,14 +2210,20 @@ impl ValidatorEngine {
         next_nonce
     }
 
-    /// Advance to the next slot. Returns the new slot number.
+    /// Advance to the next wall-clock slot. Returns the new slot number.
+    ///
+    /// audit-234 part 4 (CONSENSUS_INVARIANTS.md O3): wall-clock tick
+    /// does NOT reset `self.timeout`. The tracker is keyed on
+    /// `target_height` and only resets when the chain progresses
+    /// (`advance_target_height`) or a view-change-QC bumps the view
+    /// (deferred to step 3). This way, an in-flight recovery for an
+    /// old failed slot is preserved across multiple wall-clock ticks
+    /// instead of being silently discarded each tick.
     pub fn advance_slot(&mut self) -> u64 {
         self.consensus.advance_slot();
         // current_slot changed + pending_votes/timeouts cleared.
         self.persist_consensus();
         let new_slot = self.consensus.current_slot;
-        let now_ms = current_time_ms();
-        self.timeout = TimeoutTracker::new(new_slot, now_ms);
 
         // Clean up old vote/view-change data (keep last 10 slots)
         if new_slot > 10 {
@@ -1905,10 +2248,72 @@ impl ValidatorEngine {
         new_slot
     }
 
+    /// Advance `target_height` to `new_height` and reset the timeout
+    /// tracker for the new height. No-op if `new_height` doesn't
+    /// advance the target. Persists the consensus state.
+    ///
+    /// audit-234 part 4 (CONSENSUS_INVARIANTS.md O2): called when a
+    /// vote-QC for the current target forms — the chain has moved
+    /// on, recovery state for the old height is no longer needed.
+    fn advance_target_height(&mut self, new_height: u64) {
+        if self.consensus.advance_target_height(new_height) {
+            let now_ms = current_time_ms();
+            self.timeout = TimeoutTracker::new(new_height, now_ms);
+            self.persist_consensus();
+            debug!(target_height = new_height, "advanced target_height");
+        }
+    }
+
     /// Check if the current slot has timed out.
-    pub fn is_timed_out(&self) -> bool {
+    ///
+    /// Two timeout paths (audit 234 part 3 added the second):
+    /// 1. **Primary**: no proposal received within
+    ///    `PROPOSAL_TIMEOUT_MS` of slot start. Standard HotStuff
+    ///    leader-failure path.
+    /// 2. **Secondary (progress)**: chain hasn't advanced — i.e.
+    ///    `consensus.highest_qc.slot` hasn't moved forward in
+    ///    `PROGRESS_TIMEOUT_MS`. Gossip-mesh degradation means
+    ///    some validators received the proposal and voted (their
+    ///    primary timer is suppressed) while others didn't,
+    ///    leaving neither path with quorum. Engine-level deadline
+    ///    that survives slot advances — only resets when the
+    ///    chain genuinely moves.
+    ///
+    /// In both cases the runtime's response is the same: build a
+    /// view-change message, broadcast it, await a view-change-QC
+    /// to install the fallback proposer.
+    ///
+    /// Takes `&mut self` because the secondary path lazily
+    /// refreshes `last_qc_progress_ms` whenever it observes
+    /// `highest_qc.slot` having advanced — keeps the bookkeeping
+    /// in one place rather than scattering across every QC-update
+    /// site.
+    pub fn is_timed_out(&mut self) -> bool {
         let now_ms = current_time_ms();
-        self.timeout.is_expired(now_ms)
+        // Refresh the engine-level progress timestamp lazily.
+        if self.consensus.highest_qc.slot > self.last_seen_qc_slot {
+            self.last_seen_qc_slot = self.consensus.highest_qc.slot;
+            self.last_qc_progress_ms = now_ms;
+        }
+        if self.timeout.is_expired(now_ms) {
+            return true;
+        }
+        let progressed = self.consensus.highest_qc.slot >= self.consensus.current_slot;
+        let already_view_changed = self.timeout.view_change_qc.is_some();
+        let elapsed = now_ms.saturating_sub(self.last_qc_progress_ms);
+        if !progressed
+            && !already_view_changed
+            && elapsed >= pyde_consensus::view_change::PROGRESS_TIMEOUT_MS
+        {
+            tracing::info!(
+                slot = self.consensus.current_slot,
+                highest_qc = self.consensus.highest_qc.slot,
+                elapsed_ms = elapsed,
+                "DBG: progress timeout firing"
+            );
+            return true;
+        }
+        false
     }
 
     // ========== Threshold Decryption (MEV Protection) ==========
@@ -4488,6 +4893,164 @@ mod tests {
             matches!(tampered_outcome, DecryptOutcome::TxRootMismatch),
             "reordered decryptor must be rejected; got {:?}",
             tampered_outcome
+        );
+    }
+
+    // ========================================================================
+    // audit-234 part 4: characterization tests for the (height, view) refactor.
+    //
+    // These tests express the post-fix behavior described in
+    // crates/consensus/CONSENSUS_INVARIANTS.md. They MUST FAIL on the current
+    // (audit-234 in-flight) state machine, which uses `current_slot` as the
+    // recovery target and permits multiple fallback proposers per slot.
+    //
+    // They turn green as steps 2-3 of the audit-234 fix sequence land:
+    //   - step 2: decouple `target_height` from `current_slot`
+    //   - step 3: single deterministic leader per (H, V)
+    //
+    // Marked `#[ignore]` so the workspace test suite stays green during the
+    // refactor; remove the ignore (or re-flip to active) when the
+    // corresponding step ships.
+    // ========================================================================
+
+    /// Invariant L1 (oldest-unresolved-height): when the wall-clock slot
+    /// has drifted past the slot we're trying to commit, view-change must
+    /// still target the FAILED slot, not the current wall-clock slot.
+    ///
+    /// CURRENT behavior: `on_timeout` reads `self.consensus.current_slot`,
+    /// so the view-change message targets the wrong slot whenever recovery
+    /// takes longer than `SLOT_DURATION_MS`. This is failure mode (1) in
+    /// the audit-234 part-4 diagnosis.
+    ///
+    /// POST-FIX behavior: `on_timeout` should target
+    /// `self.consensus.last_committed_slot + 1` — the oldest unresolved
+    /// height — regardless of how far `current_slot` has drifted.
+    #[test]
+    fn slot_drift_does_not_advance_target_height() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+
+        // Bootstrap: pretend the chain has committed up through slot 144,
+        // and we are now trying to commit slot 145.
+        engine.consensus.last_committed_slot = 144;
+        engine.consensus.target_height = 145;
+        engine.consensus.current_view = 0;
+        engine.consensus.current_slot = 145;
+        engine.timeout = TimeoutTracker::new(145, current_time_ms());
+        let target_height = engine.consensus.target_height;
+        assert_eq!(target_height, 145);
+
+        // Wall-clock slot drifts during the recovery delay (gossip, RR
+        // delivery, view-change-QC formation). In a real run this is
+        // PROGRESS_TIMEOUT_MS / SLOT_DURATION_MS = 5 slot ticks.
+        for _ in 0..5 {
+            engine.advance_slot();
+        }
+        let drifted = engine.consensus.current_slot;
+        assert_eq!(drifted, 150, "wall-clock slot should have drifted");
+
+        // last_committed_slot is unchanged because no block at 145 has
+        // committed yet.
+        assert_eq!(
+            engine.consensus.last_committed_slot, 144,
+            "no block committed during the recovery window"
+        );
+
+        // Trigger view-change. Per L1, the resulting message MUST target
+        // the oldest unresolved height (145), not the drifted current
+        // slot (150). Today this assertion fails — vc_msg.slot == 150.
+        let vc_msg = engine
+            .on_timeout(&identities[0])
+            .expect("on_timeout should produce a view-change message");
+
+        assert_eq!(
+            vc_msg.slot, target_height,
+            "view-change must target the oldest unresolved height ({target_height}), \
+             not the drifted current_slot ({drifted}). \
+             See CONSENSUS_INVARIANTS.md L1."
+        );
+    }
+
+    /// Invariant L2 (single deterministic leader per (H, V)): when a
+    /// view-change-QC has formed for height H view V, exactly ONE
+    /// committee member produces a fallback proposal — the deterministic
+    /// leader `committee[fallback_index(H, V, n)]`. All other validators'
+    /// `try_build_fallback_proposal` returns None.
+    ///
+    /// CURRENT behavior: any validator with a local view-change-QC builds
+    /// a fallback proposal (the "any-validator" loosening documented in
+    /// `try_build_fallback_proposal` line 1491). With 4 validators each
+    /// holding a VC-QC, all 4 produce competing proposals. Under
+    /// asymmetric gossip delivery, votes split across the candidates and
+    /// no proposal reaches quorum. This is failure mode (2) in the
+    /// audit-234 part-4 diagnosis.
+    ///
+    /// POST-FIX behavior: only one validator (the deterministic leader
+    /// for (H, V)) produces Some(block); the other three return None.
+    #[test]
+    fn single_fallback_leader_per_view() {
+        let n = 4;
+
+        // Build n engines, each representing one validator's local state,
+        // all sharing the same committee.
+        let mut identities = Vec::new();
+        let mut keys = Vec::new();
+        for i in 0..n {
+            let id = make_identity(i as u8);
+            keys.push(id.public_key.as_bytes().to_vec());
+            identities.push(id);
+        }
+        let mut engines = Vec::new();
+        for _ in 0..n {
+            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            engine.set_committee(keys.clone());
+            engine.advance_slot(); // → slot 1
+            engines.push(engine);
+        }
+        let target_slot = engines[0].consensus.current_slot;
+
+        // Every validator sends a view-change message for the target slot.
+        let vc_messages: Vec<_> = identities
+            .iter()
+            .map(|id| {
+                pyde_consensus::view_change::create_view_change(
+                    target_slot,
+                    &pyde_consensus::block::QuorumCert::empty(),
+                    id.committee_index,
+                    id.address,
+                    &id.secret_key,
+                )
+                .unwrap()
+            })
+            .collect();
+
+        // Each engine ingests every VC message → installs a VC-QC.
+        for engine in &mut engines {
+            for msg in &vc_messages {
+                engine.on_view_change(msg.clone());
+            }
+            assert!(
+                engine.timeout.view_change_qc.is_some(),
+                "each engine should have a view-change-QC for slot {target_slot}"
+            );
+        }
+
+        // Every engine tries to build a fallback proposal. Per L2, exactly
+        // ONE engine (the deterministic leader for (target_slot, V=1))
+        // should produce Some(block); the other three return None.
+        let proposals: Vec<_> = engines
+            .iter_mut()
+            .enumerate()
+            .map(|(i, engine)| {
+                engine.try_build_fallback_proposal(&identities[i], [0u8; 32], [0u8; 32])
+            })
+            .collect();
+
+        let proposal_count = proposals.iter().filter(|p| p.is_some()).count();
+        assert_eq!(
+            proposal_count, 1,
+            "exactly ONE validator should build a fallback per (H, V); got {proposal_count}. \
+             Today every validator with a local VC-QC builds, leading to vote splits under \
+             asymmetric gossip delivery. See CONSENSUS_INVARIANTS.md L2."
         );
     }
 }

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -1065,7 +1065,11 @@ pub fn decode_consensus_message(data: &[u8]) -> Result<ConsensusMessage, &'stati
 // ConsensusState (for crash-safe persistence)
 // ============================================================
 
-const CONSENSUS_STATE_VERSION: u8 = 1;
+/// Version 2 (audit-234 part 4): adds `target_height` and
+/// `current_view` after the existing fields. Pre-mainnet: no
+/// migration support — devnets/tests start with a fresh store on
+/// version mismatch.
+const CONSENSUS_STATE_VERSION: u8 = 2;
 
 pub fn encode_consensus_state(state: &pyde_consensus::hotstuff::ConsensusState) -> Vec<u8> {
     let mut enc = Encoder::new();
@@ -1076,6 +1080,8 @@ pub fn encode_consensus_state(state: &pyde_consensus::hotstuff::ConsensusState) 
     enc.u64(state.last_voted_slot);
     enc.bytes32(&state.last_committed_hash);
     enc.u64(state.last_committed_slot);
+    enc.u64(state.target_height);
+    enc.u64(state.current_view);
     enc.u16(state.pending_votes.len() as u16);
     for msg in &state.pending_votes {
         enc.var_bytes(&encode_consensus_message(msg));
@@ -1101,6 +1107,8 @@ pub fn decode_consensus_state(
     let last_voted_slot = dec.u64()?;
     let last_committed_hash = dec.bytes32()?;
     let last_committed_slot = dec.u64()?;
+    let target_height = dec.u64()?;
+    let current_view = dec.u64()?;
 
     let votes_count = dec.u16_count(MAX_DECODE_ITEMS)?;
     let mut pending_votes = Vec::with_capacity(votes_count);
@@ -1123,6 +1131,8 @@ pub fn decode_consensus_state(
         last_voted_slot,
         last_committed_hash,
         last_committed_slot,
+        target_height,
+        current_view,
         pending_votes,
         pending_timeouts,
     })
@@ -1546,6 +1556,8 @@ mod tests {
         assert_eq!(restored.last_committed_slot, 0);
         assert_eq!(restored.last_committed_hash, [0u8; 32]);
         assert_eq!(restored.highest_qc.slot, 0);
+        assert_eq!(restored.target_height, 1);
+        assert_eq!(restored.current_view, 0);
         assert!(restored.pending_votes.is_empty());
         assert!(restored.pending_timeouts.is_empty());
     }
@@ -1559,6 +1571,8 @@ mod tests {
             last_voted_slot: 42,
             last_committed_hash: [0x77; 32],
             last_committed_slot: 40,
+            target_height: 41,
+            current_view: 2,
             pending_votes: vec![
                 ConsensusMessage::Vote {
                     slot: 42,
@@ -1593,6 +1607,8 @@ mod tests {
         assert_eq!(restored.last_voted_slot, 42);
         assert_eq!(restored.last_committed_hash, [0x77; 32]);
         assert_eq!(restored.last_committed_slot, 40);
+        assert_eq!(restored.target_height, 41);
+        assert_eq!(restored.current_view, 2);
         assert_eq!(restored.pending_votes.len(), 2);
         assert_eq!(restored.pending_timeouts.len(), 1);
 


### PR DESCRIPTION
## Summary
- Decouples `target_height`/`current_view` from wall-clock `current_slot`. `on_timeout` and `try_build_fallback_proposal` now key on `target_height`, so recovery state survives drift past the failed height.
- Single deterministic fallback leader per (H, V): `committee[(H + V) mod n]`. Replaces "any validator with a VC-QC may propose" — that rule split votes under asymmetric gossip delivery.
- `advance_slot` no longer resets the timeout tracker on wall-clock ticks; tracker keyed on `target_height` now.
- Bumps `CONSENSUS_STATE_VERSION` to 2 for the new fields. Pre-mainnet, no migration.
- New `crates/consensus/CONSENSUS_INVARIANTS.md` documents the design contract (9 invariants, Tendermint-style).

## Notes
- Surfaced while tracing audit-234.3's deeper failure modes. Closes the slot-sync drift and vote-splitting issues; does NOT close 234.3 end-to-end (needs RR fallback for consensus messages — separate PR).