### PR TITLE
consensus: dead-code cleanup + HardFinalityCert persistence

### DIFF
--- a/crates/node/src/block_store.rs
+++ b/crates/node/src/block_store.rs
@@ -136,6 +136,54 @@ impl BlockStore {
     pub fn has_block_data(&self, slot: u64) -> bool {
         self.get_block_raw(slot).is_some()
     }
+
+    // ========================================================================
+    // Hard-finality cert persistence
+    // ========================================================================
+    //
+    // Light clients and fresh-syncing nodes need to verify that a slot
+    // is hard-finalized — and to verify state proofs against the
+    // committed `state_root` at that slot. The HardFinalityCert lives
+    // only in `FinalityTracker` in-memory; without persistence the
+    // proof is lost on restart and cannot be served to peers.
+    //
+    // Stored under "c:{slot_le_bytes}" alongside the block at "b:".
+    // Wire format reuses `wire::encode_finality_checkpoint` so the
+    // bytes can be served as-is to peers via a future sync extension.
+    // Idempotent — repeated puts at the same slot overwrite with
+    // identical bytes (cert formation can fire multiple times per
+    // slot as peer votes arrive in different orders).
+
+    /// Store a `FinalityCheckpoint` (carrying the `HardFinalityCert`)
+    /// for `slot`. Idempotent.
+    pub fn put_finality_cert(
+        &self,
+        cp: &pyde_consensus::finality::FinalityCheckpoint,
+    ) -> Result<(), String> {
+        let mut key = Vec::with_capacity(2 + 8);
+        key.extend_from_slice(b"c:");
+        key.extend_from_slice(&cp.slot.to_le_bytes());
+        let bytes = crate::wire::encode_finality_checkpoint(cp);
+        self.db
+            .put(&key, &bytes)
+            .map_err(|e| format!("failed to store finality cert: {}", e))
+    }
+
+    /// Load the `FinalityCheckpoint` at `slot`, if one was persisted.
+    /// Returns `None` for slots that never reached hard finality, or
+    /// were finalized on a previous version that didn't persist
+    /// certs.
+    #[allow(dead_code)]
+    pub fn get_finality_cert(
+        &self,
+        slot: u64,
+    ) -> Option<pyde_consensus::finality::FinalityCheckpoint> {
+        let mut key = Vec::with_capacity(2 + 8);
+        key.extend_from_slice(b"c:");
+        key.extend_from_slice(&slot.to_le_bytes());
+        let bytes = self.db.get(&key).ok()??;
+        crate::wire::decode_finality_checkpoint(&bytes).ok()
+    }
 }
 
 #[cfg(test)]
@@ -208,5 +256,45 @@ mod tests {
         assert_eq!(store.get_head(), 0);
         store.put_head(42).unwrap();
         assert_eq!(store.get_head(), 42);
+    }
+
+    #[test]
+    fn finality_cert_round_trip() {
+        use pyde_consensus::finality::{FinalityCheckpoint, HardFinalityCert};
+        let dir = tempfile::tempdir().unwrap();
+        let store = BlockStore::open(dir.path()).unwrap();
+
+        let cp = FinalityCheckpoint {
+            slot: 7,
+            block_hash: [0xAA; 32],
+            state_root: [0xBB; 32],
+            cert: HardFinalityCert {
+                slot: 7,
+                block_hash: [0xAA; 32],
+                state_root: [0xBB; 32],
+                voter_bitmap: 0b0111, // 3-of-4 votes
+                signatures: vec![vec![0xCC; 64], vec![0xDD; 64], vec![0xEE; 64]],
+            },
+        };
+
+        // Missing slot returns None.
+        assert!(store.get_finality_cert(7).is_none());
+
+        // Round-trip a cert.
+        store.put_finality_cert(&cp).unwrap();
+        let loaded = store.get_finality_cert(7).expect("cert persisted");
+        assert_eq!(loaded.slot, 7);
+        assert_eq!(loaded.block_hash, [0xAA; 32]);
+        assert_eq!(loaded.cert.voter_bitmap, 0b0111);
+        assert_eq!(loaded.cert.signatures.len(), 3);
+        assert_eq!(loaded.cert.signatures[0], vec![0xCC; 64]);
+
+        // Idempotent overwrite — putting again with same data is fine.
+        store.put_finality_cert(&cp).unwrap();
+        let reloaded = store.get_finality_cert(7).unwrap();
+        assert_eq!(reloaded.cert.voter_bitmap, 0b0111);
+
+        // Different slots are independent.
+        assert!(store.get_finality_cert(8).is_none());
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1196,120 +1196,6 @@ impl PydeNode {
                                     .insert(tx_hash, std::time::Instant::now());
                             }
                         }
-                        PostEventAction::QcFormedFromGossip { slot } => {
-                            // Audit item 227 step 4: QC just formed for
-                            // `slot` via an incoming gossip vote — the
-                            // original decrypt path at `select_and_vote`
-                            // only triggered when our OWN vote closed the
-                            // QC, which is rare in a 4+-node committee.
-                            // Mirror that logic here so the decrypt flow
-                            // starts regardless of which validator's vote
-                            // was the one.
-                            if !validator_identity
-                                .as_ref()
-                                .map(|id| id.key_share.is_some())
-                                .unwrap_or(false)
-                            {
-                                continue;
-                            }
-                            // Already started decryption for this slot? Skip.
-                            if pending_decryptors.read().await.contains_key(&slot) {
-                                continue;
-                            }
-                            let block = match block_store.get_block_raw(slot)
-                                .and_then(|b| wire::decode_block(&b).ok())
-                            {
-                                Some(b) => b,
-                                None => continue,
-                            };
-                            if block.body.encrypted_txs.is_empty() {
-                                continue;
-                            }
-                            let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> = block
-                                .body
-                                .encrypted_txs
-                                .iter()
-                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
-                                .collect();
-                            let tx_root_ok = crate::block_processor::verify_decryptor_against_committed_root(
-                                &block.header.tx_root,
-                                &block.body.transactions,
-                                &enc_txs,
-                            );
-                            if !tx_root_ok {
-                                error!(slot, "decrypt-time tx_root mismatch");
-                                continue;
-                            }
-                            let engine = match validator_engine.as_mut() {
-                                Some(e) => e,
-                                None => continue,
-                            };
-                            let threshold = pyde_consensus::block::quorum_for_committee(
-                                engine.committee_keys.len(),
-                            );
-                            let identity = validator_identity.as_ref().unwrap();
-                            if let Ok(mut decryptor) =
-                                pyde_mempool::decryption::BlockDecryptor::new(
-                                    enc_txs.clone(),
-                                    threshold,
-                                )
-                            {
-                                if let Some(ks) = &identity.key_share {
-                                    decryptor.add_member_shares(ks);
-                                }
-                                // Replay any shares that arrived before
-                                // the decryptor existed.
-                                {
-                                    let mut q = queued_shares.write().await;
-                                    if let Some(queued) = q.remove(&slot) {
-                                        for qmsg in &queued {
-                                            for (i, sb) in qmsg.shares.iter().enumerate() {
-                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
-                                                    decryptor.add_share(i, s);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                pending_decryptors
-                                    .write()
-                                    .await
-                                    .insert(slot, decryptor);
-                            }
-                            // Broadcast our own decryption shares on the
-                            // consensus topic. Phase 1 hardening: route
-                            // through the audit-234 RR fallback so the
-                            // shares fan out point-to-point even when
-                            // gossipsub `topic_peers` is empty after a
-                            // restart cycle. Without the fallback the
-                            // proposer-side broadcast (the third site
-                            // below) would land but the gossip-QC and
-                            // post-reorg broadcasts would silently drop
-                            // — exactly the warm-up race the lifecycle
-                            // test was masking with `slot=15`.
-                            if let Some(shares) =
-                                engine.generate_decryption_shares(identity, &enc_txs)
-                            {
-                                let msg = wire::DecryptionShareMsg {
-                                    slot,
-                                    member_index: identity.committee_index,
-                                    shares: shares.iter().map(|s| s.to_bytes()).collect(),
-                                };
-                                let share_bytes = wire::encode_decryption_shares(&msg);
-                                let topic = pyde_net::node::topics::consensus();
-                                broadcast_consensus_with_rr_fallback(
-                                    &mut swarm,
-                                    topic,
-                                    share_bytes,
-                                    &peer_manager,
-                                );
-                                info!(
-                                    slot,
-                                    enc_txs = enc_txs.len(),
-                                    "broadcast decryption shares (gossip-QC)"
-                                );
-                            }
-                        }
                         PostEventAction::ApplyCanonicalAfterQc {
                             qc_slot,
                             qc_block_hash,
@@ -1609,185 +1495,6 @@ impl PydeNode {
                                 }
                             }
                             competing_blocks.insert(key, block);
-                        }
-                        PostEventAction::TryReorgToQc {
-                            qc_slot,
-                            qc_block_hash,
-                        } => {
-                            // Audit 232: a QC formed for `qc_block_hash` at
-                            // `qc_slot`, but our local view at that slot is
-                            // a different block. Try to reorg via the
-                            // buffered-competing-block path. Whether or not
-                            // the reorg fires, we still need to trigger the
-                            // existing post-QC decrypt pipeline (audit 227)
-                            // — so this handler does BOTH reorg + decrypt
-                            // dispatch, by re-emitting QcFormedFromGossip
-                            // at the end via the channel-style fallthrough
-                            // inside the match.
-                            let key = (qc_slot, qc_block_hash);
-                            // Audit-232 originally fed the buffer from the
-                            // FullBlock gossip path. With QC-gated apply, the
-                            // compact-block path now buffers in
-                            // `pending_block_bodies` instead. Check both so
-                            // reorg works regardless of which gossip channel
-                            // delivered the canonical block.
-                            let target = competing_blocks.remove(&key).or_else(|| {
-                                let pbb = pending_block_bodies.try_read().ok()?;
-                                pbb.get(&qc_block_hash).cloned()
-                            });
-                            if let Some(target) = target {
-                                let mut chain_w = chain.write().await;
-                                let mut state_w = state.write().await;
-                                let ws_slot = validator_engine.as_ref().and_then(|e| {
-                                    e.finality.latest_checkpoint.as_ref().map(|cp| cp.slot)
-                                });
-                                match BlockProcessor::reorg_to_block(
-                                    &mut chain_w,
-                                    &mut state_w,
-                                    &target,
-                                    Some(&aot_cache),
-                                    ws_slot,
-                                ) {
-                                    Ok((tx_count, gas_used, _)) => {
-                                        let _ = state_w.flush_pending();
-                                        state_w.refresh_root();
-                                        crate::metrics::record_reorg(
-                                            crate::metrics::ReorgOutcome::Succeeded,
-                                        );
-                                        info!(
-                                            qc_slot,
-                                            tx_count,
-                                            gas_used,
-                                            "reorg succeeded — chain now matches QC"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        crate::metrics::record_reorg(
-                                            crate::metrics::ReorgOutcome::Failed,
-                                        );
-                                        warn!(qc_slot, error = %e, "reorg failed");
-                                    }
-                                }
-                            } else {
-                                // No buffered block. Sync will recover the
-                                // canonical block on its next pass; the
-                                // local view stays inconsistent until then.
-                                // Still proceed to decrypt below — if our
-                                // local block at qc_slot has different
-                                // encrypted_txs from the QC'd block, the
-                                // tx_root check inside the decrypt path
-                                // will fail and we'll skip safely.
-                                crate::metrics::record_reorg(
-                                    crate::metrics::ReorgOutcome::TargetNotBuffered,
-                                );
-                                warn!(
-                                    qc_slot,
-                                    qc_hash = hex::encode(qc_block_hash),
-                                    "QC mismatch but competing block not buffered — sync will recover"
-                                );
-                            }
-                            // Re-dispatch as QcFormedFromGossip so the
-                            // existing decrypt pipeline still fires for
-                            // qc_slot (audit 227 dependency).
-                            // Manually run the same logic since we can't
-                            // re-invoke the match arm directly.
-                            let slot = qc_slot;
-                            // BEGIN copy of QcFormedFromGossip body
-                            // (kept inline rather than extracted because
-                            // the body captures many local mutable refs;
-                            // refactor to a closure after both call sites
-                            // settle).
-                            if !validator_identity
-                                .as_ref()
-                                .map(|id| id.key_share.is_some())
-                                .unwrap_or(false)
-                            {
-                                continue;
-                            }
-                            if pending_decryptors.read().await.contains_key(&slot) {
-                                continue;
-                            }
-                            let block = match block_store
-                                .get_block_raw(slot)
-                                .and_then(|b| wire::decode_block(&b).ok())
-                            {
-                                Some(b) => b,
-                                None => continue,
-                            };
-                            if block.body.encrypted_txs.is_empty() {
-                                continue;
-                            }
-                            let enc_txs: Vec<pyde_mempool::encrypted::EncryptedTx> = block
-                                .body
-                                .encrypted_txs
-                                .iter()
-                                .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
-                                .collect();
-                            let tx_root_ok =
-                                crate::block_processor::verify_decryptor_against_committed_root(
-                                    &block.header.tx_root,
-                                    &block.body.transactions,
-                                    &enc_txs,
-                                );
-                            if !tx_root_ok {
-                                error!(slot, "decrypt-time tx_root mismatch (post-reorg)");
-                                continue;
-                            }
-                            let engine = match validator_engine.as_mut() {
-                                Some(e) => e,
-                                None => continue,
-                            };
-                            let threshold = pyde_consensus::block::quorum_for_committee(
-                                engine.committee_keys.len(),
-                            );
-                            let identity = validator_identity.as_ref().unwrap();
-                            if let Ok(mut decryptor) = pyde_mempool::decryption::BlockDecryptor::new(
-                                enc_txs.clone(),
-                                threshold,
-                            ) {
-                                if let Some(ks) = &identity.key_share {
-                                    decryptor.add_member_shares(ks);
-                                }
-                                {
-                                    let mut q = queued_shares.write().await;
-                                    if let Some(queued) = q.remove(&slot) {
-                                        for qmsg in &queued {
-                                            for (i, sb) in qmsg.shares.iter().enumerate() {
-                                                if let Some(s) = pyde_crypto::threshold::DecryptionShare::from_bytes(sb) {
-                                                    decryptor.add_share(i, s);
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                pending_decryptors.write().await.insert(slot, decryptor);
-                            }
-                            // Phase 1 hardening: same RR fallback as
-                            // the gossip-QC broadcast above (audit 234
-                            // part 4 step 5).
-                            if let Some(shares) =
-                                engine.generate_decryption_shares(identity, &enc_txs)
-                            {
-                                let msg = wire::DecryptionShareMsg {
-                                    slot,
-                                    member_index: identity.committee_index,
-                                    shares: shares.iter().map(|s| s.to_bytes()).collect(),
-                                };
-                                let share_bytes = wire::encode_decryption_shares(&msg);
-                                let topic = pyde_net::node::topics::consensus();
-                                broadcast_consensus_with_rr_fallback(
-                                    &mut swarm,
-                                    topic,
-                                    share_bytes,
-                                    &peer_manager,
-                                );
-                                info!(
-                                    slot,
-                                    enc_txs = enc_txs.len(),
-                                    "broadcast decryption shares (post-reorg-QC)"
-                                );
-                            }
-                            // END copy of QcFormedFromGossip body
                         }
                         PostEventAction::AcceptEncryptedTransaction(enc_tx) => {
                             // Audit item 227 step 4 / option E: inbound
@@ -2765,8 +2472,8 @@ impl PydeNode {
                                             //      slot via the audit-230 revert/revert_to
                                             //      pair, then apply the canonical block.
                                             //   4. chain head > qc_slot — multi-slot reorg
-                                            //      territory; defer to TryReorgToQc /
-                                            //      sync paths instead of trying here.
+                                            //      territory; defer to the sync path
+                                            //      instead of trying here.
                                             let need_apply = if chain_w.head_slot == qc_slot {
                                                 let our_block_hash = chain_w
                                                     .header(qc_slot)
@@ -3648,22 +3355,12 @@ enum PostEventAction {
     /// block can pull encrypted_txs out of it on arrival, regardless
     /// of gossipsub ordering. Audit item 207.
     BufferEncryptedBundle(pyde_net::propagation::EncryptedTxBundle),
-    /// A fresh QC just formed via an incoming gossip vote. Main loop
-    /// uses this to trigger the post-QC decryption flow — previously
-    /// that flow was only attached to `select_and_vote`'s local-QC
-    /// path, which in a 4+-node committee rarely fires (our vote is
-    /// typically not the 3rd/Nth that closes the QC; another
-    /// validator's is). Without this action the encrypted-tx
-    /// decryption never started on real multi-node networks.
-    /// Audit item 227 step 4 / option E.
-    QcFormedFromGossip {
-        slot: u64,
-    },
     /// Path A: a soft-QC just formed (via gossip Vote, RR-fallback Vote,
     /// or our own Vote closing it) and the block whose hash equals
     /// `qc_block_hash` is sitting in `pending_block_bodies`. The main
     /// loop picks it up, runs the canonical apply (validate + execute
-    /// + cleanup + ws emit + finality-vote cast). Replaces the
+    /// + cleanup + ws emit + finality-vote cast + audit-227 decryption
+    /// share broadcast for blocks with encrypted_txs). Replaces the
     /// per-validator speculative self-apply path that used to do this
     /// at proposal time. Triggered from any QC-formation site so
     /// canonical execution happens exactly once per slot per node.
@@ -3688,15 +3385,6 @@ enum PostEventAction {
     /// `competing_blocks` so a later QC for that hash can trigger
     /// `reorg_to_block`.
     BufferCompetingBlock(pyde_consensus::block::Block),
-    /// Audit 232: a QC formed for a block whose hash doesn't match
-    /// what we committed at that slot. Main loop looks up the QC'd
-    /// block in `competing_blocks` and, if present, calls
-    /// `BlockProcessor::reorg_to_block` to switch chains. If
-    /// absent, schedules a sync request for the missing block.
-    TryReorgToQc {
-        qc_slot: u64,
-        qc_block_hash: [u8; 32],
-    },
     /// Audit 234 part 3: ack for an inbound consensus RR request.
     /// Main loop dispatches via the swarm's ConsensusRr behaviour.
     SendConsensusRrResponse(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -918,6 +918,7 @@ impl PydeNode {
                                                 if let Some(cp) =
                                                     engine.latest_finality_checkpoint()
                                                 {
+                                                    let _ = block_store.put_finality_cert(cp);
                                                     let cp_bytes =
                                                         wire::encode_finality_checkpoint_msg(cp);
                                                     broadcast_consensus_with_rr_fallback(
@@ -1353,6 +1354,7 @@ impl PydeNode {
                                                 if let Some(cp) =
                                                     engine.latest_finality_checkpoint()
                                                 {
+                                                    let _ = block_store.put_finality_cert(cp);
                                                     let cp_bytes =
                                                         wire::encode_finality_checkpoint_msg(cp);
                                                     broadcast_consensus_with_rr_fallback(
@@ -2777,6 +2779,7 @@ impl PydeNode {
                                             );
                                             if cert_formed {
                                                 if let Some(cp) = engine.latest_finality_checkpoint() {
+                                                    let _ = block_store.put_finality_cert(cp);
                                                     let cp_bytes =
                                                         wire::encode_finality_checkpoint_msg(cp);
                                                     broadcast_consensus_with_rr_fallback(
@@ -3870,6 +3873,7 @@ fn handle_swarm_event(
                                         // broadcast so non-validator peers can
                                         // advance their WS anchor.
                                         if let Some(cp) = engine.latest_finality_checkpoint() {
+                                            let _ = block_store.put_finality_cert(cp);
                                             let msg = wire::encode_finality_checkpoint_msg(cp);
                                             return PostEventAction::BroadcastConsensus(msg);
                                         }
@@ -4457,6 +4461,7 @@ fn handle_swarm_event(
                                     if let Some(cp) =
                                         engine.latest_finality_checkpoint()
                                     {
+                                        let _ = block_store.put_finality_cert(cp);
                                         info!(
                                             slot = cp.slot,
                                             "hard finality cert formed (RR-receive)"


### PR DESCRIPTION
## Summary
Two small Path A follow-ups, building on PR #295.

### `chore(consensus): remove unreachable QcFormedFromGossip + TryReorgToQc handlers`
Path A's canonical-apply consolidation made these two `PostEventAction`
variants unreachable in steady state — `cargo check` was flagging both
as `dead_code`. Removed:

- `PostEventAction::QcFormedFromGossip { slot }` variant + its 113-line
  handler. The audit-227 decryption-share broadcast it owned now lives
  in the canonical-apply handlers (both gossip and RR paths).
- `PostEventAction::TryReorgToQc { qc_slot, qc_block_hash }` variant +
  its 179-line handler. Path A's "execute post-soft-QC, no speculative
  apply" means chain.head_slot doesn't advance pre-QC — there is no
  competing-block scenario at the moment a peer's vote closes the
  soft QC.

Kept intact: `BufferCompetingBlock` (still emitted from full-block
gossip-receive), `competing_blocks` HashMap, `chain.revert` /
`state.revert_to` / `record_block_undo` audit-230 APIs (snapshot
recovery + adversarial-fork edge cases).

Net: -312 lines, no behavior change. Cluster healthy under loadgen
post-removal: 196 canonical applies/node in 45s, 0 disconnects, hard-
finality forming.

### `feat(consensus): persist HardFinalityCert in BlockStore`
The cert that validators sign post-canonical-apply (3-of-4 attesting
to `(slot, block_hash, state_root)`) was formed in `FinalityTracker`
and broadcast on the consensus topic, but never written to disk. On
restart the in-memory tracker reset and the cert was gone — light
clients and fresh-syncing nodes had no way to verify "slot N
hard-finalized to state_root R" against signed proof.

Adds:
- `BlockStore::put_finality_cert(&FinalityCheckpoint)` — stores at
  `c:{slot_le}` using `wire::encode_finality_checkpoint`. Idempotent.
- `BlockStore::get_finality_cert(slot)` — round-trips back. Tested
  via `finality_cert_round_trip` unit test (covers voter_bitmap +
  signature vec).

Cert-formation sites that now persist (5 total): both canonical-apply
handlers, the own-vote-forms-QC apply path at slot tick, and both
finality-vote receive paths in `handle_swarm_event` (gossipsub + RR
fallback).

Sync-protocol extension (delivering certs to peers via `BlocksReq`)
is deferred — fresh-syncing nodes can re-derive certs by re-execution
+ peer-vote replay; certs become critical for the light-client entry
point that doesn't exist yet.

## Notes
- Two commits, ordered: cleanup first (smaller, lower-risk), persistence
  second (additive, new wire path).
- No `BlockBody` wire-format changes; both commits are storage-only or
  dead-code removal.
- The remaining items from PR #295's "tracked follow-ups" list still
  pending: scheduler unification (encrypted+plaintext), canonical-apply
  helper extraction.