### PR TITLE
fix(consensus): bind chain_id into proposer/vote/view-change/evidence preimages

### DIFF
--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -13,16 +13,24 @@ use pyde_account::address::Address;
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 
 /// Canonical message bytes that both proposers and voters sign for a
-/// block at a given slot: `slot_le || block_hash`.
+/// block at a given slot: `chain_id_le || slot_le || block_hash`.
 ///
-/// The slot prefix binds the signature to a specific slot, preventing
-/// cross-slot replay of the same block hash. Both proposer signatures
-/// (on block headers) and vote signatures (on `Vote` messages) use this
-/// exact layout so slashing evidence can be verified with a single
-/// routine regardless of signature origin.
+/// The `chain_id` prefix binds every proposer/vote/evidence signature
+/// to a specific chain, preventing cross-chain replay even when two
+/// chains share the same FALCON committee keys. `BlockHeader::hash()`
+/// does not include `chain_id` directly — without this prefix, a vote
+/// signed on one chain would verify against the same block hash on
+/// another chain, and a double-sign on devnet would slash on testnet.
+///
+/// The `slot` prefix binds to a specific slot, preventing cross-slot
+/// replay of the same block hash. Both proposer signatures (on block
+/// headers) and vote signatures (on `Vote` messages) use this exact
+/// layout so slashing evidence can be verified with a single routine
+/// regardless of signature origin.
 #[inline]
-pub fn proposer_sign_message(slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(8 + 32);
+pub fn proposer_sign_message(chain_id: u64, slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(8 + 8 + 32);
+    msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
     msg.extend_from_slice(block_hash);
     msg
@@ -168,10 +176,15 @@ impl Default for ConsensusState {
 
 /// Vote on a proposed block. Returns a Vote message.
 ///
+/// `chain_id` is bound into the signed preimage so a vote signed on
+/// chain A cannot be replayed as a valid vote on chain B (see
+/// [`proposer_sign_message`]).
+///
 /// Safety rule: only vote if:
 /// 1. The proposal extends the highest QC we've seen
 /// 2. We haven't voted for this slot yet
 pub fn create_vote(
+    chain_id: u64,
     state: &mut ConsensusState,
     header: &BlockHeader,
     voter_index: u8,
@@ -193,10 +206,11 @@ pub fn create_vote(
         state.highest_qc = header.qc_previous.clone();
     }
 
-    // Sign (slot || block_hash) via the canonical proposer/vote message
-    // layout, binding the vote to a specific slot.
+    // Sign (chain_id || slot || block_hash) via the canonical
+    // proposer/vote message layout, binding the vote to a specific
+    // chain and slot.
     let block_hash = header.hash();
-    let vote_msg = proposer_sign_message(header.slot, &block_hash);
+    let vote_msg = proposer_sign_message(chain_id, header.slot, &block_hash);
     let sig =
         pyde_crypto::falcon::falcon_sign(voter_sk, &vote_msg).map_err(|_| "vote signing failed")?;
 
@@ -212,8 +226,11 @@ pub fn create_vote(
 }
 
 /// Verify a vote message against a validator's public key.
-/// The signature covers (slot || block_hash) to prevent cross-slot replay.
-pub fn verify_vote(vote: &ConsensusMessage, public_key: &[u8]) -> bool {
+///
+/// The signature covers `(chain_id || slot || block_hash)`. A vote signed
+/// on a different chain (different `chain_id`) will fail verification
+/// here even when the FALCON keys match — preventing cross-chain replay.
+pub fn verify_vote(chain_id: u64, vote: &ConsensusMessage, public_key: &[u8]) -> bool {
     match vote {
         ConsensusMessage::Vote {
             slot,
@@ -225,7 +242,7 @@ pub fn verify_vote(vote: &ConsensusMessage, public_key: &[u8]) -> bool {
                 Some(pk) => pk,
                 None => return false,
             };
-            let vote_msg = proposer_sign_message(*slot, block_hash);
+            let vote_msg = proposer_sign_message(chain_id, *slot, block_hash);
             let sig = match FalconSignature::from_bytes(signature) {
                 Some(s) => s,
                 None => return false,
@@ -239,6 +256,7 @@ pub fn verify_vote(vote: &ConsensusMessage, public_key: &[u8]) -> bool {
 /// Aggregate votes into a QuorumCert.
 /// Returns Some(QC) if quorum reached (86+ valid votes), None otherwise.
 pub fn try_form_qc(
+    chain_id: u64,
     slot: u64,
     block_hash: [u8; 32],
     votes: &[ConsensusMessage],
@@ -272,7 +290,7 @@ pub fn try_form_qc(
             }
 
             // Verify signature
-            if verify_vote(vote, &committee_keys[idx]) {
+            if verify_vote(chain_id, vote, &committee_keys[idx]) {
                 voter_bitmap |= 1u128 << idx;
                 signatures.push(signature.clone());
                 valid_count += 1;
@@ -346,15 +364,24 @@ pub fn is_finalized(
 }
 
 /// Create a timeout message when no valid proposal received within the timeout period.
+///
+/// NOTE: production view-change goes through
+/// `validator::on_timeout` → `view_change::create_view_change`. This
+/// function is only exercised by unit tests today; kept public for
+/// API stability. The `chain_id` prefix is bound for consistency with
+/// every other consensus signing surface so future production callers
+/// don't reintroduce a chain-replayable signature.
 pub fn create_timeout(
+    chain_id: u64,
     state: &ConsensusState,
     slot: u64,
     voter_index: u8,
     voter_address: Address,
     voter_sk: &pyde_crypto::falcon::FalconSecretKey,
 ) -> Result<ConsensusMessage, &'static str> {
-    let mut msg = Vec::new();
+    let mut msg = Vec::with_capacity(7 + 8 + 8); // "timeout"(7) + chain_id(8) + slot(8)
     msg.extend_from_slice(b"timeout");
+    msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
     let sig =
         pyde_crypto::falcon::falcon_sign(voter_sk, &msg).map_err(|_| "timeout signing failed")?;
@@ -377,6 +404,11 @@ mod tests {
     use crate::block::QuorumCert;
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::falcon_keygen;
+
+    /// Arbitrary non-mainnet, non-devnet chain_id used by every test
+    /// in this module so cross-chain replay regressions surface here
+    /// rather than slipping past with hardcoded chain_id=0.
+    const TEST_CHAIN_ID: u64 = 7;
 
     fn make_header(slot: u64, qc_slot: u64) -> BlockHeader {
         BlockHeader {
@@ -409,15 +441,35 @@ mod tests {
         let header = make_header(1, 0);
 
         // Create vote
-        let vote = create_vote(&mut state, &header, 0, addr, &sk)
+        let vote = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, &sk)
             .unwrap()
             .unwrap();
         assert!(matches!(vote, ConsensusMessage::Vote { .. }));
 
         // Verify vote
-        assert!(verify_vote(&vote, &pk_bytes));
+        assert!(verify_vote(TEST_CHAIN_ID, &vote, &pk_bytes));
 
         assert_eq!(state.last_voted_slot, 1);
+    }
+
+    /// Cross-chain replay: a vote signed under one `chain_id` must NOT
+    /// verify under another even when FALCON keys match. Mirrors
+    /// audit-240's multisig regression.
+    #[test]
+    fn vote_cross_chain_replay_rejected() {
+        let mut state = ConsensusState::new();
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let header = make_header(1, 0);
+        let vote = create_vote(1, &mut state, &header, 0, addr, &sk)
+            .unwrap()
+            .unwrap();
+
+        assert!(verify_vote(1, &vote, &pk_bytes));
+        assert!(!verify_vote(2, &vote, &pk_bytes));
+        assert!(!verify_vote(31337, &vote, &pk_bytes));
     }
 
     #[test]
@@ -428,15 +480,13 @@ mod tests {
         let mut votes = Vec::new();
         let mut keys = Vec::new();
 
-        // Generate 86 valid votes (signature covers slot || block_hash)
+        // Generate 86 valid votes (signature covers chain_id || slot || block_hash)
         for i in 0..86u8 {
             let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let mut vote_msg = Vec::with_capacity(40);
-            vote_msg.extend_from_slice(&5u64.to_le_bytes());
-            vote_msg.extend_from_slice(&block_hash);
+            let vote_msg = proposer_sign_message(TEST_CHAIN_ID, 5, &block_hash);
             let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg).unwrap();
             votes.push(ConsensusMessage::Vote {
                 slot: 5,
@@ -453,7 +503,7 @@ mod tests {
             keys.push(vec![0; 897]);
         }
 
-        let qc = try_form_qc(5, block_hash, &votes, &keys);
+        let qc = try_form_qc(TEST_CHAIN_ID, 5, block_hash, &votes, &keys);
         assert!(qc.is_some());
         let qc = qc.unwrap();
         assert!(qc.has_quorum());
@@ -476,9 +526,7 @@ mod tests {
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let mut vote_msg = Vec::with_capacity(40);
-            vote_msg.extend_from_slice(&5u64.to_le_bytes());
-            vote_msg.extend_from_slice(&block_hash);
+            let vote_msg = proposer_sign_message(TEST_CHAIN_ID, 5, &block_hash);
             let sig = pyde_crypto::falcon::falcon_sign(&sk, &vote_msg).unwrap();
             votes.push(ConsensusMessage::Vote {
                 slot: 5,
@@ -494,7 +542,7 @@ mod tests {
             keys.push(vec![0; 897]);
         }
 
-        let qc = try_form_qc(5, block_hash, &votes, &keys);
+        let qc = try_form_qc(TEST_CHAIN_ID, 5, block_hash, &votes, &keys);
         assert!(qc.is_none());
     }
 
@@ -587,11 +635,11 @@ mod tests {
         let addr = derive_eoa_address(pk.as_bytes());
 
         let header = make_header(1, 0);
-        let vote1 = create_vote(&mut state, &header, 0, addr, &sk).unwrap();
+        let vote1 = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, &sk).unwrap();
         assert!(vote1.is_some());
 
         // Try voting again for same slot
-        let vote2 = create_vote(&mut state, &header, 0, addr, &sk).unwrap();
+        let vote2 = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, &sk).unwrap();
         assert!(vote2.is_none()); // rejected
     }
 
@@ -603,13 +651,13 @@ mod tests {
 
         // Vote for slot 5
         let header5 = make_header(5, 4);
-        create_vote(&mut state, &header5, 0, addr, &sk)
+        create_vote(TEST_CHAIN_ID, &mut state, &header5, 0, addr, &sk)
             .unwrap()
             .unwrap();
 
         // Try to vote for slot 3 (old)
         let header3 = make_header(3, 2);
-        let vote = create_vote(&mut state, &header3, 0, addr, &sk).unwrap();
+        let vote = create_vote(TEST_CHAIN_ID, &mut state, &header3, 0, addr, &sk).unwrap();
         assert!(vote.is_none());
     }
 
@@ -624,7 +672,7 @@ mod tests {
         assert_eq!(state.highest_qc.slot, 0);
 
         let header = make_header(5, 4); // QC for slot 4
-        create_vote(&mut state, &header, 0, addr, &sk)
+        create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, &sk)
             .unwrap()
             .unwrap();
 
@@ -639,7 +687,7 @@ mod tests {
         let (pk, sk) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk.as_bytes());
 
-        let timeout = create_timeout(&state, 5, 0, addr, &sk).unwrap();
+        let timeout = create_timeout(TEST_CHAIN_ID, &state, 5, 0, addr, &sk).unwrap();
         assert!(matches!(timeout, ConsensusMessage::Timeout { slot: 5, .. }));
     }
 }

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -65,23 +65,29 @@ pub struct SlashResult {
 /// Double-signing evidence: two different blocks signed for the same slot.
 ///
 /// Carries block *hashes* rather than full `BlockHeader`s because both
-/// the proposer signature and vote signature formats bind (slot || hash)
-/// directly — verifying the evidence requires nothing more than the
-/// hashes, the two FALCON signatures, and the signer's public key. This
-/// keeps the on-chain payload (`TransactionType::Slash` data field)
-/// small and lets the tx pipeline verify the evidence without depending
-/// on `BlockHeader` internals.
+/// the proposer signature and vote signature formats bind
+/// `(chain_id || slot || hash)` directly — verifying the evidence
+/// requires nothing more than the local chain's `chain_id`, the two
+/// hashes, the two FALCON signatures, and the signer's public key.
+/// This keeps the on-chain payload (`TransactionType::Slash` data
+/// field) small and lets the tx pipeline verify the evidence without
+/// depending on `BlockHeader` internals.
+///
+/// The struct itself does NOT carry `chain_id`: the verifier rebuilds
+/// the preimage with the LOCAL chain's `chain_id`, so a double-sign on
+/// chain A cannot be replayed as evidence on chain B. This mirrors the
+/// audit-240 multisig pattern.
 #[derive(Clone, Debug)]
 pub struct DoubleSignEvidence {
     /// The slot where double-signing occurred.
     pub slot: u64,
     /// Hash of the first block the signer signed for this slot.
     pub block_hash_1: [u8; 32],
-    /// FALCON signature over `proposer_sign_message(slot, block_hash_1)`.
+    /// FALCON signature over `proposer_sign_message(chain_id, slot, block_hash_1)`.
     pub signature_1: Vec<u8>,
     /// Hash of the second block — must differ from `block_hash_1`.
     pub block_hash_2: [u8; 32],
-    /// FALCON signature over `proposer_sign_message(slot, block_hash_2)`.
+    /// FALCON signature over `proposer_sign_message(chain_id, slot, block_hash_2)`.
     pub signature_2: Vec<u8>,
     /// Address of the signer being accused.
     pub signer: Address,
@@ -111,16 +117,21 @@ impl LivenessReport {
 
 // ========== Verification ==========
 
-/// Verify double-sign evidence.
+/// Verify double-sign evidence against the local chain's `chain_id`.
 ///
 /// Checks:
 /// 1. The two block hashes are different (otherwise it's not equivocation).
-/// 2. Both signatures verify over `(slot || block_hash)` against the
-///    accused signer's public key.
+/// 2. Both signatures verify over `(chain_id || slot || block_hash)`
+///    against the accused signer's public key.
 ///
-/// The slot binding lives inside the signed message, so a sig for slot
-/// N cannot be replayed as evidence of equivocation at slot M.
-pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> bool {
+/// The `chain_id` binding prevents cross-chain replay: a double-sign
+/// on chain A is not valid evidence on chain B even when FALCON keys
+/// match. The slot binding prevents cross-slot replay within a chain.
+pub fn verify_double_sign(
+    chain_id: u64,
+    evidence: &DoubleSignEvidence,
+    public_key: &[u8],
+) -> bool {
     // Two distinct blocks (empty-or-equal hashes = not evidence).
     if evidence.block_hash_1 == evidence.block_hash_2 {
         return false;
@@ -139,8 +150,10 @@ pub fn verify_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> b
         None => return false,
     };
 
-    let msg_1 = crate::hotstuff::proposer_sign_message(evidence.slot, &evidence.block_hash_1);
-    let msg_2 = crate::hotstuff::proposer_sign_message(evidence.slot, &evidence.block_hash_2);
+    let msg_1 =
+        crate::hotstuff::proposer_sign_message(chain_id, evidence.slot, &evidence.block_hash_1);
+    let msg_2 =
+        crate::hotstuff::proposer_sign_message(chain_id, evidence.slot, &evidence.block_hash_2);
     falcon_verify(&pk, &msg_1, &sig_1) && falcon_verify(&pk, &msg_2, &sig_2)
 }
 
@@ -165,9 +178,13 @@ fn compute_slash(stake: u128, offense: &SlashingOffense) -> (u128, u128) {
     (burned, finder_fee)
 }
 
-/// Process a double-sign slashing event.
-pub fn slash_double_sign(evidence: &DoubleSignEvidence, public_key: &[u8]) -> Option<SlashResult> {
-    if !verify_double_sign(evidence, public_key) {
+/// Process a double-sign slashing event against the local chain's `chain_id`.
+pub fn slash_double_sign(
+    chain_id: u64,
+    evidence: &DoubleSignEvidence,
+    public_key: &[u8],
+) -> Option<SlashResult> {
+    if !verify_double_sign(chain_id, evidence, public_key) {
         return None;
     }
 
@@ -286,14 +303,20 @@ mod tests {
         }
     }
 
+    /// Arbitrary non-mainnet, non-devnet chain_id used by every test in
+    /// this module so cross-chain replay regressions surface here.
+    const TEST_CHAIN_ID: u64 = 7;
+
     /// Helper: produce a proposer signature over the canonical
-    /// `(slot || block_hash)` message layout the production code uses.
+    /// `(chain_id || slot || block_hash)` message layout the production
+    /// code uses.
     fn sign_proposer(
         sk: &pyde_crypto::falcon::FalconSecretKey,
+        chain_id: u64,
         slot: u64,
         block_hash: &[u8; 32],
     ) -> Vec<u8> {
-        let msg = crate::hotstuff::proposer_sign_message(slot, block_hash);
+        let msg = crate::hotstuff::proposer_sign_message(chain_id, slot, block_hash);
         falcon_sign(sk, &msg).unwrap().as_bytes().to_vec()
     }
 
@@ -311,16 +334,16 @@ mod tests {
         let evidence = DoubleSignEvidence {
             slot: 100,
             block_hash_1: hash_1,
-            signature_1: sign_proposer(&sk, 100, &hash_1),
+            signature_1: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_1),
             block_hash_2: hash_2,
-            signature_2: sign_proposer(&sk, 100, &hash_2),
+            signature_2: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
 
-        assert!(verify_double_sign(&evidence, &pk_bytes));
+        assert!(verify_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes));
 
-        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        let result = slash_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes).unwrap();
         assert_eq!(result.offender, addr);
         assert_eq!(result.offense, SlashingOffense::DoubleSigning);
         assert!(result.ejected);
@@ -328,6 +351,37 @@ mod tests {
         // 100% slashed: 90% burned, 10% finder fee
         assert_eq!(result.amount_burned + result.finder_fee, VALIDATOR_STAKE);
         assert_eq!(result.finder_fee, VALIDATOR_STAKE / 10);
+    }
+
+    /// Cross-chain replay: a double-sign on chain A must NOT slash on
+    /// chain B even when FALCON keys match. Mirrors audit-240's
+    /// multisig regression — operators reuse FALCON keys across
+    /// devnet/staging/testnet during dev cycles.
+    #[test]
+    fn double_sign_cross_chain_replay_rejected() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let hash_1 = make_header(100, 1_000_000).hash();
+        let hash_2 = make_header(100, 2_000_000).hash();
+
+        // Evidence signed under chain_id = 1 (mainnet-like).
+        let evidence = DoubleSignEvidence {
+            slot: 100,
+            block_hash_1: hash_1,
+            signature_1: sign_proposer(&sk, 1, 100, &hash_1),
+            block_hash_2: hash_2,
+            signature_2: sign_proposer(&sk, 1, 100, &hash_2),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        // Same evidence verifies on chain 1 but NOT on a different chain.
+        assert!(verify_double_sign(1, &evidence, &pk_bytes));
+        assert!(!verify_double_sign(2, &evidence, &pk_bytes));
+        assert!(!verify_double_sign(31337, &evidence, &pk_bytes));
+        assert!(slash_double_sign(2, &evidence, &pk_bytes).is_none());
     }
 
     // ========== Task 0515: False evidence rejected ==========
@@ -339,7 +393,7 @@ mod tests {
         let addr = derive_eoa_address(&pk_bytes);
 
         let hash = make_header(100, 1_000_000).hash();
-        let sig = sign_proposer(&sk, 100, &hash);
+        let sig = sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash);
 
         let evidence = DoubleSignEvidence {
             slot: 100,
@@ -351,8 +405,8 @@ mod tests {
             submitter: derive_eoa_address(b"submitter"),
         };
 
-        assert!(!verify_double_sign(&evidence, &pk_bytes));
-        assert!(slash_double_sign(&evidence, &pk_bytes).is_none());
+        assert!(!verify_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes));
+        assert!(slash_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes).is_none());
     }
 
     #[test]
@@ -367,21 +421,21 @@ mod tests {
         let evidence = DoubleSignEvidence {
             slot: 100,
             block_hash_1: hash_1,
-            signature_1: sign_proposer(&sk1, 100, &hash_1),
+            signature_1: sign_proposer(&sk1, TEST_CHAIN_ID, 100, &hash_1),
             block_hash_2: hash_2,
-            signature_2: sign_proposer(&sk1, 100, &hash_2),
+            signature_2: sign_proposer(&sk1, TEST_CHAIN_ID, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
 
         // Wrong key → reject
-        assert!(!verify_double_sign(&evidence, pk2.as_bytes()));
+        assert!(!verify_double_sign(TEST_CHAIN_ID, &evidence, pk2.as_bytes()));
     }
 
     #[test]
     fn wrong_slot_rejected() {
-        // Signatures are bound to (slot || hash). If the signer attested
-        // to slot 101 but the evidence claims slot 100, the FALCON
+        // Signatures are bound to (chain_id || slot || hash). If the signer
+        // attested to slot 101 but the evidence claims slot 100, the FALCON
         // verify at slot 100 fails — no cross-slot replay possible.
         let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
@@ -394,14 +448,14 @@ mod tests {
             slot: 100,
             block_hash_1: hash_1,
             // Signed at the wrong slot (101) — verify at slot 100 rejects.
-            signature_1: sign_proposer(&sk, 101, &hash_1),
+            signature_1: sign_proposer(&sk, TEST_CHAIN_ID, 101, &hash_1),
             block_hash_2: hash_2,
-            signature_2: sign_proposer(&sk, 100, &hash_2),
+            signature_2: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"submitter"),
         };
 
-        assert!(!verify_double_sign(&evidence, &pk_bytes));
+        assert!(!verify_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes));
     }
 
     // ========== Task 0513: Liveness slashes proportionally ==========
@@ -477,14 +531,14 @@ mod tests {
         let evidence = DoubleSignEvidence {
             slot: 100,
             block_hash_1: hash_1,
-            signature_1: sign_proposer(&sk, 100, &hash_1),
+            signature_1: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_1),
             block_hash_2: hash_2,
-            signature_2: sign_proposer(&sk, 100, &hash_2),
+            signature_2: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"finder"),
         };
 
-        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        let result = slash_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes).unwrap();
         assert_eq!(result.finder_fee, VALIDATOR_STAKE * 10 / 100);
         assert_eq!(result.amount_burned, VALIDATOR_STAKE * 90 / 100);
     }
@@ -508,14 +562,14 @@ mod tests {
         let evidence = DoubleSignEvidence {
             slot: 100,
             block_hash_1: hash_1,
-            signature_1: sign_proposer(&sk, 100, &hash_1),
+            signature_1: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_1),
             block_hash_2: hash_2,
-            signature_2: sign_proposer(&sk, 100, &hash_2),
+            signature_2: sign_proposer(&sk, TEST_CHAIN_ID, 100, &hash_2),
             signer: addr,
             submitter: derive_eoa_address(b"finder"),
         };
 
-        let result = slash_double_sign(&evidence, &pk_bytes).unwrap();
+        let result = slash_double_sign(TEST_CHAIN_ID, &evidence, &pk_bytes).unwrap();
         assert!(apply_slash(&mut set, &result, 500));
 
         // Stake reduced to 0 (100% slashed)

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -119,22 +119,30 @@ impl TimeoutTracker {
 }
 
 /// Build the message that validators sign for view change.
-fn view_change_sign_message(slot: u64) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(19); // "view_change"(11) + slot(8)
+///
+/// Preimage: `b"view_change" || chain_id_le || slot_le`. The `chain_id`
+/// prefix prevents cross-chain replay: a timeout signed on chain A
+/// cannot be reused as a view-change vote on chain B even if both
+/// chains share the same FALCON keys (e.g., devnet vs testnet during
+/// operator dev cycles).
+fn view_change_sign_message(chain_id: u64, slot: u64) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(27); // "view_change"(11) + chain_id(8) + slot(8)
     msg.extend_from_slice(b"view_change");
+    msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
     msg
 }
 
 /// Create a view change message when timeout is detected.
 pub fn create_view_change(
+    chain_id: u64,
     slot: u64,
     highest_qc: &QuorumCert,
     voter_index: u8,
     voter_address: Address,
     voter_sk: &FalconSecretKey,
 ) -> Result<ViewChangeMessage, &'static str> {
-    let msg = view_change_sign_message(slot);
+    let msg = view_change_sign_message(chain_id, slot);
     let sig = falcon_sign(voter_sk, &msg).map_err(|_| "view change signing failed")?;
 
     Ok(ViewChangeMessage {
@@ -146,13 +154,17 @@ pub fn create_view_change(
     })
 }
 
-/// Verify a view change message.
-pub fn verify_view_change(msg: &ViewChangeMessage, public_key: &[u8]) -> bool {
+/// Verify a view change message against the local chain's `chain_id`.
+///
+/// A timeout signed on a different chain (different `chain_id`) will
+/// fail verification here even when FALCON keys match — preventing
+/// cross-chain replay.
+pub fn verify_view_change(chain_id: u64, msg: &ViewChangeMessage, public_key: &[u8]) -> bool {
     let pk = match FalconPublicKey::from_bytes(public_key) {
         Some(pk) => pk,
         None => return false,
     };
-    let sign_msg = view_change_sign_message(msg.slot);
+    let sign_msg = view_change_sign_message(chain_id, msg.slot);
     let sig = match FalconSignature::from_bytes(&msg.signature) {
         Some(s) => s,
         None => return false,
@@ -163,6 +175,7 @@ pub fn verify_view_change(msg: &ViewChangeMessage, public_key: &[u8]) -> bool {
 /// Try to form a ViewChangeQC from collected messages.
 /// Returns Some(ViewChangeQC) if 86+ valid messages for the same slot.
 pub fn try_form_view_change_qc(
+    chain_id: u64,
     slot: u64,
     messages: &[ViewChangeMessage],
     committee_keys: &[Vec<u8>],
@@ -186,7 +199,7 @@ pub fn try_form_view_change_qc(
             continue;
         }
 
-        if verify_view_change(msg, &committee_keys[idx]) {
+        if verify_view_change(chain_id, msg, &committee_keys[idx]) {
             voter_bitmap |= 1u128 << idx;
             valid_count += 1;
 
@@ -355,6 +368,11 @@ mod tests {
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::falcon_keygen;
 
+    /// Arbitrary non-mainnet, non-devnet chain_id used by every test
+    /// in this module so cross-chain replay regressions surface here
+    /// rather than slipping past with hardcoded chain_id=0.
+    const TEST_CHAIN_ID: u64 = 7;
+
     // ========== Task 0493: Leader timeout → view change → new leader ==========
 
     #[test]
@@ -364,9 +382,9 @@ mod tests {
         let addr = derive_eoa_address(&pk_bytes);
         let qc = QuorumCert::empty();
 
-        let msg = create_view_change(5, &qc, 0, addr, &sk).unwrap();
+        let msg = create_view_change(TEST_CHAIN_ID, 5, &qc, 0, addr, &sk).unwrap();
         assert_eq!(msg.slot, 5);
-        assert!(verify_view_change(&msg, &pk_bytes));
+        assert!(verify_view_change(TEST_CHAIN_ID, &msg, &pk_bytes));
     }
 
     #[test]
@@ -376,8 +394,25 @@ mod tests {
         let addr = derive_eoa_address(pk1.as_bytes());
         let qc = QuorumCert::empty();
 
-        let msg = create_view_change(5, &qc, 0, addr, &sk1).unwrap();
-        assert!(!verify_view_change(&msg, pk2.as_bytes()));
+        let msg = create_view_change(TEST_CHAIN_ID, 5, &qc, 0, addr, &sk1).unwrap();
+        assert!(!verify_view_change(TEST_CHAIN_ID, &msg, pk2.as_bytes()));
+    }
+
+    /// Cross-chain replay: a view-change vote signed under one
+    /// `chain_id` must NOT verify under another even when FALCON keys
+    /// match. Mirrors audit-240's multisig regression.
+    #[test]
+    fn view_change_cross_chain_replay_rejected() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+        let qc = QuorumCert::empty();
+
+        let msg = create_view_change(1, 5, &qc, 0, addr, &sk).unwrap();
+        // Same key, same slot, different chain_id ⇒ verification fails.
+        assert!(verify_view_change(1, &msg, &pk_bytes));
+        assert!(!verify_view_change(2, &msg, &pk_bytes));
+        assert!(!verify_view_change(31337, &msg, &pk_bytes));
     }
 
     #[test]
@@ -391,7 +426,7 @@ mod tests {
             let addr = derive_eoa_address(&pk_bytes);
             let qc = QuorumCert::empty();
 
-            let msg = create_view_change(10, &qc, i, addr, &sk).unwrap();
+            let msg = create_view_change(TEST_CHAIN_ID, 10, &qc, i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -400,7 +435,7 @@ mod tests {
             keys.push(vec![0; 897]);
         }
 
-        let vc_qc = try_form_view_change_qc(10, &messages, &keys);
+        let vc_qc = try_form_view_change_qc(TEST_CHAIN_ID, 10, &messages, &keys);
         assert!(vc_qc.is_some());
         assert!(vc_qc.unwrap().has_quorum());
     }
@@ -415,7 +450,8 @@ mod tests {
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let msg = create_view_change(10, &QuorumCert::empty(), i, addr, &sk).unwrap();
+            let msg =
+                create_view_change(TEST_CHAIN_ID, 10, &QuorumCert::empty(), i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -424,7 +460,7 @@ mod tests {
             keys.push(vec![0; 897]);
         }
 
-        let vc_qc = try_form_view_change_qc(10, &messages, &keys);
+        let vc_qc = try_form_view_change_qc(TEST_CHAIN_ID, 10, &messages, &keys);
         assert!(vc_qc.is_none());
     }
 
@@ -443,7 +479,8 @@ mod tests {
             let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
-            let msg = create_view_change(7, &QuorumCert::empty(), i, addr, &sk).unwrap();
+            let msg =
+                create_view_change(TEST_CHAIN_ID, 7, &QuorumCert::empty(), i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -452,7 +489,7 @@ mod tests {
         keys.push(pk4.as_bytes().to_vec());
 
         // 3 valid view-change messages, committee_size=4, threshold=3 → QC.
-        let vc_qc = try_form_view_change_qc(7, &messages, &keys);
+        let vc_qc = try_form_view_change_qc(TEST_CHAIN_ID, 7, &messages, &keys);
         assert!(
             vc_qc.is_some(),
             "3 valid view-change messages on a 4-validator committee should form a QC (threshold 3)"
@@ -471,7 +508,8 @@ mod tests {
             let (pk, sk) = falcon_keygen().unwrap();
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
-            let msg = create_view_change(7, &QuorumCert::empty(), i, addr, &sk).unwrap();
+            let msg =
+                create_view_change(TEST_CHAIN_ID, 7, &QuorumCert::empty(), i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -479,7 +517,7 @@ mod tests {
             let (pk, _) = falcon_keygen().unwrap();
             keys.push(pk.as_bytes().to_vec());
         }
-        let vc_qc = try_form_view_change_qc(7, &messages, &keys);
+        let vc_qc = try_form_view_change_qc(TEST_CHAIN_ID, 7, &messages, &keys);
         assert!(
             vc_qc.is_none(),
             "2 view-change messages on a 4-validator committee must NOT form a QC (threshold 3)"
@@ -594,7 +632,7 @@ mod tests {
                 signatures: vec![],
             };
 
-            let msg = create_view_change(100, &qc, i, addr, &sk).unwrap();
+            let msg = create_view_change(TEST_CHAIN_ID, 100, &qc, i, addr, &sk).unwrap();
             messages.push(msg);
             keys.push(pk_bytes);
         }
@@ -603,7 +641,7 @@ mod tests {
             keys.push(vec![0; 897]);
         }
 
-        let vc_qc = try_form_view_change_qc(100, &messages, &keys).unwrap();
+        let vc_qc = try_form_view_change_qc(TEST_CHAIN_ID, 100, &messages, &keys).unwrap();
         // Should pick the highest QC (slot 85)
         assert_eq!(vc_qc.highest_qc.slot, 85);
     }

--- a/crates/consensus/tests/prop_hotstuff_safety.rs
+++ b/crates/consensus/tests/prop_hotstuff_safety.rs
@@ -25,6 +25,11 @@ use pyde_consensus::hotstuff::{
 use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey};
 use std::sync::OnceLock;
 
+/// Arbitrary non-mainnet, non-devnet chain_id used by every property
+/// case so cross-chain replay regressions surface here rather than
+/// slipping past with hardcoded chain_id=0.
+const TEST_CHAIN_ID: u64 = 7;
+
 fn keys() -> &'static Vec<(FalconPublicKey, FalconSecretKey, Vec<u8>)> {
     static KEYS: OnceLock<Vec<(FalconPublicKey, FalconSecretKey, Vec<u8>)>> = OnceLock::new();
     KEYS.get_or_init(|| {
@@ -62,7 +67,7 @@ fn build_votes_for(slot: u64, block_hash: [u8; 32], voter_indices: &[u8]) -> Vec
         .map(|&i| {
             let (_, sk, pk) = &keys()[i as usize];
             let addr = derive_eoa_address(pk);
-            let msg = proposer_sign_message(slot, &block_hash);
+            let msg = proposer_sign_message(TEST_CHAIN_ID, slot, &block_hash);
             let sig = falcon_sign(sk, &msg).unwrap();
             ConsensusMessage::Vote {
                 slot,
@@ -93,7 +98,7 @@ proptest! {
         let mut last_voted = 0u64;
         for s in slots {
             let header = make_header(s, QuorumCert::empty(), 0);
-            let vote = create_vote(&mut state, &header, 0, addr, sk).unwrap();
+            let vote = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, sk).unwrap();
             if s > last_voted {
                 prop_assert!(vote.is_some(), "should vote for new slot {}", s);
                 prop_assert_eq!(state.last_voted_slot, s);
@@ -143,8 +148,8 @@ proptest! {
         let votes_b = build_votes_for(7, block_b, &byzantine);
 
         let keys_v = committee_keys();
-        let qc_a = try_form_qc(7, block_a, &votes_a, &keys_v);
-        let qc_b = try_form_qc(7, block_b, &votes_b, &keys_v);
+        let qc_a = try_form_qc(TEST_CHAIN_ID, 7, block_a, &votes_a, &keys_v);
+        let qc_b = try_form_qc(TEST_CHAIN_ID, 7, block_b, &votes_b, &keys_v);
 
         prop_assert!(qc_a.is_some(), "block_a should reach quorum (H={} + B={})", h, byzantine_count);
         prop_assert!(
@@ -182,7 +187,7 @@ proptest! {
                 signatures: vec![],
             };
             let header = make_header(slot, qc, slot as u8);
-            let _ = create_vote(&mut state, &header, 0, addr, sk).unwrap();
+            let _ = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, sk).unwrap();
 
             prop_assert!(
                 state.highest_qc.slot >= prev_highest,
@@ -210,7 +215,7 @@ proptest! {
         let votes = build_votes_for(11, block_hash, &voters);
         let keys_v = committee_keys();
         let threshold = quorum_for_committee(COMMITTEE_SIZE);
-        let qc = try_form_qc(11, block_hash, &votes, &keys_v);
+        let qc = try_form_qc(TEST_CHAIN_ID, 11, block_hash, &votes, &keys_v);
         if voter_count >= threshold {
             prop_assert!(
                 qc.is_some(),

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -648,7 +648,12 @@ impl BlockProcessor {
 
     /// Extended validation for blocks received from the network.
     /// Checks: proposer signature, proposer in committee, VRF proof, QC quorum.
+    ///
+    /// `chain_id` is bound into the proposer-signature preimage so a
+    /// header signed for a different chain is rejected even when the
+    /// FALCON keys match.
     pub fn validate_network_block(
+        chain_id: u64,
         header: &BlockHeader,
         proposer_signature: &[u8],
         committee_keys: &[Vec<u8>],
@@ -683,9 +688,10 @@ impl BlockProcessor {
         let block_hash = header.hash();
         let sig = pyde_crypto::falcon::FalconSignature::from_bytes(proposer_signature)
             .ok_or("invalid proposer signature format")?;
-        // Proposers sign `slot || block_hash` (canonical layout shared
-        // with votes) to prevent cross-slot signature replay.
-        let sign_msg = proposer_sign_message(slot, &block_hash);
+        // Proposers sign `chain_id || slot || block_hash` (canonical
+        // layout shared with votes) to prevent cross-slot AND
+        // cross-chain signature replay.
+        let sign_msg = proposer_sign_message(chain_id, slot, &block_hash);
         if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
             return Err("proposer signature verification failed".into());
         }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -436,7 +436,7 @@ impl PydeNode {
                 }
             }
 
-            let mut engine = ValidatorEngine::new([0xAA; 32]); // devnet epoch randomness
+            let mut engine = ValidatorEngine::new(self.config.node.chain_id, [0xAA; 32]); // devnet epoch randomness
 
             // Attach persistent ConsensusState store. If a prior state exists,
             // it is loaded here — this is what prevents last_voted_slot or
@@ -3929,6 +3929,7 @@ fn handle_swarm_event(
                             // Validate block header (signature, VRF, proposer, QC)
                             if let Some(ref engine) = validator_engine {
                                 if let Err(e) = BlockProcessor::validate_network_block(
+                                    chain.chain_id,
                                     &block.header,
                                     &block.proposer_signature,
                                     &engine.committee_keys,

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -212,6 +212,12 @@ struct BufferedProposal {
 /// Manages the HotStuff protocol state, VRF proposer selection,
 /// voting, QC formation, and finality tracking.
 pub struct ValidatorEngine {
+    /// Local chain id. Bound into every consensus signing preimage
+    /// (proposer headers, votes, view-change votes, slashing evidence)
+    /// so a signature created on one chain cannot be replayed on
+    /// another even when FALCON keys match. See
+    /// `pyde_consensus::hotstuff::proposer_sign_message`.
+    pub chain_id: u64,
     /// HotStuff consensus state (current slot, highest QC, etc.).
     pub consensus: ConsensusState,
     /// Finality tracker (soft/hard finality, checkpoints).
@@ -333,8 +339,11 @@ pub struct ValidatorEngine {
 }
 
 impl ValidatorEngine {
-    /// Create a new validator engine at genesis.
-    pub fn new(epoch_randomness: [u8; 32]) -> Self {
+    /// Create a new validator engine at genesis bound to a specific
+    /// `chain_id`. The `chain_id` is bound into every consensus signing
+    /// preimage so signatures cannot be replayed across chains even
+    /// when FALCON keys match.
+    pub fn new(chain_id: u64, epoch_randomness: [u8; 32]) -> Self {
         let now_ms = current_time_ms();
         let consensus = ConsensusState::new();
         // audit-234 part 4: TimeoutTracker is keyed on `target_height`,
@@ -342,6 +351,7 @@ impl ValidatorEngine {
         // target_height to 1 (the first slot we want to commit).
         let initial_target = consensus.target_height;
         Self {
+            chain_id,
             consensus,
             finality: FinalityTracker::new(),
             timeout: TimeoutTracker::new(initial_target, now_ms),
@@ -1206,7 +1216,7 @@ impl ValidatorEngine {
                     return false;
                 }
             };
-            let sign_msg = proposer_sign_message(slot, &block_hash);
+            let sign_msg = proposer_sign_message(self.chain_id, slot, &block_hash);
             if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
                 warn!(slot, "proposer signature verification failed");
                 return false;
@@ -1499,7 +1509,7 @@ impl ValidatorEngine {
             }
         };
         let block_hash = header.hash();
-        let sign_msg = proposer_sign_message(slot, &block_hash);
+        let sign_msg = proposer_sign_message(self.chain_id, slot, &block_hash);
         if !pyde_crypto::falcon::falcon_verify(&pk, &sign_msg, &sig) {
             warn!(slot, "fallback proposer signature verification failed");
             return false;
@@ -1608,7 +1618,7 @@ impl ValidatorEngine {
         };
 
         let block_hash = header.hash();
-        let sign_msg = proposer_sign_message(slot, &block_hash);
+        let sign_msg = proposer_sign_message(self.chain_id, slot, &block_hash);
         let proposer_signature = match pyde_crypto::falcon::falcon_sign(&identity.secret_key, &sign_msg) {
             Ok(sig) => sig.to_vec(),
             Err(_) => {
@@ -1660,10 +1670,11 @@ impl ValidatorEngine {
             timestamp: current_time_ms(),
         };
 
-        // Sign the canonical (slot || block_hash) message with the
-        // proposer's FALCON key. See proposer_sign_message for the format.
+        // Sign the canonical (chain_id || slot || block_hash) message
+        // with the proposer's FALCON key. See proposer_sign_message
+        // for the format.
         let block_hash = header.hash();
-        let sign_msg = proposer_sign_message(header.slot, &block_hash);
+        let sign_msg = proposer_sign_message(self.chain_id, header.slot, &block_hash);
         let proposer_signature =
             match pyde_crypto::falcon::falcon_sign(&identity.secret_key, &sign_msg) {
                 Ok(sig) => sig.to_vec(),
@@ -1700,6 +1711,7 @@ impl ValidatorEngine {
 
         // Create vote (HotStuff safety rules enforced inside create_vote)
         match create_vote(
+            self.chain_id,
             &mut self.consensus,
             header,
             identity.committee_index,
@@ -1751,7 +1763,7 @@ impl ValidatorEngine {
 
         // Verify vote signature
         if voter_index < self.committee_keys.len()
-            && !verify_vote(&vote, &self.committee_keys[voter_index])
+            && !verify_vote(self.chain_id, &vote, &self.committee_keys[voter_index])
         {
             warn!(slot, voter_index, "invalid vote signature");
             return None;
@@ -1824,7 +1836,7 @@ impl ValidatorEngine {
         // Try to form QC (dynamic quorum based on actual committee size)
         let threshold = quorum_for_committee(self.committee_keys.len());
         if entry.votes.len() >= threshold {
-            let qc = try_form_qc(slot, block_hash, &entry.votes, &self.committee_keys);
+            let qc = try_form_qc(self.chain_id, slot, block_hash, &entry.votes, &self.committee_keys);
             if let Some(ref qc) = qc {
                 info!(slot, votes = qc.vote_count(), "QC formed");
                 // Update consensus state
@@ -1874,6 +1886,7 @@ impl ValidatorEngine {
         // permanently uncommitted.
         let slot = self.consensus.target_height;
         match create_view_change(
+            self.chain_id,
             slot,
             &self.consensus.highest_qc,
             identity.committee_index,
@@ -1929,7 +1942,7 @@ impl ValidatorEngine {
         entry.push(msg);
 
         // Try to form view change QC
-        if let Some(vc_qc) = try_form_view_change_qc(slot, entry, &self.committee_keys) {
+        if let Some(vc_qc) = try_form_view_change_qc(self.chain_id, slot, entry, &self.committee_keys) {
             let first_formation = self.timeout.view_change_qc.is_none();
             if first_formation {
                 self.consensus.bump_view();
@@ -2140,8 +2153,10 @@ impl ValidatorEngine {
 
         // slash_double_sign returns None if the sig/format verification
         // fails. We discard the SlashResult — only verification matters;
-        // the on-chain handler re-computes it from state.
-        if slash_double_sign(&evidence, &pk_bytes).is_none() {
+        // the on-chain handler re-computes it from state. The local
+        // chain's `chain_id` is bound into the verifier's preimage so
+        // evidence forged on a foreign chain is rejected here.
+        if slash_double_sign(self.chain_id, &evidence, &pk_bytes).is_none() {
             debug!(
                 slot = evidence.slot,
                 signer = hex::encode(evidence.signer),
@@ -2428,6 +2443,11 @@ mod tests {
     use pyde_account::address::derive_eoa_address;
     use pyde_crypto::falcon::falcon_keygen;
 
+    /// Arbitrary non-mainnet, non-devnet chain_id used by every test
+    /// in this module so cross-chain replay regressions surface here
+    /// rather than slipping past with hardcoded chain_id=0.
+    const TEST_CHAIN_ID: u64 = 7;
+
     fn make_identity(index: u8) -> ValidatorIdentity {
         let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
@@ -2451,20 +2471,20 @@ mod tests {
             identities.push(id);
         }
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(keys);
         (engine, identities)
     }
 
     #[test]
     fn engine_starts_at_genesis() {
-        let engine = ValidatorEngine::new([0; 32]);
+        let engine = ValidatorEngine::new(TEST_CHAIN_ID, [0; 32]);
         assert_eq!(engine.consensus.current_slot, 0);
     }
 
     #[test]
     fn advance_slot_increments() {
-        let mut engine = ValidatorEngine::new([0; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0; 32]);
         let new_slot = engine.advance_slot();
         assert_eq!(new_slot, 1);
         assert_eq!(engine.consensus.current_slot, 1);
@@ -2722,9 +2742,9 @@ mod tests {
         let new_committee_keys = vec![vec![0xAA; 897]; 6];
 
         // Two new members, independent engines — model separate nodes.
-        let mut engine_a = ValidatorEngine::new([0u8; 32]);
+        let mut engine_a = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine_a.set_committee(new_committee_keys.clone());
-        let mut engine_b = ValidatorEngine::new([0u8; 32]);
+        let mut engine_b = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine_b.set_committee(new_committee_keys.clone());
 
         engine_a.prepare_for_reshare_reception(1, new_committee_keys.clone(), 1);
@@ -2775,7 +2795,7 @@ mod tests {
         // Can't combine with only 2 of 4 required — add more honest shares.
         let mut helpers: Vec<ValidatorEngine> = (3..=6)
             .map(|_| {
-                let mut e = ValidatorEngine::new([0u8; 32]);
+                let mut e = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
                 e.set_committee(new_committee_keys.clone());
                 e
             })
@@ -2805,7 +2825,7 @@ mod tests {
     #[test]
     fn reshare_aggregation_waits_for_trigger() {
         let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         let new_committee = vec![vec![0xAA; 897]; 4];
         engine.prepare_for_reshare_reception(1, new_committee.clone(), 1);
         let mut id = make_identity(0);
@@ -2832,7 +2852,7 @@ mod tests {
         // doesn't fire — and `reshare_aggregated` stays false so a
         // subsequent slot tick with a fuller pool can succeed.
         let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]; 4], 1);
         let mut id = make_identity(0);
 
@@ -2902,7 +2922,7 @@ mod tests {
 
         let trigger_slot;
         {
-            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             engine.set_committee(vec![vec![0x01; 897]; 4]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
@@ -2914,7 +2934,7 @@ mod tests {
 
         // Reopen store, reattach.
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.attach_consensus_store(store);
 
         // Post-restore invariants.
@@ -2939,7 +2959,7 @@ mod tests {
 
         {
             let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-            let mut engine = ValidatorEngine::new([0u8; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
             engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]; 4], 1);
@@ -2954,7 +2974,7 @@ mod tests {
         }
 
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.attach_consensus_store(store);
         assert!(
             engine.reshare_aggregated,
@@ -2969,7 +2989,7 @@ mod tests {
         let (_, old_shares) = threshold_keygen(3, 2).unwrap();
 
         {
-            let mut engine = ValidatorEngine::new([0u8; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
             engine.set_committee(vec![vec![0x01; 897]; 3]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
@@ -2981,7 +3001,7 @@ mod tests {
         }
 
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.attach_consensus_store(store);
         assert!(
             engine.pending_reshare_rebroadcast.is_some(),
@@ -2994,7 +3014,7 @@ mod tests {
         // Departing member (not on new committee): prepare_for_reshare_reception
         // with index 0 → contributions get silently dropped, no share derived.
         let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.prepare_for_reshare_reception(1, vec![vec![0xAA; 897]], /* our_new_index */ 0);
         let mut leaving = identity_with_share(0, old_shares[0].clone());
 
@@ -3008,7 +3028,7 @@ mod tests {
         // Tampered contribution: must fail internal consistency check and
         // NOT be counted toward threshold.
         let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         let new_committee = vec![vec![0xAA; 897]; 4];
         engine.prepare_for_reshare_reception(1, new_committee, 1);
         let mut new_id = make_identity(0);
@@ -3031,7 +3051,7 @@ mod tests {
         // double-count duplicates; subsequent calls with the same
         // `from_old_index` return false.
         let (_, old_shares) = threshold_keygen(4, 3).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         let new_committee = vec![vec![0xAA; 897]; 4];
         engine.prepare_for_reshare_reception(1, new_committee, 1);
         let mut new_id = make_identity(0);
@@ -3049,7 +3069,7 @@ mod tests {
         // Outgoing member stashes a contribution and re-broadcasts every
         // RESHARE_REBROADCAST_INTERVAL_SLOTS slots for RESHARE_REBROADCAST_SLOTS.
         let (_, old_shares) = threshold_keygen(3, 2).unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.set_committee(vec![vec![0xAA; 897]; 3]);
         let mut id = identity_with_share(0, old_shares[0].clone());
 
@@ -3092,7 +3112,7 @@ mod tests {
     #[test]
     fn reshare_rebroadcast_none_without_prior_start() {
         // maybe_rebroadcast with no stashed contribution → always None.
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         assert!(engine.maybe_rebroadcast_reshare().is_none());
         for _ in 0..20 {
             engine.advance_slot();
@@ -3104,7 +3124,7 @@ mod tests {
 
     #[test]
     fn install_bootstrap_ws_anchor_sets_checkpoint_slot() {
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         assert!(engine.finality.latest_checkpoint.is_none());
 
         engine.install_bootstrap_ws_anchor(500);
@@ -3118,11 +3138,11 @@ mod tests {
         let dir = tempdir().unwrap();
 
         {
-            let mut engine = ValidatorEngine::new([0u8; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
             engine.attach_consensus_store(Arc::new(ConsensusStateStore::open(dir.path()).unwrap()));
             engine.install_bootstrap_ws_anchor(777);
         }
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.attach_consensus_store(Arc::new(ConsensusStateStore::open(dir.path()).unwrap()));
         let cp = engine.finality.latest_checkpoint.as_ref().unwrap();
         assert_eq!(cp.slot, 777);
@@ -3134,7 +3154,7 @@ mod tests {
         // than the current anchor could be a replay of an old message,
         // or a malicious peer trying to rewind the WS guard.
         use pyde_consensus::finality::{FinalityCheckpoint, HardFinalityCert};
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.install_bootstrap_ws_anchor(100);
 
         let stale = FinalityCheckpoint {
@@ -3161,7 +3181,7 @@ mod tests {
         // A validator cross-verifies sigs against their own committee.
         // A cert with fewer sigs than quorum must be rejected.
         use pyde_consensus::finality::{FinalityCheckpoint, HardFinalityCert};
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.set_committee(vec![vec![0xAA; 897]; 4]); // 4-member committee → quorum 3
         engine.install_bootstrap_ws_anchor(10);
 
@@ -3186,7 +3206,7 @@ mod tests {
         use tempfile::tempdir;
 
         let dir = tempdir().unwrap();
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         engine.set_committee(vec![vec![0xAA; 897]; 4]);
         engine.attach_consensus_store(Arc::new(ConsensusStateStore::open(dir.path()).unwrap()));
 
@@ -3210,7 +3230,7 @@ mod tests {
 
         // Survives restart.
         drop(engine);
-        let mut fresh = ValidatorEngine::new([0u8; 32]);
+        let mut fresh = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         fresh.attach_consensus_store(Arc::new(ConsensusStateStore::open(dir.path()).unwrap()));
         assert_eq!(fresh.finality.latest_checkpoint.as_ref().unwrap().slot, 500);
     }
@@ -3221,7 +3241,7 @@ mod tests {
         // Caller (non-validator full node) trusts the consensus-topic
         // filter (slice 3.4) to gate publication.
         use pyde_consensus::finality::{FinalityCheckpoint, HardFinalityCert};
-        let mut engine = ValidatorEngine::new([0u8; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
         // Do NOT set_committee → empty → non-validator mode.
         assert!(engine.committee_keys.is_empty());
 
@@ -3288,7 +3308,7 @@ mod tests {
         }
 
         // --- Post-crash: reopen and attempt to vote for slot 1 again ---
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(committee_keys);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
@@ -3331,7 +3351,7 @@ mod tests {
 
         // Pre-crash: form a QC at slot 5, which becomes highest_qc.
         {
-            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
 
@@ -3348,7 +3368,7 @@ mod tests {
         }
 
         // Post-crash: reopen.
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
 
@@ -3362,7 +3382,7 @@ mod tests {
         use tempfile::tempdir;
 
         let dir = tempdir().unwrap();
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
 
@@ -3378,7 +3398,7 @@ mod tests {
         let dir = tempdir().unwrap();
 
         {
-            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
             for _ in 0..7 {
@@ -3387,7 +3407,7 @@ mod tests {
             assert_eq!(engine.consensus.current_slot, 7);
         }
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
         assert_eq!(engine.consensus.current_slot, 7);
@@ -3427,7 +3447,7 @@ mod tests {
         }
 
         // Fresh engine attaches the same store and must restore the index.
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
 
@@ -3453,7 +3473,7 @@ mod tests {
             store.save_seen_vote(12, 4, &block_hash, &sig).unwrap();
         }
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
 
@@ -3490,7 +3510,7 @@ mod tests {
         }
 
         // Attach, jump forward to slot 15, advancing triggers prune.
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(Arc::clone(&store));
         // Sanity: reload pulled them all in.
@@ -3528,7 +3548,7 @@ mod tests {
 
     #[test]
     fn drain_pending_evidence_empties_queue() {
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine
             .pending_evidence
             .push(evidence_fixture(1, [0xAB; 32]));
@@ -3550,7 +3570,7 @@ mod tests {
     fn push_evidence_restores_queue() {
         // Simulates the failed-block-build recovery path: drain, fail to
         // build, push back, drain again.
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine
             .pending_evidence
             .push(evidence_fixture(7, [0x99; 32]));
@@ -3566,7 +3586,7 @@ mod tests {
 
     #[test]
     fn push_evidence_appends_preserving_order() {
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine
             .pending_evidence
             .push(evidence_fixture(1, [0x01; 32]));
@@ -3597,24 +3617,19 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(vec![pk_bytes]);
 
         let slot = 42u64;
         let hash_1 = [0x01u8; 32];
         let hash_2 = [0x02u8; 32];
-        let sign_1 = {
-            let mut m = Vec::with_capacity(40);
-            m.extend_from_slice(&slot.to_le_bytes());
-            m.extend_from_slice(&hash_1);
-            m
-        };
-        let sign_2 = {
-            let mut m = Vec::with_capacity(40);
-            m.extend_from_slice(&slot.to_le_bytes());
-            m.extend_from_slice(&hash_2);
-            m
-        };
+        // Build the canonical (chain_id || slot || block_hash) preimage —
+        // must match what `verify_double_sign` reconstructs for the
+        // engine's chain_id, otherwise FALCON verify rejects.
+        let sign_1 =
+            pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_1);
+        let sign_2 =
+            pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_2);
         let sig_1 = pyde_crypto::falcon::falcon_sign(&sk, &sign_1)
             .unwrap()
             .as_bytes()
@@ -3724,7 +3739,8 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        const TEST_CHAIN_ID: u64 = 7;
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(vec![pk_bytes]);
 
         let slot = 7u64;
@@ -3732,7 +3748,7 @@ mod tests {
         let hash_b = [0x02u8; 32];
 
         let sign_vote = |h: &[u8; 32]| -> Vec<u8> {
-            falcon_sign(&sk, &proposer_sign_message(slot, h))
+            falcon_sign(&sk, &proposer_sign_message(TEST_CHAIN_ID, slot, h))
                 .unwrap()
                 .as_bytes()
                 .to_vec()
@@ -3793,7 +3809,7 @@ mod tests {
             committee_pk = pk.as_bytes().to_vec();
             signer_addr = pyde_account::address::derive_eoa_address(&committee_pk);
 
-            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             engine.set_committee(vec![committee_pk.clone()]);
             let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
             engine.attach_consensus_store(store);
@@ -3801,18 +3817,13 @@ mod tests {
             let slot = 50u64;
             let hash_1 = [0x01u8; 32];
             let hash_2 = [0x02u8; 32];
-            let sign_1 = {
-                let mut m = Vec::with_capacity(40);
-                m.extend_from_slice(&slot.to_le_bytes());
-                m.extend_from_slice(&hash_1);
-                m
-            };
-            let sign_2 = {
-                let mut m = Vec::with_capacity(40);
-                m.extend_from_slice(&slot.to_le_bytes());
-                m.extend_from_slice(&hash_2);
-                m
-            };
+            // Bind chain_id into the preimage so the engine's
+            // `ingest_evidence` (which rebuilds with self.chain_id =
+            // TEST_CHAIN_ID) actually verifies the sigs.
+            let sign_1 =
+                pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_1);
+            let sign_2 =
+                pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_2);
             let sig_1 = pyde_crypto::falcon::falcon_sign(&sk, &sign_1)
                 .unwrap()
                 .as_bytes()
@@ -3838,7 +3849,7 @@ mod tests {
         }
 
         // --- Run 2: reopen, attach, evidence must still be there ---
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(vec![committee_pk.clone()]);
         let store = Arc::new(ConsensusStateStore::open(dir.path()).unwrap());
         engine.attach_consensus_store(store);
@@ -3878,7 +3889,7 @@ mod tests {
             key_share: None,
         };
 
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine
             .pending_evidence
             .push(evidence_fixture(42, [0xFF; 32]));
@@ -3955,22 +3966,17 @@ mod tests {
         .unwrap();
 
         // Craft two real FALCON-signed attestations for the same slot —
-        // exactly what an equivocating proposer would produce.
+        // exactly what an equivocating proposer would produce. Use the
+        // chain_id we'll execute against (set on `ctx` below) so the
+        // pipeline's verifier rebuild matches.
+        let chain_id = 1u64;
         let slot = 100u64;
         let hash_1 = [0xA1u8; 32];
         let hash_2 = [0xA2u8; 32];
-        let sign_msg_1 = {
-            let mut m = Vec::with_capacity(40);
-            m.extend_from_slice(&slot.to_le_bytes());
-            m.extend_from_slice(&hash_1);
-            m
-        };
-        let sign_msg_2 = {
-            let mut m = Vec::with_capacity(40);
-            m.extend_from_slice(&slot.to_le_bytes());
-            m.extend_from_slice(&hash_2);
-            m
-        };
+        let sign_msg_1 =
+            pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_1);
+        let sign_msg_2 =
+            pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_2);
         let sig_1 = falcon_sign(&offender_sk, &sign_msg_1)
             .unwrap()
             .as_bytes()
@@ -3988,7 +3994,9 @@ mod tests {
             committee_index: 0,
             key_share: None,
         };
-        let mut engine = ValidatorEngine::new([0xAA; 32]);
+        // Engine is bound to the same chain_id as the block context so
+        // its `ingest_evidence` (when used) and on-chain handler agree.
+        let mut engine = ValidatorEngine::new(chain_id, [0xAA; 32]);
         engine.pending_evidence.push(DoubleSignEvidence {
             slot,
             block_hash_1: hash_1,
@@ -4001,7 +4009,7 @@ mod tests {
 
         // Drain into Slash txs.
         let mut slash_txs = Vec::new();
-        engine.drain_evidence_into_slash_txs(&identity, 0, 1, &mut slash_txs);
+        engine.drain_evidence_into_slash_txs(&identity, 0, chain_id, &mut slash_txs);
         assert_eq!(slash_txs.len(), 1);
 
         // Execute on the SMT.
@@ -4010,7 +4018,7 @@ mod tests {
             timestamp: 1_000_000,
             base_fee: 1_000,
             block_gas_limit: 400_000_000,
-            chain_id: 1,
+            chain_id,
             validator_address: [0xEE; 32],
             dev_skip_signature: false,
             block_sigs_pre_verified: false,
@@ -4072,7 +4080,7 @@ mod tests {
         // Each validator creates their vote using their own engine
         let mut votes = Vec::new();
         for id in &identities {
-            let mut voter_engine = ValidatorEngine::new([0xAA; 32]);
+            let mut voter_engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             voter_engine.set_committee(committee_keys.clone());
             voter_engine.advance_slot();
             if let Some(vote) = voter_engine.on_proposal(&header, id) {
@@ -4082,7 +4090,7 @@ mod tests {
         assert_eq!(votes.len(), 3);
 
         // Collect votes in a single engine (simulates the proposer node)
-        let mut collector = ValidatorEngine::new([0xAA; 32]);
+        let mut collector = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         collector.set_committee(committee_keys);
         collector.advance_slot();
 
@@ -4124,7 +4132,7 @@ mod tests {
         // Each validator votes using their own engine
         let mut votes = Vec::new();
         for id in &identities {
-            let mut voter_engine = ValidatorEngine::new([0xAA; 32]);
+            let mut voter_engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             voter_engine.set_committee(committee_keys.clone());
             voter_engine.advance_slot();
             if let Some(vote) = voter_engine.on_proposal(&header, id) {
@@ -4134,7 +4142,7 @@ mod tests {
         assert_eq!(votes.len(), 2);
 
         // Collector engine
-        let mut collector = ValidatorEngine::new([0xAA; 32]);
+        let mut collector = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         collector.set_committee(committee_keys);
         collector.advance_slot();
 
@@ -4152,7 +4160,7 @@ mod tests {
 
     #[test]
     fn old_votes_pruned() {
-        let mut engine = ValidatorEngine::new([0; 32]);
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0; 32]);
         engine.votes.insert(
             1,
             SlotVotes {
@@ -5024,9 +5032,10 @@ mod tests {
             keys.push(id.public_key.as_bytes().to_vec());
             identities.push(id);
         }
+        const TEST_CHAIN_ID: u64 = 7;
         let mut engines = Vec::new();
         for _ in 0..n {
-            let mut engine = ValidatorEngine::new([0xAA; 32]);
+            let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
             engine.set_committee(keys.clone());
             engine.advance_slot(); // → slot 1
             engines.push(engine);
@@ -5038,6 +5047,7 @@ mod tests {
             .iter()
             .map(|id| {
                 pyde_consensus::view_change::create_view_change(
+                    TEST_CHAIN_ID,
                     target_slot,
                     &pyde_consensus::block::QuorumCert::empty(),
                     id.committee_index,

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -1156,10 +1156,13 @@ pub(crate) const EVIDENCE_VERSION: u8 = 1;
 ///   [u8; 32] signer
 ///   [u8; 32] submitter
 ///
-/// Carrying just the hashes (not full `BlockHeader`s) is enough because
-/// each signature is verified over `proposer_sign_message(slot, hash)`
-/// — the slot binding lives inside the signed message, not the wire
-/// format, so a third-party verifier needs nothing besides the hashes.
+/// Carrying just the hashes (not full `BlockHeader`s) is enough
+/// because each signature is verified over
+/// `proposer_sign_message(chain_id, slot, hash)`. The `chain_id` and
+/// `slot` bindings live inside the signed message, not the wire
+/// format, so a third-party verifier needs nothing besides the local
+/// chain's `chain_id`, the hashes, the signatures, and the signer's
+/// pubkey.
 pub fn encode_double_sign_evidence(evidence: &DoubleSignEvidence) -> Vec<u8> {
     let mut enc = Encoder::new();
     enc.u8(EVIDENCE_VERSION);

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -308,14 +308,15 @@ fn run_consensus(
         .iter()
         .map(|v| v.pk.as_bytes().to_vec())
         .collect();
+    const CHAIN_ID: u64 = 31337;
     let mut votes = Vec::new();
     for (i, v) in validators.iter().enumerate() {
-        if let Ok(Some(vote)) = create_vote(&mut states[i], &header, i as u8, v.address, &v.sk) {
-            assert!(verify_vote(&vote, v.pk.as_bytes()));
+        if let Ok(Some(vote)) = create_vote(CHAIN_ID, &mut states[i], &header, i as u8, v.address, &v.sk) {
+            assert!(verify_vote(CHAIN_ID, &vote, v.pk.as_bytes()));
             votes.push(vote);
         }
     }
-    let qc = try_form_qc(slot, block_hash, &votes, &committee_keys).expect("QC must form");
+    let qc = try_form_qc(CHAIN_ID, slot, block_hash, &votes, &committee_keys).expect("QC must form");
     (block_hash, qc)
 }
 

--- a/crates/node/tests/lifecycle_bench.rs
+++ b/crates/node/tests/lifecycle_bench.rs
@@ -509,13 +509,14 @@ fn validator_block_lifecycle() {
     };
     let bh = hdr.hash();
     let mut votes = Vec::new();
+    const CHAIN_ID: u64 = 31337;
     for (i, v) in validators.iter().enumerate() {
-        if let Ok(Some(vote)) = create_vote(&mut cstates[i], &hdr, i as u8, v.address, &v.sk) {
-            assert!(verify_vote(&vote, v.pk.as_bytes()));
+        if let Ok(Some(vote)) = create_vote(CHAIN_ID, &mut cstates[i], &hdr, i as u8, v.address, &v.sk) {
+            assert!(verify_vote(CHAIN_ID, &vote, v.pk.as_bytes()));
             votes.push(vote);
         }
     }
-    let _ = try_form_qc(1, bh, &votes, &ckeys).unwrap();
+    let _ = try_form_qc(CHAIN_ID, 1, bh, &votes, &ckeys).unwrap();
     let consensus_ms = t.elapsed().as_secs_f64() * 1000.0;
 
     // ── RESULTS ──────────────────────────────────────────────

--- a/crates/node/tests/multi_node_double_sign_slash.rs
+++ b/crates/node/tests/multi_node_double_sign_slash.rs
@@ -75,12 +75,16 @@ fn double_sign_debits_stake() {
     // Build forged-but-valid double-sign evidence. Slot is arbitrary;
     // the pipeline doesn't cross-check slot against actual block
     // history, only that the signatures verify over
-    // `proposer_sign_message(slot, hash)`.
+    // `proposer_sign_message(chain_id, slot, hash)`. Sigs MUST be
+    // produced under the local chain's `chain_id` — evidence signed
+    // for a different chain is rejected by the slash handler (the
+    // cross-chain replay defense).
     let slot: u64 = 100;
+    let chain_id = net.chain_id;
     let block_hash_1 = [0x11u8; 32];
     let block_hash_2 = [0x22u8; 32];
-    let msg_1 = proposer_sign_message(slot, &block_hash_1);
-    let msg_2 = proposer_sign_message(slot, &block_hash_2);
+    let msg_1 = proposer_sign_message(chain_id, slot, &block_hash_1);
+    let msg_2 = proposer_sign_message(chain_id, slot, &block_hash_2);
     let sig_1 = falcon_sign(&sk, &msg_1).expect("FALCON sign msg_1");
     let sig_2 = falcon_sign(&sk, &msg_2).expect("FALCON sign msg_2");
 

--- a/crates/node/tests/production_sim.rs
+++ b/crates/node/tests/production_sim.rs
@@ -5,6 +5,11 @@
 use pyde_account::address::derive_eoa_address;
 use pyde_consensus::block::{BlockHeader, QuorumCert};
 use pyde_consensus::hotstuff::{create_vote, try_form_qc, verify_vote, ConsensusState};
+
+/// Devnet chain_id used by every consensus signing call in this
+/// production-simulation test. Must match the `chain_id` field on the
+/// txs and block_ctx the test constructs (which all use 31337).
+const CHAIN_ID: u64 = 31337;
 use pyde_crypto::falcon::{falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey};
 use pyde_crypto::poseidon2::poseidon2_hash;
 use pyde_state::smt::{PersistentSMT, StateAccess, StateOverlay};
@@ -596,6 +601,7 @@ fn production_simulation() {
 
     for i in 0..4 {
         let vote = create_vote(
+            CHAIN_ID,
             &mut consensus_states[i],
             &header,
             i as u8,
@@ -606,7 +612,7 @@ fn production_simulation() {
         if let Some(v) = vote {
             // Verify this vote
             assert!(
-                verify_vote(&v, validators[i].pk.as_bytes()),
+                verify_vote(CHAIN_ID, &v, validators[i].pk.as_bytes()),
                 "vote {} failed verification",
                 i
             );
@@ -616,7 +622,7 @@ fn production_simulation() {
 
     // Form QC
     let block_hash = header.hash();
-    let qc = try_form_qc(1, block_hash, &votes, &committee_keys);
+    let qc = try_form_qc(CHAIN_ID, 1, block_hash, &votes, &committee_keys);
     let consensus_time = t0.elapsed();
     println!(
         "    4 validators voted + QC formed: {:.0}ms",
@@ -708,6 +714,7 @@ fn production_simulation() {
     let mut votes2 = Vec::new();
     for i in 0..4 {
         if let Some(v) = create_vote(
+            CHAIN_ID,
             &mut consensus_states[i],
             &header2,
             i as u8,
@@ -716,11 +723,11 @@ fn production_simulation() {
         )
         .unwrap()
         {
-            assert!(verify_vote(&v, validators[i].pk.as_bytes()));
+            assert!(verify_vote(CHAIN_ID, &v, validators[i].pk.as_bytes()));
             votes2.push(v);
         }
     }
-    let qc2 = try_form_qc(2, header2.hash(), &votes2, &committee_keys);
+    let qc2 = try_form_qc(CHAIN_ID, 2, header2.hash(), &votes2, &committee_keys);
     assert!(qc2.is_some(), "QC2 must form");
 
     // Sync local nonce counters from state (parallel exec changed them)
@@ -864,6 +871,7 @@ fn production_simulation() {
     let mut votes3 = Vec::new();
     for i in 0..4 {
         if let Some(v) = create_vote(
+            CHAIN_ID,
             &mut consensus_states[i],
             &header3,
             i as u8,
@@ -872,11 +880,11 @@ fn production_simulation() {
         )
         .unwrap()
         {
-            assert!(verify_vote(&v, validators[i].pk.as_bytes()));
+            assert!(verify_vote(CHAIN_ID, &v, validators[i].pk.as_bytes()));
             votes3.push(v);
         }
     }
-    let qc3 = try_form_qc(3, header3.hash(), &votes3, &committee_keys);
+    let qc3 = try_form_qc(CHAIN_ID, 3, header3.hash(), &votes3, &committee_keys);
     assert!(qc3.is_some(), "QC3 must form");
 
     // ═══ SUMMARY ═════════════════════════════════════════════════════

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -513,7 +513,7 @@ fn execute_transaction_inner(
             sender.auth_keys = pyde_account::types::AuthKeys::Single(tx.data.clone());
             (true, 0u64, 0u64, Vec::new(), Vec::new())
         }
-        TransactionType::Slash => execute_slash(tx, smt, &mut sender.balance),
+        TransactionType::Slash => execute_slash(block_ctx.chain_id, tx, smt, &mut sender.balance),
         TransactionType::ClaimAirdrop => {
             execute_claim_airdrop(tx, smt, block_ctx, &mut sender.balance)
         }
@@ -1304,10 +1304,14 @@ fn decode_slash_evidence(data: &[u8]) -> Result<SlashEvidence, String> {
 /// Parse a serialized validator entry:
 /// `[pk_len:4 LE][pk][stake:16 LE][status:1]`.
 /// Returns `(pk_bytes, stake, status, status_offset)`.
-/// Canonical `(slot_le || block_hash)` bytes that proposers and voters
-/// sign. Mirrors `pyde_consensus::hotstuff::proposer_sign_message`.
-fn proposer_sign_message_bytes(slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(40);
+/// Canonical `(chain_id_le || slot_le || block_hash)` bytes that
+/// proposers and voters sign. Mirrors
+/// `pyde_consensus::hotstuff::proposer_sign_message` — kept here as a
+/// local copy to avoid a `pyde-tx` → `pyde-consensus` dep cycle. The
+/// `chain_id` prefix prevents cross-chain replay of slashing evidence.
+fn proposer_sign_message_bytes(chain_id: u64, slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(8 + 8 + 32);
+    msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
     msg.extend_from_slice(block_hash);
     msg
@@ -1318,7 +1322,12 @@ fn proposer_sign_message_bytes(slot: u64, block_hash: &[u8; 32]) -> Vec<u8> {
 /// by the outer pipeline match. On success, `submitter_balance` is
 /// credited the finder's fee and the offender's validator entry is
 /// updated in the SMT (stake zeroed, status = Ejected).
+///
+/// `chain_id` is the LOCAL chain's id; evidence signatures are
+/// re-verified against `(chain_id || slot || block_hash)` so a
+/// double-sign on a different chain cannot slash here.
 fn execute_slash(
+    chain_id: u64,
     tx: &Transaction,
     smt: &mut dyn pyde_state::smt::StateAccess,
     submitter_balance: &mut u128,
@@ -1368,8 +1377,8 @@ fn execute_slash(
         Some(s) => s,
         None => return failed(21_000, b"signature_2 malformed"),
     };
-    let msg_1 = proposer_sign_message_bytes(ev.slot, &ev.block_hash_1);
-    let msg_2 = proposer_sign_message_bytes(ev.slot, &ev.block_hash_2);
+    let msg_1 = proposer_sign_message_bytes(chain_id, ev.slot, &ev.block_hash_1);
+    let msg_2 = proposer_sign_message_bytes(chain_id, ev.slot, &ev.block_hash_2);
     if !pyde_crypto::falcon::falcon_verify(&pk, &msg_1, &sig_1)
         || !pyde_crypto::falcon::falcon_verify(&pk, &msg_2, &sig_2)
     {
@@ -3882,10 +3891,11 @@ mod tests {
 
     fn sign_proposer_for_test(
         sk: &pyde_crypto::falcon::FalconSecretKey,
+        chain_id: u64,
         slot: u64,
         block_hash: &[u8; 32],
     ) -> Vec<u8> {
-        let msg = proposer_sign_message_bytes(slot, block_hash);
+        let msg = proposer_sign_message_bytes(chain_id, slot, block_hash);
         falcon_sign(sk, &msg).unwrap().as_bytes().to_vec()
     }
 
@@ -3968,8 +3978,8 @@ mod tests {
         let slot = 100u64;
         let hash_1 = [0x01u8; 32];
         let hash_2 = [0x02u8; 32];
-        let sig_1 = sign_proposer_for_test(&osk, slot, &hash_1);
-        let sig_2 = sign_proposer_for_test(&osk, slot, &hash_2);
+        let sig_1 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &hash_1);
+        let sig_2 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &hash_2);
 
         let evidence = encode_evidence_for_test(
             slot, &hash_1, &sig_1, &hash_2, &sig_2, &offender, &submitter,
@@ -4010,7 +4020,7 @@ mod tests {
 
         let slot = 100;
         let hash = [0x01u8; 32];
-        let sig = sign_proposer_for_test(&osk, slot, &hash);
+        let sig = sign_proposer_for_test(&osk, ctx.chain_id, slot, &hash);
         let evidence =
             encode_evidence_for_test(slot, &hash, &sig, &hash, &sig, &offender, &submitter);
         let tx = build_slash_tx(submitter, &ssk, evidence);
@@ -4040,8 +4050,8 @@ mod tests {
         let (_opk, osk) = falcon_keygen().unwrap();
         let ghost_signer = [0xAB; 32]; // never registered
         let slot = 100;
-        let sig_1 = sign_proposer_for_test(&osk, slot, &[0x01; 32]);
-        let sig_2 = sign_proposer_for_test(&osk, slot, &[0x02; 32]);
+        let sig_1 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &[0x01; 32]);
+        let sig_2 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &[0x02; 32]);
         let evidence = encode_evidence_for_test(
             slot,
             &[0x01; 32],
@@ -4073,8 +4083,8 @@ mod tests {
         let slot = 100;
         let hash_1 = [0x01u8; 32];
         let hash_2 = [0x02u8; 32];
-        let sig_1 = sign_proposer_for_test(&osk, slot, &hash_1);
-        let sig_2 = sign_proposer_for_test(&osk, slot, &hash_2);
+        let sig_1 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &hash_1);
+        let sig_2 = sign_proposer_for_test(&osk, ctx.chain_id, slot, &hash_2);
         let evidence = encode_evidence_for_test(
             slot, &hash_1, &sig_1, &hash_2, &sig_2, &offender, &submitter,
         );
@@ -4097,8 +4107,8 @@ mod tests {
         let signed_slot = 101u64; // wrong!
         let hash_1 = [0x01u8; 32];
         let hash_2 = [0x02u8; 32];
-        let sig_1 = sign_proposer_for_test(&osk, signed_slot, &hash_1);
-        let sig_2 = sign_proposer_for_test(&osk, signed_slot, &hash_2);
+        let sig_1 = sign_proposer_for_test(&osk, ctx.chain_id, signed_slot, &hash_1);
+        let sig_2 = sign_proposer_for_test(&osk, ctx.chain_id, signed_slot, &hash_2);
 
         let evidence = encode_evidence_for_test(
             evidence_slot,
@@ -4150,6 +4160,45 @@ mod tests {
         let tx = build_slash_tx(submitter, &ssk, vec![SLASH_EVIDENCE_VERSION, 0x00]);
         let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
         assert!(!receipt.success);
+    }
+
+    /// Cross-chain replay: a double-sign signed under a foreign
+    /// `chain_id` must NOT slash on the local chain, even when the
+    /// FALCON keys match. Mirrors audit-240 multisig regression and
+    /// the consensus-layer cross-chain test.
+    #[test]
+    fn slash_tx_cross_chain_replay_rejected() {
+        let mut smt = PydeSMT::new();
+        let ctx = make_block_ctx(); // chain_id = 1
+        let (_opk, osk, offender, _spk, ssk, submitter) =
+            slash_fixture(&mut smt, SLASH_VALIDATOR_STAKE, 1_000_000_000_000);
+
+        let slot = 100u64;
+        let hash_1 = [0x01u8; 32];
+        let hash_2 = [0x02u8; 32];
+        // Sign evidence under a DIFFERENT chain_id than the local chain.
+        let foreign_chain_id = ctx.chain_id + 1;
+        let sig_1 = sign_proposer_for_test(&osk, foreign_chain_id, slot, &hash_1);
+        let sig_2 = sign_proposer_for_test(&osk, foreign_chain_id, slot, &hash_2);
+
+        let evidence = encode_evidence_for_test(
+            slot, &hash_1, &sig_1, &hash_2, &sig_2, &offender, &submitter,
+        );
+        let tx = build_slash_tx(submitter, &ssk, evidence);
+
+        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
+        assert!(
+            !receipt.success,
+            "evidence signed under a different chain_id must not slash here"
+        );
+
+        // State untouched.
+        let val_data = smt
+            .get(&pyde_state::keys::validator_key(&offender))
+            .unwrap();
+        let entry = ValidatorEntry::decode(&val_data).unwrap();
+        assert_eq!(entry.stake, SLASH_VALIDATOR_STAKE);
+        assert_eq!(entry.status, 0x00);
     }
 
     // ========== Slice 4.4b: airdrop claim + sweep ==========


### PR DESCRIPTION
## Summary

- Mirrors the audit-240 multisig fix for every consensus signing surface (proposer, vote, view-change, slashing evidence). `BlockHeader` does not carry `chain_id`, so without this prefix a vote or double-sign signed on chain A verifies as-is on chain B whenever FALCON keys match — a real cross-chain replay vector since operators reuse keys across devnet/staging/testnet during dev cycles.
- No wire-format struct change. Verifiers rebuild the preimage with their LOCAL `chain_id`, so foreign-chain sigs fail FALCON verify. `ValidatorEngine` gets a `chain_id` field threaded from `PydeNode` config; slash-tx execution threads it from `BlockContext`.
- Adds four cross-chain replay regression tests (vote, view-change, `verify_double_sign`, end-to-end slash tx).

## Preimages

| Function | Before | After |
|---|---|---|
| `proposer_sign_message` | `slot_le \|\| block_hash` | `chain_id_le \|\| slot_le \|\| block_hash` |
| `view_change_sign_message` | `b\"view_change\" \|\| slot_le` | `b\"view_change\" \|\| chain_id_le \|\| slot_le` |
| `create_timeout` (test-only path) | `b\"timeout\" \|\| slot_le` | `b\"timeout\" \|\| chain_id_le \|\| slot_le` |

## Verification

- \`cargo check --workspace --all-targets\` clean
- \`cargo test -p pyde-consensus --lib\` → 118 passed / 0 failed
- \`cargo test -p pyde-consensus --test prop_hotstuff_safety\` → 5/5 proptests passed
- \`cargo test -p pyde-tx --lib\` → 231 passed / 0 failed
- \`cargo test -p pyde-node --bin pyde\` → 268 passed / 0 failed
- \`cargo clippy -p pyde-consensus --all-targets -- -D warnings\` clean
- \`cargo clippy -p pyde-tx --all-targets -- -D warnings\` clean