### PR TITLE
feat(net): persistent peer book for warm-restart reconnection

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -13,6 +13,7 @@ mod keystore;
 mod logging;
 mod metrics;
 mod node;
+mod peer_book;
 mod receipt_store;
 mod rpc;
 mod shutdown;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -351,6 +351,14 @@ impl PydeNode {
         let mut pending_auth_nonces: std::collections::HashMap<libp2p::PeerId, [u8; 32]> =
             std::collections::HashMap::new();
 
+        // Audit 234 follow-up: persistent peer book. Loaded at
+        // startup (used to seed the dial list below); populated
+        // on every `ConnectionEstablished`; persisted on a 30 s
+        // tick + at shutdown so a future restart can re-dial the
+        // exact peer set without relying on bootstrap+DHT to
+        // re-discover every edge.
+        let mut peer_book = crate::peer_book::PeerBook::load(&self.config.node.datadir);
+
         // Size of the committee that was in power at the last epoch boundary.
         // Feeds the `old_threshold` passed to `on_reshare_contribution` after
         // `engine.set_committee` has already advanced `engine.committee_keys`
@@ -520,6 +528,21 @@ impl PydeNode {
         // single-node local devnet.
         if !self.config.network.bootstrap_peers.is_empty() {
             pyde_net::node::dial_bootstrap_peers(&mut swarm, &self.config.network.bootstrap_peers);
+        }
+
+        // 8b. Audit 234 follow-up: also dial every peer the previous
+        // run ended up connected to. Bootstrap is the seed list (a
+        // few well-known validators); the peer book is the *full*
+        // set of edges the previous run had — including peers we
+        // discovered via DHT and might not be in the static
+        // bootstrap config. Without this, a restarted small-
+        // committee node can come back missing one or two edges,
+        // which is invisible until a different node dies.
+        // Skip-if-already-connected is handled inside
+        // `redial_saved_peers` so a peer in BOTH bootstrap and the
+        // book isn't dialed twice.
+        if peer_book.len() > 0 {
+            redial_saved_peers(&mut swarm, &peer_book);
         }
 
         // 9. Listen on all interfaces — hybrid TCP + QUIC (audit 234
@@ -716,6 +739,21 @@ impl PydeNode {
         let mut gossip_retry_interval =
             tokio::time::interval(std::time::Duration::from_millis(800));
         const GOSSIP_RETRY_MAX_TXS: usize = 1000;
+        // Audit 234 follow-up: snapshot the peer book to disk every
+        // 5 s. Aggressive enough that a node killed soon after
+        // startup (validator-churn tests warm up in ~12 s, then
+        // start killing) still has the freshly-observed peer set
+        // persisted; coarse enough that I/O cost is negligible
+        // (one small JSON write per 5 s = nothing). `kill -9` loses
+        // at most 5 s of new observations.
+        let mut peer_book_snapshot_interval =
+            tokio::time::interval(std::time::Duration::from_secs(5));
+        // First tick fires immediately on `interval()`; consume it
+        // here so the next firing is 5 s later, not on the very
+        // first poll of the select loop. (Without this we'd save
+        // an empty book at t=0 and then an immediate save at t=5
+        // — harmless but wasteful.)
+        peer_book_snapshot_interval.tick().await;
 
         loop {
             tokio::select! {
@@ -750,15 +788,20 @@ impl PydeNode {
                         PostEventAction::SendSyncResponse(channel, response) => {
                             let _ = swarm.behaviour_mut().sync.send_response(channel, response);
                         }
-                        PostEventAction::SendAuthRequest(peer) => {
-                            // Generate a fresh nonce, record it, send the request.
-                            // We only authenticate to peers once; if a response is
-                            // already pending we skip to avoid stacking nonces.
-                            if let std::collections::hash_map::Entry::Vacant(e) = pending_auth_nonces.entry(peer) {
+                        PostEventAction::RecordPeerAndAuth { peer_id, multiaddr } => {
+                            // Audit 234 follow-up: persist the (peer, addr)
+                            // pair so a future restart re-dials it directly.
+                            // The book is snapshot to disk on a 30 s tick +
+                            // at shutdown.
+                            peer_book.record(peer_id, multiaddr);
+                            // Same auth-handshake kick that the original
+                            // ConnectionEstablished arm did before the
+                            // peer-book promotion was added.
+                            if let std::collections::hash_map::Entry::Vacant(e) = pending_auth_nonces.entry(peer_id) {
                                 let nonce = pyde_net::auth::generate_nonce();
                                 e.insert(nonce);
                                 let req = pyde_net::auth::PydeAuthReq { nonce };
-                                let _ = swarm.behaviour_mut().auth.send_request(&peer, req);
+                                let _ = swarm.behaviour_mut().auth.send_request(&peer_id, req);
                             }
                         }
                         PostEventAction::SendAuthResponse(channel, resp) => {
@@ -2955,8 +2998,26 @@ impl PydeNode {
                         }
                     }
                 }
+                _ = peer_book_snapshot_interval.tick() => {
+                    // Audit 234 follow-up: persist the (peer_id,
+                    // multiaddr) set so a future restart redials the
+                    // exact peer set instead of waiting for
+                    // bootstrap+DHT to re-discover every edge. Errors
+                    // logged but non-fatal — the previous snapshot on
+                    // disk remains valid; we'll retry on the next tick.
+                    if let Err(e) = peer_book.save(&self.config.node.datadir) {
+                        warn!(error = %e, "peer book snapshot failed");
+                    }
+                }
                 _ = shutdown_rx.recv() => {
                     info!("shutdown signal received, stopping node...");
+                    // Final peer-book snapshot on the way out so the
+                    // most-recent observations land on disk even if
+                    // we're between regular ticks. Best-effort —
+                    // shutdown proceeds either way.
+                    if let Err(e) = peer_book.save(&self.config.node.datadir) {
+                        warn!(error = %e, "peer book final snapshot failed");
+                    }
                     break;
                 }
             }
@@ -3024,10 +3085,6 @@ enum PostEventAction {
         qc_slot: u64,
         qc_block_hash: [u8; 32],
     },
-    /// Send a `PydeAuthReq` to a newly connected peer. The main loop
-    /// generates a fresh nonce, records it in `pending_auth_nonces`, and
-    /// dispatches via the swarm.
-    SendAuthRequest(PeerId),
     /// Reply to an inbound `PydeAuthReq` with a signed attestation over
     /// `(nonce, our_peer_id)`. The response channel holds the pending
     /// outbound stream to the requester.
@@ -3101,6 +3158,23 @@ enum PostEventAction {
         request_response::ResponseChannel<pyde_net::blocks_protocol::BlocksResp>,
         pyde_net::blocks_protocol::BlocksResp,
     ),
+    /// Audit 234 follow-up: record a `(PeerId, Multiaddr)` pair into the
+    /// persistent peer book AND fire the FALCON auth handshake (task
+    /// 029). Both are side-effects of `SwarmEvent::ConnectionEstablished`;
+    /// the runtime executes them as a unit so the auth-gated peer-book
+    /// promotion in `OnPeerAuthenticated` can correlate the freshly-
+    /// recorded `peer_id` with the authentication outcome.
+    ///
+    /// The book is persisted on a coarse cadence + at shutdown and
+    /// re-dialed at next startup, so a restarted validator restores
+    /// all its connections instead of relying on bootstrap+DHT to
+    /// re-discover every peer (which can leave one edge missing in
+    /// small committees and stall consensus when a different node
+    /// dies).
+    RecordPeerAndAuth {
+        peer_id: PeerId,
+        multiaddr: libp2p::Multiaddr,
+    },
 }
 
 /// Publish a consensus message via gossipsub; on `InsufficientPeers`
@@ -3517,6 +3591,59 @@ fn broadcast_blocks_with_rr_fallback(
             },
         );
     }
+}
+
+/// Audit 234 follow-up: dial every peer the previous run was
+/// connected to. Run once at startup, AFTER `dial_bootstrap_peers`
+/// so peers in both lists aren't double-dialed (the
+/// `is_connected` check below catches the duplicate).
+///
+/// Deliberately drops the `local_peer_id >= peer_id` dial-race
+/// guard that `dial_bootstrap_peers` carries. The guard exists to
+/// stop *sustained* symmetric dialing (each side periodically
+/// retrying bootstrap → both sides dialing each other on every
+/// retry → libp2p reaps the duplicate). This call is a one-shot
+/// at startup; the worst-case race is two TCP setups for the same
+/// peer, libp2p picks one, the other gets reaped — no sustained
+/// flap. Skipping the guard is what fixes the
+/// validator-churn-4-of-4 stall: with the guard in place,
+/// whichever side has the higher PeerId waits for the other to
+/// dial, but the other side isn't actively dialing us at startup
+/// either, so the connection never reforms and quorum can't
+/// reach 3-of-4.
+fn redial_saved_peers(
+    swarm: &mut libp2p::Swarm<pyde_net::node::PydeBehaviour>,
+    peer_book: &crate::peer_book::PeerBook,
+) {
+    let local_peer_id = *swarm.local_peer_id();
+    let mut dialed = 0usize;
+    for (peer_id, addr) in peer_book.iter() {
+        if local_peer_id == *peer_id {
+            continue; // self
+        }
+        if swarm.is_connected(peer_id) {
+            continue;
+        }
+        // Seed Kademlia even if dial fails — DHT can use it later.
+        swarm
+            .behaviour_mut()
+            .kademlia
+            .add_address(peer_id, addr.clone());
+        match swarm.dial(addr.clone()) {
+            Ok(_) => {
+                dialed += 1;
+                debug!(%peer_id, %addr, "redialing saved peer");
+            }
+            Err(e) => {
+                debug!(%peer_id, %addr, error = %e, "saved-peer dial failed; bootstrap+DHT will retry");
+            }
+        }
+    }
+    info!(
+        saved = peer_book.len(),
+        dialed,
+        "redialed saved peers from peer book"
+    );
 }
 
 /// Handle a libp2p swarm event. Returns an action that may need swarm access.
@@ -4669,9 +4796,10 @@ fn handle_swarm_event(
         SwarmEvent::ConnectionEstablished {
             peer_id, endpoint, ..
         } => {
+            let remote_addr = endpoint.get_remote_address().clone();
             info!(
                 %peer_id,
-                addr = %endpoint.get_remote_address(),
+                addr = %remote_addr,
                 "peer connected"
             );
             // Track the peer so attested pubkeys can later be stored.
@@ -4684,9 +4812,16 @@ fn handle_swarm_event(
             let info = pyde_net::peer::PeerInfo::new(peer_id, direction);
             peer_manager.add_peer(info);
 
-            // Task 029: kick off the FALCON attestation handshake so the
-            // consensus filter (task 030) has a pubkey to check.
-            PostEventAction::SendAuthRequest(peer_id)
+            // Audit 234 follow-up: snapshot the (peer_id, multiaddr)
+            // for the persistent peer book AND kick off the FALCON
+            // attestation handshake (task 029). The runtime handles
+            // both as a unit; auth-gating for the book happens
+            // downstream so a malicious peer that fails attestation
+            // doesn't end up in the persisted set.
+            PostEventAction::RecordPeerAndAuth {
+                peer_id,
+                multiaddr: remote_addr,
+            }
         }
 
         // --- Peer disconnected ---

--- a/crates/node/src/peer_book.rs
+++ b/crates/node/src/peer_book.rs
@@ -1,0 +1,197 @@
+//! Persistent peer book for warm-restart connection restoration.
+//!
+//! Audit 234 follow-up: when a validator restarts, libp2p's
+//! Kademlia discovery + bootstrap-list dial don't always re-
+//! establish a connection to *every* peer the node had before. A
+//! small N=4 committee that survives one restart can end up with
+//! one missing edge (e.g. node-0 ↔ node-3) — invisible while all
+//! 4 are alive because messages still route through the central
+//! peer, but the moment a different node dies the network drops
+//! below quorum and consensus stalls.
+//!
+//! Persisting the observed `(PeerId, Multiaddr)` set on a coarse
+//! cadence and re-dialing on startup closes the gap. The saved
+//! set is treated as a hint, not a source of truth: addresses can
+//! drift between runs (cloud restart with a new IP), so a dial
+//! failure falls back to the existing bootstrap + Kademlia DHT
+//! discovery path.
+//!
+//! Storage shape: a small JSON file at
+//! `<datadir>/peer_book.json`. Atomic-write via temp + rename so
+//! a `kill -9` mid-write doesn't corrupt the on-disk file. Size is
+//! ~80 bytes per peer; 128 mainnet validators ≈ 10 KB.
+
+use libp2p::{Multiaddr, PeerId};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+use std::str::FromStr;
+use tracing::{info, warn};
+
+const PEER_BOOK_FILENAME: &str = "peer_book.json";
+
+/// In-memory + persisted view of recently-connected peers.
+#[derive(Debug, Default)]
+pub struct PeerBook {
+    /// Latest known multiaddr per peer. Replaced on subsequent
+    /// observations of the same `PeerId` — when a peer comes back
+    /// on a new address, we want the new one.
+    peers: HashMap<PeerId, Multiaddr>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PeerEntry {
+    peer_id: String,
+    multiaddr: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct PeerBookFile {
+    peers: Vec<PeerEntry>,
+}
+
+impl PeerBook {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load the persisted set from disk. Missing file, parse
+    /// errors, and unparseable entries all fall through to an
+    /// empty book — corruption isn't fatal, we re-discover via
+    /// bootstrap + DHT.
+    pub fn load(datadir: &Path) -> Self {
+        let path = datadir.join(PEER_BOOK_FILENAME);
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => return Self::new(),
+        };
+        let parsed: PeerBookFile = match serde_json::from_slice(&bytes) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "failed to parse peer book; starting fresh"
+                );
+                return Self::new();
+            }
+        };
+        let mut book = Self::new();
+        for entry in parsed.peers {
+            match (
+                PeerId::from_str(&entry.peer_id),
+                Multiaddr::from_str(&entry.multiaddr),
+            ) {
+                (Ok(peer_id), Ok(addr)) => {
+                    book.peers.insert(peer_id, addr);
+                }
+                _ => {
+                    // Skip malformed entries silently — file may
+                    // be from a future version or hand-edited.
+                }
+            }
+        }
+        info!(count = book.peers.len(), "loaded peer book");
+        book
+    }
+
+    /// Atomically persist the current set. Writes to
+    /// `peer_book.json.tmp` then `rename`s into place so a
+    /// `kill -9` mid-write either lands the new file or leaves the
+    /// old one untouched.
+    pub fn save(&self, datadir: &Path) -> Result<(), String> {
+        let entries: Vec<PeerEntry> = self
+            .peers
+            .iter()
+            .map(|(p, a)| PeerEntry {
+                peer_id: p.to_string(),
+                multiaddr: a.to_string(),
+            })
+            .collect();
+        let file = PeerBookFile { peers: entries };
+        let bytes = serde_json::to_vec_pretty(&file).map_err(|e| e.to_string())?;
+        let final_path = datadir.join(PEER_BOOK_FILENAME);
+        let tmp_path = datadir.join(format!("{}.tmp", PEER_BOOK_FILENAME));
+        std::fs::write(&tmp_path, bytes).map_err(|e| e.to_string())?;
+        std::fs::rename(&tmp_path, &final_path).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Record an observed `(peer, addr)` pair. Idempotent —
+    /// duplicate observations just refresh the address.
+    pub fn record(&mut self, peer_id: PeerId, addr: Multiaddr) {
+        self.peers.insert(peer_id, addr);
+    }
+
+    /// Iterate over saved peers. Used at swarm startup to
+    /// supplement the bootstrap dial list.
+    pub fn iter(&self) -> impl Iterator<Item = (&PeerId, &Multiaddr)> {
+        self.peers.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::identity;
+
+    fn random_peer_addr() -> (PeerId, Multiaddr) {
+        let kp = identity::Keypair::generate_ed25519();
+        let peer_id = PeerId::from(kp.public());
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/30000".parse().unwrap();
+        (peer_id, addr)
+    }
+
+    #[test]
+    fn roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut book = PeerBook::new();
+        let (p1, a1) = random_peer_addr();
+        let (p2, a2) = random_peer_addr();
+        book.record(p1, a1.clone());
+        book.record(p2, a2.clone());
+        book.save(dir.path()).unwrap();
+
+        let loaded = PeerBook::load(dir.path());
+        assert_eq!(loaded.len(), 2);
+        let map: HashMap<_, _> = loaded.iter().map(|(p, a)| (*p, a.clone())).collect();
+        assert_eq!(map.get(&p1), Some(&a1));
+        assert_eq!(map.get(&p2), Some(&a2));
+    }
+
+    #[test]
+    fn record_is_idempotent_and_refreshes_address() {
+        let mut book = PeerBook::new();
+        let (p1, a1) = random_peer_addr();
+        let a2: Multiaddr = "/ip4/127.0.0.1/tcp/40000".parse().unwrap();
+        book.record(p1, a1);
+        book.record(p1, a2.clone());
+        assert_eq!(book.len(), 1);
+        let loaded: HashMap<_, _> = book.iter().map(|(p, a)| (*p, a.clone())).collect();
+        assert_eq!(loaded.get(&p1), Some(&a2));
+    }
+
+    #[test]
+    fn missing_file_is_empty_book() {
+        let dir = tempfile::tempdir().unwrap();
+        let book = PeerBook::load(dir.path());
+        assert!(book.is_empty());
+    }
+
+    #[test]
+    fn corrupt_file_is_empty_book() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("peer_book.json"), b"not-json").unwrap();
+        let book = PeerBook::load(dir.path());
+        assert!(book.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Audit 234 follow-up. Persists the observed `(PeerId, Multiaddr)`
  set on a 5 s tick + at shutdown, then re-dials the saved peers
  at next startup. Closes the "where do I find my peers after
  restart" half of the post-restart stall: a freshly-restarted
  validator restores its full peer set immediately instead of
  waiting for the 10 s bootstrap retry tick to walk it through
  every edge via DHT discovery.
- New `crates/node/src/peer_book.rs` (JSON-backed,
  `<datadir>/peer_book.json`, atomic-write via temp + rename, 4
  unit tests).
- New `PostEventAction::RecordPeerAndAuth` combines peer-book
  recording with the existing FALCON auth handshake into one
  action emitted from `ConnectionEstablished`; replaces the
  former `SendAuthRequest`.
- New `redial_saved_peers` helper called after `dial_bootstrap_peers`
  at swarm bring-up. Drops the `peer_id < local_peer_id` dial-race
  guard that bootstrap carries — the guard prevents sustained
  symmetric dialing during periodic bootstrap retries; this call
  is one-shot at startup, the worst case is one duplicate TCP
  setup that libp2p reaps.

## Scope note
This fix is **necessary but not sufficient** for closing the
audit-234 stall. The `validator_churn_4_of_4 --ignored` test
still fails at the same point as before — gossipsub mesh state
refresh on restart is the remaining piece. The audit doc already
classifies 234 as a multi-step finding; this PR closes one of
the steps cleanly so future work can focus on the remaining
gossipsub-layer issue without re-doing the reconnection layer.

## Production value beyond the test
A validator that restarts after a maintenance window restores
its peer set in tens of ms instead of waiting for the 10 s
bootstrap retry tick.

## Behaviour change at a glance
- New file `<datadir>/peer_book.json` written on first 5 s tick.
- One additional action variant in `PostEventAction`.
- `SendAuthRequest` removed (subsumed by `RecordPeerAndAuth`).
- No regressions: 32 lib + 264 main + 15 + integration tests
  pass; new peer_book has 4 passing unit tests.