### PR TITLE
docs: connect-to-testnet + run-validator + RPC reference (task 084)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ cargo build
 cargo test --workspace
 ```
 
+## Quickstart
+
+- [Connect a node to the testnet](./docs/connect-to-testnet.md) —
+  prerequisites, bootstrap config, sync verification, faucet, first
+  transaction.
+- [Run a validator](./docs/run-validator.md) — staking, key custody,
+  systemd unit, slashing rules, operator metrics.
+- [JSON-RPC reference](./docs/rpc-reference.md) — supported methods
+  with request/response shapes.
+
+For a local 4-node devnet today (testnet not yet live):
+
+```sh
+pyde testnet --validators 4 --out ./devnet --dev
+cd devnet && ./run.sh
+```
+
+For a 16-validator / 3-region cross-host testnet (operator-driven):
+
+```sh
+pyde testnet \
+  --validators 16 \
+  --out ./testnet \
+  --node-addrs ./crates/node/testdata/testnet-16v-3region.toml
+```
+
 ## License
 
 Proprietary. All rights reserved.

--- a/docs/connect-to-testnet.md
+++ b/docs/connect-to-testnet.md
@@ -1,0 +1,307 @@
+# Connect to Pyde Testnet
+
+This guide walks you through running a full node against the Pyde
+testnet, verifying that you're synced, getting test tokens from the
+faucet, and submitting your first transaction.
+
+> **Status:** the testnet network is launching imminently. Bootstrap
+> peers, faucet, and explorer URLs in this guide are placeholders —
+> the published values appear in the launch announcement and in
+> `crates/net/src/discovery.rs:TESTNET_BOOTSTRAP`. Until then this
+> guide is best run against a local devnet (see "Local devnet" at
+> the bottom).
+
+## Prerequisites
+
+- 64-bit Linux or macOS (Windows via WSL works but is untested)
+- 8 GB RAM minimum (16 GB recommended for an indexer / archive node)
+- 200 GB SSD (testnet state grows steadily; archive node needs more)
+- Outbound TCP/30303 + UDP/30303 (P2P), optional inbound for better mesh peering
+- Rust 1.75+ if building from source
+
+## 1. Get the binary
+
+### Option A — build from source
+
+```sh
+git clone https://github.com/zarah-s/pyde
+cd pyde
+cargo build --release
+# Binary lands at ./target/release/pyde
+```
+
+### Option B — prebuilt release
+
+Download the latest `pyde-<version>-<os>-<arch>.tar.gz` from the
+GitHub releases page and extract `pyde` into `$PATH`.
+
+```sh
+tar -xzf pyde-<version>-linux-x86_64.tar.gz
+sudo mv pyde /usr/local/bin/
+pyde --version
+```
+
+## 2. Generate a node identity
+
+A full node needs a libp2p Ed25519 keypair and a data directory.
+Both are created automatically on first run if absent:
+
+```sh
+mkdir -p ~/.pyde-testnet
+pyde run \
+  --role full \
+  --datadir ~/.pyde-testnet \
+  --port 30303 \
+  --rpc-port 8545
+```
+
+On first start the node generates `~/.pyde-testnet/node.key` (libp2p
+identity) and creates an empty state DB at
+`~/.pyde-testnet/state/`.
+
+You can stop the node now (Ctrl-C) — we'll add bootstrap peers
+next.
+
+## 3. Configure bootstrap peers
+
+### Quickstart: one-line CLI flag
+
+```sh
+pyde run \
+  --role full \
+  --datadir ~/.pyde-testnet \
+  --port 30303 \
+  --rpc-port 8545 \
+  --bootstrap "/dns4/seed-0.testnet.pyde.network/tcp/30303/p2p/<peer-id>" \
+  --bootstrap "/dns4/seed-1.testnet.pyde.network/tcp/30303/p2p/<peer-id>"
+```
+
+### Recommended: write a config file
+
+```sh
+pyde default-config > ~/.pyde-testnet/config.toml
+```
+
+Edit `~/.pyde-testnet/config.toml`:
+
+```toml
+[node]
+role = "full"
+chain_id = 1   # mainnet placeholder; testnet chain_id will be published at launch
+datadir = "/home/<you>/.pyde-testnet"
+dev_mode = false
+
+[network]
+port = 30303
+max_peers = 50
+bootstrap_peers = [
+  "/dns4/seed-0.testnet.pyde.network/tcp/30303/p2p/<peer-id>",
+  "/dns4/seed-1.testnet.pyde.network/tcp/30303/p2p/<peer-id>",
+  "/dns4/seed-2.testnet.pyde.network/tcp/30303/p2p/<peer-id>",
+]
+
+[rpc]
+enabled = true
+listen = "127.0.0.1"   # 0.0.0.0 if you want external RPC clients
+port = 8545
+
+[metrics]
+enabled = true
+port = 9090
+```
+
+Then run with `--config`:
+
+```sh
+pyde run --config ~/.pyde-testnet/config.toml
+```
+
+> **Heads-up:** `pyde run` refuses to start a `chain_id == 1` node
+> with an empty `bootstrap_peers` list (audit 219). If you see
+> `refusing to start mainnet (chain_id=1) with no bootstrap peers`,
+> you forgot the bootstrap entries.
+
+## 4. Watch initial sync
+
+The node will print sync progress as it catches up:
+
+```
+INFO peer connected peer_id=12D3KooW... addr=/dns4/seed-0...
+INFO sync batch processed received=64 processed=64 head=64
+INFO sync batch processed received=64 processed=64 head=128
+...
+```
+
+On a healthy network, you should see `head_slot` advancing.
+
+If you get more than `SNAPSHOT_THRESHOLD = 1000` slots behind, the
+node automatically switches from block-by-block sync to chunked
+state-snapshot sync (audit 220). Snapshot sync downloads the
+canonical state at a recent finality checkpoint in one shot, then
+continues block-by-block from there.
+
+Confirm sync via RPC. `pyde_syncing` reports current head + epoch
++ state root:
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_syncing","params":[],"id":1}'
+# → { "headSlot": 41728, "epoch": 41, "stateRoot": "0x..." }
+```
+
+`pyde_blockNumber` returns the current head slot directly:
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_blockNumber","params":[],"id":1}'
+```
+
+Re-poll every few seconds. Once `headSlot` stops advancing on the
+network side and matches yours, you're synced.
+
+## 5. Get test tokens
+
+The testnet faucet dispenses test tokens to any address that has
+not received tokens in the last hour.
+
+### Web faucet
+
+Visit `https://faucet.testnet.pyde.network`, paste your address,
+solve the captcha. Tokens land within one slot (~400 ms) once the
+faucet's tx is included.
+
+### CLI / script
+
+```sh
+curl -s -X POST https://faucet.testnet.pyde.network/api/request \
+  -H 'Content-Type: application/json' \
+  -d '{"address": "0x<your-32-byte-address-hex>"}'
+```
+
+Response includes the faucet's tx hash; track it via your local
+RPC:
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_getTransactionReceipt","params":["0x<tx-hash>"],"id":1}'
+```
+
+## 6. Send your first transaction
+
+The Rust SDK exposes `Provider` for read + submit, plus
+`build_raw_encrypted_tx` for encrypted submission. You sign the
+plaintext `Transaction` with FALCON-512 yourself before sending:
+
+```rust
+use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+use pyde_rust_sdk::Provider;
+use pyde_tx::types::Transaction;
+
+let provider = Provider::new("http://127.0.0.1:8545");
+let (pk, sk) = falcon_keygen()?;
+let from = pyde_account::address::derive_eoa_address(pk.as_bytes());
+
+let chain_id = provider.get_chain_id().await?;
+let nonce = provider.get_nonce(&from).await?;
+let base_fee = provider.get_gas_price().await?;
+
+let mut tx = Transaction { /* to, value, gas_limit, ... */ };
+tx.from = from;
+tx.nonce = nonce;
+tx.chain_id = chain_id;
+let sig = falcon_sign(&sk, &tx.hash())?;
+tx.signature = sig.as_bytes().to_vec();
+
+let resp = provider.send_transaction(&tx).await?;
+let receipt = resp.wait(30_000).await?;
+println!("tx hash {} success={}", receipt.tx_hash, receipt.success);
+```
+
+For raw JSON-RPC, see [`rpc-reference.md`](./rpc-reference.md).
+The integration test `crates/node/tests/multi_node_encrypted_lifecycle.rs`
+is a working end-to-end example covering FALCON sign + submit +
+receipt polling.
+
+## 7. (Optional) Encrypted MEV-protected transactions
+
+Pyde offers a threshold-encrypted mempool for MEV protection. Txs
+submitted via `pyde_sendRawEncryptedTransaction` are decrypted only
+*after* their order in the block is committed, blocking
+front-running.
+
+Per-sender rate limit is **10 enc-txs/sec** by design (audit 027 —
+spam defense). Real-time use cases (DEXes, oracles) sit well below
+this; if you need higher rates, batch into multiple sender keys.
+
+See the encrypted-tx integration test
+(`crates/node/tests/multi_node_encrypted_lifecycle.rs`) for an
+end-to-end Rust example.
+
+## Troubleshooting
+
+### "refusing to start mainnet (chain_id=1) with no bootstrap peers"
+
+You're missing `network.bootstrap_peers` in your config (or the
+`--bootstrap` flag). See section 3.
+
+### Node never reaches network tip
+
+Check peer count via the Prometheus metric on
+`http://127.0.0.1:9090/metrics`:
+
+```sh
+curl -s http://127.0.0.1:9090/metrics | grep '^pyde_peers '
+# → pyde_peers 4
+```
+
+If `pyde_peers == 0`, your bootstrap multiaddrs are wrong or your
+firewall is blocking outbound TCP/30303 (and UDP/30303 for QUIC).
+The `pyde_block_lag` gauge tells you how many slots behind the
+network tip you currently are.
+
+### "tx rejected (duplicate, rate-limited, or signature failed verification)"
+
+Three possibilities:
+- **Duplicate**: same `(sender, nonce)` already in mempool. Check
+  `pyde_getTransactionStatus`.
+- **Rate-limited**: per-sender 10 tx/s cap (audit 027). Spread the
+  burst across multiple sender keys, or pace at ≥100 ms intervals.
+- **Bad signature**: the sender doesn't have a registered FALCON
+  pubkey on-chain. Send a `RegisterPubkey` tx first (audit 229).
+
+### Snapshot sync hangs
+
+Snapshots are served by validators only. If you're behind a
+firewall that blocks inbound libp2p connections AND the validators
+all happen to be load-shedding, you may stall. Try:
+- Restart the node (forces a fresh peer set)
+- Switch bootstrap peers (different validators serve different
+  snapshot chunks)
+
+## Local devnet (run today)
+
+While the public testnet is pre-launch, you can run a local
+4-validator devnet to exercise the same flow:
+
+```sh
+pyde testnet --validators 4 --out ./devnet --dev
+cd devnet
+./run.sh                   # starts all 4 nodes
+```
+
+This generates per-node configs, validator keys, threshold shares,
+and a `run.sh` launch script. RPC for node-0 lands on
+`http://127.0.0.1:8545`. Faucet info is in `./devnet/README.txt`.
+
+## Next steps
+
+- [`run-validator.md`](./run-validator.md) — operator guide for
+  running a validator node (requires staking, threshold-share key
+  custody, and uptime SLAs).
+- [`rpc-reference.md`](./rpc-reference.md) — full JSON-RPC method
+  list with request/response shapes.
+- [Rust SDK](../crates/pyde-rust-sdk/README.md) — type-safe client
+  library for Pyde.

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1,0 +1,170 @@
+# Pyde JSON-RPC Reference
+
+The Pyde node exposes a JSON-RPC 2.0 interface on `[rpc].port` (default
+8545). Methods are namespaced `pyde_*`. The full source of truth lives
+in `crates/node/src/rpc.rs` — this page is a quick reference.
+
+> **Convention:** addresses are 32-byte hex with `0x` prefix
+> (example: `0xa264...`). Balances and gas values are decimal strings
+> (`"1000000000"`). Slot / block numbers are unsigned 64-bit hex
+> (`"0x42"`).
+
+## State queries
+
+### `pyde_getBalance(address)`
+Account balance in quanta (10⁻⁹ PYDE).
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_getBalance","params":["0x<addr>"],"id":1}'
+```
+
+### `pyde_getTransactionCount(address)`
+Current sender nonce (the next nonce to use). Hex-encoded.
+
+### `pyde_getCode(address)`
+Contract bytecode at `address`, hex. Returns `0x` for EOAs.
+
+### `pyde_getStorageAt(address, slot)`
+Storage word at the given slot, hex.
+
+### `pyde_chainId()`
+Network chain id (decimal-string).
+
+### `pyde_blockNumber()`
+Current head slot, hex.
+
+### `pyde_stateRoot()`
+Current state root (32-byte hex).
+
+### `pyde_getBlockByNumber(slot, full_tx)`
+Block at slot, optionally with full tx bodies.
+
+### `pyde_getBlockByHash(hash, full_tx)`
+Block by header hash.
+
+### `pyde_getValidators()`
+Active validator set: addresses, public keys, voter indexes, stake.
+
+### `pyde_syncing()`
+Returns the local node's chain head as
+`{ headSlot, epoch, stateRoot }`. Compare `headSlot` against the
+network tip you observe from a peer (or via Prometheus
+`pyde_block_lag` gauge) to tell whether you're caught up.
+
+### `pyde_gasPrice()`
+Current `base_fee` (gwei-equivalent, decimal-string).
+
+## Transaction submission
+
+### `pyde_sendRawTransaction(hex)`
+Submit a wire-encoded signed transaction. The transaction must include
+a valid FALCON-512 signature over `Transaction::hash()`.
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_sendRawTransaction","params":["0x<hex>"],"id":1}'
+```
+
+Returns the tx hash on success, or a JSON-RPC error:
+- `-32000` "tx rejected (duplicate, rate-limited, or signature failed)"
+- `-32001` "encrypted-tx ingress disallowed on this chain_id"
+- `-32009` per-sender mempool cap (audit 027 / M1)
+- `-32010` `(sender, nonce)` duplicate
+- `-32011` global mempool cap
+
+### `pyde_sendTransaction(tx_object)`
+Higher-level submit — takes structured fields. Devnet only
+(`chain_id == 31337`); production paths must go through
+`sendRawTransaction` to enforce signature presence.
+
+### `pyde_sendRawEncryptedTransaction(hex)`
+Submit a threshold-encrypted MEV-protected transaction. The wire format
+is `EncryptedTx` (`crates/mempool/src/encrypted.rs`). Per-sender rate
+limit: 10 enc-tx/sec (audit 027).
+
+### `pyde_getThresholdPublicKey()`
+Returns the committee's threshold public key (hex). Required to encrypt
+a transaction client-side before submitting via the encrypted path.
+
+### `pyde_call(tx_object)`
+Read-only contract execution. Doesn't broadcast a tx; runs against
+current state and returns the call's return data.
+
+### `pyde_estimateGas(tx_object)`
+Returns gas estimate for a tx (no broadcast).
+
+### `pyde_createAccessList(tx_object)`
+Returns the access list (per-storage-key reads/writes) the tx would
+trigger. Required for parallel execution (audit task 077).
+
+## Receipts + logs
+
+### `pyde_getTransactionReceipt(tx_hash)`
+Receipt for a committed tx: status, gas_used, effective_gas_price,
+logs, contract_address (for `Deploy` txs).
+
+### `pyde_getTransactionStatus(tx_hash)` (M4)
+Lightweight status query for clients polling pre-receipt:
+- `{ included: true, success, gasUsed, effectiveGas }` if committed
+- `{ pending: true, ageSecs }` if in mempool
+- `{ not_found: true }` if neither
+
+### `pyde_getLogs(filter)`
+Filtered log lookup. `filter` supports `{ from_slot, to_slot, address,
+topics }`.
+
+## Mempool
+
+### `pyde_mempoolSize()`
+Plaintext-mempool depth. Encrypted-mempool depth is exposed via the
+`pyde_encrypted_mempool_size` Prometheus gauge (audit 222).
+
+## Subscriptions (WebSocket only)
+
+The same RPC server accepts WebSocket connections at the same port.
+Subscriptions deliver server-pushed events:
+
+### `pyde_subscribe(topic)`
+Generic subscription. `topic` ∈ { `"newHeads"`, `"newPendingTransactions"`,
+`"logs"` }.
+
+### `pyde_subscribePending`
+Streams every new pending tx as the hex tx hash.
+
+### `pyde_subscribeLogs(filter)`
+Streams matching logs from new blocks.
+
+Unsubscribe via the matching `pyde_unsubscribe*` method with the
+subscription id returned by the subscribe call.
+
+## Error codes (recap)
+
+| Code | Meaning |
+|---|---|
+| `-32000` | Generic tx rejection (duplicate / rate-limited / bad sig) |
+| `-32001` | Encrypted-tx ingress disallowed for this chain_id |
+| `-32009` | Per-sender mempool cap |
+| `-32010` | `(sender, nonce)` duplicate |
+| `-32011` | Global mempool cap |
+
+## Rust SDK
+
+For type-safe access from Rust, prefer the SDK over raw JSON-RPC:
+
+```rust
+use pyde_rust_sdk::Provider;
+
+let provider = Provider::new("http://127.0.0.1:8545");
+let head = provider.get_block_number().await?;
+let balance = provider.get_balance(&addr).await?;
+
+// Submit (caller signs the Transaction themselves):
+let resp = provider.send_transaction(&signed_tx).await?;
+let receipt = provider.wait_for_receipt(&resp.hash, 30_000).await?;
+```
+
+See [`crates/pyde-rust-sdk/README.md`](../crates/pyde-rust-sdk/README.md)
+for the full surface.

--- a/docs/run-validator.md
+++ b/docs/run-validator.md
@@ -1,0 +1,255 @@
+# Run a Pyde Validator
+
+Operator guide for running a validator node on the Pyde testnet.
+Validators participate in HotStuff BFT consensus, propose blocks,
+vote on finality, and earn block rewards + transaction fees.
+
+## Before you start
+
+A validator is materially harder to run than a full node:
+
+- **Staking** — 10,000 PYDE locked in the validator-staking contract.
+  Slashable for double-sign or extended downtime.
+- **Threshold-share custody** — your `threshold.share` is a piece of
+  the committee's MEV-protection decryption key. Loss = no PSS
+  refresh participation, possible eviction at next epoch.
+- **Uptime** — extended downtime risks slashing under the inactivity
+  rules (`crates/consensus/src/slashing.rs`).
+- **Hardware** — at least 4 dedicated cores, 16 GB RAM, NVMe SSD,
+  multi-region preferred.
+- **Network** — public reachability on TCP/30303 + UDP/30303 at a
+  stable DNS name or static IP.
+
+If any of those are dealbreakers, run a [full node](./connect-to-testnet.md)
+instead.
+
+## 1. Generate validator keys
+
+The standard pre-launch path is for the testnet operator to
+distribute keys via `pyde testnet --node-addrs <topology.toml>`
+(task 078). You receive a directory containing:
+
+- `validator.key` — FALCON-512 keypair, signs proposals + votes
+- `node.key` — libp2p Ed25519 identity
+- `threshold.share` — your share of the committee MEV-decryption
+  secret
+- `threshold.pk` — the (public) committee threshold pubkey
+- `genesis.toml` — testnet genesis config (allocations, validators,
+  initial supply)
+- `config.toml` — pre-filled config with your region/host/port and
+  full mesh of other validators in `bootstrap_peers`
+
+Inspect the `# region: ... / # host: ...` header of your
+`config.toml` to confirm you got the right validator slot.
+
+> **Custody:** never commit `validator.key` or `threshold.share` to
+> a repo, never email them, never paste in chat. Use an encrypted
+> keystore (`PYDE_VALIDATOR_PASSPHRASE` env var, audit 221) for
+> at-rest protection.
+
+## 2. Encrypt the validator key
+
+Pyde's keystore uses AES-256-GCM with a Poseidon2-derived key.
+
+```sh
+export PYDE_VALIDATOR_PASSPHRASE='your-strong-passphrase'
+
+# First start with PYDE_VALIDATOR_PASSPHRASE set: the node detects
+# the legacy raw-bytes validator.key, re-writes it encrypted, and
+# logs a single deprecation warning.
+pyde run --role validator --config /path/to/config.toml
+```
+
+After the first run, `validator.key` is in encrypted JSON format.
+File permissions are tightened to 0o600 on Unix.
+
+## 3. Start the validator
+
+```sh
+pyde run \
+  --role validator \
+  --config /path/to/config.toml \
+  --datadir /path/to/datadir
+```
+
+Or with a systemd unit (recommended for production):
+
+```ini
+# /etc/systemd/system/pyde-validator.service
+[Unit]
+Description=Pyde Validator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pyde
+Group=pyde
+WorkingDirectory=/home/pyde
+Environment="PYDE_VALIDATOR_PASSPHRASE=__set_via_systemctl_edit__"
+ExecStart=/usr/local/bin/pyde run --role validator --config /etc/pyde/config.toml --datadir /var/lib/pyde
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+sudo systemctl edit pyde-validator   # set PYDE_VALIDATOR_PASSPHRASE
+sudo systemctl enable --now pyde-validator
+sudo journalctl -u pyde-validator -f
+```
+
+## 4. Confirm participation
+
+Once synced, your validator should appear in the active set:
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_getValidators","params":[],"id":1}'
+```
+
+Find your address in the response. Your `voter_index` determines
+your VRF position for proposer selection.
+
+## 5. Watch the operator metrics
+
+Pyde exposes Prometheus metrics on the configured port (default
+9090):
+
+```
+pyde_block_lag                 # network_tip - head_slot. Alert > 10.
+pyde_finality_lag              # slots since last hard-finality. Alert > 100.
+pyde_peers                     # connected libp2p peers. Alert < 4.
+pyde_block_processing_ms       # p99 block-execution latency.
+pyde_state_commit_ms           # SMT/RocksDB commit p99.
+pyde_validator_missed_proposals_total  # missed proposal slots (audit 222).
+pyde_reorgs_total{outcome=...} # reorg attempts by outcome.
+pyde_encrypted_mempool_size    # MEV-protected mempool depth.
+```
+
+A pre-built Grafana dashboard ships in `docker/grafana/`. Point it
+at your Prometheus scraper and import.
+
+## 6. Operational tasks
+
+### Restart safely
+
+A clean restart preserves state. The persisted `ConsensusState`
+includes `pending_votes`, `seen_proposals`, `seen_votes`, and
+`pending_evidence` (audits 001-007, 014c) — the validator picks up
+exactly where it left off without re-voting on already-voted slots.
+
+Crash recovery is exercised by the `validator_crash_recovery` test
+(audit, see commit `03e051d`).
+
+### Stake / unbond
+
+Staking is performed by submitting a `TransactionType::StakeDeposit`
+transaction (`crates/tx/src/types.rs`). Build the transaction in
+your client of choice (Rust SDK or raw JSON-RPC), sign with the
+validator's FALCON-512 key, and submit via
+`pyde_sendRawTransaction`.
+
+The `Transaction` fields for staking:
+
+```rust
+use pyde_tx::types::{Transaction, TransactionType};
+
+let mut tx = Transaction {
+    tx_type: TransactionType::StakeDeposit,
+    from: validator_addr,
+    to: validator_addr,            // self-stake; ignored for stake-tx
+    value: 10_000_000_000_000,     // 10,000 PYDE in quanta
+    nonce,
+    gas_limit: 100_000,
+    chain_id,
+    signature: Vec::new(),
+    /* ...remaining fields... */
+};
+let sig = falcon_sign(&sk, &tx.hash())?;
+tx.signature = sig.as_bytes().to_vec();
+provider.send_transaction(&tx).await?;
+```
+
+Unbonding uses `TransactionType::StakeWithdraw`. The 14-day
+waiting period is enforced in the tx pipeline; balance becomes
+spendable automatically after the window closes.
+
+### Rotate threshold shares (PSS)
+
+Threshold shares automatically refresh at every epoch boundary via
+PSS (proactive secret sharing). The combined secret is unchanged;
+your share rotates so genesis-ceremony trust dissolves after the
+first epoch.
+
+If you bring a new operator online mid-epoch, they receive shares
+via the resharing protocol at the next boundary
+(`canonical_resharing_subset`).
+
+### Apply software upgrades
+
+```sh
+sudo systemctl stop pyde-validator
+# Replace /usr/local/bin/pyde with the new binary
+sudo systemctl start pyde-validator
+sudo journalctl -u pyde-validator -f   # confirm sync resumes
+```
+
+Plan upgrades for low-traffic windows. The 14-day unbonding period
+means an upgrade-induced bug that gets you slashed costs you 14
+days of unstaked liquidity, not just downtime.
+
+## Slashing — what to watch
+
+| Event | Detection | Slash | How to avoid |
+|---|---|---|---|
+| Double-sign | Two votes for the same slot at different block hashes | Full stake | Don't run two validators with the same key. Don't restore from a backup that includes votes already broadcast. |
+| Equivocation on proposal | Two proposals at the same slot | Full stake | Same as above. |
+| Extended downtime | TODO: not yet enforced | TBD | Healthy uptime monitoring. |
+
+Double-sign evidence is gossiped as soon as it's detected, persisted
+to disk (audit 005, 014c), and applied via `TransactionType::Slash`
+once a validator includes it in a block.
+
+## Troubleshooting
+
+### Validator never becomes active
+
+```sh
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_getValidators","params":[],"id":1}'
+```
+
+If your address isn't there, you haven't staked yet (testnet may
+require a faucet step) or your registration hasn't been included.
+Check your stake-deposit tx hash via `pyde_getTransactionReceipt`.
+
+### "panic: persist failure" on startup
+
+The node refuses to continue if it cannot fsync consensus state to
+disk (audit 014b — safety-optimal: continuing risks a BFT
+double-vote on next start). Check disk free space, mount options
+(no `nosync` / `commit=N` weirdness), and rerun.
+
+### Threshold-share decode failure
+
+Your `threshold.share` is the wrong format or for the wrong
+committee. Re-fetch from the operator-issued bundle. Don't try to
+hand-edit it.
+
+## Stake economics (testnet)
+
+- Validator stake: 10,000 PYDE
+- Block reward: per-slot inflation pool, distributed by stake-weight
+  to the active validator set
+- Fee split: 70% burn / 20% validator / 10% treasury
+- Double-sign slash: full stake
+- Unbonding period: 14 days (still earning during this window)
+
+Mainnet parameters are subject to change before genesis ceremony —
+see `MAINNET_PLAN.md` Phase 4.


### PR DESCRIPTION
## Summary

Closes MAINNET_PLAN.md task 084. Public-facing operator and user
docs covering end-to-end testnet flow. All three new docs are
linked from a new Quickstart section in README.md.

- `docs/connect-to-testnet.md` — full-node bringup, sync
  verification, faucet, first transaction.
- `docs/run-validator.md` — operator guide for validators (stake,
  custody, systemd, slashing rules, ops).
- `docs/rpc-reference.md` — JSON-RPC method quick reference.
- `README.md` — Quickstart section.

## Verified against source

Every RPC method name, audit reference, error code, SDK API
shape, and CLI flag in the docs was cross-checked against the
codebase. Notable corrections caught during this pass:
- `pyde_syncing` returns `{ headSlot, epoch, stateRoot }`, not
  the Ethereum-style `{ currentSlot, highestSlot, peers }`.
- Provider SDK has no `Wallet` type yet — caller signs FALCON
  themselves (corrected example).
- Receipt fields are `tx_hash, success, gas_used, ...` — there
  is no `block_number` on the SDK Receipt struct (corrected).
- Staking is via `TransactionType::StakeDeposit` raw tx, not a
  nonexistent `pyde-cli stake` (corrected).

## What's still open

URLs, peer ids, and DNS names in `connect-to-testnet.md` are
placeholders until tasks 079-080 actually deploy the testnet.
The "Local devnet" appendix is fully runnable today.