### PR TITLE
chore: ci hygiene — fmt + clippy + audit/deny ignore-list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,9 +14,15 @@ ignore = [
     "RUSTSEC-2025-0009", # ring 0.16: AES panic on overflow check
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints
     "RUSTSEC-2026-0099", # rustls-webpki: wildcard name constraints
+    "RUSTSEC-2026-0104", # rustls-webpki: CRL parsing panic (we don't use CRLs)
     # Unmaintained — same libp2p-upgrade blocker.
     "RUSTSEC-2025-0010", # ring <0.17 unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
     "RUSTSEC-2024-0384", # instant 0.1.x unmaintained (via libp2p-gossipsub futures-ticker)
     "RUSTSEC-2026-0002", # lru IterMut Stacked Borrows soundness (via libp2p-swarm)
+    # Transitive via reqwest's DNS resolver. Pyde nodes connect to a
+    # fixed set of RPC peers via hostname; DNS responses come from
+    # validator-controlled resolvers, not arbitrary attacker-chosen
+    # ones. Tracked for the reqwest/hickory bump slice.
+    "RUSTSEC-2026-0119", # hickory-proto 0.24.x: O(n²) name compression DoS
 ]

--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -667,7 +667,9 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
                         let oversize =
-                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                            builder
+                                .ins()
+                                .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
                         let shifted = builder.ins().ishl(a, b);
                         let zero = builder.ins().iconst(I64, 0);
                         let r = builder.ins().select(oversize, zero, shifted);
@@ -677,7 +679,9 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
                         let oversize =
-                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                            builder
+                                .ins()
+                                .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
                         let shifted = builder.ins().ushr(a, b);
                         let zero = builder.ins().iconst(I64, 0);
                         let r = builder.ins().select(oversize, zero, shifted);
@@ -687,7 +691,9 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let a = gp_read!(builder, d.rs1);
                         let b = gp_read!(builder, (d.rs2_or_imm & 0xF) as u8);
                         let oversize =
-                            builder.ins().icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
+                            builder
+                                .ins()
+                                .icmp_imm(IntCC::UnsignedGreaterThanOrEqual, b, 64);
                         let shifted = builder.ins().sshr(a, b);
                         // shift >= 64 fills with the sign bit: 0 for
                         // non-negative, -1 (u64::MAX) for negative.

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -803,11 +803,7 @@ pub extern "C" fn host_tx_hash(ctx: *mut VmCtx, wd: u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file).
     let vm = unsafe { &mut *ctx };
-    if vm
-        .cpu
-        .write_wide_checked(wd as u8, vm.ctx.tx_hash)
-        .is_err()
-    {
+    if vm.cpu.write_wide_checked(wd as u8, vm.ctx.tx_hash).is_err() {
         return 1;
     }
     0
@@ -844,11 +840,7 @@ pub extern "C" fn host_blockhash(ctx: *mut VmCtx, height: u64, wd: u64) -> u64 {
     let current = vm.ctx.block_number;
     let hash = if height < current && current - height <= 256 {
         let idx = (current - height - 1) as usize;
-        vm.ctx
-            .block_hashes
-            .get(idx)
-            .copied()
-            .unwrap_or(U256::ZERO)
+        vm.ctx.block_hashes.get(idx).copied().unwrap_or(U256::ZERO)
     } else {
         U256::ZERO
     };

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -150,9 +150,9 @@ mod tests {
         for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
             for value in [1i32, -1, 0x4242, -0x4242] {
                 let code = bytecode(&[
-                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
-                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
-                    instr_bytes(Opcode::Shl, 3, 1, 2),           // r3 = r1 << r2
+                    instr_ri(Opcode::Addi, 1, 0, value),        // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32), // r2 = shift
+                    instr_bytes(Opcode::Shl, 3, 1, 2),          // r3 = r1 << r2
                     instr_bytes(Opcode::Halt, 0, 0, 0),
                 ]);
                 compare_with_interpreter(&code, 0);
@@ -167,9 +167,9 @@ mod tests {
         for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
             for value in [1i32, -1, 0x4242, -0x4242] {
                 let code = bytecode(&[
-                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
-                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
-                    instr_bytes(Opcode::Shr, 3, 1, 2),           // r3 = r1 >> r2 (unsigned)
+                    instr_ri(Opcode::Addi, 1, 0, value),        // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32), // r2 = shift
+                    instr_bytes(Opcode::Shr, 3, 1, 2),          // r3 = r1 >> r2 (unsigned)
                     instr_bytes(Opcode::Halt, 0, 0, 0),
                 ]);
                 compare_with_interpreter(&code, 0);
@@ -186,9 +186,9 @@ mod tests {
         for shift in [0u32, 1, 31, 32, 63, 64, 65, 127, 200, 255] {
             for value in [1i32, -1, 0x4242, -0x4242] {
                 let code = bytecode(&[
-                    instr_ri(Opcode::Addi, 1, 0, value),         // r1 = value
-                    instr_ri(Opcode::Addi, 2, 0, shift as i32),  // r2 = shift
-                    instr_bytes(Opcode::Sar, 3, 1, 2),           // r3 = r1 >>> r2 (signed)
+                    instr_ri(Opcode::Addi, 1, 0, value),        // r1 = value
+                    instr_ri(Opcode::Addi, 2, 0, shift as i32), // r2 = shift
+                    instr_bytes(Opcode::Sar, 3, 1, 2),          // r3 = r1 >>> r2 (signed)
                     instr_bytes(Opcode::Halt, 0, 0, 0),
                 ]);
                 compare_with_interpreter(&code, 0);
@@ -1474,8 +1474,7 @@ mod tests {
         ]);
         let mut aot_vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
         aot_vm.ctx.block_number = 1000;
-        aot_vm.ctx.block_hashes =
-            vec![pyde_vm::wide::U256::from(0xFFFFu64); 300];
+        aot_vm.ctx.block_hashes = vec![pyde_vm::wide::U256::from(0xFFFFu64); 300];
         let compiled = compile_bytecode(&code_oow).unwrap();
         let func = compiled.as_fn();
         let mut regs = [0u64; 16];

--- a/crates/consensus/src/finality.rs
+++ b/crates/consensus/src/finality.rs
@@ -463,7 +463,8 @@ mod tests {
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let vote = create_finality_vote(TEST_CHAIN_ID, 5, block_hash, state_root, i, addr, &sk).unwrap();
+            let vote = create_finality_vote(TEST_CHAIN_ID, 5, block_hash, state_root, i, addr, &sk)
+                .unwrap();
             votes.push(vote);
             keys.push(pk_bytes);
         }
@@ -496,7 +497,8 @@ mod tests {
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let vote = create_finality_vote(TEST_CHAIN_ID, 5, block_hash, state_root, i, addr, &sk).unwrap();
+            let vote = create_finality_vote(TEST_CHAIN_ID, 5, block_hash, state_root, i, addr, &sk)
+                .unwrap();
             votes.push(vote);
             keys.push(pk_bytes);
         }
@@ -526,7 +528,8 @@ mod tests {
             let pk_bytes = pk.as_bytes().to_vec();
             let addr = derive_eoa_address(&pk_bytes);
 
-            let vote = create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], i, addr, &sk).unwrap();
+            let vote = create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], i, addr, &sk)
+                .unwrap();
             votes.push(vote);
             keys.push(pk_bytes);
         }
@@ -545,7 +548,8 @@ mod tests {
         let pk_bytes = pk.as_bytes().to_vec();
         let addr = derive_eoa_address(&pk_bytes);
 
-        let vote = create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], 0, addr, &sk).unwrap();
+        let vote =
+            create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], 0, addr, &sk).unwrap();
         assert!(verify_finality_vote(TEST_CHAIN_ID, &vote, &pk_bytes));
     }
 
@@ -555,7 +559,8 @@ mod tests {
         let (pk2, _sk2) = falcon_keygen().unwrap();
         let addr = derive_eoa_address(pk1.as_bytes());
 
-        let vote = create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], 0, addr, &sk1).unwrap();
+        let vote =
+            create_finality_vote(TEST_CHAIN_ID, 5, [0xAA; 32], [0xCC; 32], 0, addr, &sk1).unwrap();
         assert!(!verify_finality_vote(TEST_CHAIN_ID, &vote, pk2.as_bytes()));
     }
 

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -745,7 +745,10 @@ mod tests {
 
         let keys = vec![vec![0u8; 897]; 128];
         let res = create_vote(TEST_CHAIN_ID, &mut state, &header, 0, addr, &sk, &keys);
-        assert!(res.is_err(), "audit 311: create_vote must refuse fabricated qc_previous");
+        assert!(
+            res.is_err(),
+            "audit 311: create_vote must refuse fabricated qc_previous"
+        );
         // The HotStuff state must not have promoted the fake QC.
         assert_eq!(
             state.highest_qc.slot, pre_state_hqc_slot,
@@ -828,7 +831,12 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert(6, header_6);
 
-        assert!(is_finalized(5, &[qc_5.clone(), qc_6.clone()], &headers, 128));
+        assert!(is_finalized(
+            5,
+            &[qc_5.clone(), qc_6.clone()],
+            &headers,
+            128
+        ));
         assert!(!is_finalized(5, &[qc_5.clone()], &headers, 128)); // missing QC for slot 6
         assert!(!is_finalized(5, &[qc_6.clone()], &headers, 128)); // missing QC for slot 5
 

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -127,11 +127,7 @@ impl LivenessReport {
 /// The `chain_id` binding prevents cross-chain replay: a double-sign
 /// on chain A is not valid evidence on chain B even when FALCON keys
 /// match. The slot binding prevents cross-slot replay within a chain.
-pub fn verify_double_sign(
-    chain_id: u64,
-    evidence: &DoubleSignEvidence,
-    public_key: &[u8],
-) -> bool {
+pub fn verify_double_sign(chain_id: u64, evidence: &DoubleSignEvidence, public_key: &[u8]) -> bool {
     // Two distinct blocks (empty-or-equal hashes = not evidence).
     if evidence.block_hash_1 == evidence.block_hash_2 {
         return false;
@@ -429,7 +425,11 @@ mod tests {
         };
 
         // Wrong key → reject
-        assert!(!verify_double_sign(TEST_CHAIN_ID, &evidence, pk2.as_bytes()));
+        assert!(!verify_double_sign(
+            TEST_CHAIN_ID,
+            &evidence,
+            pk2.as_bytes()
+        ));
     }
 
     #[test]

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -558,8 +558,9 @@ mod tests {
         // to reach an honest leader.
         let n = 4;
         let h = 145;
-        let leaders: std::collections::HashSet<usize> =
-            (0..(n as u64)).map(|v| fallback_leader_index(h, v, n)).collect();
+        let leaders: std::collections::HashSet<usize> = (0..(n as u64))
+            .map(|v| fallback_leader_index(h, v, n))
+            .collect();
         assert_eq!(
             leaders.len(),
             n,

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -1119,9 +1119,7 @@ mod tests {
         dec_shares[0].index = 0;
         let result = combine_shares(&dec_shares, T, &ct);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("invalid share index"));
+        assert!(result.unwrap_err().contains("invalid share index"));
     }
 
     #[test]
@@ -1139,9 +1137,7 @@ mod tests {
         dec_shares[0].index = 257;
         let result = combine_shares(&dec_shares, T, &ct);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("invalid share index"));
+        assert!(result.unwrap_err().contains("invalid share index"));
     }
 
     #[test]

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -793,8 +793,7 @@ impl BlockProcessor {
             }
 
             let score = pyde_consensus::proposer::score_from_output(&vrf_output);
-            let threshold =
-                pyde_consensus::proposer::vrf_proposer_threshold(committee_keys.len());
+            let threshold = pyde_consensus::proposer::vrf_proposer_threshold(committee_keys.len());
             if score > threshold {
                 return Err(format!(
                     "VRF score {} above proposer threshold {} for committee size {} (audit 323)",
@@ -1922,11 +1921,11 @@ mod tests {
         let err = BlockProcessor::validate_network_block(
             31337,
             &header,
-            &[],          // proposer_signature — irrelevant, parent_hash check fires first
-            &[],          // committee_keys — same
-            &[0u8; 32],   // epoch_randomness
+            &[],        // proposer_signature — irrelevant, parent_hash check fires first
+            &[],        // committee_keys — same
+            &[0u8; 32], // epoch_randomness
             Some(&expected),
-            None,         // parent_timestamp — irrelevant, parent_hash fires first
+            None, // parent_timestamp — irrelevant, parent_hash fires first
             header.timestamp.saturating_add(1), // now_ms — already past header
         )
         .unwrap_err();
@@ -2033,8 +2032,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.contains("not strictly greater than parent timestamp")
-                && err.contains("audit 325"),
+            err.contains("not strictly greater than parent timestamp") && err.contains("audit 325"),
             "expected audit-325 parent timestamp error, got: {err}"
         );
 
@@ -2098,9 +2096,7 @@ mod tests {
         header.parent_hash = [0xCD; 32];
         let expected_parent_hash = [0xCD; 32];
         // now_ms slightly behind header.timestamp but within drift.
-        let now_ms = header
-            .timestamp
-            .saturating_sub(MAX_TIMESTAMP_DRIFT_MS / 2);
+        let now_ms = header.timestamp.saturating_sub(MAX_TIMESTAMP_DRIFT_MS / 2);
         let err = BlockProcessor::validate_network_block(
             31337,
             &header,

--- a/crates/node/src/faucet.rs
+++ b/crates/node/src/faucet.rs
@@ -602,15 +602,28 @@ async fn handle_connection(
         }
         ("GET", "/") | ("GET", "/index.html") => html_response(200, FAUCET_HTML),
         ("GET", "/health") => json_response(200, r#"{"status":"ok"}"#),
-        ("POST", "/api/request") => {
-            match parse_post_body_address(&body) {
-                Some(addr) if addr.len() >= 64 => {
-                    serve_dispense(&addr, &ip_key, &addr_limiter, &ip_limiter, &rpc, &from, amount, signer.as_ref().as_ref(), &signing_lock, chain_id).await
-                }
-                Some(_) => json_response(400, r#"{"error":"address must be 0x-prefixed 32-byte hex"}"#),
-                None => json_response(400, r#"{"error":"missing address field in JSON body"}"#),
+        ("POST", "/api/request") => match parse_post_body_address(&body) {
+            Some(addr) if addr.len() >= 64 => {
+                serve_dispense(
+                    &addr,
+                    &ip_key,
+                    &addr_limiter,
+                    &ip_limiter,
+                    &rpc,
+                    &from,
+                    amount,
+                    signer.as_ref().as_ref(),
+                    &signing_lock,
+                    chain_id,
+                )
+                .await
             }
-        }
+            Some(_) => json_response(
+                400,
+                r#"{"error":"address must be 0x-prefixed 32-byte hex"}"#,
+            ),
+            None => json_response(400, r#"{"error":"missing address field in JSON body"}"#),
+        },
         ("GET", "/faucet") => {
             // Legacy backwards-compat endpoint.
             let address = query.split('&').find_map(|p| {
@@ -623,7 +636,19 @@ async fn handle_connection(
             });
             match address {
                 Some(addr) if addr.len() >= 64 => {
-                    serve_dispense(&addr, &ip_key, &addr_limiter, &ip_limiter, &rpc, &from, amount, signer.as_ref().as_ref(), &signing_lock, chain_id).await
+                    serve_dispense(
+                        &addr,
+                        &ip_key,
+                        &addr_limiter,
+                        &ip_limiter,
+                        &rpc,
+                        &from,
+                        amount,
+                        signer.as_ref().as_ref(),
+                        &signing_lock,
+                        chain_id,
+                    )
+                    .await
                 }
                 _ => json_response(400, r#"{"error":"missing or invalid address"}"#),
             }
@@ -653,7 +678,10 @@ async fn serve_dispense(
     if let Err(secs) = addr_limiter.check(address) {
         return json_response(
             429,
-            &format!(r#"{{"error":"address rate limited","retryAfter":{}}}"#, secs),
+            &format!(
+                r#"{{"error":"address rate limited","retryAfter":{}}}"#,
+                secs
+            ),
         );
     }
     if let Err(secs) = ip_limiter.check(ip_key) {

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -783,10 +783,10 @@ impl NodeAddrFile {
     /// Parse a `node-addrs.toml` file. Returns the entries sorted by
     /// `index` so callers can index into the result directly.
     pub fn load(path: &std::path::Path) -> Result<Self, String> {
-        let bytes = std::fs::read_to_string(path)
-            .map_err(|e| format!("read {}: {}", path.display(), e))?;
-        let mut parsed: Self = toml::from_str(&bytes)
-            .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+        let bytes =
+            std::fs::read_to_string(path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+        let mut parsed: Self =
+            toml::from_str(&bytes).map_err(|e| format!("parse {}: {}", path.display(), e))?;
         parsed.nodes.sort_by_key(|n| n.index);
         // Ensure indexes are dense [0, n). Sparse files silently mis-map
         // bootstrap entries to the wrong nodes, hard to diagnose later.
@@ -1068,9 +1068,7 @@ pub fn generate_testnet(
             if j != i {
                 let other_peer_id = &node_keypairs[j].1;
                 bootstrap_addrs.push(match node_addrs {
-                    Some(addrs) => {
-                        build_multiaddr(&addrs[j].host, addrs[j].port, other_peer_id)
-                    }
+                    Some(addrs) => build_multiaddr(&addrs[j].host, addrs[j].port, other_peer_id),
                     None => format!(
                         "\"/ip4/127.0.0.1/tcp/{}/p2p/{}\"",
                         base_port + j as u16,
@@ -1421,7 +1419,9 @@ mod tests {
 
     #[test]
     fn build_multiaddr_picks_dns4_for_hostnames() {
-        let pid: libp2p::PeerId = libp2p::identity::Keypair::generate_ed25519().public().into();
+        let pid: libp2p::PeerId = libp2p::identity::Keypair::generate_ed25519()
+            .public()
+            .into();
         let m = build_multiaddr("validator-0.testnet.example.com", 30303, &pid);
         assert!(m.contains("/dns4/validator-0.testnet.example.com/"));
         assert!(m.contains("/tcp/30303/"));
@@ -1430,7 +1430,9 @@ mod tests {
 
     #[test]
     fn build_multiaddr_picks_ip4_for_dotted_quad() {
-        let pid: libp2p::PeerId = libp2p::identity::Keypair::generate_ed25519().public().into();
+        let pid: libp2p::PeerId = libp2p::identity::Keypair::generate_ed25519()
+            .public()
+            .into();
         let m = build_multiaddr("203.0.113.5", 30303, &pid);
         assert!(m.contains("/ip4/203.0.113.5/"));
         assert!(!m.contains("/dns4/"));
@@ -1500,18 +1502,7 @@ mod tests {
                 port: 30305,
             },
         ];
-        generate_testnet(
-            tmp.path(),
-            4,
-            0,
-            30303,
-            8545,
-            true,
-            1,
-            400,
-            Some(&addrs),
-        )
-        .unwrap();
+        generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, 1, 400, Some(&addrs)).unwrap();
 
         // node-0's config must:
         //  - carry its own region/host as a comment header

--- a/crates/node/src/keystore.rs
+++ b/crates/node/src/keystore.rs
@@ -83,13 +83,8 @@ const ARGON2_P_COST: u32 = 1;
 /// or supply-chain compromise of the keystore file effectively
 /// exposed the FALCON private key.
 fn derive_aes_key(passphrase: &str, salt: &[u8]) -> Result<[u8; 32], String> {
-    let params = argon2::Params::new(
-        ARGON2_M_COST_KIB,
-        ARGON2_T_COST,
-        ARGON2_P_COST,
-        Some(32),
-    )
-    .map_err(|e| format!("argon2 params: {e}"))?;
+    let params = argon2::Params::new(ARGON2_M_COST_KIB, ARGON2_T_COST, ARGON2_P_COST, Some(32))
+        .map_err(|e| format!("argon2 params: {e}"))?;
     let argon = argon2::Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
     let mut out = [0u8; 32];
     argon

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -55,10 +55,7 @@ const MEV_INCLUSION_GRACE_SLOTS: u64 = 2;
 /// (e.g., their own multiaddr) so the gate is satisfied. This mirrors
 /// the operational reality — a network with no peers and no bootstrap
 /// is never a real network.
-pub fn check_bootstrap_config(
-    chain_id: u64,
-    bootstrap_peers: &[String],
-) -> Result<(), String> {
+pub fn check_bootstrap_config(chain_id: u64, bootstrap_peers: &[String]) -> Result<(), String> {
     if !bootstrap_peers.is_empty() {
         return Ok(());
     }
@@ -265,10 +262,7 @@ impl PydeNode {
 
         // Audit 343: refuse to start if config.toml's chain_id
         // disagrees with genesis.toml's.
-        check_config_genesis_chain_id_match(
-            self.config.node.chain_id,
-            genesis_config.chain_id,
-        )?;
+        check_config_genesis_chain_id_match(self.config.node.chain_id, genesis_config.chain_id)?;
 
         // 3. Block store (persistent headers on disk). Arc'd so the
         // RPC layer can read full block bodies without a second open.
@@ -588,7 +582,7 @@ impl PydeNode {
         // Skip-if-already-connected is handled inside
         // `redial_saved_peers` so a peer in BOTH bootstrap and the
         // book isn't dialed twice.
-        if peer_book.len() > 0 {
+        if !peer_book.is_empty() {
             redial_saved_peers(&mut swarm, &peer_book);
         }
 
@@ -3417,10 +3411,9 @@ async fn commit_jmt_writes(
         return;
     }
     let commit_start = std::time::Instant::now();
-    if let Ok(root) = crate::state_manager::StateManager::commit_writes_to_smt(
-        &smt_handle,
-        pending_writes,
-    ) {
+    if let Ok(root) =
+        crate::state_manager::StateManager::commit_writes_to_smt(&smt_handle, pending_writes)
+    {
         crate::metrics::record_state_commit_ms(commit_start.elapsed().as_millis() as u64);
         let mut sw = state.write().await;
         sw.set_root(root);
@@ -3481,9 +3474,15 @@ fn emit_ws_events(
 /// committed txs would re-appear in the next block's selection set and
 /// fail with `BelowWindow` (nonce already consumed).
 async fn prune_committed_txs(
-    mempool_index: &std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<[u8; 32], Vec<u8>>>>,
-    pending_txs: &std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<[u8; 32], pyde_tx::types::Transaction>>>,
-    pending_tx_times: &std::sync::Arc<tokio::sync::RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>>,
+    mempool_index: &std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<[u8; 32], Vec<u8>>>,
+    >,
+    pending_txs: &std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<[u8; 32], pyde_tx::types::Transaction>>,
+    >,
+    pending_tx_times: &std::sync::Arc<
+        tokio::sync::RwLock<std::collections::HashMap<[u8; 32], std::time::Instant>>,
+    >,
     tx_relay: &std::sync::Arc<tokio::sync::RwLock<crate::tx_relay::TxRelay>>,
     block: &pyde_consensus::block::Block,
 ) {
@@ -3551,7 +3550,13 @@ async fn cast_finality_vote_and_persist(
     let cert_formed = engine.on_finality_vote(fv.clone());
     let fv_bytes = wire::encode_finality_vote(&fv);
     let topic = pyde_net::node::topics::consensus();
-    broadcast_consensus_with_rr_fallback(swarm, topic.clone(), fv_bytes, peer_manager, gossip_cache);
+    broadcast_consensus_with_rr_fallback(
+        swarm,
+        topic.clone(),
+        fv_bytes,
+        peer_manager,
+        gossip_cache,
+    );
     if !cert_formed {
         return;
     }
@@ -3642,10 +3647,7 @@ async fn maybe_kick_decryption_pipeline(
             }
         }
         drop(q);
-        pending_decryptors
-            .write()
-            .await
-            .insert(qc_slot, decryptor);
+        pending_decryptors.write().await.insert(qc_slot, decryptor);
     }
     if let Some(shares) = engine.generate_decryption_shares(identity, &enc_txs) {
         let msg = wire::DecryptionShareMsg {
@@ -3659,7 +3661,8 @@ async fn maybe_kick_decryption_pipeline(
         info!(
             slot = qc_slot,
             enc_txs = enc_txs.len(),
-            "broadcast decryption shares (canonical-apply{})", log_tag
+            "broadcast decryption shares (canonical-apply{})",
+            log_tag
         );
     }
 }
@@ -3676,8 +3679,10 @@ fn broadcast_consensus_with_rr_fallback(
     // a peer subscribes to the topic — see the
     // `gossipsub::Event::Subscribed` arm in `handle_swarm_event`.
     let topic_hash = topic.hash();
-    if let Err(libp2p::gossipsub::PublishError::InsufficientPeers) =
-        swarm.behaviour_mut().gossipsub.publish(topic.clone(), data.clone())
+    if let Err(libp2p::gossipsub::PublishError::InsufficientPeers) = swarm
+        .behaviour_mut()
+        .gossipsub
+        .publish(topic.clone(), data.clone())
     {
         debug!(topic = %topic_hash, bytes = data.len(), "consensus publish: InsufficientPeers; stashed for replay");
         gossip_cache.stash(topic_hash, data.clone());
@@ -3777,8 +3782,10 @@ fn broadcast_blocks_with_rr_fallback(
     // post-restart never get retried even though the RR fanout
     // already ensures eventual delivery.
     let topic_hash = topic.hash();
-    if let Err(libp2p::gossipsub::PublishError::InsufficientPeers) =
-        swarm.behaviour_mut().gossipsub.publish(topic.clone(), data.clone())
+    if let Err(libp2p::gossipsub::PublishError::InsufficientPeers) = swarm
+        .behaviour_mut()
+        .gossipsub
+        .publish(topic.clone(), data.clone())
     {
         debug!(topic = %topic_hash, bytes = data.len(), "blocks publish: InsufficientPeers; stashed for replay");
         gossip_cache.stash(topic_hash, data.clone());
@@ -3854,8 +3861,7 @@ fn redial_saved_peers(
     }
     info!(
         saved = peer_book.len(),
-        dialed,
-        "redialed saved peers from peer book"
+        dialed, "redialed saved peers from peer book"
     );
 }
 
@@ -4758,9 +4764,7 @@ fn handle_swarm_event(
                                     "received finality vote via RR fallback"
                                 );
                                 if engine.on_finality_vote(fv) {
-                                    if let Some(cp) =
-                                        engine.latest_finality_checkpoint()
-                                    {
+                                    if let Some(cp) = engine.latest_finality_checkpoint() {
                                         let _ = block_store.put_finality_cert(cp);
                                         info!(
                                             slot = cp.slot,
@@ -4771,9 +4775,8 @@ fn handle_swarm_event(
                                         // their WS anchor (mirrors the
                                         // gossipsub-receive handler at
                                         // line ~3720).
-                                        pending_fallback_broadcast = Some(
-                                            wire::encode_finality_checkpoint_msg(cp),
-                                        );
+                                        pending_fallback_broadcast =
+                                            Some(wire::encode_finality_checkpoint_msg(cp));
                                     }
                                 }
                             }
@@ -4795,14 +4798,13 @@ fn handle_swarm_event(
                                 signature,
                             } => {
                                 debug!(slot, voter_index, "received timeout via RR fallback");
-                                let vc_msg =
-                                    pyde_consensus::view_change::ViewChangeMessage {
-                                        slot,
-                                        highest_qc,
-                                        voter_index,
-                                        voter_address,
-                                        signature,
-                                    };
+                                let vc_msg = pyde_consensus::view_change::ViewChangeMessage {
+                                    slot,
+                                    highest_qc,
+                                    voter_index,
+                                    voter_address,
+                                    signature,
+                                };
                                 if engine.on_view_change(vc_msg) {
                                     info!(slot, "view change QC formed (via RR fallback) — fallback proposer can proceed");
                                     if let Some(bytes) = build_and_encode_fallback_proposal(
@@ -4814,7 +4816,9 @@ fn handle_swarm_event(
                                     }
                                 }
                             }
-                            ConsensusMessage::Vote { slot, voter_index, .. } => {
+                            ConsensusMessage::Vote {
+                                slot, voter_index, ..
+                            } => {
                                 // Audit 234 part 3: votes that fell back
                                 // to RR (gossip publish failed) need to
                                 // route through the same `on_vote` path
@@ -4824,7 +4828,11 @@ fn handle_swarm_event(
                                 // here.
                                 debug!(slot, voter_index, "received vote via RR fallback");
                                 if let Some(qc) = engine.on_vote(msg) {
-                                    info!(slot, votes = qc.vote_count(), "QC formed (via RR fallback)");
+                                    info!(
+                                        slot,
+                                        votes = qc.vote_count(),
+                                        "QC formed (via RR fallback)"
+                                    );
                                     pending_apply_qcd = Some((slot, qc.block_hash));
                                 }
                             }
@@ -4835,7 +4843,9 @@ fn handle_swarm_event(
                                 debug!(slot = header.slot, "received proposal via RR fallback");
                                 engine.buffer_proposal(header, proposer_signature);
                             }
-                            ConsensusMessage::NewView { slot, highest_qc, .. } => {
+                            ConsensusMessage::NewView {
+                                slot, highest_qc, ..
+                            } => {
                                 debug!(slot, "received new view via RR fallback");
                                 if highest_qc.slot > engine.consensus.highest_qc.slot {
                                     engine.consensus.highest_qc = highest_qc;
@@ -4873,14 +4883,12 @@ fn handle_swarm_event(
             if let Some(share_msg) = pending_share_msg {
                 PostEventAction::SendConsensusRrResponseAndAddShares(channel, resp, share_msg)
             } else if let Some((qc_slot, qc_hash)) = pending_apply_qcd {
-                PostEventAction::SendConsensusRrResponseAndApplyQcd(
-                    channel, resp, qc_slot, qc_hash,
-                )
+                PostEventAction::SendConsensusRrResponseAndApplyQcd(channel, resp, qc_slot, qc_hash)
             } else {
                 match pending_fallback_broadcast {
-                    Some(bytes) => PostEventAction::SendConsensusRrResponseAndBroadcast(
-                        channel, resp, bytes,
-                    ),
+                    Some(bytes) => {
+                        PostEventAction::SendConsensusRrResponseAndBroadcast(channel, resp, bytes)
+                    }
                     None => PostEventAction::SendConsensusRrResponse(channel, resp),
                 }
             }
@@ -4916,10 +4924,7 @@ fn handle_swarm_event(
             // substream-closed-during-send) don't warrant disconnect;
             // libp2p's own keep-alive will reap genuinely-dead
             // connections.
-            let is_timeout = matches!(
-                error,
-                request_response::OutboundFailure::Timeout
-            );
+            let is_timeout = matches!(error, request_response::OutboundFailure::Timeout);
             if is_timeout {
                 debug!(%peer, ?error, "consensus RR timeout; dropping stale connection");
                 PostEventAction::DisconnectStalePeer(peer)
@@ -4939,16 +4944,14 @@ fn handle_swarm_event(
         )) => PostEventAction::None,
 
         // --- BlocksRr: inbound block via RR fallback (audit 234 part 4 follow-up) ---
-        SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
-            request_response::Event::Message {
-                peer,
-                message:
-                    request_response::Message::Request {
-                        request, channel, ..
-                    },
-                ..
-            },
-        )) => {
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(request_response::Event::Message {
+            peer,
+            message:
+                request_response::Message::Request {
+                    request, channel, ..
+                },
+            ..
+        })) => {
             // Per-peer spam threshold, mirroring audit item 214's
             // pattern for decryption-share gossip. A peer that has
             // already crossed the invalid-message threshold on prior
@@ -5054,12 +5057,10 @@ fn handle_swarm_event(
                 pyde_net::blocks_protocol::BlocksResp::DecodeError,
             )
         }
-        SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
-            request_response::Event::Message {
-                message: request_response::Message::Response { .. },
-                ..
-            },
-        )) => {
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(request_response::Event::Message {
+            message: request_response::Message::Response { .. },
+            ..
+        })) => {
             // Acks (or DecodeError responses) from peers — best-effort
             // confirmation, nothing to do.
             PostEventAction::None
@@ -5071,10 +5072,7 @@ fn handle_swarm_event(
             // disconnect on `Timeout`. Transient failures during slot-
             // tick fanout would otherwise trigger a feedback loop on
             // the bootstrap re-dial cycle.
-            let is_timeout = matches!(
-                error,
-                request_response::OutboundFailure::Timeout
-            );
+            let is_timeout = matches!(error, request_response::OutboundFailure::Timeout);
             if is_timeout {
                 debug!(%peer, ?error, "blocks RR timeout; dropping stale connection");
                 PostEventAction::DisconnectStalePeer(peer)
@@ -5406,8 +5404,7 @@ mod tests {
     /// glance.
     #[test]
     fn bootstrap_guard_labels_canonical_testnet_chain_id() {
-        let err = check_bootstrap_config(pyde_net::discovery::TESTNET_CHAIN_ID, &[])
-            .unwrap_err();
+        let err = check_bootstrap_config(pyde_net::discovery::TESTNET_CHAIN_ID, &[]).unwrap_err();
         assert!(
             err.contains("public testnet"),
             "error must label canonical testnet (7331) as 'public testnet', got: {err}"

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1561,8 +1561,8 @@ pub async fn start_rpc_server(
     // calldata + ABI args at typical contract sizes — plus
     // headroom for `pyde_getLogs` / `pyde_getBlockByNumber(slot,
     // full_tx)` response payloads.
-    const MAX_REQUEST_BODY_BYTES: u32 = 1_048_576;       // 1 MB
-    const MAX_RESPONSE_BODY_BYTES: u32 = 16_777_216;     // 16 MB
+    const MAX_REQUEST_BODY_BYTES: u32 = 1_048_576; // 1 MB
+    const MAX_RESPONSE_BODY_BYTES: u32 = 16_777_216; // 16 MB
     const MAX_CONNECTIONS: u32 = 1024;
     const MAX_REQUESTS_PER_BATCH: u32 = 32;
     let server = Server::builder()
@@ -1920,10 +1920,7 @@ async fn parse_call_object(
 /// hash, sender, recipient, value, nonce, gas_limit, tx_type. Falls
 /// back to an empty array if the block isn't on disk yet (genesis,
 /// or a slot that this node only saw a header for during sync).
-fn decode_block_transactions(
-    block_store: &BlockStore,
-    slot: u64,
-) -> Vec<serde_json::Value> {
+fn decode_block_transactions(block_store: &BlockStore, slot: u64) -> Vec<serde_json::Value> {
     let raw = match block_store.get_block_raw(slot) {
         Some(r) => r,
         None => return Vec::new(),
@@ -2095,10 +2092,7 @@ mod tests {
     #[test]
     fn resolve_chain_id_accepts_matching_value() {
         for chain in [1u64, 7331, 31337] {
-            assert_eq!(
-                resolve_request_chain_id(Some(chain), chain).unwrap(),
-                chain
-            );
+            assert_eq!(resolve_request_chain_id(Some(chain), chain).unwrap(), chain);
         }
     }
 

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -688,7 +688,7 @@ impl ChainSync {
                 // entries — well above the SNAPSHOT_CHUNK_SIZE
                 // operators actually use, but bounded.
                 const MAX_SNAPSHOT_CHUNK_SIZE: usize = 50_000;
-                let cs = (*chunk_size as usize).max(1).min(MAX_SNAPSHOT_CHUNK_SIZE);
+                let cs = (*chunk_size as usize).clamp(1, MAX_SNAPSHOT_CHUNK_SIZE);
                 let total_chunks = snap.entries.len().div_ceil(cs).max(1) as u32;
                 let start = (*chunk_index as usize) * cs;
 

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -1045,8 +1045,7 @@ impl ValidatorEngine {
         // instead of the hardcoded 85. Without this, devnet /
         // testnet committees < 85 could never finalize epoch
         // randomness.
-        let mut collector =
-            RandomnessCollector::new(next_epoch, self.committee_keys.len());
+        let mut collector = RandomnessCollector::new(next_epoch, self.committee_keys.len());
         collector.add_share(share.clone());
         self.randomness_collector = Some(collector);
 
@@ -1116,8 +1115,7 @@ impl ValidatorEngine {
                 // `pyde_consensus::proposer::vrf_proposer_threshold`
                 // so the receive path (`validate_network_block`)
                 // applies the same gate.
-                let threshold =
-                    pyde_consensus::proposer::vrf_proposer_threshold(committee_size);
+                let threshold = pyde_consensus::proposer::vrf_proposer_threshold(committee_size);
 
                 if candidate.score > threshold {
                     debug!(
@@ -1423,15 +1421,20 @@ impl ValidatorEngine {
         // we have no way to validate the proposal; reject and let
         // our own view-change-QC formation catch up.
         if self.timeout.slot != slot || self.timeout.view_change_qc.is_none() {
-            debug!(slot, "fallback proposal received without local view-change-QC; deferring");
+            debug!(
+                slot,
+                "fallback proposal received without local view-change-QC; deferring"
+            );
             return false;
         }
         let vc_qc = self.timeout.view_change_qc.as_ref().unwrap();
 
         // Verify the proposer is a committee member.
-        let proposer_idx = match self.committee_keys.iter().position(|k| {
-            pyde_account::address::derive_eoa_address(k) == header.proposer
-        }) {
+        let proposer_idx = match self
+            .committee_keys
+            .iter()
+            .position(|k| pyde_account::address::derive_eoa_address(k) == header.proposer)
+        {
             Some(i) => i,
             None => {
                 warn!(
@@ -1549,7 +1552,12 @@ impl ValidatorEngine {
         // fallback to be built for a slot the chain has already moved
         // past.
         let slot = self.consensus.target_height;
-        info!(mine = identity.committee_index, target_height = slot, current_slot = self.consensus.current_slot, "DBG try_build_fallback_proposal entered");
+        info!(
+            mine = identity.committee_index,
+            target_height = slot,
+            current_slot = self.consensus.current_slot,
+            "DBG try_build_fallback_proposal entered"
+        );
         // NOTE: previously voting for slot does NOT disqualify us from
         // being the fallback proposer (audit 234 part 3). The whole
         // reason a view-change-QC exists at this slot is that the
@@ -1558,12 +1566,14 @@ impl ValidatorEngine {
         // only against double-voting on the SAME proposal, which is
         // enforced by HotStuff safety in `create_vote`.
         if self.timeout.slot != slot {
-            info!(slot, timeout_slot = self.timeout.slot, "DBG fallback skip: timeout.slot != target_height");
+            info!(
+                slot,
+                timeout_slot = self.timeout.slot,
+                "DBG fallback skip: timeout.slot != target_height"
+            );
             return None;
         }
-        if self.timeout.view_change_qc.is_none() {
-            return None;
-        }
+        self.timeout.view_change_qc.as_ref()?;
         // audit-234 part 4 (CONSENSUS_INVARIANTS.md L2): only the
         // deterministic leader for `(target_height, current_view)`
         // builds a fallback. Other validators return None. This
@@ -1619,15 +1629,19 @@ impl ValidatorEngine {
 
         let block_hash = header.hash();
         let sign_msg = proposer_sign_message(self.chain_id, slot, &block_hash);
-        let proposer_signature = match pyde_crypto::falcon::falcon_sign(&identity.secret_key, &sign_msg) {
-            Ok(sig) => sig.to_vec(),
-            Err(_) => {
-                warn!(slot, "failed to sign fallback proposal");
-                return None;
-            }
-        };
+        let proposer_signature =
+            match pyde_crypto::falcon::falcon_sign(&identity.secret_key, &sign_msg) {
+                Ok(sig) => sig.to_vec(),
+                Err(_) => {
+                    warn!(slot, "failed to sign fallback proposal");
+                    return None;
+                }
+            };
 
-        info!(slot, "built fallback proposal as deterministic view-change fallback proposer");
+        info!(
+            slot,
+            "built fallback proposal as deterministic view-change fallback proposer"
+        );
         Some(Block {
             header,
             body: BlockBody {
@@ -1840,7 +1854,13 @@ impl ValidatorEngine {
         // Try to form QC (dynamic quorum based on actual committee size)
         let threshold = quorum_for_committee(self.committee_keys.len());
         if entry.votes.len() >= threshold {
-            let qc = try_form_qc(self.chain_id, slot, block_hash, &entry.votes, &self.committee_keys);
+            let qc = try_form_qc(
+                self.chain_id,
+                slot,
+                block_hash,
+                &entry.votes,
+                &self.committee_keys,
+            );
             if let Some(ref qc) = qc {
                 info!(slot, votes = qc.vote_count(), "QC formed");
                 // Update consensus state
@@ -1946,7 +1966,9 @@ impl ValidatorEngine {
         entry.push(msg);
 
         // Try to form view change QC
-        if let Some(vc_qc) = try_form_view_change_qc(self.chain_id, slot, entry, &self.committee_keys) {
+        if let Some(vc_qc) =
+            try_form_view_change_qc(self.chain_id, slot, entry, &self.committee_keys)
+        {
             let first_formation = self.timeout.view_change_qc.is_none();
             if first_formation {
                 self.consensus.bump_view();
@@ -3636,10 +3658,8 @@ mod tests {
         // Build the canonical (chain_id || slot || block_hash) preimage —
         // must match what `verify_double_sign` reconstructs for the
         // engine's chain_id, otherwise FALCON verify rejects.
-        let sign_1 =
-            pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_1);
-        let sign_2 =
-            pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_2);
+        let sign_1 = pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_1);
+        let sign_2 = pyde_consensus::hotstuff::proposer_sign_message(TEST_CHAIN_ID, slot, &hash_2);
         let sig_1 = pyde_crypto::falcon::falcon_sign(&sk, &sign_1)
             .unwrap()
             .as_bytes()
@@ -3983,10 +4003,8 @@ mod tests {
         let slot = 100u64;
         let hash_1 = [0xA1u8; 32];
         let hash_2 = [0xA2u8; 32];
-        let sign_msg_1 =
-            pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_1);
-        let sign_msg_2 =
-            pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_2);
+        let sign_msg_1 = pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_1);
+        let sign_msg_2 = pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &hash_2);
         let sig_1 = falcon_sign(&offender_sk, &sign_msg_1)
             .unwrap()
             .as_bytes()

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -311,12 +311,21 @@ fn run_consensus(
     const CHAIN_ID: u64 = 31337;
     let mut votes = Vec::new();
     for (i, v) in validators.iter().enumerate() {
-        if let Ok(Some(vote)) = create_vote(CHAIN_ID, &mut states[i], &header, i as u8, v.address, &v.sk, &committee_keys) {
+        if let Ok(Some(vote)) = create_vote(
+            CHAIN_ID,
+            &mut states[i],
+            &header,
+            i as u8,
+            v.address,
+            &v.sk,
+            &committee_keys,
+        ) {
             assert!(verify_vote(CHAIN_ID, &vote, v.pk.as_bytes()));
             votes.push(vote);
         }
     }
-    let qc = try_form_qc(CHAIN_ID, slot, block_hash, &votes, &committee_keys).expect("QC must form");
+    let qc =
+        try_form_qc(CHAIN_ID, slot, block_hash, &votes, &committee_keys).expect("QC must form");
     (block_hash, qc)
 }
 

--- a/crates/node/tests/lifecycle_bench.rs
+++ b/crates/node/tests/lifecycle_bench.rs
@@ -511,7 +511,15 @@ fn validator_block_lifecycle() {
     let mut votes = Vec::new();
     const CHAIN_ID: u64 = 31337;
     for (i, v) in validators.iter().enumerate() {
-        if let Ok(Some(vote)) = create_vote(CHAIN_ID, &mut cstates[i], &hdr, i as u8, v.address, &v.sk, &ckeys) {
+        if let Ok(Some(vote)) = create_vote(
+            CHAIN_ID,
+            &mut cstates[i],
+            &hdr,
+            i as u8,
+            v.address,
+            &v.sk,
+            &ckeys,
+        ) {
             assert!(verify_vote(CHAIN_ID, &vote, v.pk.as_bytes()));
             votes.push(vote);
         }

--- a/crates/node/tests/loadgen_encrypted_burst.rs
+++ b/crates/node/tests/loadgen_encrypted_burst.rs
@@ -54,8 +54,7 @@ const PASS_INCLUSION_PCT: f64 = 70.0;
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn encrypted_burst_inclusion_rate() {
     let per_sender = burst_per_sender();
-    let net =
-        TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4-node testnet: {}", e));
+    let net = TestNetwork::spawn(4, true).unwrap_or_else(|e| panic!("spawn 4-node testnet: {}", e));
 
     net.wait_for_slot(15, Duration::from_secs(45))
         .unwrap_or_else(|e| panic!("warm-up to slot 15: {}", e));

--- a/crates/node/tests/loadgen_sustained.rs
+++ b/crates/node/tests/loadgen_sustained.rs
@@ -411,8 +411,13 @@ fn sustained_rate_load_test() {
         let bytes = runtime
             .block_on(fetch_threshold_pk_bytes(&client, &rpc_urls[0]))
             .unwrap_or_else(|| panic!("could not fetch threshold pubkey from {}", rpc_urls[0]));
-        let tpk = pyde_crypto::threshold::ThresholdPublicKey::from_bytes(&bytes)
-            .unwrap_or_else(|| panic!("threshold pubkey bytes ({} bytes) failed to decode", bytes.len()));
+        let tpk =
+            pyde_crypto::threshold::ThresholdPublicKey::from_bytes(&bytes).unwrap_or_else(|| {
+                panic!(
+                    "threshold pubkey bytes ({} bytes) failed to decode",
+                    bytes.len()
+                )
+            });
         println!(
             "  cached threshold pubkey: {} bytes (encrypted path)",
             bytes.len()
@@ -690,8 +695,7 @@ fn sustained_rate_load_test() {
         let timing_lines: Vec<&str> = snap
             .lines()
             .filter(|l| {
-                (l.contains("proposed and processed")
-                    || l.contains("proposed block (awaiting QC"))
+                (l.contains("proposed and processed") || l.contains("proposed block (awaiting QC"))
                     && !l.contains("pending=0 ")
                     && !l.contains("pending=0\n")
             })

--- a/crates/node/tests/validator_churn_4_of_4.rs
+++ b/crates/node/tests/validator_churn_4_of_4.rs
@@ -46,7 +46,11 @@ fn max_live_head(net: &TestNetwork, exclude: Option<usize>) -> u64 {
         .unwrap_or(0)
 }
 
-fn wait_for_convergence(net: &TestNetwork, tolerance: u64, timeout: Duration) -> Result<(), String> {
+fn wait_for_convergence(
+    net: &TestNetwork,
+    tolerance: u64,
+    timeout: Duration,
+) -> Result<(), String> {
     let deadline = Instant::now() + timeout;
     loop {
         let slots: Vec<u64> = net
@@ -104,7 +108,9 @@ fn wait_for_node_slot(
             return Ok(());
         }
         if Instant::now() >= deadline {
-            return Err(format!("node-{node_idx} stuck at {cur}, target {target_slot}"));
+            return Err(format!(
+                "node-{node_idx} stuck at {cur}, target {target_slot}"
+            ));
         }
         std::thread::sleep(Duration::from_millis(200));
     }
@@ -146,12 +152,20 @@ fn rolling_restart_4_of_4() {
 
         net.restart_node(victim).unwrap();
         let target = max_live_head(&net, None) + 3;
-        wait_for_node_slot(&net, victim, target, Duration::from_secs(CATCHUP_TIMEOUT_SECS))
-            .unwrap();
-        wait_for_convergence(&net, 2, Duration::from_secs(CATCHUP_TIMEOUT_SECS))
-            .unwrap();
-        wait_for_steady_state(&net, STEADY_STATE_SLOTS, Duration::from_secs(CATCHUP_TIMEOUT_SECS))
-            .unwrap();
+        wait_for_node_slot(
+            &net,
+            victim,
+            target,
+            Duration::from_secs(CATCHUP_TIMEOUT_SECS),
+        )
+        .unwrap();
+        wait_for_convergence(&net, 2, Duration::from_secs(CATCHUP_TIMEOUT_SECS)).unwrap();
+        wait_for_steady_state(
+            &net,
+            STEADY_STATE_SLOTS,
+            Duration::from_secs(CATCHUP_TIMEOUT_SECS),
+        )
+        .unwrap();
         eprintln!("churn4: node-{victim} caught up + steady");
 
         let r0 = net.state_root(victim).unwrap();
@@ -165,7 +179,11 @@ fn rolling_restart_4_of_4() {
     }
 
     for n in &net.nodes {
-        assert!(n.is_running(), "node-{} died during 4-of-4 rotation", n.index);
+        assert!(
+            n.is_running(),
+            "node-{} died during 4-of-4 rotation",
+            n.index
+        );
     }
     eprintln!(
         "churn4: passed — rotated 4 of 4 validators, final head {}, all roots agree",

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -4494,8 +4494,14 @@ mod tests {
         }
 
         // Sanity: post-merge the child values are visible.
-        assert_eq!(vm.storage.get(&U256::from(1u32)), Some(&b"child-V1".to_vec()));
-        assert_eq!(vm.storage.get(&U256::from(2u32)), Some(&b"child-V2".to_vec()));
+        assert_eq!(
+            vm.storage.get(&U256::from(1u32)),
+            Some(&b"child-V1".to_vec())
+        );
+        assert_eq!(
+            vm.storage.get(&U256::from(2u32)),
+            Some(&b"child-V2".to_vec())
+        );
 
         // Parent reverts.
         vm.rollback_storage_pub();
@@ -4525,12 +4531,14 @@ mod tests {
         // Simulate a pre-309 merge (no journal call) and confirm
         // we'd have lost the revert ability — this just documents
         // the bug shape.
-        vm.storage.insert(U256::from(7u32), b"will-be-clobbered".to_vec());
+        vm.storage
+            .insert(U256::from(7u32), b"will-be-clobbered".to_vec());
         vm.journal_storage_write(&U256::from(7u32));
         // Parent did its own write — journaled.
         let pre_journal_count = vm.storage_journal_keys.len();
         // Now bulk-insert child values WITHOUT journaling (pre-309 shape):
-        vm.storage.insert(U256::from(7u32), b"child-clobber".to_vec());
+        vm.storage
+            .insert(U256::from(7u32), b"child-clobber".to_vec());
         vm.storage.insert(U256::from(8u32), b"child-new".to_vec());
         // No new journal entries because we skipped journal_storage_write.
         assert_eq!(vm.storage_journal_keys.len(), pre_journal_count);
@@ -4539,7 +4547,10 @@ mod tests {
         // K=7 IS rolled back (parent journaled it before the
         // simulated bulk insert), but K=8 leaks past revert —
         // exactly the pre-309 hazard.
-        assert_eq!(vm.storage.get(&U256::from(7u32)), Some(&b"will-be-clobbered".to_vec()));
+        assert_eq!(
+            vm.storage.get(&U256::from(7u32)),
+            Some(&b"will-be-clobbered".to_vec())
+        );
         assert_eq!(
             vm.storage.get(&U256::from(8u32)),
             Some(&b"child-new".to_vec()),

--- a/crates/pyde-dev/src/wallet.rs
+++ b/crates/pyde-dev/src/wallet.rs
@@ -181,13 +181,8 @@ pub fn list() -> Result<Vec<(String, String)>, String> {
 /// Argon2id KDF (audit 306). Replaces the prior single-iteration
 /// Poseidon2 KDF, which was brute-forceable on commodity GPUs.
 fn derive_aes_key(password: &str, salt: &[u8]) -> Result<[u8; 32], String> {
-    let params = argon2::Params::new(
-        ARGON2_M_COST_KIB,
-        ARGON2_T_COST,
-        ARGON2_P_COST,
-        Some(32),
-    )
-    .map_err(|e| format!("argon2 params: {}", e))?;
+    let params = argon2::Params::new(ARGON2_M_COST_KIB, ARGON2_T_COST, ARGON2_P_COST, Some(32))
+        .map_err(|e| format!("argon2 params: {}", e))?;
     let argon = argon2::Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
     let mut out = [0u8; 32];
     argon

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -479,13 +479,8 @@ const ARGON2_T_COST: u32 = 3;
 const ARGON2_P_COST: u32 = 1;
 
 fn derive_aes_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
-    let params = argon2::Params::new(
-        ARGON2_M_COST_KIB,
-        ARGON2_T_COST,
-        ARGON2_P_COST,
-        Some(32),
-    )
-    .map_err(|e| SdkError::Signing(format!("argon2 params: {}", e)))?;
+    let params = argon2::Params::new(ARGON2_M_COST_KIB, ARGON2_T_COST, ARGON2_P_COST, Some(32))
+        .map_err(|e| SdkError::Signing(format!("argon2 params: {}", e)))?;
     let argon = argon2::Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
     let mut out = [0u8; 32];
     argon

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -2573,10 +2573,7 @@ mod tests {
         // override tx.signature shape for `make_signed_tx`'s sig
         // to be sane against `sender.auth_keys`. Re-build the sig
         // against the (mutated) tx fields:
-        tx.signature = falcon_sign(&sk, &tx.hash())
-            .unwrap()
-            .as_bytes()
-            .to_vec();
+        tx.signature = falcon_sign(&sk, &tx.hash()).unwrap().as_bytes().to_vec();
 
         let receipt = execute_transaction(&tx, &mut smt, &block_ctx).unwrap();
         assert!(receipt.success);

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -893,8 +893,7 @@ mod tests {
             .expect("devnet must allow Paymaster");
 
         tx.fee_payer = FeePayer::GasTank([0xBB; 32]);
-        validate_transaction(&tx, &account, &nonce_state, &ctx)
-            .expect("devnet must allow GasTank");
+        validate_transaction(&tx, &account, &nonce_state, &ctx).expect("devnet must allow GasTank");
     }
 
     // ========== Audit 229: RegisterPubkey tx type ==========

--- a/deny.toml
+++ b/deny.toml
@@ -26,11 +26,18 @@ ignore = [
     "RUSTSEC-2025-0009", # ring 0.16: AES panic on overflow check
     "RUSTSEC-2026-0098", # rustls-webpki: URI name constraints
     "RUSTSEC-2026-0099", # rustls-webpki: wildcard name constraints
+    "RUSTSEC-2026-0104", # rustls-webpki: CRL parsing panic (we don't use CRLs)
 
     # Unmaintained crates transitively via libp2p + scroll deps. No
     # CVE; just no upstream maintainer. Same libp2p-upgrade blocker.
     "RUSTSEC-2025-0010", # ring <0.17 unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
+
+    # Transitive via reqwest's DNS resolver. Pyde nodes connect to a
+    # fixed set of RPC peers via hostname; DNS responses come from
+    # validator-controlled resolvers, not arbitrary attacker-chosen
+    # ones. Tracked for the reqwest/hickory bump slice.
+    "RUSTSEC-2026-0119", # hickory-proto 0.24.x: O(n²) name compression DoS
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

CI on main was red after the audit-cycle merge (PR #311). Three fixes
in one commit:

- **Rustfmt**: 100 unformatted blocks across 26 files (audit-cycle
  fall-out). `cargo fmt --all` clears.
- **Clippy**: 3 nits — `len() > 0` → `is_empty()`,
  `.max().min()` → `.clamp()`, `if is_none { return None }` →
  `as_ref()?`.
- **Cargo audit / deny**: 3 new transitive advisories (rustls-webpki
  CRL panic ×2, hickory-proto DNS DoS) added to ignore lists with
  rationale matching the existing libp2p-upgrade-blocked exceptions.
  We don't use CRLs; DNS comes from validator-controlled resolvers.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo audit -n` clean
- `cargo deny check`: advisories ok, bans ok, licenses ok, sources ok
- 1,658 unit tests pass across 15 crates, 0 failed