### PR TITLE
fix(tx): bind chain_id into multisig signing preimages (audit 240)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -864,6 +864,42 @@
         devnets — `mesh_n_low=4` is unsatisfiable with N=4
         validators (max possible mesh peers = N-1 = 3).
 
+- [x] 240 — `✓` **Multisig signing preimage missing `chain_id` —
+      cross-chain replay.** Found while compiling testnet-readiness
+      gaps. All four signed multisig preimages
+      (`MultisigSpend`, `MultisigRotate`, `EmergencyPausePayload`,
+      `EmergencyResumePayload`) hashed `nonce + action_label +
+      payload_fields` with no chain id. Two chains that share the
+      same FALCON multisig signer set (e.g., devnet 31337 and
+      mainnet 1) end up with the same treasury address and the
+      same signature space — a `MultisigTx` signed for nonce N on
+      devnet replays as a valid mainnet payload at the same nonce
+      position, draining the mainnet treasury. Same threat applies
+      to rotation, pause, and resume.
+
+      Fixed: prepended `chain_id: u64` to every signing-bytes
+      preimage and threaded `block_ctx.chain_id` through the four
+      execute handlers (`execute_multisig_spend`,
+      `execute_rotate_multisig`, `execute_emergency_pause`,
+      `execute_emergency_resume`) so verification rebuilds the
+      preimage with the active chain. Test helpers in
+      `crates/tx/tests/common/mod.rs` mirror via a
+      `TEST_CHAIN_ID` constant. New regression test
+      `cross_chain_spend_replay_rejected` builds a 3-of-3 quorum
+      under chain A and asserts the same sigs verify under chain
+      A but fail under chain B. 230 pyde-tx lib tests + all
+      integration proptests pass.
+
+      Risk-acceptance note: this is a wire-format break for any
+      already-signed preimage. No production multisig governance
+      has executed yet, so the break costs nothing operationally.
+      Wire `MULTISIG_VERSION` byte on the encoded payload is
+      unchanged (the encoded `MultisigPayload` doesn't carry the
+      preimage — only the sigs over it), so receivers already
+      reject inconsistent sigs and the only observable change is
+      that signers must include `chain_id` in the preimage they
+      hash.
+
 ---
 
 ## Test-coverage follow-ups (not standalone fix items)

--- a/crates/tx/src/multisig.rs
+++ b/crates/tx/src/multisig.rs
@@ -127,11 +127,15 @@ impl EmergencyPausePayload {
     }
 
     /// Bytes over which signers compute their FALCON signature. The
-    /// signed preimage binds the action label, the multisig nonce,
-    /// AND the duration — so a signature authorizing a 100-slot pause
-    /// can't be replayed to authorize a 10M-slot pause.
-    pub fn signing_bytes(&self, nonce: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + 5 + 8);
+    /// signed preimage binds the chain id, the action label, the
+    /// multisig nonce, AND the duration — so a signature authorizing
+    /// a 100-slot pause can't be replayed to authorize a 10M-slot
+    /// pause, and a signature collected on devnet (chain_id=31337)
+    /// can't be re-wrapped onto mainnet (chain_id=1) at the same
+    /// nonce.
+    pub fn signing_bytes(&self, nonce: u64, chain_id: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 8 + 5 + 8);
+        buf.extend_from_slice(&chain_id.to_le_bytes());
         buf.extend_from_slice(&nonce.to_le_bytes());
         buf.extend_from_slice(b"PAUSE");
         buf.extend_from_slice(&self.duration_slots.to_le_bytes());
@@ -157,10 +161,13 @@ impl EmergencyResumePayload {
         Some(Self { sigs })
     }
 
-    /// Signed preimage for a resume: just the nonce + action label.
+    /// Signed preimage for a resume: chain_id + nonce + action label.
     /// Resume doesn't carry a duration — it's always a single action.
-    pub fn signing_bytes(nonce: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + 6);
+    /// `chain_id` binds the signature to a single chain (cross-chain
+    /// replay defense); see `EmergencyPausePayload::signing_bytes`.
+    pub fn signing_bytes(nonce: u64, chain_id: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 8 + 6);
+        buf.extend_from_slice(&chain_id.to_le_bytes());
         buf.extend_from_slice(&nonce.to_le_bytes());
         buf.extend_from_slice(b"RESUME");
         poseidon2_hash(&buf).to_bytes().to_vec()
@@ -172,8 +179,16 @@ impl MultisigSpend {
     /// the on-chain nonce so each signature is bound to a specific
     /// execution. Signers must coordinate on the current nonce before
     /// signing.
-    pub fn signing_bytes(&self, nonce: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + 32 + 16 + 32);
+    ///
+    /// `chain_id` is prepended so a Spend signed on devnet
+    /// (chain_id=31337) cannot be re-wrapped onto mainnet
+    /// (chain_id=1) and drain the mainnet treasury at the same
+    /// nonce position. Without this binding the same FALCON multisig
+    /// keys (and hence the same treasury address) on two chains
+    /// would share a signature space.
+    pub fn signing_bytes(&self, nonce: u64, chain_id: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 8 + 32 + 16 + 32);
+        buf.extend_from_slice(&chain_id.to_le_bytes());
         buf.extend_from_slice(&nonce.to_le_bytes());
         buf.extend_from_slice(&self.target);
         buf.extend_from_slice(&self.value.to_le_bytes());
@@ -210,8 +225,12 @@ impl MultisigSpend {
 }
 
 impl MultisigRotate {
-    pub fn signing_bytes(&self, nonce: u64) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + 1 + self.new_signer_pks.len() * 897 + 1);
+    /// Signed preimage for a signer-set rotation: chain_id + nonce
+    /// + new pubkey list + new threshold. `chain_id` prevents
+    /// cross-chain replay (see `MultisigSpend::signing_bytes`).
+    pub fn signing_bytes(&self, nonce: u64, chain_id: u64) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(8 + 8 + 1 + self.new_signer_pks.len() * 897 + 1);
+        buf.extend_from_slice(&chain_id.to_le_bytes());
         buf.extend_from_slice(&nonce.to_le_bytes());
         buf.push(self.new_signer_pks.len() as u8);
         for pk in &self.new_signer_pks {
@@ -459,6 +478,11 @@ mod tests {
     use super::*;
     use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconSecretKey};
 
+    /// Synthetic chain id used by every signing-bytes test in this
+    /// module. Mirrors the production devnet id so the tests
+    /// exercise the same value space the integration paths see.
+    const TEST_CHAIN_ID: u64 = 31337;
+
     fn gen_signers(n: usize) -> (Vec<Vec<u8>>, Vec<FalconSecretKey>) {
         let mut pks = Vec::with_capacity(n);
         let mut sks = Vec::with_capacity(n);
@@ -580,7 +604,7 @@ mod tests {
             value: 100,
             data_digest: [0x44; 32],
         };
-        let msg = spend.signing_bytes(7);
+        let msg = spend.signing_bytes(7, TEST_CHAIN_ID);
         let sigs = vec![
             sign_at(&sks[0], &msg, 0),
             sign_at(&sks[2], &msg, 2),
@@ -598,7 +622,7 @@ mod tests {
             value: 0,
             data_digest: [0; 32],
         };
-        let msg = spend.signing_bytes(0);
+        let msg = spend.signing_bytes(0, TEST_CHAIN_ID);
         let sigs = vec![sign_at(&sks[1], &msg, 1), sign_at(&sks[1], &msg, 1)];
         let err = count_valid_sigs(&sigs, &pks, &msg).unwrap_err();
         assert!(err.contains("duplicate"));
@@ -612,9 +636,9 @@ mod tests {
             value: 0,
             data_digest: [0; 32],
         };
-        let msg = spend.signing_bytes(0);
+        let msg = spend.signing_bytes(0, TEST_CHAIN_ID);
         // Signer 2 signs a DIFFERENT message — should fail verify.
-        let wrong_msg = spend.signing_bytes(99);
+        let wrong_msg = spend.signing_bytes(99, TEST_CHAIN_ID);
         let sigs = vec![sign_at(&sks[0], &msg, 0), sign_at(&sks[2], &wrong_msg, 2)];
         let valid = count_valid_sigs(&sigs, &pks, &msg).unwrap();
         assert_eq!(valid, 1, "only signer 0's sig is valid");
@@ -628,7 +652,7 @@ mod tests {
             value: 0,
             data_digest: [0; 32],
         };
-        let msg = spend.signing_bytes(0);
+        let msg = spend.signing_bytes(0, TEST_CHAIN_ID);
         // signer_index = 99 is beyond MAX_SIGNERS → hard error.
         let sigs = vec![sign_at(&sks[0], &msg, 99)];
         let err = count_valid_sigs(&sigs, &pks, &msg).unwrap_err();
@@ -693,19 +717,24 @@ mod tests {
             sigs: vec![],
         };
         assert_ne!(
-            p1.signing_bytes(0),
-            p2.signing_bytes(0),
+            p1.signing_bytes(0, TEST_CHAIN_ID),
+            p2.signing_bytes(0, TEST_CHAIN_ID),
             "duration must affect signing bytes"
         );
         assert_ne!(
-            p1.signing_bytes(0),
-            p1.signing_bytes(1),
+            p1.signing_bytes(0, TEST_CHAIN_ID),
+            p1.signing_bytes(1, TEST_CHAIN_ID),
             "nonce must affect signing bytes"
         );
         assert_ne!(
-            p1.signing_bytes(0),
-            EmergencyResumePayload::signing_bytes(0),
+            p1.signing_bytes(0, TEST_CHAIN_ID),
+            EmergencyResumePayload::signing_bytes(0, TEST_CHAIN_ID),
             "action label must differentiate pause from resume"
+        );
+        assert_ne!(
+            p1.signing_bytes(0, TEST_CHAIN_ID),
+            p1.signing_bytes(0, TEST_CHAIN_ID + 1),
+            "chain_id must affect signing bytes"
         );
     }
 
@@ -716,6 +745,48 @@ mod tests {
             value: 123,
             data_digest: [0x66; 32],
         };
-        assert_ne!(spend.signing_bytes(0), spend.signing_bytes(1));
+        assert_ne!(
+            spend.signing_bytes(0, TEST_CHAIN_ID),
+            spend.signing_bytes(1, TEST_CHAIN_ID)
+        );
+    }
+
+    /// Cross-chain replay regression: a Spend signed at nonce N on
+    /// chain A must NOT verify against the same nonce N on chain B.
+    /// Without `chain_id` in the preimage this assertion passes for
+    /// the wrong reason; with the binding the second `count_valid_sigs`
+    /// must report zero valid sigs.
+    #[test]
+    fn cross_chain_spend_replay_rejected() {
+        let (pks, sks) = gen_signers(3);
+        let spend = MultisigSpend {
+            target: [0x77; 32],
+            value: 1_000,
+            data_digest: [0x88; 32],
+        };
+        let nonce = 5;
+
+        // Sign on chain A.
+        let chain_a = TEST_CHAIN_ID;
+        let chain_b = TEST_CHAIN_ID + 1;
+        let msg_a = spend.signing_bytes(nonce, chain_a);
+        let sigs_a: Vec<SigEntry> = (0..3u8)
+            .map(|i| sign_at(&sks[i as usize], &msg_a, i))
+            .collect();
+
+        // Quorum verifies on chain A — the path the legitimate
+        // execution takes.
+        let valid_on_a = count_valid_sigs(&sigs_a, &pks, &msg_a).unwrap();
+        assert_eq!(valid_on_a, 3);
+
+        // Replay attempt on chain B at the same nonce: rebuild the
+        // preimage with chain_b and feed the chain-A sigs through.
+        // None should verify.
+        let msg_b = spend.signing_bytes(nonce, chain_b);
+        let valid_on_b = count_valid_sigs(&sigs_a, &pks, &msg_b).unwrap();
+        assert_eq!(
+            valid_on_b, 0,
+            "chain-A sigs must not verify under chain-B preimage"
+        );
     }
 }

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -518,8 +518,8 @@ fn execute_transaction_inner(
             execute_claim_airdrop(tx, smt, block_ctx, &mut sender.balance)
         }
         TransactionType::SweepAirdrop => execute_sweep_airdrop(tx, smt, block_ctx),
-        TransactionType::MultisigTx => execute_multisig_spend(tx, smt),
-        TransactionType::RotateMultisig => execute_rotate_multisig(tx, smt),
+        TransactionType::MultisigTx => execute_multisig_spend(tx, smt, block_ctx),
+        TransactionType::RotateMultisig => execute_rotate_multisig(tx, smt, block_ctx),
         TransactionType::EmergencyPause => execute_emergency_pause(tx, smt, block_ctx),
         TransactionType::EmergencyResume => execute_emergency_resume(tx, smt, block_ctx),
         TransactionType::ClaimReward => {
@@ -1623,6 +1623,7 @@ const MULTISIG_ROTATE_PER_NEW_SIGNER_GAS: u64 = 10_000;
 fn execute_multisig_spend(
     tx: &Transaction,
     smt: &mut dyn pyde_state::smt::StateAccess,
+    block_ctx: &BlockContext,
 ) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
     let payload = match crate::multisig::MultisigPayload::decode(&tx.data) {
         Some(p) => p,
@@ -1731,7 +1732,7 @@ fn execute_multisig_spend(
     }
 
     let nonce = read_multisig_nonce(smt);
-    let msg = spend.signing_bytes(nonce);
+    let msg = spend.signing_bytes(nonce, block_ctx.chain_id);
     let valid = match crate::multisig::count_valid_sigs(&sigs, &signer_pks, &msg) {
         Ok(v) => v,
         Err(e) => return (false, gas, 0, vec![], e.as_bytes().to_vec()),
@@ -1788,6 +1789,7 @@ fn execute_multisig_spend(
 fn execute_rotate_multisig(
     tx: &Transaction,
     smt: &mut dyn pyde_state::smt::StateAccess,
+    block_ctx: &BlockContext,
 ) -> (bool, u64, u64, Vec<LogEntry>, Vec<u8>) {
     let payload = match crate::multisig::MultisigPayload::decode(&tx.data) {
         Some(p) => p,
@@ -1883,7 +1885,7 @@ fn execute_rotate_multisig(
     }
 
     let nonce = read_multisig_nonce(smt);
-    let msg = rotate.signing_bytes(nonce);
+    let msg = rotate.signing_bytes(nonce, block_ctx.chain_id);
     let valid = match crate::multisig::count_valid_sigs(&sigs, &current_signers, &msg) {
         Ok(v) => v,
         Err(e) => return (false, gas, 0, vec![], e.as_bytes().to_vec()),
@@ -2021,7 +2023,7 @@ fn execute_emergency_pause(
     }
 
     let nonce = read_multisig_nonce(smt);
-    let msg = payload.signing_bytes(nonce);
+    let msg = payload.signing_bytes(nonce, block_ctx.chain_id);
     if let Err(e) = multisig_ok(smt, &payload.sigs, &msg, gas) {
         return e;
     }
@@ -2073,7 +2075,7 @@ fn execute_emergency_resume(
     }
 
     let nonce = read_multisig_nonce(smt);
-    let msg = crate::multisig::EmergencyResumePayload::signing_bytes(nonce);
+    let msg = crate::multisig::EmergencyResumePayload::signing_bytes(nonce, block_ctx.chain_id);
     if let Err(e) = multisig_ok(smt, &payload.sigs, &msg, gas) {
         return e;
     }
@@ -4616,8 +4618,9 @@ mod tests {
         sks: &[&pyde_crypto::falcon::FalconSecretKey],
         indices: &[u8],
         nonce: u64,
+        chain_id: u64,
     ) -> Vec<crate::multisig::SigEntry> {
-        let msg = spend.signing_bytes(nonce);
+        let msg = spend.signing_bytes(nonce, chain_id);
         sks.iter()
             .zip(indices.iter())
             .map(|(sk, idx)| {
@@ -4642,7 +4645,7 @@ mod tests {
 
         let target = [0xEE; 32];
         let spend = make_spend(target, 1_000_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1], &sks[2]], &[0, 1, 2], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1], &sks[2]], &[0, 1, 2], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
 
@@ -4672,7 +4675,7 @@ mod tests {
 
         let spend = make_spend([0xEE; 32], 1_000_000);
         // Only 2 sigs but threshold = 3.
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
 
@@ -4692,7 +4695,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend([0xEE; 32], 500_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend {
             spend: spend.clone(),
             sigs: sigs.clone(),
@@ -4723,7 +4726,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend([0xEE; 32], 0);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
@@ -4740,7 +4743,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend([0u8; 32], 1_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
@@ -4757,7 +4760,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend(pyde_account::address::treasury_address(), 1_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
@@ -4774,7 +4777,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend([0xEE; 32], 1_000_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
@@ -4792,7 +4795,7 @@ mod tests {
 
         let spend = make_spend([0xEE; 32], 1_000);
         // Same signer_index twice — hard reject at sig-count stage.
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[0]], &[0, 0], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[0]], &[0, 0], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
@@ -4813,7 +4816,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend(submitter, 500_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
 
@@ -4847,7 +4850,7 @@ mod tests {
 
         let target = [0xEE; 32];
         let spend = make_spend(target, 500_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let mut tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         tx.to = target; // non-zero tx.to — would clobber target credit
@@ -4881,7 +4884,7 @@ mod tests {
             new_signer_pks: new_pks.clone(),
             new_threshold: 3,
         };
-        let msg = rotate.signing_bytes(0);
+        let msg = rotate.signing_bytes(0, 1);
         let sigs = vec![
             crate::multisig::SigEntry {
                 signer_index: 0,
@@ -4925,7 +4928,7 @@ mod tests {
             new_signer_pks: vec![new_pk.as_bytes().to_vec()],
             new_threshold: 5, // > signer count
         };
-        let msg = rotate.signing_bytes(0);
+        let msg = rotate.signing_bytes(0, 1);
         let sigs = vec![
             crate::multisig::SigEntry {
                 signer_index: 0,
@@ -4964,7 +4967,7 @@ mod tests {
             new_signer_pks: vec![dup.clone(), dup.clone()],
             new_threshold: 1,
         };
-        let msg = rotate.signing_bytes(0);
+        let msg = rotate.signing_bytes(0, 1);
         let sigs = vec![
             crate::multisig::SigEntry {
                 signer_index: 0,
@@ -5010,7 +5013,7 @@ mod tests {
             new_signer_pks: new_pks,
             new_threshold: 2,
         };
-        let rmsg = rotate.signing_bytes(0);
+        let rmsg = rotate.signing_bytes(0, 1);
         let rsigs = vec![
             crate::multisig::SigEntry {
                 signer_index: 0,
@@ -5037,7 +5040,7 @@ mod tests {
 
         // Spend signed by OLD signers should now fail.
         let spend = make_spend([0xEE; 32], 1_000);
-        let old_sigs = sign_spend(&spend, &[&old_sks[0], &old_sks[1]], &[0, 1], 1);
+        let old_sigs = sign_spend(&spend, &[&old_sks[0], &old_sks[1]], &[0, 1], 1, 1);
         let old_payload = crate::multisig::MultisigPayload::Spend {
             spend: spend.clone(),
             sigs: old_sigs,
@@ -5049,7 +5052,7 @@ mod tests {
         assert!(!orr.success, "old signers must no longer authorize");
 
         // Spend signed by NEW signers should succeed.
-        let new_sigs = sign_spend(&spend, &[&new_sk_a, &new_sk_b], &[0, 1], 1);
+        let new_sigs = sign_spend(&spend, &[&new_sk_a, &new_sk_b], &[0, 1], 1, 1);
         let new_payload = crate::multisig::MultisigPayload::Spend {
             spend,
             sigs: new_sigs,
@@ -5107,7 +5110,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let spend = make_spend([0xEE; 32], 1_000);
-        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let mut tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
         // Needed: 50k base + 2*50k = 150k. Set below.
@@ -5135,12 +5138,13 @@ mod tests {
         indices: &[u8],
         duration_slots: u64,
         nonce: u64,
+        chain_id: u64,
     ) -> Vec<crate::multisig::SigEntry> {
         let stub = crate::multisig::EmergencyPausePayload {
             duration_slots,
             sigs: vec![],
         };
-        let msg = stub.signing_bytes(nonce);
+        let msg = stub.signing_bytes(nonce, chain_id);
         sks.iter()
             .zip(indices.iter())
             .map(|(sk, idx)| crate::multisig::SigEntry {
@@ -5157,8 +5161,9 @@ mod tests {
         sks: &[&pyde_crypto::falcon::FalconSecretKey],
         indices: &[u8],
         nonce: u64,
+        chain_id: u64,
     ) -> Vec<crate::multisig::SigEntry> {
-        let msg = crate::multisig::EmergencyResumePayload::signing_bytes(nonce);
+        let msg = crate::multisig::EmergencyResumePayload::signing_bytes(nonce, chain_id);
         sks.iter()
             .zip(indices.iter())
             .map(|(sk, idx)| crate::multisig::SigEntry {
@@ -5236,7 +5241,7 @@ mod tests {
 
         assert!(!is_paused(&smt, ctx.height));
 
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, 500, sigs, 0);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(receipt.success);
@@ -5258,11 +5263,11 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
-        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1);
+        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1, 1);
         let resume_tx = build_resume_tx(submitter, &sub_sk, resume_sigs, 1);
         let r = execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
         assert!(r.success);
@@ -5280,7 +5285,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 10, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 10, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, 10, sigs, 0);
         execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(is_paused(&smt, ctx.height));
@@ -5310,7 +5315,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 0, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 0, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, 0, sigs, 0);
         let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!r.success);
@@ -5328,7 +5333,7 @@ mod tests {
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
         let over = MAX_PAUSE_DURATION_SLOTS + 1;
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], over, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], over, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, over, sigs, 0);
         let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!r.success);
@@ -5344,7 +5349,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_pause_sigs(&[&sks[0]], &[0], 500, 0);
+        let sigs = sign_pause_sigs(&[&sks[0]], &[0], 500, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, 500, sigs, 0);
         let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!r.success);
@@ -5361,12 +5366,12 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, sigs.clone(), 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
         // Resume so we can attempt re-pause.
-        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1);
+        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1, 1);
         let resume_tx = build_resume_tx(submitter, &sub_sk, resume_sigs, 1);
         execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
 
@@ -5392,7 +5397,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs_over_500 = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let sigs_over_500 = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let tx = build_pause_tx(submitter, &sub_sk, 100, sigs_over_500, 0);
         let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!r.success, "duration tamper must fail sig verification");
@@ -5407,7 +5412,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 0);
+        let sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let tx = build_resume_tx(submitter, &sub_sk, sigs, 0);
         let r = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!r.success);
@@ -5423,7 +5428,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
@@ -5443,12 +5448,12 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
         let spend = make_spend([0xEE; 32], 1_000);
-        let spend_sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 1);
+        let spend_sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 1, 1);
         let payload = crate::multisig::MultisigPayload::Spend {
             spend,
             sigs: spend_sigs,
@@ -5469,7 +5474,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
@@ -5478,7 +5483,7 @@ mod tests {
             new_signer_pks: vec![new_pk.as_bytes().to_vec()],
             new_threshold: 1,
         };
-        let rmsg = rotate.signing_bytes(1);
+        let rmsg = rotate.signing_bytes(1, 1);
         let rsigs = vec![
             crate::multisig::SigEntry {
                 signer_index: 0,
@@ -5515,12 +5520,12 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
         assert!(is_paused(&smt, ctx.height));
 
-        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1);
+        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1, 1);
         let resume_tx = build_resume_tx(submitter, &sub_sk, resume_sigs, 1);
         let r = execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
         assert!(r.success);
@@ -5536,11 +5541,11 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let pause_sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let pause_tx = build_pause_tx(submitter, &sub_sk, 500, pause_sigs, 0);
         execute_transaction(&pause_tx, &mut smt, &ctx).unwrap();
 
-        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1);
+        let resume_sigs = sign_resume_sigs(&[&sks[0], &sks[1]], &[0, 1], 1, 1);
         let resume_tx = build_resume_tx(submitter, &sub_sk, resume_sigs, 1);
         execute_transaction(&resume_tx, &mut smt, &ctx).unwrap();
 
@@ -5560,7 +5565,7 @@ mod tests {
         let submitter = derive_eoa_address(sub_pk.as_bytes());
         fund_account_with_pk(&mut smt, &submitter, 5_000_000_000_000, sub_pk.as_bytes());
 
-        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0);
+        let sigs = sign_pause_sigs(&[&sks[0], &sks[1]], &[0, 1], 500, 0, 1);
         let mut tx = build_pause_tx(submitter, &sub_sk, 500, sigs, 0);
         tx.gas_limit = 50_000;
         sign_tx(&mut tx, &sub_sk);

--- a/crates/tx/tests/common/mod.rs
+++ b/crates/tx/tests/common/mod.rs
@@ -28,6 +28,12 @@ use std::sync::OnceLock;
 /// (MAX_SIGNERS = 16) plus headroom for submitters and random targets.
 pub const POOL_SIZE: usize = 32;
 
+/// Single chain id used by every integration-test fixture in this
+/// crate. Mirrors `block_ctx().chain_id` so the multisig signing
+/// helpers below produce signatures the production handlers will
+/// accept under that same context.
+pub const TEST_CHAIN_ID: u64 = 1;
+
 /// Lazily-initialized keypair pool.
 static POOL: OnceLock<Vec<(FalconPublicKey, FalconSecretKey)>> = OnceLock::new();
 
@@ -209,7 +215,7 @@ pub fn sign_multisig_spend(
     indices: &[u8],
     multisig_nonce: u64,
 ) -> Vec<multisig::SigEntry> {
-    let msg = spend.signing_bytes(multisig_nonce);
+    let msg = spend.signing_bytes(multisig_nonce, TEST_CHAIN_ID);
     sks.iter()
         .zip(indices)
         .map(|(sk, idx)| multisig::SigEntry {
@@ -229,7 +235,7 @@ pub fn sign_pause(
         duration_slots,
         sigs: vec![],
     };
-    let msg = msg_holder.signing_bytes(multisig_nonce);
+    let msg = msg_holder.signing_bytes(multisig_nonce, TEST_CHAIN_ID);
     sks.iter()
         .zip(indices)
         .map(|(sk, idx)| multisig::SigEntry {
@@ -244,7 +250,7 @@ pub fn sign_resume(
     indices: &[u8],
     multisig_nonce: u64,
 ) -> Vec<multisig::SigEntry> {
-    let msg = multisig::EmergencyResumePayload::signing_bytes(multisig_nonce);
+    let msg = multisig::EmergencyResumePayload::signing_bytes(multisig_nonce, TEST_CHAIN_ID);
     sks.iter()
         .zip(indices)
         .map(|(sk, idx)| multisig::SigEntry {

--- a/crates/tx/tests/prop_emergency.rs
+++ b/crates/tx/tests/prop_emergency.rs
@@ -96,7 +96,7 @@ proptest! {
         prop_assume!((n1, d1) != (n2, d2));
         let p1 = EmergencyPausePayload { duration_slots: d1, sigs: vec![] };
         let p2 = EmergencyPausePayload { duration_slots: d2, sigs: vec![] };
-        prop_assert_ne!(p1.signing_bytes(n1), p2.signing_bytes(n2));
+        prop_assert_ne!(p1.signing_bytes(n1, 1u64), p2.signing_bytes(n2, 1u64));
     }
 
     /// Resume signing_bytes must differ by nonce.
@@ -107,8 +107,8 @@ proptest! {
     ) {
         prop_assume!(n1 != n2);
         prop_assert_ne!(
-            EmergencyResumePayload::signing_bytes(n1),
-            EmergencyResumePayload::signing_bytes(n2)
+            EmergencyResumePayload::signing_bytes(n1, 1u64),
+            EmergencyResumePayload::signing_bytes(n2, 1u64)
         );
     }
 
@@ -120,9 +120,9 @@ proptest! {
         nonce in 0u64..u64::MAX,
         duration in 1u64..=10_000_000,
     ) {
-        let pause_bytes =
-            EmergencyPausePayload { duration_slots: duration, sigs: vec![] }.signing_bytes(nonce);
-        let resume_bytes = EmergencyResumePayload::signing_bytes(nonce);
+        let pause_bytes = EmergencyPausePayload { duration_slots: duration, sigs: vec![] }
+            .signing_bytes(nonce, 1u64);
+        let resume_bytes = EmergencyResumePayload::signing_bytes(nonce, 1u64);
         prop_assert_ne!(pause_bytes, resume_bytes);
     }
 }

--- a/crates/tx/tests/prop_integration_nonce.rs
+++ b/crates/tx/tests/prop_integration_nonce.rs
@@ -106,7 +106,7 @@ proptest! {
             new_signer_pks: vec![new_pk],
             new_threshold: 1,
         };
-        let msg = rotate.signing_bytes(0);
+        let msg = rotate.signing_bytes(0, TEST_CHAIN_ID);
         let indices: Vec<u8> = (0..good as u8).collect();
         let sigs: Vec<multisig::SigEntry> = indices
             .iter()

--- a/crates/tx/tests/prop_integration_replay.rs
+++ b/crates/tx/tests/prop_integration_replay.rs
@@ -107,7 +107,7 @@ proptest! {
             new_signer_pks: vec![new_pk],
             new_threshold: 1,
         };
-        let msg = rotate.signing_bytes(0);
+        let msg = rotate.signing_bytes(0, TEST_CHAIN_ID);
         let indices: Vec<u8> = (0..t as u8).collect();
         let sigs: Vec<multisig::SigEntry> = indices
             .iter()
@@ -160,7 +160,7 @@ proptest! {
             new_signer_pks: vec![new_pk],
             new_threshold: 1,
         };
-        let rmsg = rotate.signing_bytes(0);
+        let rmsg = rotate.signing_bytes(0, TEST_CHAIN_ID);
         let rindices: Vec<u8> = (0..t as u8).collect();
         let rsigs: Vec<multisig::SigEntry> = rindices
             .iter()

--- a/crates/tx/tests/prop_multisig.rs
+++ b/crates/tx/tests/prop_multisig.rs
@@ -106,7 +106,10 @@ proptest! {
         prop_assume!((n1, t1, v1, d1) != (n2, t2, v2, d2));
         let s1 = MultisigSpend { target: t1, value: v1, data_digest: d1 };
         let s2 = MultisigSpend { target: t2, value: v2, data_digest: d2 };
-        prop_assert_ne!(s1.signing_bytes(n1), s2.signing_bytes(n2));
+        prop_assert_ne!(
+            s1.signing_bytes(n1, 1u64),
+            s2.signing_bytes(n2, 1u64)
+        );
     }
 
     /// Rotate signing_bytes must differ whenever the new set or
@@ -125,7 +128,10 @@ proptest! {
         prop_assume!((n1, pks1.clone(), t1) != (n2, pks2.clone(), t2));
         let r1 = MultisigRotate { new_signer_pks: pks1, new_threshold: t1 };
         let r2 = MultisigRotate { new_signer_pks: pks2, new_threshold: t2 };
-        prop_assert_ne!(r1.signing_bytes(n1), r2.signing_bytes(n2));
+        prop_assert_ne!(
+            r1.signing_bytes(n1, 1u64),
+            r2.signing_bytes(n2, 1u64)
+        );
     }
 
     /// `count_valid_sigs` must reject any slate with duplicate


### PR DESCRIPTION
## Summary

Closes audit 240 (multisig cross-chain replay).

All four multisig signed preimages (`MultisigSpend`,
`MultisigRotate`, `EmergencyPausePayload`,
`EmergencyResumePayload`) hashed `nonce + action_label + payload`
without `chain_id`. Two chains sharing the same FALCON multisig
signer set share the same treasury address and same signature
space — a Spend signed at nonce N on devnet replays as a valid
mainnet payload at the same nonce position, draining the
mainnet treasury.

Fix: `chain_id: u64` prepended to every `signing_bytes`
preimage; `block_ctx.chain_id` threaded through the four
execute handlers; test helpers mirror via a `TEST_CHAIN_ID`
constant. New `cross_chain_spend_replay_rejected` regression
builds a 3-of-3 quorum on chain A and asserts the same sigs
verify on A but fail on B.

Wire-format note: encoded `MULTISIG_VERSION` byte unchanged
(encoded payload only carries sigs, not preimage). Pre-fix
sigs no longer verify; acceptable — no production multisig
governance has executed yet.

230 pyde-tx lib + all integration proptests pass.