### PR TITLE
fix(node): hard-refuse mainnet startup with empty bootstrap_peers (audit 219)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -446,11 +446,36 @@
 
 ## P2 — Pre-testnet-alpha hygiene
 
-- [ ] 219 — **Startup guard on empty `MAINNET_BOOTSTRAP`.**
-      `crates/net/src/discovery.rs:14` — empty array, allowed by
-      task 011's config-file-injection option. Add a startup
-      refusal when `chain_id == 1` and no bootstrap peers
-      configured.
+- [x] 219 — `✓` **Startup guard on empty `MAINNET_BOOTSTRAP`.**
+      `crates/net/src/discovery.rs:14` constants
+      (`MAINNET_BOOTSTRAP`, `TESTNET_BOOTSTRAP`) are empty arrays
+      pre-launch, allowed by task 011's config-file-injection
+      option. The previous behaviour: a `warn!` then proceed —
+      operators who missed the warn produced an isolated mainnet
+      "fork of one" until they noticed.
+
+      Shipped: new `check_bootstrap_config(chain_id, bootstrap_peers)`
+      helper in `crates/node/src/node.rs`, called at the very
+      first line of `PydeNode::run()` (before any datadir, key,
+      or swarm setup). Rules:
+      - `chain_id == 1` with empty bootstrap → hard refusal
+        returned as `Err(...)` from `run`.
+      - `chain_id != 31337` with empty bootstrap → `warn!` and
+        proceed (testnet pre-launch may legitimately bootstrap a
+        single node).
+      - Devnet (`31337`) → silent.
+
+      Inline post-init dial block at the bootstrap step is now a
+      simple "if non-empty, dial" — the guard already ran, so an
+      empty list at that point can only mean intentional devnet.
+
+      Tests: 5 unit tests in the new `node::tests` module
+      (`bootstrap_guard_rejects_empty_mainnet`,
+      `bootstrap_guard_accepts_mainnet_with_peers`,
+      `bootstrap_guard_accepts_devnet_with_no_peers`,
+      `bootstrap_guard_accepts_testnet_with_no_peers_but_warns`,
+      `bootstrap_guard_accepts_any_chain_with_peers`). 243
+      pyde-node bin tests pass.
 
 - [x] 220 — `✓` **Fast-sync / snapshot wiring.** Investigation
       found that snapshot endpoints (`request_state_snapshot`,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -37,6 +37,49 @@ use tracing::{debug, error, info, warn};
 /// a censoring proposer can't hide behind latency.
 const MEV_INCLUSION_GRACE_SLOTS: u64 = 2;
 
+/// Audit 219: validate `(chain_id, bootstrap_peers)` at startup.
+///
+/// Returns `Err` for the one configuration that's catastrophic and
+/// silent without this guard: launching a mainnet node
+/// (`chain_id == 1`) with an empty `bootstrap_peers` list. That
+/// node would never discover peers, never sync, and produce a
+/// "fork of one" until an operator notices — by which point real
+/// state may have diverged. A hard refusal at the first line of
+/// `run()` makes the misconfiguration impossible to miss.
+///
+/// For other non-devnet chain ids (testnet, custom networks) we
+/// emit a warning but still allow startup — those chains may be
+/// in pre-launch states where a single-node bootstrap is
+/// intentional. Devnet (`chain_id == 31337`) is silent.
+pub fn check_bootstrap_config(
+    chain_id: u64,
+    bootstrap_peers: &[String],
+) -> Result<(), String> {
+    if !bootstrap_peers.is_empty() {
+        return Ok(());
+    }
+    const MAINNET_CHAIN_ID: u64 = 1;
+    const DEVNET_CHAIN_ID: u64 = 31337;
+    if chain_id == MAINNET_CHAIN_ID {
+        return Err(
+            "refusing to start mainnet (chain_id=1) with no bootstrap peers — \
+             set network.bootstrap_peers in config.toml before launch. \
+             A mainnet node with no peers produces an isolated fork that \
+             cannot sync to the canonical chain."
+                .to_string(),
+        );
+    }
+    if chain_id != DEVNET_CHAIN_ID {
+        warn!(
+            chain_id,
+            "no bootstrap_peers configured for a non-devnet chain — this node \
+             will not discover peers and cannot sync. Set network.bootstrap_peers \
+             in config.toml before launch."
+        );
+    }
+    Ok(())
+}
+
 /// The main Pyde node. Owns all subsystems.
 pub struct PydeNode {
     config: NodeConfig,
@@ -62,6 +105,16 @@ impl PydeNode {
             chain_id = self.config.node.chain_id,
             "starting pyde node"
         );
+
+        // Audit 219: hard-refuse to start a mainnet node with no
+        // bootstrap peers configured. Run this BEFORE any subsystem
+        // init so a misconfigured launch fails loudly at the first
+        // line of node startup, not after datadir/keystore/swarm
+        // setup partially completes.
+        check_bootstrap_config(
+            self.config.node.chain_id,
+            &self.config.network.bootstrap_peers,
+        )?;
 
         // Ensure data directory exists
         let datadir = &self.config.node.datadir;
@@ -429,21 +482,13 @@ impl PydeNode {
         subscribe_topics(&mut swarm, is_validator)?;
         info!("gossipsub topics subscribed");
 
-        // 8. Dial bootstrap peers. Empty on anything other than a single
-        // isolated devnet node is almost certainly misconfiguration —
-        // without peers the node produces a fork of one and can never
-        // sync. Warn loudly so operators catch this before genesis
-        // rather than after.
-        if self.config.network.bootstrap_peers.is_empty() {
-            if self.config.node.chain_id != 31337 {
-                warn!(
-                    chain_id = self.config.node.chain_id,
-                    "no bootstrap_peers configured for a non-devnet chain — this node will not \
-                     discover peers and cannot sync. Set network.bootstrap_peers in config.toml \
-                     before launch."
-                );
-            }
-        } else {
+        // 8. Dial bootstrap peers. Audit 219: the
+        // `check_bootstrap_config` call earlier in `run()` already
+        // hard-refused mainnet starts with no peers and warned for
+        // other non-devnet chains, so by the time we reach this
+        // point an empty list means devnet — which is fine for a
+        // single-node local devnet.
+        if !self.config.network.bootstrap_peers.is_empty() {
             pyde_net::node::dial_bootstrap_peers(&mut swarm, &self.config.network.bootstrap_peers);
         }
 
@@ -4281,5 +4326,56 @@ fn load_or_generate_identity(datadir: &Path) -> Result<libp2p::identity::Keypair
             .map_err(|e| format!("failed to write {}: {}", key_path.display(), e))?;
         info!(path = %key_path.display(), "generated new node identity");
         Ok(keypair)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========== Audit 219: bootstrap config startup guard ==========
+
+    #[test]
+    fn bootstrap_guard_rejects_empty_mainnet() {
+        let err = check_bootstrap_config(1, &[]).unwrap_err();
+        assert!(
+            err.contains("mainnet"),
+            "error must name mainnet so the operator knows what tripped, got: {err}"
+        );
+        assert!(err.contains("bootstrap_peers"));
+    }
+
+    #[test]
+    fn bootstrap_guard_accepts_mainnet_with_peers() {
+        let peers = vec!["/ip4/1.2.3.4/tcp/30303/p2p/12D3KooWfoo".to_string()];
+        assert!(check_bootstrap_config(1, &peers).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_guard_accepts_devnet_with_no_peers() {
+        // Single-node local devnet is the one legitimate "no peers" case.
+        assert!(check_bootstrap_config(31337, &[]).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_guard_accepts_testnet_with_no_peers_but_warns() {
+        // Non-mainnet, non-devnet (testnet ids etc.) is not a hard
+        // refusal — operators may legitimately spin up a single-node
+        // testnet pre-launch. The accompanying warn! is a side effect
+        // we don't assert here; the contract is "Ok, but logged".
+        assert!(check_bootstrap_config(2, &[]).is_ok());
+        assert!(check_bootstrap_config(7, &[]).is_ok());
+        assert!(check_bootstrap_config(1_000_000, &[]).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_guard_accepts_any_chain_with_peers() {
+        let peers = vec!["/ip4/1.2.3.4/tcp/30303/p2p/12D3KooWfoo".to_string()];
+        for chain_id in [1u64, 2, 7, 31337, 1_000_000] {
+            assert!(
+                check_bootstrap_config(chain_id, &peers).is_ok(),
+                "chain_id {chain_id} with peers should pass"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes audit 219.

`MAINNET_BOOTSTRAP` and `TESTNET_BOOTSTRAP` constants in
`crates/net/src/discovery.rs` are empty arrays pre-launch (filled
via config-file injection per task 011). The previous behaviour
for an empty `bootstrap_peers` list on a non-devnet chain was a
`warn!` then proceed — so an operator who missed the warning could
silently launch an isolated mainnet \"fork of one\" node that never
discovered peers.

Fix: new `check_bootstrap_config(chain_id, bootstrap_peers)` helper
called as the first action in `PydeNode::run()` (before any
subsystem init):
- `chain_id == 1` + empty → hard refusal as `Err(...)`
- non-devnet, non-mainnet + empty → `warn!` and proceed
- devnet (`31337`) → silent

The post-init dial block simplifies because the guard has already
run — empty at that point can only mean intentional devnet.

5 unit tests covering all branches; 243 pyde-node bin tests pass.