### PR TITLE
fix(encrypted): cap proposer + align wire decoder + ingress nonce-window check

### DIFF
--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -37,6 +37,38 @@ pub const DEFAULT_MAX_CONCURRENT_PER_SENDER: u32 = 100;
 /// the "10 tx/s" mainnet target.
 pub const RATE_WINDOW_MS: u64 = 1000;
 
+/// Maximum encrypted txs the proposer will include in a single block.
+///
+/// Two separate constraints set this ceiling:
+///
+/// 1. **Wire format.** The committee broadcasts one
+///    `DecryptionShareMsg` per validator per slot, carrying one
+///    decryption share per encrypted tx in the block. The
+///    consensus-topic message budget is 64 KB and the wire decoder
+///    bounds the share count via `dec.u16_count(...)` — anything
+///    above the bound is silently rejected at deserialization, so
+///    the threshold never reaches and the encrypted_txs never
+///    decrypt. Setting the proposer-side cap below the decoder's
+///    bound is what keeps the broadcast self-consistent.
+///
+/// 2. **Per-validator decrypt + apply CPU.** Threshold-decrypt +
+///    apply for an encrypted tx costs ~3-5 ms per validator (Lagrange
+///    combine, Kyber decap, FALCON re-verify, state apply). Slot
+///    budget is 400 ms; leaving room for vote+QC means decrypt+apply
+///    should fit in ~200 ms ⇒ ~50 txs/block on laptop, ~200 on
+///    dedicated cores. Below this ceiling the chain commits steady;
+///    above it `prune_committed_txs` falls behind, the proposer
+///    re-includes the same set every slot, and the chain wedges.
+///
+/// 100/block hits the safe sweet-spot: comfortably under the wire
+/// decoder's 128-share bound (so encoded share messages round-trip
+/// cleanly), and high enough to not throttle laptop loadgen (which
+/// organically tops out at ~50/block under the audit-027 per-sender
+/// caps), while preventing the runaway pile-ups (5 000+-per-slot
+/// re-circle observed at 5 K-sender loadgen). Operator-config knob
+/// for cluster-class hardware lands in a follow-up.
+pub const MAX_ENCRYPTED_TXS_PER_BLOCK: usize = 100;
+
 /// Mempool validation error.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MempoolError {
@@ -425,13 +457,32 @@ impl Mempool {
         &self.txs
     }
 
-    /// Select transactions for a block in arrival order, respecting gas limit.
+    /// Select transactions for a block in arrival order, respecting
+    /// the gas limit AND a per-block count cap.
+    ///
+    /// `max_count` bounds the number of encrypted txs the proposer
+    /// will include per block. Production callers pass
+    /// [`MAX_ENCRYPTED_TXS_PER_BLOCK`]; tests that don't care about
+    /// this dimension pass `usize::MAX` to fall back to gas-only
+    /// selection. See the constant's doc comment for the full
+    /// rationale (tl;dr: without it the proposer over-includes and
+    /// the receive-side decrypt+apply pipeline falls indefinitely
+    /// behind).
+    ///
     /// The proposer VRF-shuffles the selected set after this.
-    pub fn select_for_block(&self, block_gas_limit: u64, current_slot: u64) -> Vec<&EncryptedTx> {
+    pub fn select_for_block(
+        &self,
+        block_gas_limit: u64,
+        max_count: usize,
+        current_slot: u64,
+    ) -> Vec<&EncryptedTx> {
         let mut selected = Vec::new();
         let mut gas_used = 0u64;
 
         for tx in &self.txs {
+            if selected.len() >= max_count {
+                break;
+            }
             if tx.is_expired(current_slot) {
                 continue;
             }
@@ -717,7 +768,7 @@ mod tests {
         pool.add(make_enc_tx(&pk, 40_000, 2)).unwrap();
 
         // Block gas limit of 100K → picks 60K + 40K (or 60K + 50K... highest first)
-        let selected = pool.select_for_block(100_000, 0);
+        let selected = pool.select_for_block(100_000, usize::MAX, 0);
         let total_gas: u64 = selected.iter().map(|t| t.gas_limit).sum();
         assert!(total_gas <= 100_000);
         assert!(!selected.is_empty());
@@ -733,9 +784,44 @@ mod tests {
         pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap(); // no deadline
 
         // At slot 300, first tx is expired
-        let selected = pool.select_for_block(1_000_000, 300);
+        let selected = pool.select_for_block(1_000_000, usize::MAX, 300);
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].gas_limit, 60_000);
+    }
+
+    #[test]
+    fn select_for_block_caps_at_max_count() {
+        // Per-block cap is the brake on proposer over-inclusion
+        // (PR follow-up to the encrypted-path loadgen). With gas
+        // headroom for 5 txs but max_count=2, only 2 are selected.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        // Lift rate limits so add() doesn't rate-limit us before the
+        // pool has the test-relevant txs.
+        pool.set_rate_limits(1_000, 1_000);
+        for nonce in 0..5 {
+            pool.add(make_enc_tx(&pk, 30_000, nonce)).unwrap();
+        }
+        // Gas room = 5×30k = 150k well under 1M, count cap = 2
+        let selected = pool.select_for_block(1_000_000, 2, 0);
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn select_for_block_uses_production_cap_const() {
+        // Sanity check: passing MAX_ENCRYPTED_TXS_PER_BLOCK behaves
+        // identically to passing the constant by value. Locks the
+        // production-call shape so a future refactor that shadows
+        // the constant fails this test.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_rate_limits(10_000, 10_000);
+        // Add more than the cap so the cap is the binding constraint.
+        for nonce in 0..(MAX_ENCRYPTED_TXS_PER_BLOCK as u64 + 5) {
+            pool.add(make_enc_tx(&pk, 30_000, nonce)).unwrap();
+        }
+        let selected = pool.select_for_block(1_000_000_000, MAX_ENCRYPTED_TXS_PER_BLOCK, 0);
+        assert_eq!(selected.len(), MAX_ENCRYPTED_TXS_PER_BLOCK);
     }
 
     // ========== Prune expired ==========

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1975,11 +1975,25 @@ impl PydeNode {
                                         }
                                     }
 
-                                    // Also collect encrypted txs from the threshold-encrypted mempool
+                                    // Also collect encrypted txs from the threshold-encrypted mempool.
+                                    //
+                                    // The MAX_ENCRYPTED_TXS_PER_BLOCK cap is what stops the
+                                    // chain from wedging above the per-validator decrypt-apply
+                                    // throughput: without it, gas-only selection greedily
+                                    // fills up to ~16 K encrypted-tx-equivalents per block,
+                                    // but receive-side decrypt+apply takes ~3-5 ms per tx
+                                    // and can't keep up with the proposer. `prune_committed_
+                                    // txs` then never fires for the in-flight set, so the
+                                    // proposer keeps re-selecting the same set every slot
+                                    // and the chain falls indefinitely behind. See the
+                                    // const's doc-comment in `pyde-mempool::pool` for the
+                                    // measurement that motivates the value.
                                     let encrypted_blobs = {
                                         let relay_r = tx_relay.read().await;
                                         let selected = relay_r.mempool().select_for_block(
-                                            gas_ceiling, current_slot,
+                                            gas_ceiling,
+                                            pyde_mempool::pool::MAX_ENCRYPTED_TXS_PER_BLOCK,
+                                            current_slot,
                                         );
                                         // Serialize each EncryptedTx to bytes for block inclusion
                                         selected.iter().map(|etx| etx.to_bytes()).collect::<Vec<Vec<u8>>>()

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1291,7 +1291,7 @@ impl PydeApiServer for RpcServer {
         let tx_hash = enc_tx.hash();
         // Clone for the gossip fan-out below. We gossip only after
         // local acceptance so the ingress policy (auth_key lookup,
-        // sig verify) gates what the network sees.
+        // sig verify, nonce-window) gates what the network sees.
         let tx_for_gossip = enc_tx.clone();
 
         // Same ingest policy as the server-side path (audit item 206):
@@ -1301,17 +1301,66 @@ impl PydeApiServer for RpcServer {
         // actually binds to a ciphertext the client knows about — so
         // on mainnet the FALCON verify inside `receive_tx_verified`
         // is meaningful, not a no-op length check.
-        let sender_pk_opt = {
+        //
+        // While we have the read-lock open, also fetch the sender's
+        // current nonce state for the ingress window check below —
+        // saves a second state read on the hot path.
+        let (sender_pk_opt, nonce_state_opt) = {
             let state_r = self.state.state.read().await;
             let sender_key = pyde_state::keys::balance_key(&from);
-            state_r
+            let pk_opt = state_r
                 .get(&sender_key)
                 .and_then(|bytes| pyde_account::types::Account::from_bytes(&bytes))
                 .and_then(|acct| match acct.auth_keys {
                     pyde_account::types::AuthKeys::Single(pk) => Some(pk),
                     _ => None,
-                })
+                });
+            let ns_opt = state_r
+                .get(&pyde_state::keys::nonce_key(&from))
+                .map(|bytes| pyde_account::nonce::NonceState::from_bytes(&bytes));
+            (pk_opt, ns_opt)
         };
+
+        // Pre-check the nonce window at ingress. Without this, a
+        // submitter who can encrypt + FALCON-sign faster than the
+        // chain can decrypt + apply (true on any laptop the moment
+        // submit-rate exceeds chain-commit-rate) piles arbitrary
+        // future nonces into the encrypted mempool, where they sit
+        // unprocessable until their parent nonces commit. The mempool
+        // grows past the per-sender concurrent cap, submission
+        // collapses to errors, and from the operator's view the
+        // encrypted path appears to "stall under load" even though
+        // the chain is committing what it can.
+        //
+        // Rejecting above-window submissions at ingress flips the
+        // failure shape from "silent backlog → submitter sees
+        // TooManyConcurrent later" to "submitter gets a clean
+        // -32008 immediately and can back off". Also keeps mempool
+        // depth proportional to the actual in-flight window
+        // (`WINDOW_SIZE = 16` per sender) instead of the wall-clock
+        // submission rate.
+        if let Some(ns) = &nonce_state_opt {
+            if enc_tx.nonce >= ns.base + pyde_account::nonce::WINDOW_SIZE {
+                return Err(rpc_err(
+                    -32008,
+                    format!(
+                        "encrypted-tx nonce {} is past the in-flight window [{}, {}); submit when prior nonces commit",
+                        enc_tx.nonce,
+                        ns.base,
+                        ns.base + pyde_account::nonce::WINDOW_SIZE,
+                    ),
+                ));
+            }
+            if enc_tx.nonce < ns.base {
+                return Err(rpc_err(
+                    -32008,
+                    format!(
+                        "encrypted-tx nonce {} is below the chain's committed nonce {}",
+                        enc_tx.nonce, ns.base
+                    ),
+                ));
+            }
+        }
 
         let mut relay = self.state.tx_relay.write().await;
         let accepted = match encrypted_tx_ingest_policy(sender_pk_opt, self.chain_id) {

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -515,7 +515,17 @@ pub fn decode_decryption_shares(data: &[u8]) -> Result<DecryptionShareMsg, &'sta
     }
     let slot = dec.u64()?;
     let member_index = dec.u8()?;
-    let count = dec.u16_count(COMMITTEE_SIZE)?;
+    // Bound the share count by the proposer-side cap on encrypted txs
+    // per block: the count IS one share per encrypted_tx the validator
+    // signed shares for, not (as the previous bound `COMMITTEE_SIZE`
+    // suggested) the committee size. With the old bound, any block
+    // carrying more than 128 encrypted_txs produced a share message
+    // that decoded-fail-silently on receivers ⇒ threshold never
+    // reached ⇒ encrypted_txs re-circulated forever (the actual root
+    // cause of the encrypted-path wedge above ~125 enc-tx/s on the
+    // laptop loadgen). Aligning the wire decoder with the proposer
+    // cap closes the silent-drop window.
+    let count = dec.u16_count(pyde_mempool::pool::MAX_ENCRYPTED_TXS_PER_BLOCK)?;
     let mut shares = Vec::with_capacity(count);
     for _ in 0..count {
         shares.push(dec.var_bytes()?);


### PR DESCRIPTION
## Summary

Three correlated fixes that together turn the encrypted-path "stall under load" failure mode into clean backpressure.

## Root cause (the silent-loss bug)

\`crates/node/src/wire.rs:518\` bounded the share count in \`decode_decryption_shares\` via \`dec.u16_count(COMMITTEE_SIZE)?\` where \`COMMITTEE_SIZE = 128\`. But the count being bounded is **one share per encrypted_tx in the block**, not the committee size. Any block carrying more than 128 encrypted_txs produced a \`DecryptionShareMsg\` that silently failed decode at every receiver — threshold never reached, encrypted_txs never decrypted, the same set re-flighted every slot forever. This is the actual mechanism behind the wedge above ~125 enc-tx/s on the laptop loadgen (\`encrypted=4741\` constant across 20+ slots in the slot logs).

## Three changes

1. **\`MAX_ENCRYPTED_TXS_PER_BLOCK = 100\`** constant + per-call argument to \`Mempool::select_for_block\`. Caps the proposer's per-block inclusion below the receive-side decrypt-apply CPU budget at the spec'd hardware floor — under the cap, the chain commits at its real ceiling without falling behind on apply. Two unit tests pin the cap behavior.

2. **Wire decoder bound aligned.** \`decode_decryption_shares\` now uses \`MAX_ENCRYPTED_TXS_PER_BLOCK\` as the count bound, so a block at the proposer cap produces a share message that decodes cleanly on every receiver instead of silently failing.

3. **RPC ingress nonce-window check on the encrypted path.** Without it, submitters who can encrypt+sign faster than the chain can decrypt+apply pile arbitrary future nonces into the mempool, where they sit unprocessable. The per-sender concurrent cap eventually trips and submission collapses to errors — visible to operators as "encrypted path stalls under load" even though the chain is committing what it can. Pre-checking \`tx.nonce\` against the sender's chain \`nonce_state.base + WINDOW_SIZE\` (16) at ingress flips that to **submitter gets a clean -32008 immediately and backs off**. Mempool depth stays proportional to the in-flight window, not the wall-clock submission rate.

## Verified behavior

| Target TPS | Before          | After            |
|------------|-----------------|------------------|
| 100        | 100 % inclusion | 100 % inclusion  |
| 125        | 100 % inclusion | 100 % inclusion  |
| 150        | 3 % (stall)     | bounded mempool  |
| 200        | 3 % (stall)     | bounded mempool  |
| 5 000      | wedge / 0 %     | bounded mempool  |

Slot-log shape changed from \`encrypted=4741\` re-circling-forever to \`encrypted=100\` constant within the decoder budget. Submitters above the chain's hardware ceiling now see explicit \`-32008\` above-window errors instead of silent backlog.

## Not-fixed-here

Hardware ceiling is hardware ceiling. On the laptop, ~125 enc-tx/s is what 4 cores can sustain for sequential threshold-decrypt + Kyber decap + FALCON re-verify + apply. Cluster-class hardware will move this 3-5× the same way plaintext does (4 K laptop → 12.5 K mainnet target). Throughput optimization (parallel apply via snapshot reads, RwLock on JMT, etc.) lands separately — initial rayon experiment regressed at low N due to mutex contention; needs deeper SMT work.

A pre-injection benchmark to measure the **pure** chain ceiling (separated from submission overhead) is queued as a follow-up.

## Verification

- \`cargo test -p pyde-mempool --lib\` → 65 passed (2 new cap tests)
- \`cargo test -p pyde-node --bin pyde\` → 268 passed
- \`cargo build --release -p pyde-node --tests\` clean