### PR TITLE
fix(rpc): accept Ethereum-style 2-arg pyde_getBlockByNumber(slot, full_tx)

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -114,8 +114,17 @@ pub trait PydeApi {
     #[method(name = "pyde_blockNumber")]
     async fn block_number(&self) -> Result<String, ErrorObjectOwned>;
 
+    /// `pyde_getBlockByNumber(slot, full_tx?)`. The second parameter
+    /// is accepted for compatibility with Ethereum-style 2-arg
+    /// callers (e.g. `eth_getBlockByNumber(slot, true)`); both the
+    /// `transactions` and `transactionHashes` arrays are always
+    /// included in the response so the flag is currently informational.
     #[method(name = "pyde_getBlockByNumber")]
-    async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned>;
+    async fn get_block_by_number(
+        &self,
+        slot: u64,
+        full_tx: Option<bool>,
+    ) -> Result<serde_json::Value, ErrorObjectOwned>;
 
     /// Get block info by block hash.
     #[method(name = "pyde_getBlockByHash")]
@@ -320,7 +329,16 @@ impl PydeApiServer for RpcServer {
         Ok(format!("0x{:x}", chain.head_slot))
     }
 
-    async fn get_block_by_number(&self, slot: u64) -> Result<serde_json::Value, ErrorObjectOwned> {
+    async fn get_block_by_number(
+        &self,
+        slot: u64,
+        _full_tx: Option<bool>,
+    ) -> Result<serde_json::Value, ErrorObjectOwned> {
+        // `_full_tx` is currently ignored — the response always
+        // includes both `transactions` and `transactionHashes` so any
+        // caller (Ethereum-style with `true`, terse with no arg) gets
+        // the data they wanted. Kept on the signature so jsonrpsee
+        // accepts the 2-positional-arg form without "Invalid params".
         // ChainState only keeps the last ~2 epochs of headers in
         // memory; for older slots fall back to the persistent
         // BlockStore so block-explorer-style range queries don't go


### PR DESCRIPTION
## Summary

- The sibling \`pyde-explorer\` indexer calls \`pyde_getBlockByNumber(slot, true)\` — two positional params, mirroring Ethereum's \`eth_getBlockByNumber(blockNumber, full_tx)\` convention. The pyde RPC trait declared a single-arg signature (\`slot: u64\`), so jsonrpsee 0.24's macro-generated parser would reject the call as "Invalid params: trailing characters" the moment the explorer tried to index against testnet. Discovered while wiring up Tier 2.5 (explorer integration) for testnet readiness.
- Add \`full_tx: Option<bool>\` as a trailing optional positional parameter. jsonrpsee accepts both \`[slot]\` and \`[slot, true]\` forms; missing trailing args deserialize as \`None\`.
- The flag itself is informational — pyde already returns BOTH \`transactions\` and \`transactionHashes\` arrays unconditionally, so callers requesting either shape get the data they wanted with no behavior change.

## Verification

- \`cargo build -p pyde-node\` clean — jsonrpsee macro accepts the trailing \`Option<bool>\` param.
- \`cargo test -p pyde-node --bin pyde\` → 268 passed / 0 failed.
- Manual runtime smoke (curl both call shapes against a devnet) recommended as part of pyde-explorer integration test.

## Explorer compatibility check (out of band)

Verified all 7 RPC methods used by \`pyde-explorer/backend/src/\`:
\`pyde_blockNumber\`, \`pyde_chainId\`, \`pyde_getBalance\`, \`pyde_getBlockByNumber\`, \`pyde_getTransactionReceipt\`, \`pyde_getValidators\`, \`pyde_syncing\` — all exist on the node side. Response field names match (camelCase serde rename + explicit aliases on the explorer side). Defaults \`PYDE_RPC_URL=http://127.0.0.1:8545\` match \`RpcSection::default()\`.