### PR TITLE
Stabilize 4-node devnet: net hardening + Path A consensus + RPC tx bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@ target/
 pyde-book/
 ROADMAP.md
 
+# Operator-facing planning docs that live next to source for ergonomic
+# cross-reference but aren't part of the project's public history.
+# Keep these in sync with the corresponding doc in their target repo
+# (or the dedicated planning workspace) when content matters.
+MAINNET_PLAN.md
+BENCH_PLAN.md
+BENCH_CONTRACTS.md
+EXPLORER_PLAN.md
+
 # cargo-fuzz artefacts (task 053). Crate lives outside the workspace
 # and has its own Cargo.lock + target/ dir + corpus dir which we don't
 # commit. Fuzz crashes go into fuzz/artifacts/ and should also stay

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -228,7 +228,37 @@ pub mod topics {
 }
 
 /// Dial bootstrap peers and add them to Kademlia.
+///
+/// Avoids two libp2p flap sources that wreck consensus on a
+/// fully-meshed bootstrap config:
+///
+/// 1. **Simultaneous open.** With every node listing every other
+///    node, both peers in a pair dial each other concurrently;
+///    libp2p establishes both connections, then dedupes one with
+///    cause `None` (local close) or `ApplicationClosed`. On a 4-node
+///    localhost devnet that produced ~4 flaps/sec/peer and dropped
+///    ~33% of gossipsub block proposals, leaving each validator's
+///    `buffered_proposals` set holding only its own block at vote
+///    time — every node then voted for itself, formed a self-QC
+///    over a synth empty-body block, and the chain forked into N
+///    independent local chains. Mitigation: per-pair, only the
+///    LOWER peer-id dials; the higher accepts the inbound. Symmetric
+///    tie-break — both ends agree without coordination.
+///
+/// 2. **Re-dialing connected peers.** This function is called on a
+///    2-second tick to recover from post-restart mesh degradation,
+///    but firing the dial unconditionally has the same effect as #1
+///    on every tick — libp2p sees a connected peer being dialed,
+///    races the new connection against the live one, and dedupes.
+///    Mitigation: skip peers we already have a connection to. The
+///    earlier audit-234 comment said this gating "regressed" chain
+///    advancement, but that regression was specific to SIGKILL-style
+///    restarts where libp2p still considers a TCP-half-closed peer
+///    "connected"; the steady-state cost of re-dialing every tick
+///    is far worse than that edge case, which is better handled by
+///    explicit disconnect-then-redial.
 pub fn dial_bootstrap_peers(swarm: &mut Swarm<PydeBehaviour>, bootstrap_peers: &[String]) {
+    let local_peer_id = *swarm.local_peer_id();
     for addr_str in bootstrap_peers {
         if let Ok(addr) = addr_str.parse::<Multiaddr>() {
             // Extract PeerId from the multiaddr
@@ -241,12 +271,30 @@ pub fn dial_bootstrap_peers(swarm: &mut Swarm<PydeBehaviour>, bootstrap_peers: &
             });
 
             if let Some(peer_id) = peer_id {
-                // Add to Kademlia routing table
+                // Always seed Kademlia — even when we don't dial, the
+                // routing entry lets us answer DHT queries about this
+                // peer and lets discovery promote the address if
+                // we end up dialing later.
                 swarm
                     .behaviour_mut()
                     .kademlia
                     .add_address(&peer_id, addr.clone());
-                // Dial the peer
+                // Skip dialing peers with peer-ids higher than ours —
+                // they will dial us instead. This breaks the dial
+                // race symmetrically.
+                if local_peer_id >= peer_id {
+                    tracing::debug!(
+                        %peer_id,
+                        "skipping bootstrap dial (waiting for higher peer to dial us)"
+                    );
+                    continue;
+                }
+                // Skip dialing peers we already have a live
+                // connection to — re-dial only if the connection
+                // dropped.
+                if swarm.is_connected(&peer_id) {
+                    continue;
+                }
                 if let Err(e) = swarm.dial(addr) {
                     tracing::warn!(%peer_id, error = %e, "failed to dial bootstrap peer");
                 } else {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -777,6 +777,259 @@ impl PydeNode {
                                 &peer_manager,
                             );
                         }
+                        PostEventAction::SendConsensusRrResponseAndApplyQcd(
+                            channel,
+                            resp,
+                            qc_slot,
+                            qc_block_hash,
+                        ) => {
+                            // Path A: RR-receive of a Vote closed the soft
+                            // QC. Ack the RR sender, then trigger canonical
+                            // apply for the now-QC'd block. Mirrors the
+                            // standalone ApplyCanonicalAfterQc handler
+                            // body — duplicated until the call sites
+                            // settle and a helper extraction is worth its
+                            // 12-arg signature.
+                            let _ = swarm.behaviour_mut().consensus_rr.send_response(channel, resp);
+                            let block = {
+                                let pbb = pending_block_bodies.read().await;
+                                match pbb.get(&qc_block_hash).cloned() {
+                                    Some(b) => b,
+                                    None => {
+                                        debug!(
+                                            qc_slot,
+                                            "RR-QC canonical apply: block not in buffer (sync will recover)"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            };
+                            let mut chain_w = chain.write().await;
+                            let mut state_w = state.write().await;
+                            if chain_w.head_slot >= qc_slot {
+                                drop(state_w);
+                                drop(chain_w);
+                                continue;
+                            }
+                            let ws_slot = validator_engine
+                                .as_ref()
+                                .and_then(|e| e.finality.latest_checkpoint.as_ref().map(|c| c.slot));
+                            match BlockProcessor::process_full_block_with_aot_and_checkpoint(
+                                &mut chain_w,
+                                &mut state_w,
+                                &block,
+                                Some(&aot_cache),
+                                ws_slot,
+                            ) {
+                                Ok((tc, gas, ref receipts_list)) => {
+                                    let pending_writes = state_w.take_pending_writes();
+                                    let smt_handle = state_w.smt_handle();
+                                    drop(state_w);
+                                    drop(chain_w);
+                                    if !pending_writes.is_empty() {
+                                        let commit_start = std::time::Instant::now();
+                                        if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending_writes) {
+                                            crate::metrics::record_state_commit_ms(
+                                                commit_start.elapsed().as_millis() as u64,
+                                            );
+                                            let mut sw = state.write().await;
+                                            sw.set_root(root);
+                                            drop(sw);
+                                        }
+                                    }
+                                    let full_bytes = wire::encode_block(&block);
+                                    let _ = block_store.put_block(&block.header, &full_bytes);
+                                    let _ = block_store.put_head(qc_slot);
+                                    chain_sync.on_block_processed(qc_slot);
+                                    if !receipts_list.is_empty() {
+                                        let mut receipts_w = receipts.write().await;
+                                        receipts_w.insert_block_receipts(qc_slot, receipts_list.clone());
+                                    }
+                                    let _ = ws_heads.send(serde_json::json!({
+                                        "slot": format!("0x{:x}", qc_slot),
+                                        "timestamp": format!("0x{:x}", block.header.timestamp),
+                                        "proposer": format!("0x{}", hex::encode(block.header.proposer)),
+                                        "txCount": format!("0x{:x}", tc),
+                                    }));
+                                    for r in receipts_list.iter() {
+                                        for log in &r.logs {
+                                            let _ = ws_logs.send(serde_json::json!({
+                                                "address": format!("0x{}", hex::encode(log.address)),
+                                                "topics": log.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
+                                                "data": format!("0x{}", hex::encode(&log.data)),
+                                            }));
+                                        }
+                                    }
+                                    let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
+                                        .map(|tx| tx.hash()).collect();
+                                    if !tx_hashes.is_empty() {
+                                        let mut idx = mempool_index.write().await;
+                                        for h in &tx_hashes { idx.remove(h); }
+                                        drop(idx);
+                                        let mut pending_w = pending_txs.write().await;
+                                        for h in &tx_hashes { pending_w.remove(h); }
+                                        drop(pending_w);
+                                        let mut times_w = pending_tx_times.write().await;
+                                        for h in &tx_hashes { times_w.remove(h); }
+                                    }
+                                    if !block.body.encrypted_txs.is_empty() {
+                                        let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
+                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                            .map(|etx| etx.hash())
+                                            .collect();
+                                        if !enc_hashes.is_empty() {
+                                            let mut relay_w = tx_relay.write().await;
+                                            relay_w.remove_included(&enc_hashes);
+                                        }
+                                    }
+                                    {
+                                        let mut pbb = pending_block_bodies.write().await;
+                                        pbb.remove(&qc_block_hash);
+                                    }
+                                    info!(
+                                        slot = qc_slot,
+                                        txs = tc,
+                                        gas,
+                                        proposer = hex::encode(block.header.proposer),
+                                        "applied block from QC (canonical, RR path)"
+                                    );
+                                    if let (Some(engine), Some(identity)) = (
+                                        validator_engine.as_mut(),
+                                        validator_identity.as_ref(),
+                                    ) {
+                                        let state_root = state.read().await.root();
+                                        if let Some(fv) = engine.create_finality_vote(
+                                            qc_slot,
+                                            qc_block_hash,
+                                            state_root,
+                                            identity,
+                                        ) {
+                                            let cert_formed =
+                                                engine.on_finality_vote(fv.clone());
+                                            let fv_bytes = wire::encode_finality_vote(&fv);
+                                            let topic = pyde_net::node::topics::consensus();
+                                            broadcast_consensus_with_rr_fallback(
+                                                &mut swarm,
+                                                topic.clone(),
+                                                fv_bytes,
+                                                &peer_manager,
+                                            );
+                                            if cert_formed {
+                                                if let Some(cp) =
+                                                    engine.latest_finality_checkpoint()
+                                                {
+                                                    let cp_bytes =
+                                                        wire::encode_finality_checkpoint_msg(cp);
+                                                    broadcast_consensus_with_rr_fallback(
+                                                        &mut swarm,
+                                                        topic,
+                                                        cp_bytes,
+                                                        &peer_manager,
+                                                    );
+                                                    info!(
+                                                        slot = qc_slot,
+                                                        "hard finality cert formed (RR canonical-apply path)"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Audit-227 share broadcast — same logic
+                                    // as the gossip canonical-apply path.
+                                    // Duplicated for now (TODO: extract to a
+                                    // helper once the call sites settle).
+                                    if !block.body.encrypted_txs.is_empty()
+                                        && validator_identity
+                                            .as_ref()
+                                            .and_then(|id| id.key_share.as_ref())
+                                            .is_some()
+                                        && !pending_decryptors.read().await.contains_key(&qc_slot)
+                                    {
+                                        let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> = block
+                                            .body
+                                            .encrypted_txs
+                                            .iter()
+                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                            .collect();
+                                        let tx_root_ok = crate::block_processor::verify_decryptor_against_committed_root(
+                                            &block.header.tx_root,
+                                            &block.body.transactions,
+                                            &enc_txs,
+                                        );
+                                        if tx_root_ok {
+                                            if let Some(engine) = validator_engine.as_mut() {
+                                                let identity = validator_identity.as_ref().unwrap();
+                                                let threshold = pyde_consensus::block::quorum_for_committee(
+                                                    engine.committee_keys.len(),
+                                                );
+                                                if let Ok(mut decryptor) =
+                                                    pyde_mempool::decryption::BlockDecryptor::new(
+                                                        enc_txs.clone(),
+                                                        threshold,
+                                                    )
+                                                {
+                                                    if let Some(ks) = &identity.key_share {
+                                                        decryptor.add_member_shares(ks);
+                                                    }
+                                                    let mut q = queued_shares.write().await;
+                                                    if let Some(queued) = q.remove(&qc_slot) {
+                                                        for qmsg in &queued {
+                                                            for (i, sb) in qmsg.shares.iter().enumerate() {
+                                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
+                                                                    decryptor.add_share(i, s);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    drop(q);
+                                                    pending_decryptors
+                                                        .write()
+                                                        .await
+                                                        .insert(qc_slot, decryptor);
+                                                }
+                                                if let Some(shares) =
+                                                    engine.generate_decryption_shares(identity, &enc_txs)
+                                                {
+                                                    let msg = wire::DecryptionShareMsg {
+                                                        slot: qc_slot,
+                                                        member_index: identity.committee_index,
+                                                        shares: shares.iter().map(|s| s.to_bytes()).collect(),
+                                                    };
+                                                    let share_bytes = wire::encode_decryption_shares(&msg);
+                                                    let topic = pyde_net::node::topics::consensus();
+                                                    broadcast_consensus_with_rr_fallback(
+                                                        &mut swarm,
+                                                        topic,
+                                                        share_bytes,
+                                                        &peer_manager,
+                                                    );
+                                                    info!(
+                                                        slot = qc_slot,
+                                                        enc_txs = enc_txs.len(),
+                                                        "broadcast decryption shares (RR canonical-apply)"
+                                                    );
+                                                }
+                                            }
+                                        } else {
+                                            error!(
+                                                slot = qc_slot,
+                                                "decrypt-time tx_root mismatch (RR canonical-apply)"
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    drop(state_w);
+                                    drop(chain_w);
+                                    debug!(
+                                        slot = qc_slot,
+                                        error = %e,
+                                        "RR canonical apply failed"
+                                    );
+                                }
+                            }
+                        }
                         PostEventAction::SendConsensusRrResponseAndAddShares(
                             channel,
                             resp,
@@ -1055,6 +1308,285 @@ impl PydeNode {
                                     enc_txs = enc_txs.len(),
                                     "broadcast decryption shares (gossip-QC)"
                                 );
+                            }
+                        }
+                        PostEventAction::ApplyCanonicalAfterQc {
+                            qc_slot,
+                            qc_block_hash,
+                        } => {
+                            // Path A canonical apply.
+                            //
+                            // Look up the block (committed by the QC) in
+                            // `pending_block_bodies`, run process_full_block,
+                            // commit the JMT diff, populate side-effects
+                            // (block_store, receipts, mempool prune,
+                            // ws_heads/ws_logs), and then cast our own
+                            // hard-finality vote with the now-canonical
+                            // `state.root()`. Same code shape as the
+                            // own-vote-forms-QC inline apply at
+                            // ~line 2284 — kept duplicated for now (the
+                            // surrounding context captures different sets
+                            // of locals on each path; extracting a helper
+                            // would mean ~12 args). When both paths
+                            // settle, fold into a shared `apply_qcd`.
+                            let block = {
+                                let pbb = pending_block_bodies.read().await;
+                                match pbb.get(&qc_block_hash).cloned() {
+                                    Some(b) => b,
+                                    None => {
+                                        debug!(
+                                            qc_slot,
+                                            "ApplyCanonicalAfterQc: block not in buffer (sync will recover)"
+                                        );
+                                        continue;
+                                    }
+                                }
+                            };
+                            let mut chain_w = chain.write().await;
+                            let mut state_w = state.write().await;
+                            // Skip if we've already applied this slot
+                            // (e.g. the own-vote-QC inline path got there
+                            // first this turn) — avoid double-apply
+                            // tripping the `slot <= head` validator.
+                            if chain_w.head_slot >= qc_slot {
+                                drop(state_w);
+                                drop(chain_w);
+                                continue;
+                            }
+                            let ws_slot = validator_engine
+                                .as_ref()
+                                .and_then(|e| e.finality.latest_checkpoint.as_ref().map(|c| c.slot));
+                            match BlockProcessor::process_full_block_with_aot_and_checkpoint(
+                                &mut chain_w,
+                                &mut state_w,
+                                &block,
+                                Some(&aot_cache),
+                                ws_slot,
+                            ) {
+                                Ok((tc, gas, ref receipts_list)) => {
+                                    let pending_writes = state_w.take_pending_writes();
+                                    let smt_handle = state_w.smt_handle();
+                                    drop(state_w);
+                                    drop(chain_w);
+                                    if !pending_writes.is_empty() {
+                                        let commit_start = std::time::Instant::now();
+                                        if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending_writes) {
+                                            crate::metrics::record_state_commit_ms(
+                                                commit_start.elapsed().as_millis() as u64,
+                                            );
+                                            let mut sw = state.write().await;
+                                            sw.set_root(root);
+                                            drop(sw);
+                                        }
+                                    }
+                                    let full_bytes = wire::encode_block(&block);
+                                    let _ = block_store.put_block(&block.header, &full_bytes);
+                                    let _ = block_store.put_head(qc_slot);
+                                    chain_sync.on_block_processed(qc_slot);
+                                    if !receipts_list.is_empty() {
+                                        let mut receipts_w = receipts.write().await;
+                                        receipts_w.insert_block_receipts(qc_slot, receipts_list.clone());
+                                    }
+                                    let _ = ws_heads.send(serde_json::json!({
+                                        "slot": format!("0x{:x}", qc_slot),
+                                        "timestamp": format!("0x{:x}", block.header.timestamp),
+                                        "proposer": format!("0x{}", hex::encode(block.header.proposer)),
+                                        "txCount": format!("0x{:x}", tc),
+                                    }));
+                                    for r in receipts_list.iter() {
+                                        for log in &r.logs {
+                                            let _ = ws_logs.send(serde_json::json!({
+                                                "address": format!("0x{}", hex::encode(log.address)),
+                                                "topics": log.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
+                                                "data": format!("0x{}", hex::encode(&log.data)),
+                                            }));
+                                        }
+                                    }
+                                    // Mempool / tx-relay cleanup.
+                                    let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
+                                        .map(|tx| tx.hash()).collect();
+                                    if !tx_hashes.is_empty() {
+                                        let mut idx = mempool_index.write().await;
+                                        for h in &tx_hashes { idx.remove(h); }
+                                        drop(idx);
+                                        let mut pending_w = pending_txs.write().await;
+                                        for h in &tx_hashes { pending_w.remove(h); }
+                                        drop(pending_w);
+                                        let mut times_w = pending_tx_times.write().await;
+                                        for h in &tx_hashes { times_w.remove(h); }
+                                    }
+                                    if !block.body.encrypted_txs.is_empty() {
+                                        let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
+                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                            .map(|etx| etx.hash())
+                                            .collect();
+                                        if !enc_hashes.is_empty() {
+                                            let mut relay_w = tx_relay.write().await;
+                                            relay_w.remove_included(&enc_hashes);
+                                        }
+                                    }
+                                    {
+                                        let mut pbb = pending_block_bodies.write().await;
+                                        pbb.remove(&qc_block_hash);
+                                    }
+                                    info!(
+                                        slot = qc_slot,
+                                        txs = tc,
+                                        gas,
+                                        proposer = hex::encode(block.header.proposer),
+                                        "applied block from QC (canonical)"
+                                    );
+
+                                    // Cast hard-finality vote post-canonical-apply
+                                    // — state.root() now reflects the canonical
+                                    // post-execution JMT root, so all honest
+                                    // validators converge on the same value and
+                                    // the cert can form.
+                                    if let (Some(engine), Some(identity)) = (
+                                        validator_engine.as_mut(),
+                                        validator_identity.as_ref(),
+                                    ) {
+                                        let state_root = state.read().await.root();
+                                        if let Some(fv) = engine.create_finality_vote(
+                                            qc_slot,
+                                            qc_block_hash,
+                                            state_root,
+                                            identity,
+                                        ) {
+                                            let cert_formed =
+                                                engine.on_finality_vote(fv.clone());
+                                            let fv_bytes = wire::encode_finality_vote(&fv);
+                                            let topic = pyde_net::node::topics::consensus();
+                                            broadcast_consensus_with_rr_fallback(
+                                                &mut swarm,
+                                                topic.clone(),
+                                                fv_bytes,
+                                                &peer_manager,
+                                            );
+                                            if cert_formed {
+                                                if let Some(cp) =
+                                                    engine.latest_finality_checkpoint()
+                                                {
+                                                    let cp_bytes =
+                                                        wire::encode_finality_checkpoint_msg(cp);
+                                                    broadcast_consensus_with_rr_fallback(
+                                                        &mut swarm,
+                                                        topic,
+                                                        cp_bytes,
+                                                        &peer_manager,
+                                                    );
+                                                    info!(
+                                                        slot = qc_slot,
+                                                        "hard finality cert formed (canonical-apply path)"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Audit-227 step 4: kick off threshold
+                                    // decryption for the block's encrypted txs
+                                    // now that QC has formed and the block is
+                                    // canonical. Logic mirrors the original
+                                    // `QcFormedFromGossip` handler — kept
+                                    // here (instead of re-emitting that
+                                    // action) because the share broadcast
+                                    // only runs on validators that are also
+                                    // committee members holding a key share,
+                                    // and we already have the canonical block
+                                    // body in scope so the original
+                                    // `block_store.get_block_raw` lookup is
+                                    // unnecessary. No-op for plaintext-only
+                                    // blocks (most of the testnet load).
+                                    if !block.body.encrypted_txs.is_empty()
+                                        && validator_identity
+                                            .as_ref()
+                                            .and_then(|id| id.key_share.as_ref())
+                                            .is_some()
+                                        && !pending_decryptors.read().await.contains_key(&qc_slot)
+                                    {
+                                        let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> = block
+                                            .body
+                                            .encrypted_txs
+                                            .iter()
+                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                            .collect();
+                                        let tx_root_ok = crate::block_processor::verify_decryptor_against_committed_root(
+                                            &block.header.tx_root,
+                                            &block.body.transactions,
+                                            &enc_txs,
+                                        );
+                                        if tx_root_ok {
+                                            if let Some(engine) = validator_engine.as_mut() {
+                                                let identity = validator_identity.as_ref().unwrap();
+                                                let threshold = pyde_consensus::block::quorum_for_committee(
+                                                    engine.committee_keys.len(),
+                                                );
+                                                if let Ok(mut decryptor) =
+                                                    pyde_mempool::decryption::BlockDecryptor::new(
+                                                        enc_txs.clone(),
+                                                        threshold,
+                                                    )
+                                                {
+                                                    if let Some(ks) = &identity.key_share {
+                                                        decryptor.add_member_shares(ks);
+                                                    }
+                                                    let mut q = queued_shares.write().await;
+                                                    if let Some(queued) = q.remove(&qc_slot) {
+                                                        for qmsg in &queued {
+                                                            for (i, sb) in qmsg.shares.iter().enumerate() {
+                                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
+                                                                    decryptor.add_share(i, s);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    drop(q);
+                                                    pending_decryptors
+                                                        .write()
+                                                        .await
+                                                        .insert(qc_slot, decryptor);
+                                                }
+                                                if let Some(shares) =
+                                                    engine.generate_decryption_shares(identity, &enc_txs)
+                                                {
+                                                    let msg = wire::DecryptionShareMsg {
+                                                        slot: qc_slot,
+                                                        member_index: identity.committee_index,
+                                                        shares: shares.iter().map(|s| s.to_bytes()).collect(),
+                                                    };
+                                                    let share_bytes = wire::encode_decryption_shares(&msg);
+                                                    let topic = pyde_net::node::topics::consensus();
+                                                    broadcast_consensus_with_rr_fallback(
+                                                        &mut swarm,
+                                                        topic,
+                                                        share_bytes,
+                                                        &peer_manager,
+                                                    );
+                                                    info!(
+                                                        slot = qc_slot,
+                                                        enc_txs = enc_txs.len(),
+                                                        "broadcast decryption shares (canonical-apply)"
+                                                    );
+                                                }
+                                            }
+                                        } else {
+                                            error!(
+                                                slot = qc_slot,
+                                                "decrypt-time tx_root mismatch (canonical-apply)"
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    drop(state_w);
+                                    drop(chain_w);
+                                    debug!(
+                                        slot = qc_slot,
+                                        error = %e,
+                                        "canonical apply failed"
+                                    );
+                                }
                             }
                         }
                         PostEventAction::BufferCompetingBlock(block) => {
@@ -1991,172 +2523,58 @@ impl PydeNode {
                                         exec_schedule,
                                     );
 
-                                    // Process our own block immediately.
-                                    // VRF selection ensures only one proposal wins votes, so
-                                    // speculative execution is safe: our block either wins (QC forms)
-                                    // or nobody's block wins (timeout). In the rare case another
-                                    // proposer's block wins for the same slot, our state diverges
-                                    // but the gossip block handler rejects duplicate slots.
-                                    let t_exec = std::time::Instant::now();
+                                    // Path A: do NOT execute the block here.
+                                    //
+                                    // Per BlockHeader's design (state_root = 0
+                                    // at proposal, set after optimistic
+                                    // execution at soft finality, verified in
+                                    // HardFinalityCert): the proposer's only
+                                    // pre-soft-QC work is to schedule the
+                                    // (possibly encrypted) txs and broadcast
+                                    // header + commitments. Execution moves
+                                    // to the post-QC canonical-apply site,
+                                    // run by every validator against the
+                                    // single canonical block.
+                                    //
+                                    // Removing the speculative self-apply:
+                                    //   - eliminates the per-slot reorg
+                                    //     ceremony (audit-230/231/232) for
+                                    //     the steady state, since losing-VRF
+                                    //     validators no longer commit a block
+                                    //     that needs reverting
+                                    //   - is the only structurally correct
+                                    //     path for encrypted txs in mainnet
+                                    //     (the proposer doesn't have the
+                                    //     decryption shares yet, so it
+                                    //     cannot execute the block)
+                                    //   - centralizes block-side-effects
+                                    //     (mempool cleanup, receipts, ws
+                                    //     emits, block_store put) at the
+                                    //     canonical-apply hook so they fire
+                                    //     once for the canonical block,
+                                    //     never for a discarded
+                                    //     speculation
+                                    //
+                                    // We still buffer our own block in
+                                    // `pending_block_bodies` so the
+                                    // QC-formed apply path can find it when
+                                    // we win the VRF (peers populate the
+                                    // same buffer via gossip-receive).
                                     {
-                                        let mut chain_w = chain.write().await;
-                                        let mut state_w = state.write().await;
-                                        let ws_slot = engine
-                                            .finality
-                                            .latest_checkpoint
-                                            .as_ref()
-                                            .map(|cp| cp.slot);
-                                        match BlockProcessor::process_full_block_with_aot_and_checkpoint(&mut chain_w, &mut state_w, &block, Some(&aot_cache), ws_slot) {
-                                            Ok((tc, gas, ref receipts_list)) => {
-                                                // Commit speculative SMT writes
-                                                // synchronously.
-                                                //
-                                                // The earlier `tokio::spawn` was a
-                                                // perf optimization — overlap the
-                                                // Merkle commit with subsequent slot
-                                                // work — but it created a race against
-                                                // the QC-formed rollback path. When
-                                                // this proposer loses the VRF
-                                                // tournament, the QC handler runs
-                                                // `state.revert_to(slot - 1)` then
-                                                // applies the canonical block. If the
-                                                // background spawn for THIS block
-                                                // lagged past the revert (large state
-                                                // diff or SMT contention pushing it
-                                                // past the ~100ms vote-collection
-                                                // window), it would acquire the SMT
-                                                // mutex AFTER the revert and the
-                                                // canonical apply, overwriting both
-                                                // with the speculative writes — state
-                                                // root then drifts from the canonical
-                                                // chain on every reorg. Hard to
-                                                // observe (only fires under the
-                                                // proposer-loses-VRF + slow-SMT
-                                                // intersection), correctness-fatal
-                                                // when it does.
-                                                //
-                                                // Sync commit closes the race: by the
-                                                // time the QC handler runs, the
-                                                // speculative SMT write has either
-                                                // landed (revert can undo it) or
-                                                // never started (no race). Cost is
-                                                // a few ms of slot-tick blocking on
-                                                // small block writes — acceptable on
-                                                // a 400ms slot. For mainnet-scale
-                                                // throughput, a slot-tagged commit
-                                                // (drop stale spawn results post-
-                                                // revert) or a JoinHandle awaited by
-                                                // the rollback path can restore
-                                                // pipelining without the race.
-                                                let pending = state_w.take_pending_writes();
-                                                let smt_handle = state_w.smt_handle();
-                                                drop(state_w);
-                                                drop(chain_w);
-                                                if !pending.is_empty() {
-                                                    let commit_start = std::time::Instant::now();
-                                                    if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending) {
-                                                        crate::metrics::record_state_commit_ms(
-                                                            commit_start.elapsed().as_millis() as u64,
-                                                        );
-                                                        let mut sw = state.write().await;
-                                                        sw.set_root(root);
-                                                        drop(sw);
-                                                    }
-                                                }
-                                                let _ = block_store.put_header(&block.header);
-                                                let _ = block_store.put_head(current_slot);
-                                                chain_sync.on_block_processed(current_slot);
-                                                let mut receipts_w = receipts.write().await;
-                                                receipts_w.insert_block_receipts(current_slot, receipts_list.clone());
-                                                // Broadcast to WS subscribers
-                                                let _ = ws_heads.send(serde_json::json!({
-                                                    "slot": format!("0x{:x}", current_slot),
-                                                    "timestamp": format!("0x{:x}", block.header.timestamp),
-                                                    "proposer": format!("0x{}", hex::encode(block.header.proposer)),
-                                                    "txCount": format!("0x{:x}", tc),
-                                                }));
-                                                for r in receipts_list.iter() {
-                                                    for log in &r.logs {
-                                                        let _ = ws_logs.send(serde_json::json!({
-                                                            "address": format!("0x{}", hex::encode(log.address)),
-                                                            "topics": log.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
-                                                            "data": format!("0x{}", hex::encode(&log.data)),
-                                                        }));
-                                                    }
-                                                }
-                                                let exec_ms = t_exec.elapsed().as_secs_f64() * 1000.0;
-                                                let slot_ms = slot_t0.elapsed().as_secs_f64() * 1000.0;
-                                                info!(
-                                                    slot = current_slot,
-                                                    txs = tc,
-                                                    gas,
-                                                    pending = pending_len,
-                                                    clone_ms,
-                                                    build_ms,
-                                                    exec_ms,
-                                                    slot_ms,
-                                                    "proposed and processed block"
-                                                );
-
-                                                // Remove plaintext tx hashes from the local
-                                                // pending queue and mempool_index. Without this,
-                                                // self-proposed blocks leave their txs in
-                                                // pending forever — the next slot's builder
-                                                // keeps re-selecting them, execution fails
-                                                // `BelowWindow` (nonce already consumed), and
-                                                // the block's 16-tx slot never fills with
-                                                // fresh txs. BlockProcessed in the gossip
-                                                // path handles the same cleanup for blocks
-                                                // received from peers; the self-proposal
-                                                // path must do it here too.
-                                                let committed_tx_hashes: Vec<[u8; 32]> = block
-                                                    .body
-                                                    .transactions
-                                                    .iter()
-                                                    .map(|tx| tx.hash())
-                                                    .collect();
-                                                if !committed_tx_hashes.is_empty() {
-                                                    {
-                                                        let mut pending_w = pending_txs.write().await;
-                                                        for h in &committed_tx_hashes {
-                                                            pending_w.remove(h);
-                                                        }
-                                                    }
-                                                    {
-                                                        let mut times_w = pending_tx_times.write().await;
-                                                        for h in &committed_tx_hashes {
-                                                            times_w.remove(h);
-                                                        }
-                                                    }
-                                                    {
-                                                        let mut idx = mempool_index.write().await;
-                                                        for h in &committed_tx_hashes {
-                                                            idx.remove(h);
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            Err(e) => {
-                                                warn!(slot = current_slot, error = %e, "failed to process own block");
-                                            }
-                                        }
+                                        let mut pbb = pending_block_bodies.write().await;
+                                        pbb.insert(block.header.hash(), block.clone());
                                     }
-
-                                    // Audit item 227 step 4: do NOT remove encrypted txs
-                                    // from tx_relay here. Self-proposals can lose the
-                                    // multi-proposer VRF lottery, and removing at self-
-                                    // propose time would permanently orphan the tx when
-                                    // a different validator's block wins the slot. The
-                                    // removal happens in the `ReconstructCompactBlock`
-                                    // handler once the committed block has been processed
-                                    // — if our block ends up being the winner, it arrives
-                                    // back to us via gossip like any other block and the
-                                    // cleanup fires there. If it loses, the tx stays in
-                                    // the mempool for future slots.
-
-                                    // Store full block for sync serving + missing tx requests
-                                    let full_block_bytes = wire::encode_block(&block);
-                                    let _ = block_store.put_block(&block.header, &full_block_bytes);
+                                    let slot_ms = slot_t0.elapsed().as_secs_f64() * 1000.0;
+                                    info!(
+                                        slot = current_slot,
+                                        txs = block.body.transactions.len(),
+                                        encrypted = block.body.encrypted_txs.len(),
+                                        pending = pending_len,
+                                        clone_ms,
+                                        build_ms,
+                                        slot_ms,
+                                        "proposed block (awaiting QC for canonical apply)"
+                                    );
 
                                     // Broadcast block to peers.
                                     // If block has encrypted txs, send FULL block (encrypted blobs
@@ -2447,6 +2865,27 @@ impl PydeNode {
                                                     if !receipts_list.is_empty() {
                                                         let mut receipts_w = receipts.write().await;
                                                         receipts_w.insert_block_receipts(qc_slot, receipts_list.clone());
+                                                    }
+
+                                                    // WebSocket subscribers — head + per-receipt
+                                                    // logs. Path A moved these out of the
+                                                    // proposer self-apply (no longer exists);
+                                                    // they fire here so subscribers see exactly
+                                                    // the canonical block events.
+                                                    let _ = ws_heads.send(serde_json::json!({
+                                                        "slot": format!("0x{:x}", qc_slot),
+                                                        "timestamp": format!("0x{:x}", block.header.timestamp),
+                                                        "proposer": format!("0x{}", hex::encode(block.header.proposer)),
+                                                        "txCount": format!("0x{:x}", tc),
+                                                    }));
+                                                    for r in receipts_list.iter() {
+                                                        for log in &r.logs {
+                                                            let _ = ws_logs.send(serde_json::json!({
+                                                                "address": format!("0x{}", hex::encode(log.address)),
+                                                                "topics": log.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
+                                                                "data": format!("0x{}", hex::encode(&log.data)),
+                                                            }));
+                                                        }
                                                     }
 
                                                     // Mempool / tx-relay cleanup — previously
@@ -3220,6 +3659,18 @@ enum PostEventAction {
     QcFormedFromGossip {
         slot: u64,
     },
+    /// Path A: a soft-QC just formed (via gossip Vote, RR-fallback Vote,
+    /// or our own Vote closing it) and the block whose hash equals
+    /// `qc_block_hash` is sitting in `pending_block_bodies`. The main
+    /// loop picks it up, runs the canonical apply (validate + execute
+    /// + cleanup + ws emit + finality-vote cast). Replaces the
+    /// per-validator speculative self-apply path that used to do this
+    /// at proposal time. Triggered from any QC-formation site so
+    /// canonical execution happens exactly once per slot per node.
+    ApplyCanonicalAfterQc {
+        qc_slot: u64,
+        qc_block_hash: [u8; 32],
+    },
     /// Send a `PydeAuthReq` to a newly connected peer. The main loop
     /// generates a fresh nonce, records it in `pending_auth_nonces`, and
     /// dispatches via the swarm.
@@ -3260,6 +3711,19 @@ enum PostEventAction {
         request_response::ResponseChannel<pyde_net::consensus_protocol::ConsensusResp>,
         pyde_net::consensus_protocol::ConsensusResp,
         Vec<u8>,
+    ),
+    /// Path A: an RR-receive of a Vote closed the soft QC. The
+    /// runtime acks the RR request and triggers the canonical apply
+    /// (process_full_block + side effects + finality vote) for
+    /// `(qc_slot, qc_block_hash)`. Same body as
+    /// `ApplyCanonicalAfterQc`, just sent alongside the RR ack so
+    /// the requester sees the response without us having to drop
+    /// the channel.
+    SendConsensusRrResponseAndApplyQcd(
+        request_response::ResponseChannel<pyde_net::consensus_protocol::ConsensusResp>,
+        pyde_net::consensus_protocol::ConsensusResp,
+        u64,
+        [u8; 32],
     ),
     /// Phase 1 hardening (audit 074b): decryption shares delivered
     /// via RR fallback. The runtime acks the RR request and routes
@@ -4003,33 +4467,25 @@ fn handle_swarm_event(
                                         debug!(slot, voter_index, "received vote");
                                         if let Some(qc) = engine.on_vote(msg) {
                                             info!(slot, votes = qc.vote_count(), "QC formed");
-                                            // Audit 232: detect QC-vs-local-head
-                                            // mismatch (multi-proposer race where we
-                                            // committed block A but consensus picked
-                                            // B). Local view says block at `slot` has
-                                            // hash `local_hash`; the QC carries
-                                            // `qc.block_hash`. If they differ AND we
-                                            // have B buffered (or can sync it),
-                                            // reorg_to_block will switch chains.
-                                            let local_hash = chain.header(slot).map(|h| h.hash());
-                                            if let Some(local) = local_hash {
-                                                if local != qc.block_hash {
-                                                    warn!(
-                                                        slot,
-                                                        local = hex::encode(local),
-                                                        qc = hex::encode(qc.block_hash),
-                                                        "QC-vs-local-head mismatch — triggering reorg"
-                                                    );
-                                                    return PostEventAction::TryReorgToQc {
-                                                        qc_slot: slot,
-                                                        qc_block_hash: qc.block_hash,
-                                                    };
-                                                }
-                                            }
-                                            // Audit item 227 step 4: notify main loop so
-                                            // the decrypt pipeline starts even when OUR
-                                            // own vote isn't the one that closes the QC.
-                                            return PostEventAction::QcFormedFromGossip { slot };
+                                            // Path A: under no-speculative-apply,
+                                            // chain.head_slot < qc.slot at this point
+                                            // (we haven't applied yet). The audit-232
+                                            // mismatch path was for the speculative-
+                                            // apply era; with Path A there's no
+                                            // already-committed block at this slot
+                                            // to mismatch. Go straight to the
+                                            // canonical-apply trigger which the main
+                                            // loop fulfills against the buffered
+                                            // block. The audit-232 reorg machinery
+                                            // remains for adversarial fork cases
+                                            // where some node DID speculatively
+                                            // commit (e.g. an older client) — kept
+                                            // wired but no longer the steady-state
+                                            // path.
+                                            return PostEventAction::ApplyCanonicalAfterQc {
+                                                qc_slot: slot,
+                                                qc_block_hash: qc.block_hash,
+                                            };
                                         }
                                     }
                                     ConsensusMessage::Timeout {
@@ -4280,6 +4736,13 @@ fn handle_swarm_event(
             // exactly the failure mode this RR fallback exists to fix.
             let mut pending_fallback_broadcast: Option<Vec<u8>> = None;
             let mut pending_share_msg: Option<wire::DecryptionShareMsg> = None;
+            // Path A: when an RR-fallback Vote closes the soft QC, the
+            // bottom-of-arm dispatch emits a combo action that acks the
+            // RR sender AND triggers canonical apply against the QC'd
+            // block_hash. Mutually exclusive with the other two pending
+            // slots because only one ConsensusMessage variant fires per
+            // RR message.
+            let mut pending_apply_qcd: Option<(u64, [u8; 32])> = None;
             let resp = {
                 // Tag-byte routing: the consensus topic carries
                 // FinalityVote alongside the ConsensusMessage variants
@@ -4369,6 +4832,7 @@ fn handle_swarm_event(
                                 debug!(slot, voter_index, "received vote via RR fallback");
                                 if let Some(qc) = engine.on_vote(msg) {
                                     info!(slot, votes = qc.vote_count(), "QC formed (via RR fallback)");
+                                    pending_apply_qcd = Some((slot, qc.block_hash));
                                 }
                             }
                             ConsensusMessage::Proposal {
@@ -4409,12 +4873,16 @@ fn handle_swarm_event(
                     pyde_net::consensus_protocol::ConsensusResp::DecodeError
                 }
             };
-            // Three-way dispatch: ack the RR sender, then route the
+            // Four-way dispatch: ack the RR sender, then route the
             // decoded payload through the same PostEventAction queue
-            // as the gossip-receive arm. The three pending_* slots
+            // as the gossip-receive arm. The four pending_* slots
             // are mutually exclusive because the decode branches are.
             if let Some(share_msg) = pending_share_msg {
                 PostEventAction::SendConsensusRrResponseAndAddShares(channel, resp, share_msg)
+            } else if let Some((qc_slot, qc_hash)) = pending_apply_qcd {
+                PostEventAction::SendConsensusRrResponseAndApplyQcd(
+                    channel, resp, qc_slot, qc_hash,
+                )
             } else {
                 match pending_fallback_broadcast {
                     Some(bytes) => PostEventAction::SendConsensusRrResponseAndBroadcast(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -282,6 +282,35 @@ impl PydeNode {
         let mempool_index: Arc<RwLock<std::collections::HashMap<[u8; 32], Vec<u8>>>> =
             Arc::new(RwLock::new(std::collections::HashMap::new()));
 
+        // Reconstructed full blocks awaiting QC, keyed by block hash.
+        //
+        // HotStuff QC-gated apply: a peer's compact block is
+        // reassembled into a full Block on receipt, but apply is
+        // deferred until the slot's vote-QC forms. Without this,
+        // non-proposer validators applied the proposer's block
+        // eagerly on gossip — chain_head advanced past current_slot
+        // before their own slot tick fired, hitting the
+        // `current_slot <= chain_head` skip in the proposer-build
+        // loop and collapsing the cluster into single-leader chains
+        // (one validator wins 100%, never rotates). The proposer's
+        // own self-apply path remains at the slot tick (it needs
+        // the post-execution state_root for its own header) — for
+        // the proposer-loses-VRF case, the QC-formed handler
+        // detects a chain/QC mismatch and rolls back via
+        // chain.revert + state.revert_to before applying the
+        // canonical block. The map is keyed by block_hash so the
+        // QC handler can look up the real body that matches the
+        // QC's hash; falls back to the audit-234 synthesized
+        // empty-body path when the body hasn't arrived yet
+        // (e.g., RR fallback delivered the QC vote before the
+        // gossip block body).
+        //
+        // Bounded by a slot-window prune in the maintenance tick
+        // so a stalled gossip peer can't pile up bodies forever.
+        let pending_block_bodies: Arc<
+            RwLock<std::collections::HashMap<[u8; 32], pyde_consensus::block::Block>>,
+        > = Arc::new(RwLock::new(std::collections::HashMap::new()));
+
         // Pending block decryptors: slot → BlockDecryptor (collecting shares for threshold decryption)
         let pending_decryptors: Arc<
             RwLock<std::collections::HashMap<u64, pyde_mempool::decryption::BlockDecryptor>>,
@@ -1064,7 +1093,17 @@ impl PydeNode {
                             // at the end via the channel-style fallthrough
                             // inside the match.
                             let key = (qc_slot, qc_block_hash);
-                            if let Some(target) = competing_blocks.remove(&key) {
+                            // Audit-232 originally fed the buffer from the
+                            // FullBlock gossip path. With QC-gated apply, the
+                            // compact-block path now buffers in
+                            // `pending_block_bodies` instead. Check both so
+                            // reorg works regardless of which gossip channel
+                            // delivered the canonical block.
+                            let target = competing_blocks.remove(&key).or_else(|| {
+                                let pbb = pending_block_bodies.try_read().ok()?;
+                                pbb.get(&qc_block_hash).cloned()
+                            });
+                            if let Some(target) = target {
                                 let mut chain_w = chain.write().await;
                                 let mut state_w = state.write().await;
                                 let ws_slot = validator_engine.as_ref().and_then(|e| {
@@ -1455,101 +1494,41 @@ impl PydeNode {
                                 }
                             }
 
-                            // Validate and process with WS checkpoint (slice 4.3).
+                            // QC-gated apply: buffer the reconstructed
+                            // block, don't mutate chain or state yet.
+                            // The slot's vote-QC formation handler
+                            // (`select_and_vote` + the QC-formed branch
+                            // below) is responsible for applying
+                            // whichever block_hash the committee voted
+                            // for. Eager-applying here would race the
+                            // proposer-selection loop on every other
+                            // validator and collapse the cluster into a
+                            // leader-takes-all chain (see the
+                            // `pending_block_bodies` declaration up top
+                            // for the failure mode this replaces).
+                            //
+                            // We still need the inclusion-audit logic
+                            // ABOVE this point (it sets `inclusion_violated`
+                            // on the engine so the vote phase abstains
+                            // for slots that skipped mandatory txs) —
+                            // that part doesn't depend on apply.
+                            //
+                            // mempool / tx-relay cleanup that previously
+                            // ran on this branch is now done in the
+                            // QC-formed apply path so it fires once,
+                            // for the canonical block, regardless of
+                            // who proposed.
                             {
-                                let mut chain_w = chain.write().await;
-                                let mut state_w = state.write().await;
-                                let ws_slot = validator_engine
-                                    .as_ref()
-                                    .and_then(|e| e.finality.latest_checkpoint.as_ref().map(|cp| cp.slot));
-                                match BlockProcessor::process_full_block_with_aot_and_checkpoint(&mut chain_w, &mut state_w, &block, Some(&aot_cache), ws_slot) {
-                                    Ok((tc, gas, ref receipts_list)) => {
-                                        // PIPELINED: extract writes + SMT handle, release lock
-                                        let pending = state_w.take_pending_writes();
-                                        let smt_handle = state_w.smt_handle();
-                                        drop(state_w);
-                                        drop(chain_w);
-
-                                        // Spawn background Merkle commit — doesn't hold state lock
-                                        if !pending.is_empty() {
-                                            let state_for_root = state.clone();
-                                            tokio::spawn(async move {
-                                                // SMT mutex is separate from the state RwLock.
-                                                // Audit 222: time the commit so operators can
-                                                // alert on SMT/RocksDB pressure independent of
-                                                // pyde_block_processing_ms.
-                                                let commit_start = std::time::Instant::now();
-                                                if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending) {
-                                                    crate::metrics::record_state_commit_ms(
-                                                        commit_start.elapsed().as_millis() as u64,
-                                                    );
-                                                    // Update cached root (brief write lock)
-                                                    if let Ok(mut sw) = state_for_root.try_write() {
-                                                        sw.set_root(root);
-                                                    }
-                                                }
-                                            });
-                                        }
-
-                                        let full_bytes = wire::encode_block(&block);
-                                        let _ = block_store.put_block(&block.header, &full_bytes);
-                                        let _ = block_store.put_head(slot);
-                                        chain_sync.on_block_processed(slot);
-                                        if !receipts_list.is_empty() {
-                                            let mut receipts_w = receipts.write().await;
-                                            receipts_w.insert_block_receipts(slot, receipts_list.clone());
-                                        }
-                                        let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
-                                            .map(|tx| tx.hash()).collect();
-                                        {
-                                            let mut idx = mempool_index.write().await;
-                                            for h in &tx_hashes { idx.remove(h); }
-                                        }
-                                        {
-                                            let mut pending_w = pending_txs.write().await;
-                                            for h in &tx_hashes {
-                                                pending_w.remove(h);
-                                            }
-                                        }
-                                        {
-                                            let mut times_w = pending_tx_times.write().await;
-                                            for h in &tx_hashes {
-                                                times_w.remove(h);
-                                            }
-                                        }
-                                        // Audit item 227 step 4: clear encrypted txs from
-                                        // the local tx_relay once the block committing
-                                        // them has been fully processed. The self-propose
-                                        // path deliberately does NOT do this — self-proposals
-                                        // can lose the multi-proposer VRF lottery, and
-                                        // removing on self-propose would permanently drop
-                                        // the tx even when a different validator's block
-                                        // wins the slot. Doing it here, after the block
-                                        // has actually been QC'd and processed, matches
-                                        // the P7a-2 plaintext fix.
-                                        if !block.body.encrypted_txs.is_empty() {
-                                            let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
-                                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
-                                                .map(|etx| etx.hash())
-                                                .collect();
-                                            if !enc_hashes.is_empty() {
-                                                let mut relay_w = tx_relay.write().await;
-                                                relay_w.remove_included(&enc_hashes);
-                                            }
-                                        }
-                                        info!(
-                                            slot,
-                                            txs = tc,
-                                            encrypted = block.body.encrypted_txs.len(),
-                                            gas,
-                                            "compact block reconstructed and processed"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        debug!(slot, error = %e, "compact block rejected");
-                                    }
-                                }
+                                let mut pbb = pending_block_bodies.write().await;
+                                pbb.insert(block_hash, block.clone());
                             }
+                            debug!(
+                                slot,
+                                block_hash = hex::encode(block_hash),
+                                txs = block.body.transactions.len(),
+                                encrypted = block.body.encrypted_txs.len(),
+                                "compact block reconstructed and buffered (awaiting QC)"
+                            );
                         }
                         PostEventAction::BlockProcessed { slot, receipts: receipts_list, tx_hashes } => {
                             if !receipts_list.is_empty() {
@@ -2262,7 +2241,16 @@ impl PydeNode {
                                     // gossip/RR path as before).
                                     if let Some((qc_slot, qc_hash)) = qc_slot_hash {
                                         if let Some((header, sig)) = engine.buffered_proposal_for(qc_slot, &qc_hash) {
-                                            let block = pyde_consensus::block::Block {
+                                            // Prefer the real body buffered at gossip
+                                            // receipt; fall back to the audit-234
+                                            // synthesized empty body for blocks whose
+                                            // gossip body hasn't arrived yet (RR
+                                            // fallback can deliver the QC vote before
+                                            // the Blocks-topic payload).
+                                            let block = {
+                                                let pbb = pending_block_bodies.read().await;
+                                                pbb.get(&qc_hash).cloned()
+                                            }.unwrap_or_else(|| pyde_consensus::block::Block {
                                                 header: header.clone(),
                                                 body: pyde_consensus::block::BlockBody {
                                                     transactions: vec![],
@@ -2273,9 +2261,77 @@ impl PydeNode {
                                                     },
                                                 },
                                                 proposer_signature: sig,
-                                            };
+                                            });
                                             let mut chain_w = chain.write().await;
                                             let mut state_w = state.write().await;
+
+                                            // Three cases at QC time:
+                                            //   1. chain head < qc_slot — we never applied
+                                            //      anything for this slot; apply forward.
+                                            //   2. chain head == qc_slot && hashes match —
+                                            //      we ARE the winning proposer and self-
+                                            //      applied earlier in the tick (line ~2002,
+                                            //      needed for our header's state_root). The
+                                            //      block is already canonical; skip apply.
+                                            //   3. chain head == qc_slot && hashes differ —
+                                            //      we self-applied a block but lost the VRF
+                                            //      tournament. Roll back the speculative
+                                            //      slot via the audit-230 revert/revert_to
+                                            //      pair, then apply the canonical block.
+                                            //   4. chain head > qc_slot — multi-slot reorg
+                                            //      territory; defer to TryReorgToQc /
+                                            //      sync paths instead of trying here.
+                                            let need_apply = if chain_w.head_slot == qc_slot {
+                                                let our_block_hash = chain_w
+                                                    .header(qc_slot)
+                                                    .map(|h| h.hash());
+                                                if our_block_hash == Some(qc_hash) {
+                                                    debug!(slot = qc_slot, "QC matches our self-applied block — already canonical");
+                                                    false
+                                                } else {
+                                                    let target = qc_slot.saturating_sub(1);
+                                                    if let Err(e) = chain_w.revert(target) {
+                                                        warn!(slot = qc_slot, error = %e, "chain revert before QC apply failed");
+                                                    }
+                                                    match state_w.revert_to(target) {
+                                                        Ok(_) => {
+                                                            info!(
+                                                                slot = qc_slot,
+                                                                from = hex::encode(our_block_hash.unwrap_or([0u8; 32])),
+                                                                to = hex::encode(qc_hash),
+                                                                "rolled back speculative self-proposal — applying canonical block"
+                                                            );
+                                                            true
+                                                        }
+                                                        Err(e) => {
+                                                            warn!(slot = qc_slot, error = %e, "state revert before QC apply failed");
+                                                            false
+                                                        }
+                                                    }
+                                                }
+                                            } else if chain_w.head_slot < qc_slot {
+                                                true
+                                            } else {
+                                                debug!(
+                                                    qc_slot,
+                                                    head = chain_w.head_slot,
+                                                    "QC behind our chain head — skipping (handled by reorg path)"
+                                                );
+                                                false
+                                            };
+
+                                            if !need_apply {
+                                                drop(state_w);
+                                                drop(chain_w);
+                                                // Drop buffered body even when we skip apply
+                                                // (winner case: we already have the canonical
+                                                // copy via self-apply; the buffered copy is
+                                                // a duplicate from gossip).
+                                                let mut pbb = pending_block_bodies.write().await;
+                                                pbb.remove(&qc_hash);
+                                                continue;
+                                            }
+
                                             let ws_slot = engine
                                                 .finality
                                                 .latest_checkpoint
@@ -2288,20 +2344,93 @@ impl PydeNode {
                                                 Some(&aot_cache),
                                                 ws_slot,
                                             ) {
-                                                Ok(_) => {
-                                                    let _ = state_w.flush_pending();
-                                                    state_w.refresh_root();
-                                                    let _ = block_store.put_header(&header);
+                                                Ok((tc, gas, ref receipts_list)) => {
+                                                    // PIPELINED state commit — same pattern as the
+                                                    // gossip-apply path (now removed) and the
+                                                    // proposer self-apply path: extract pending
+                                                    // writes, release locks, commit Merkle root in
+                                                    // a background task so the slot tick isn't
+                                                    // blocked on RocksDB.
+                                                    let pending_writes = state_w.take_pending_writes();
+                                                    let smt_handle = state_w.smt_handle();
+                                                    drop(state_w);
+                                                    drop(chain_w);
+
+                                                    if !pending_writes.is_empty() {
+                                                        let state_for_root = state.clone();
+                                                        tokio::spawn(async move {
+                                                            let commit_start = std::time::Instant::now();
+                                                            if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending_writes) {
+                                                                crate::metrics::record_state_commit_ms(
+                                                                    commit_start.elapsed().as_millis() as u64,
+                                                                );
+                                                                if let Ok(mut sw) = state_for_root.try_write() {
+                                                                    sw.set_root(root);
+                                                                }
+                                                            }
+                                                        });
+                                                    }
+
+                                                    let full_bytes = wire::encode_block(&block);
+                                                    let _ = block_store.put_block(&block.header, &full_bytes);
                                                     let _ = block_store.put_head(qc_slot);
                                                     chain_sync.on_block_processed(qc_slot);
-                                                    info!(slot = qc_slot, "applied block from local QC (synthesized empty body)");
+
+                                                    if !receipts_list.is_empty() {
+                                                        let mut receipts_w = receipts.write().await;
+                                                        receipts_w.insert_block_receipts(qc_slot, receipts_list.clone());
+                                                    }
+
+                                                    // Mempool / tx-relay cleanup — previously
+                                                    // run on the gossip-apply branch; moved
+                                                    // here so it fires once for the canonical
+                                                    // block.
+                                                    let tx_hashes: Vec<[u8; 32]> = block.body.transactions.iter()
+                                                        .map(|tx| tx.hash()).collect();
+                                                    if !tx_hashes.is_empty() {
+                                                        let mut idx = mempool_index.write().await;
+                                                        for h in &tx_hashes { idx.remove(h); }
+                                                        drop(idx);
+                                                        let mut pending_w = pending_txs.write().await;
+                                                        for h in &tx_hashes { pending_w.remove(h); }
+                                                        drop(pending_w);
+                                                        let mut times_w = pending_tx_times.write().await;
+                                                        for h in &tx_hashes { times_w.remove(h); }
+                                                    }
+                                                    if !block.body.encrypted_txs.is_empty() {
+                                                        let enc_hashes: Vec<[u8; 32]> = block.body.encrypted_txs.iter()
+                                                            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+                                                            .map(|etx| etx.hash())
+                                                            .collect();
+                                                        if !enc_hashes.is_empty() {
+                                                            let mut relay_w = tx_relay.write().await;
+                                                            relay_w.remove_included(&enc_hashes);
+                                                        }
+                                                    }
+
+                                                    // Drop the buffered body — kept around
+                                                    // only for the QC apply, not for sync
+                                                    // serving (block_store has the canonical
+                                                    // copy now).
+                                                    {
+                                                        let mut pbb = pending_block_bodies.write().await;
+                                                        pbb.remove(&qc_hash);
+                                                    }
+
+                                                    info!(
+                                                        slot = qc_slot,
+                                                        txs = tc,
+                                                        gas,
+                                                        proposer = hex::encode(block.header.proposer),
+                                                        "applied block from QC"
+                                                    );
                                                 }
                                                 Err(e) => {
-                                                    debug!(slot = qc_slot, error = %e, "synthesized-body apply failed (header expects non-empty body — waiting for gossip)");
+                                                    drop(state_w);
+                                                    drop(chain_w);
+                                                    debug!(slot = qc_slot, error = %e, "QC-gated apply failed");
                                                 }
                                             }
-                                            drop(state_w);
-                                            drop(chain_w);
                                         }
                                     }
                                     // Broadcast vote.
@@ -2908,6 +3037,11 @@ impl PydeNode {
                         // failure, gossip drop, or an adversarial orphan).
                         let mut qb = queued_encrypted_bundles.write().await;
                         qb.retain(|(slot, _), _| *slot + 100 > head);
+                        // Prune QC-gated apply buffer. Same window — a body
+                        // that hasn't been QC'd within 100 slots is from a
+                        // losing/stale proposal that no future QC will pull.
+                        let mut pbb = pending_block_bodies.write().await;
+                        pbb.retain(|_, block| block.header.slot + 100 > head);
                     }
                     let head = chain.read().await.head_slot;
                     debug!(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2588,7 +2588,25 @@ impl PydeNode {
 
                                     // If QC formed: broadcast hard finality vote
                                     if qc_formed {
-                                        let state_root = chain.read().await.state_root;
+                                        // The finality vote's state_root must be
+                                        // this validator's ACTUAL post-execution
+                                        // root, not chain.state_root. After the
+                                        // proposer-header fix, chain.state_root is
+                                        // 0x00…00 (per BlockHeader's "empty at
+                                        // proposal" semantics), so all validators
+                                        // would otherwise sign a zero state_root,
+                                        // making `try_form_hard_finality`'s
+                                        // state-root agreement check vacuous and
+                                        // letting any validator's divergent state
+                                        // be included in the cert. Reading
+                                        // `state.root()` is the canonical
+                                        // post-commit SMT root — every honest
+                                        // validator that executed the block
+                                        // deterministically produces the same
+                                        // value; honest-but-divergent validators
+                                        // have their votes correctly excluded
+                                        // from the cert.
+                                        let state_root = state.read().await.root();
                                         if let Some(fv) = engine.create_finality_vote(
                                             current_slot,
                                             engine.consensus.highest_qc.block_hash,
@@ -4263,7 +4281,53 @@ fn handle_swarm_event(
             let mut pending_fallback_broadcast: Option<Vec<u8>> = None;
             let mut pending_share_msg: Option<wire::DecryptionShareMsg> = None;
             let resp = {
-                if let Ok(msg) = wire::decode_consensus_message(&request.bytes) {
+                // Tag-byte routing: the consensus topic carries
+                // FinalityVote alongside the ConsensusMessage variants
+                // (Proposal/Vote/Timeout/NewView). Gossipsub-receive at
+                // line ~3706 routes these via the explicit tag byte
+                // because `decode_consensus_message` doesn't handle
+                // CONSENSUS_FINALITY_VOTE — the same routing has to
+                // happen here, otherwise finality votes broadcast via
+                // RR fallback are silently dropped on the receiver side
+                // and hard-finality cert formation never gathers a
+                // quorum of votes.
+                if !request.bytes.is_empty()
+                    && request.bytes[0] == wire::tag::CONSENSUS_FINALITY_VOTE
+                {
+                    if let Some(engine) = validator_engine.as_mut() {
+                        match wire::decode_finality_vote(&request.bytes) {
+                            Ok(fv) => {
+                                debug!(
+                                    slot = fv.slot,
+                                    voter = fv.voter_index,
+                                    "received finality vote via RR fallback"
+                                );
+                                if engine.on_finality_vote(fv) {
+                                    if let Some(cp) =
+                                        engine.latest_finality_checkpoint()
+                                    {
+                                        info!(
+                                            slot = cp.slot,
+                                            "hard finality cert formed (RR-receive)"
+                                        );
+                                        // Re-broadcast the checkpoint so
+                                        // non-validator peers can advance
+                                        // their WS anchor (mirrors the
+                                        // gossipsub-receive handler at
+                                        // line ~3720).
+                                        pending_fallback_broadcast = Some(
+                                            wire::encode_finality_checkpoint_msg(cp),
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                debug!(error = e, "RR-fallback finality vote decode failed");
+                            }
+                        }
+                    }
+                    pyde_net::consensus_protocol::ConsensusResp::Ack
+                } else if let Ok(msg) = wire::decode_consensus_message(&request.bytes) {
                     use pyde_consensus::hotstuff::ConsensusMessage;
                     if let Some(engine) = validator_engine.as_mut() {
                         match msg {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -234,8 +234,9 @@ impl PydeNode {
             }
         };
 
-        // 3. Block store (persistent headers on disk)
-        let block_store = BlockStore::open(datadir)?;
+        // 3. Block store (persistent headers on disk). Arc'd so the
+        // RPC layer can read full block bodies without a second open.
+        let block_store = Arc::new(BlockStore::open(datadir)?);
         let saved_head = block_store.get_head();
 
         // 4. Chain state tracker (resume from saved head if available)
@@ -548,6 +549,7 @@ impl PydeNode {
                 state: state.clone(),
                 tx_relay: tx_relay.clone(),
                 receipts: receipts.clone(),
+                block_store: block_store.clone(),
                 pending_txs: pending_txs.clone(),
                 pending_tx_times: pending_tx_times.clone(),
                 threshold_pk: {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1980,20 +1980,60 @@ impl PydeNode {
                                             .map(|cp| cp.slot);
                                         match BlockProcessor::process_full_block_with_aot_and_checkpoint(&mut chain_w, &mut state_w, &block, Some(&aot_cache), ws_slot) {
                                             Ok((tc, gas, ref receipts_list)) => {
-                                                // PIPELINED: background Merkle commit
+                                                // Commit speculative SMT writes
+                                                // synchronously.
+                                                //
+                                                // The earlier `tokio::spawn` was a
+                                                // perf optimization — overlap the
+                                                // Merkle commit with subsequent slot
+                                                // work — but it created a race against
+                                                // the QC-formed rollback path. When
+                                                // this proposer loses the VRF
+                                                // tournament, the QC handler runs
+                                                // `state.revert_to(slot - 1)` then
+                                                // applies the canonical block. If the
+                                                // background spawn for THIS block
+                                                // lagged past the revert (large state
+                                                // diff or SMT contention pushing it
+                                                // past the ~100ms vote-collection
+                                                // window), it would acquire the SMT
+                                                // mutex AFTER the revert and the
+                                                // canonical apply, overwriting both
+                                                // with the speculative writes — state
+                                                // root then drifts from the canonical
+                                                // chain on every reorg. Hard to
+                                                // observe (only fires under the
+                                                // proposer-loses-VRF + slow-SMT
+                                                // intersection), correctness-fatal
+                                                // when it does.
+                                                //
+                                                // Sync commit closes the race: by the
+                                                // time the QC handler runs, the
+                                                // speculative SMT write has either
+                                                // landed (revert can undo it) or
+                                                // never started (no race). Cost is
+                                                // a few ms of slot-tick blocking on
+                                                // small block writes — acceptable on
+                                                // a 400ms slot. For mainnet-scale
+                                                // throughput, a slot-tagged commit
+                                                // (drop stale spawn results post-
+                                                // revert) or a JoinHandle awaited by
+                                                // the rollback path can restore
+                                                // pipelining without the race.
                                                 let pending = state_w.take_pending_writes();
                                                 let smt_handle = state_w.smt_handle();
                                                 drop(state_w);
                                                 drop(chain_w);
                                                 if !pending.is_empty() {
-                                                    let state_for_root = state.clone();
-                                                    tokio::spawn(async move {
-                                                        if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending) {
-                                                            if let Ok(mut sw) = state_for_root.try_write() {
-                                                                sw.set_root(root);
-                                                            }
-                                                        }
-                                                    });
+                                                    let commit_start = std::time::Instant::now();
+                                                    if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending) {
+                                                        crate::metrics::record_state_commit_ms(
+                                                            commit_start.elapsed().as_millis() as u64,
+                                                        );
+                                                        let mut sw = state.write().await;
+                                                        sw.set_root(root);
+                                                        drop(sw);
+                                                    }
                                                 }
                                                 let _ = block_store.put_header(&block.header);
                                                 let _ = block_store.put_head(current_slot);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -497,22 +497,48 @@ impl PydeNode {
         // part 4 step 7r). TCP is the default for bootstrap-multiaddr
         // resolution; QUIC is available so peers that prefer it can
         // negotiate it from a `/udp/PORT/quic-v1` address.
+        //
+        // In dev mode, bind only to loopback and skip QUIC entirely.
+        // Two reasons:
+        //  - 0.0.0.0 binds advertise every reachable interface
+        //    (loopback + LAN + others) via Identify. With every node
+        //    running on the same host, peers learn 2-3 addresses for
+        //    each other, then libp2p races dials across all of them
+        //    and dedupes the losers — producing ~4 connection flaps
+        //    per second on a fully meshed 4-node localhost devnet,
+        //    enough to keep gossipsub mesh formation in constant
+        //    churn and drop ~33% of consensus messages.
+        //  - QUIC + TCP simultaneously is the same problem one
+        //    layer down: same peer reachable via two transports,
+        //    libp2p tries both. Single-transport dev mode dodges
+        //    that race.
+        // Production binds remain on 0.0.0.0 with both transports
+        // because real peers come from different hosts and the
+        // multi-address advertising is what makes connectivity work
+        // through NAT/firewall paths.
+        let bind_ip = if self.config.node.dev_mode {
+            "127.0.0.1"
+        } else {
+            "0.0.0.0"
+        };
         let tcp_listen_addr: libp2p::Multiaddr =
-            format!("/ip4/0.0.0.0/tcp/{}", self.config.network.port)
+            format!("/ip4/{}/tcp/{}", bind_ip, self.config.network.port)
                 .parse()
                 .map_err(|e| format!("invalid tcp listen addr: {}", e))?;
         swarm
             .listen_on(tcp_listen_addr)
             .map_err(|e| format!("failed to listen on tcp: {}", e))?;
 
-        let quic_listen_addr: libp2p::Multiaddr =
-            format!("/ip4/0.0.0.0/udp/{}/quic-v1", self.config.network.port)
-                .parse()
-                .map_err(|e| format!("invalid quic listen addr: {}", e))?;
-        if let Err(e) = swarm.listen_on(quic_listen_addr) {
-            // QUIC bind failure is non-fatal — TCP is the primary
-            // transport. Log so operators know but keep going.
-            warn!(error = %e, port = self.config.network.port, "QUIC listen failed; running TCP-only");
+        if !self.config.node.dev_mode {
+            let quic_listen_addr: libp2p::Multiaddr =
+                format!("/ip4/0.0.0.0/udp/{}/quic-v1", self.config.network.port)
+                    .parse()
+                    .map_err(|e| format!("invalid quic listen addr: {}", e))?;
+            if let Err(e) = swarm.listen_on(quic_listen_addr) {
+                // QUIC bind failure is non-fatal — TCP is the primary
+                // transport. Log so operators know but keep going.
+                warn!(error = %e, port = self.config.network.port, "QUIC listen failed; running TCP-only");
+            }
         }
 
         // 9. Start metrics if enabled
@@ -1238,10 +1264,59 @@ impl PydeNode {
                             }
                             // Proactively dial peers we learn about through Identify.
                             // This builds a mesh so nodes survive bootstrap node failure.
+                            //
+                            // We must dial only ONE address per peer. Identify
+                            // commonly returns multiple paths to the same node
+                            // (loopback + LAN + WAN), and parallel-dialing all
+                            // of them races libp2p's connection-deduplication:
+                            // both dials succeed, the second is force-closed
+                            // with `ApplicationClosed`, both ends log
+                            // "peer disconnected", and gossipsub re-meshes.
+                            // On a 4-node localhost devnet this produced ~1.5
+                            // connect/disconnect cycles per second per peer
+                            // and dropped ~80% of consensus messages, since
+                            // the mesh was never stable for a full slot.
+                            //
+                            // libp2p maintains the rest of the address list in
+                            // Kademlia (lines above), and on dial-failure it
+                            // walks alternatives via `DialOpts::addresses`
+                            // automatically, so dropping addresses here costs
+                            // nothing.
+                            //
+                            // Loopback is preferred for same-host peers — when
+                            // a peer announces `/ip4/127.0.0.1/...` alongside
+                            // a LAN address, the loopback path always wins on
+                            // latency and avoids NAT/firewall variability.
                             if !swarm.is_connected(&peer_id) {
-                                for addr in addrs {
-                                    if let Err(e) = swarm.dial(addr) {
-                                        debug!(error = %e, "failed to dial discovered peer");
+                                // Same peer-id ordering as
+                                // `dial_bootstrap_peers`: only the
+                                // lower peer-id dials, the higher
+                                // accepts inbound. Identify-driven
+                                // discovery can race with bootstrap on
+                                // a fresh devnet (peer learns of us
+                                // via DHT before our outbound from
+                                // bootstrap completes), and a parallel
+                                // dial in either direction triggers
+                                // the same dedupe-and-flap problem.
+                                let local = *swarm.local_peer_id();
+                                if local < peer_id {
+                                    let dial_addr = addrs
+                                        .iter()
+                                        .find(|a| {
+                                            a.iter().any(|p| {
+                                                matches!(
+                                                    p,
+                                                    libp2p::multiaddr::Protocol::Ip4(ip)
+                                                        if ip.is_loopback()
+                                                )
+                                            })
+                                        })
+                                        .cloned()
+                                        .or_else(|| addrs.first().cloned());
+                                    if let Some(addr) = dial_addr {
+                                        if let Err(e) = swarm.dial(addr) {
+                                            debug!(error = %e, "failed to dial discovered peer");
+                                        }
                                     }
                                 }
                             }
@@ -4093,12 +4168,36 @@ fn handle_swarm_event(
         SwarmEvent::Behaviour(PydeBehaviourEvent::ConsensusRr(
             request_response::Event::OutboundFailure { peer, error, .. },
         )) => {
-            debug!(%peer, ?error, "consensus RR outbound failed; dropping stale connection");
-            // Audit 234 part 4 step 7: a failed RR send to a peer
-            // libp2p still considers connected is the canonical
-            // signal of a half-broken QUIC connection. Drop it so
-            // the next dial reconnects fresh.
-            PostEventAction::DisconnectStalePeer(peer)
+            // Audit 234 part 4 step 7 originally disconnected the
+            // peer here on the theory that a failed RR send is the
+            // canonical signal of a half-broken QUIC connection.
+            // That works for the "real stale peer" case it targeted
+            // (post-restart QUIC half-open), but on a healthy mesh
+            // it creates a feedback loop: every slot tick the
+            // proposer fans out RR consensus messages, a few fail
+            // (substream not ready, peer momentarily busy, gossipsub
+            // heartbeat racing), each failure disconnects the peer,
+            // bootstrap re-dials 2s later, and the mesh never
+            // converges. On a 4-node localhost devnet that produced
+            // ~4 connect/disconnect cycles per second per peer.
+            //
+            // Only disconnect on `Timeout` — a 30-second-no-response
+            // failure is a real signal of a wedged connection. The
+            // common transient failures (`DialFailure`, `Io`,
+            // substream-closed-during-send) don't warrant disconnect;
+            // libp2p's own keep-alive will reap genuinely-dead
+            // connections.
+            let is_timeout = matches!(
+                error,
+                request_response::OutboundFailure::Timeout
+            );
+            if is_timeout {
+                debug!(%peer, ?error, "consensus RR timeout; dropping stale connection");
+                PostEventAction::DisconnectStalePeer(peer)
+            } else {
+                debug!(%peer, ?error, "consensus RR transient failure; keeping connection");
+                PostEventAction::None
+            }
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::ConsensusRr(
             request_response::Event::InboundFailure { peer, error, .. },
@@ -4197,10 +4296,21 @@ fn handle_swarm_event(
         SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
             request_response::Event::OutboundFailure { peer, error, .. },
         )) => {
-            debug!(%peer, ?error, "blocks RR outbound failed; dropping stale connection");
-            // Same rationale as ConsensusRr OutboundFailure (audit 234
-            // part 4 step 7): drop the half-broken connection.
-            PostEventAction::DisconnectStalePeer(peer)
+            // Same rationale as ConsensusRr OutboundFailure: only
+            // disconnect on `Timeout`. Transient failures during slot-
+            // tick fanout would otherwise trigger a feedback loop on
+            // the bootstrap re-dial cycle.
+            let is_timeout = matches!(
+                error,
+                request_response::OutboundFailure::Timeout
+            );
+            if is_timeout {
+                debug!(%peer, ?error, "blocks RR timeout; dropping stale connection");
+                PostEventAction::DisconnectStalePeer(peer)
+            } else {
+                debug!(%peer, ?error, "blocks RR transient failure; keeping connection");
+                PostEventAction::None
+            }
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
             request_response::Event::InboundFailure { peer, error, .. },

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1900,8 +1900,26 @@ impl PydeNode {
                                     let _tx_count = txs.len();
 
                                     // Build block with transactions
+                                    //
+                                    // `parent_hash` is the Poseidon2 hash of the
+                                    // parent BLOCK HEADER (per BlockHeader's doc and
+                                    // the chain-linking safety check in
+                                    // `pyde_consensus::hotstuff` line 342:
+                                    // `next_header.parent_hash == qc_for_block.block_hash`).
+                                    // The earlier code passed `chain_r.state_root`
+                                    // here, which never matched the parent's block
+                                    // hash — that silently broke HotStuff's
+                                    // chain-linking invariant on every consecutive
+                                    // block pair (the safety check was vacuously
+                                    // unsatisfiable, so the protocol was
+                                    // load-bearing on the audit-234 fallback paths
+                                    // for liveness). Genesis falls back to all-zeros
+                                    // per `Block::is_genesis`.
                                     let chain_r = chain.read().await;
-                                    let parent_hash = chain_r.state_root;
+                                    let parent_hash = chain_r
+                                        .header(chain_r.head_slot)
+                                        .map(|h| h.hash())
+                                        .unwrap_or([0u8; 32]);
                                     let _head = chain_r.head_slot;
                                     drop(chain_r);
 
@@ -1952,10 +1970,20 @@ impl PydeNode {
                                     vrf_data.extend_from_slice(candidate.vrf_output.as_bytes());
                                     vrf_data.extend_from_slice(candidate.vrf_proof.as_bytes());
 
+                                    // `state_root` is intentionally [0u8;32] at
+                                    // proposal time — per BlockHeader's doc, the
+                                    // post-execution root is set after optimistic
+                                    // execution at soft finality, then verified on
+                                    // re-execution and committed in the
+                                    // HardFinalityCert (so the header's state_root
+                                    // can't be a forged claim by the proposer).
+                                    // The earlier code passed `parent_hash` (which
+                                    // was already misset to parent's state_root)
+                                    // here too, doubling the bug.
                                     let block = engine.build_proposal(
                                         identity,
                                         parent_hash,
-                                        parent_hash,
+                                        [0u8; 32],
                                         tx_root,
                                         vrf_data,
                                         txs,
@@ -3273,7 +3301,9 @@ fn build_and_encode_fallback_proposal(
         .get(&chain.head_slot)
         .map(|h| h.hash())
         .unwrap_or([0u8; 32]);
-    let block = engine.try_build_fallback_proposal(identity, parent_hash, chain.state_root)?;
+    // state_root is intentionally [0u8;32] at proposal time — see the
+    // primary `build_proposal` call site for the rationale.
+    let block = engine.try_build_fallback_proposal(identity, parent_hash, [0u8; 32])?;
     let msg = pyde_consensus::hotstuff::ConsensusMessage::Proposal {
         header: block.header,
         proposer_signature: block.proposer_signature,

--- a/crates/node/src/receipt_store.rs
+++ b/crates/node/src/receipt_store.rs
@@ -84,6 +84,17 @@ impl ReceiptStore {
         self.receipts.len()
     }
 
+    /// Tx hashes committed at `slot`, in inclusion order. Returns
+    /// `None` for a slot that's been pruned or never indexed.
+    /// Used by `pyde_getBlockByNumber` to surface transactions in
+    /// the block-detail RPC response — the chain's `header(slot)`
+    /// only carries `tx_root`, so external indexers (block
+    /// explorers) need this to enumerate a slot's contents without
+    /// per-tx-hash lookups.
+    pub fn tx_hashes_at_slot(&self, slot: u64) -> Option<Vec<[u8; 32]>> {
+        self.slot_txs.get(&slot).cloned()
+    }
+
     fn prune_before(&mut self, slot: u64) {
         let slots_to_remove: Vec<u64> = self
             .slot_txs

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -2,10 +2,12 @@
 //!
 //! Exposes chain state queries and transaction submission over HTTP.
 
+use crate::block_store::BlockStore;
 use crate::chain::ChainState;
 use crate::receipt_store::ReceiptStore;
 use crate::state_manager::StateManager;
 use crate::tx_relay::TxRelay;
+use crate::wire;
 use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::server::Server;
@@ -48,6 +50,11 @@ pub struct RpcState {
     pub state: Arc<RwLock<StateManager>>,
     pub tx_relay: Arc<RwLock<TxRelay>>,
     pub receipts: Arc<RwLock<ReceiptStore>>,
+    /// Persistent block store. Used by `getBlockByNumber` to decode
+    /// the wire-encoded block body and surface full transaction
+    /// fields (from, to, value, nonce, tx_type) — the in-memory
+    /// `ChainState::header` only carries the merkle commitments.
+    pub block_store: Arc<BlockStore>,
     /// Plain transaction queue (devnet mode — no threshold encryption).
     /// Proposer drains this to build blocks. Keyed by `tx.hash()` so
     /// block-commit retains are O(|block|) instead of O(|mempool| ×
@@ -314,37 +321,79 @@ impl PydeApiServer for RpcServer {
     }
 
     async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned> {
-        let chain = self.state.chain.read().await;
-        match chain.header(slot) {
-            Some(header) => Ok(serde_json::json!({
-                "slot": header.slot,
-                "epoch": header.epoch,
-                "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
-                "stateRoot": format!("0x{}", hex::encode(header.state_root)),
-                "txRoot": format!("0x{}", hex::encode(header.tx_root)),
-                "timestamp": format!("0x{:x}", header.timestamp),
-                "proposer": format!("0x{}", hex::encode(header.proposer)),
-            })),
-            None => Ok(serde_json::Value::Null),
-        }
+        // ChainState only keeps the last ~2 epochs of headers in
+        // memory; for older slots fall back to the persistent
+        // BlockStore so block-explorer-style range queries don't go
+        // dark past the in-memory window.
+        let header = {
+            let chain = self.state.chain.read().await;
+            match chain.header(slot) {
+                Some(h) => h.clone(),
+                None => match self.state.block_store.get_header(slot) {
+                    Some(h) => h,
+                    None => return Ok(serde_json::Value::Null),
+                },
+            }
+        };
+        let tx_hashes = self
+            .state
+            .receipts
+            .read()
+            .await
+            .tx_hashes_at_slot(slot)
+            .unwrap_or_default();
+        let block_hash = header.hash();
+        let transactions = decode_block_transactions(&self.state.block_store, slot);
+        Ok(serde_json::json!({
+            "slot": header.slot,
+            "epoch": header.epoch,
+            "blockHash": format!("0x{}", hex::encode(block_hash)),
+            "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
+            "stateRoot": format!("0x{}", hex::encode(header.state_root)),
+            "txRoot": format!("0x{}", hex::encode(header.tx_root)),
+            "timestamp": format!("0x{:x}", header.timestamp),
+            "proposer": format!("0x{}", hex::encode(header.proposer)),
+            "transactionHashes": tx_hashes
+                .iter()
+                .map(|h| format!("0x{}", hex::encode(h)))
+                .collect::<Vec<_>>(),
+            "transactions": transactions,
+        }))
     }
 
     async fn get_block_by_hash(&self, hash: String) -> Result<serde_json::Value, ErrorObjectOwned> {
         let block_hash = parse_hash(&hash)?;
         let chain = self.state.chain.read().await;
-        match chain.header_by_hash(&block_hash) {
-            Some(header) => Ok(serde_json::json!({
-                "slot": header.slot,
-                "epoch": header.epoch,
-                "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
-                "stateRoot": format!("0x{}", hex::encode(header.state_root)),
-                "txRoot": format!("0x{}", hex::encode(header.tx_root)),
-                "timestamp": format!("0x{:x}", header.timestamp),
-                "proposer": format!("0x{}", hex::encode(header.proposer)),
-                "hash": format!("0x{}", hex::encode(block_hash)),
-            })),
-            None => Err(rpc_err(-32602, "block not found for hash".to_string())),
-        }
+        let header = match chain.header_by_hash(&block_hash) {
+            Some(h) => h.clone(),
+            None => return Err(rpc_err(-32602, "block not found for hash".to_string())),
+        };
+        drop(chain);
+        let slot = header.slot;
+        let tx_hashes = self
+            .state
+            .receipts
+            .read()
+            .await
+            .tx_hashes_at_slot(slot)
+            .unwrap_or_default();
+        let transactions = decode_block_transactions(&self.state.block_store, slot);
+        Ok(serde_json::json!({
+            "slot": header.slot,
+            "epoch": header.epoch,
+            "blockHash": format!("0x{}", hex::encode(block_hash)),
+            "parentHash": format!("0x{}", hex::encode(header.parent_hash)),
+            "stateRoot": format!("0x{}", hex::encode(header.state_root)),
+            "txRoot": format!("0x{}", hex::encode(header.tx_root)),
+            "timestamp": format!("0x{:x}", header.timestamp),
+            "proposer": format!("0x{}", hex::encode(header.proposer)),
+            "hash": format!("0x{}", hex::encode(block_hash)),
+            "transactionHashes": tx_hashes
+                .iter()
+                .map(|h| format!("0x{}", hex::encode(h)))
+                .collect::<Vec<_>>(),
+            "transactions": transactions,
+        }))
     }
 
     async fn state_root(&self) -> Result<String, ErrorObjectOwned> {
@@ -1672,6 +1721,44 @@ async fn parse_call_object(
         block_sigs_pre_verified: false,
     };
     Ok((tx, block_ctx))
+}
+
+/// Decode the wire-encoded block at `slot` and emit one JSON object
+/// per transaction with the fields an indexer/explorer needs to
+/// render a tx without a second `getTransactionByHash` round-trip:
+/// hash, sender, recipient, value, nonce, gas_limit, tx_type. Falls
+/// back to an empty array if the block isn't on disk yet (genesis,
+/// or a slot that this node only saw a header for during sync).
+fn decode_block_transactions(
+    block_store: &BlockStore,
+    slot: u64,
+) -> Vec<serde_json::Value> {
+    let raw = match block_store.get_block_raw(slot) {
+        Some(r) => r,
+        None => return Vec::new(),
+    };
+    let block = match wire::decode_block(&raw) {
+        Ok(b) => b,
+        Err(_) => return Vec::new(),
+    };
+    block
+        .body
+        .transactions
+        .iter()
+        .enumerate()
+        .map(|(idx, tx)| {
+            serde_json::json!({
+                "hash": format!("0x{}", hex::encode(tx.hash())),
+                "from": format!("0x{}", hex::encode(tx.from)),
+                "to": format!("0x{}", hex::encode(tx.to)),
+                "value": tx.value.to_string(),
+                "nonce": tx.nonce,
+                "gasLimit": tx.gas_limit,
+                "txType": tx.tx_type as u8,
+                "indexInBlock": idx,
+            })
+        })
+        .collect()
 }
 
 fn receipt_to_json(receipt: &Receipt) -> serde_json::Value {


### PR DESCRIPTION
## Summary
- 8 commits on top of main resolving the cascade of testnet-correctness
  issues uncovered while building the block explorer. Pre-PR: a 4-node
  devnet exhibited 1 validator producing 100% of blocks, 215+ flaps/min,
  0 hard-finality certs, and silent state-root divergence across nodes.
  Post-PR: 0 flaps, 0 reorgs in steady state, VRF rotation balanced
  across all 4 validators, hard-finality cert forming each slot, all
  nodes agreeing on slot hash + proposer + state root.

- Three layers of fix landed in commit order:
  1. **RPC** — `pyde_getBlockByNumber`/`getBlockByHash` now return
     `transactions` (from/to/value/nonce/txType) and `transactionHashes`
     so external indexers (block explorers) can enumerate slot contents
     in one round-trip.
  2. **Network** — loopback bind in dev mode, peer-id-ordered bootstrap
     dial, skip-dial-if-connected, RR-failure conditional disconnect.
     Eliminates the simultaneous-open dial race that was producing
     ~4 connect/disconnect cycles per second on a healthy 4-node mesh.
  3. **Consensus** — the largest arc:
     - QC-gated block apply (don't eager-apply on gossip receipt)
     - Sync SMT commit to close the speculative-apply rollback race
     - Correct `parent_hash` (was being set to parent's state_root,
       silently breaking HotStuff's chain-linking safety check)
     - `state_root = 0` at proposal time per BlockHeader's design
     - Switch finality-vote site to read `state.root()` (the actual
       canonical JMT root) instead of `chain.state_root` (which is
       now 0 by design)
     - RR-fallback wire routing for `CONSENSUS_FINALITY_VOTE`
     - **Path A**: remove proposer self-apply entirely. Execute happens
       post-soft-QC, on the canonical block, via a single apply hook
       reachable from gossipsub-Vote, RR-fallback-Vote, and own-vote
       paths. Audit-227 decryption-share broadcast moves into the
       same hook. Eliminates the per-slot reorg ceremony in steady
       state.

## Tracked follow-ups (not in this PR)
- Encrypted-tx scheduler unification — `BlockBody` wire-format change so
  `block.body.execution_schedule` covers both plaintext and encrypted txs,
  and `try_decrypt_and_execute` walks groups instead of executing
  sequentially. Performance-critical for the 12.5K TPS target on encrypted
  workloads. Audit-grade review needed.
- Persist `HardFinalityCert` alongside the block in `BlockStore` + sync-
  protocol extension. Light clients and fresh-syncing nodes need this to
  verify state proofs against finalized slots.
- Extract the canonical-apply body (~250 lines duplicated across two
  PostEventAction handlers) into a shared helper. The 19-arg signature
  is why it was kept inline; refactor with a borrowed-context struct.
- Remove the `audit-230/231/232` reorg-machinery emission sites that Path
  A rendered dead-in-steady-state. The revert APIs themselves stay
  (snapshot recovery + adversarial-fork edge cases still need them).

## Notes
- Diff is large (~1500 lines net across `node.rs`) because Path A
  consolidates three apply paths into one and inlines the audit-227
  share-broadcast. Each commit stands alone — recommend reviewing
  commit-by-commit.
- Network fixes are largely dev-mode-gated (loopback bind); the peer-id
  ordering and RR-failure handling apply to all modes but were deliberate
  improvements, not regressions for production.
- `record_block_undo` / `chain.revert` / `state.revert_to` (audit-230)
  remain wired. Steady-state cost goes away under Path A; tests stay.