### PR TITLE
fix(aot): match interpreter's shift-by-≥64 zero/sign-fill semantics

### DIFF
--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -631,22 +631,45 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let r = builder.ins().bnot(a);
                         gp_write!(builder, d.rd, r);
                     }
+                    // Shift opcodes: interpreter (cpu.rs:164-189) treats
+                    // `shift >= 64` as zero-fill (Shl/Shr) or sign-fill
+                    // (Sar). Cranelift's ishl/ushr/sshr mask the shift
+                    // count to operand_size-1 (so `x << 64 == x << 0`),
+                    // which would diverge from the interpreter and fork
+                    // the chain on any contract that shifts by a value
+                    // ≥64. Select on `b >= 64` to match interp exactly.
                     Opcode::Shl => {
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
-                        let r = builder.ins().ishl(a, b);
+                        let oversize =
+                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                        let shifted = builder.ins().ishl(a, b);
+                        let zero = builder.ins().iconst(I64, 0);
+                        let r = builder.ins().select(oversize, zero, shifted);
                         gp_write!(builder, d.rd, r);
                     }
                     Opcode::Shr => {
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
-                        let r = builder.ins().ushr(a, b);
+                        let oversize =
+                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                        let shifted = builder.ins().ushr(a, b);
+                        let zero = builder.ins().iconst(I64, 0);
+                        let r = builder.ins().select(oversize, zero, shifted);
                         gp_write!(builder, d.rd, r);
                     }
                     Opcode::Sar => {
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
-                        let r = builder.ins().sshr(a, b);
+                        let oversize =
+                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                        let shifted = builder.ins().sshr(a, b);
+                        // shift >= 64 fills with the sign bit: 0 for
+                        // non-negative, -1 (u64::MAX) for negative.
+                        // sshr_imm(a, 63) broadcasts the sign bit
+                        // across all 64 bits.
+                        let sign_fill = builder.ins().sshr_imm(a, 63);
+                        let r = builder.ins().select(oversize, sign_fill, shifted);
                         gp_write!(builder, d.rd, r);
                     }
 

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -140,6 +140,63 @@ mod tests {
     }
 
     #[test]
+    fn shl_aot_interp_parity_across_shift_counts() {
+        // Audit Tier 1C — interpreter (cpu.rs:164-189) treats
+        // `shift >= 64` as 0, but AOT codegen (codegen.rs:634-650) emits
+        // raw Cranelift `ishl` which masks the count to operand_size-1.
+        // `1u64 << 64` therefore yielded `1` on AOT and `0` on interp —
+        // a consensus fork on any contract that shifts by a value
+        // derived from user input.
+        for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
+            for value in [1i32, -1, 0x4242, -0x4242] {
+                let code = bytecode(&[
+                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
+                    instr_bytes(Opcode::Shl, 3, 1, 2),           // r3 = r1 << r2
+                    instr_bytes(Opcode::Halt, 0, 0, 0),
+                ]);
+                compare_with_interpreter(&code, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn shr_aot_interp_parity_across_shift_counts() {
+        // See shl_aot_interp_parity_across_shift_counts. AOT's `ushr`
+        // masks the count to 6 bits; interp returns 0 for `shift >= 64`.
+        for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
+            for value in [1i32, -1, 0x4242, -0x4242] {
+                let code = bytecode(&[
+                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
+                    instr_bytes(Opcode::Shr, 3, 1, 2),           // r3 = r1 >> r2 (unsigned)
+                    instr_bytes(Opcode::Halt, 0, 0, 0),
+                ]);
+                compare_with_interpreter(&code, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn sar_aot_interp_parity_across_shift_counts() {
+        // See shl_aot_interp_parity_across_shift_counts. Sar is the
+        // arithmetic right shift: interp fills with the sign bit when
+        // `shift >= 64` (returns 0 for non-negative, `-1` for negative);
+        // AOT's `sshr` masks to 6 bits and returned the unshifted value.
+        for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
+            for value in [1i32, -1, 0x4242, -0x4242] {
+                let code = bytecode(&[
+                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
+                    instr_bytes(Opcode::Sar, 3, 1, 2),           // r3 = r1 >>> r2 (signed)
+                    instr_bytes(Opcode::Halt, 0, 0, 0),
+                ]);
+                compare_with_interpreter(&code, 0);
+            }
+        }
+    }
+
+    #[test]
     fn memcpy_aot_charges_dynamic_gas_parity_with_interp() {
         // Audit item 215 — host_memcpy used to skip the per-byte
         // dynamic-gas charge that the interpreter pays. Same contract


### PR DESCRIPTION
## Summary

- Cranelift's `ishl`/`ushr`/`sshr` mask the shift count to `operand_size-1`, so emitting them raw made `1u64 << 64` produce `1` on AOT validators while the interpreter (`crates/pvm/src/cpu.rs:164-189`) returns `0`. Same divergence on `Shr` (zero-fill) and `Sar` (sign-fill).
- Any otic contract shifting by a value derived from user input could fork the chain between interp and AOT validators. **This is a P0 consensus bug.**
- Fix selects on `b >= 64` to match interp exactly: zero for `Shl`/`Shr`, sign-bit broadcast for `Sar` (via `sshr_imm(a, 63)`).
- Adds three parity tests across shift counts `{0, 1, 31, 32, 63, 64, 65, 127, 200, 255}` × four input values. All three failed pre-fix on shift ≥64 and pass post-fix.

## Bug demonstration (red test before fix)

\`\`\`text
test tests::shl_aot_interp_parity_across_shift_counts ... FAILED
panicked at crates/aot/src/lib.rs:77:17:
register r3 mismatch: aot=1 interp=0
\`\`\`

(\`1u64 << 64\`: AOT returned 1, interpreter returned 0.)

## Verification

- \`cargo test -p pyde-aot --lib\` → 43 passed / 0 failed
- \`cargo test -p pyde-node --bin pyde\` → 268 passed / 0 failed
- \`cargo clippy -p pyde-aot --all-targets -- -D warnings\` clean