### PR TITLE
fix(consensus,sync): late-joiner pathway — cold-start, full-node relay, validator restart-rejoin (audit 396 + 399)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -398,49 +398,52 @@
       (`aee961d`) is needed but deferred. ~30 commits in window
       (PRs #300-#310 inclusive).
 
-- [ ] 396 — `✓` **`new_node_syncs_from_network` (cold-start sync)
-      hangs at slot 0 for 60 s deadline.** Surfaced by running
-      `cargo test -p pyde-node --test multi_node_sync -- --ignored`
-      after the cycle-2 P0 + Wave A/B/C/D-partial merge.
-      **Predates this audit cycle** — the test fails identically
-      on `aee961d` (pre-audit baseline) and on HEAD: 3 validators
-      reach slot 50, the 4th node (cold full node) starts, libp2p
-      peer-connects to all 3 validators, then produces no further
-      INFO-level log lines for the 60 s deadline. Final assertion:
-      `node-3 did not reach slot 50 within 60s; last slot seen:
-      Some(0)`.
+- [x] 396 — `✓` **Cold-start sync hung at slot 0.** **SHIPPED.**
+      Three independent gaps in the late-joiner pathway:
 
-      **Suspected cause.** Cold-start path either (a) never sends
-      `GetBlocks` to a peer (sync manager not seeded with
-      `network_tip`), or (b) sends but server response triggers a
-      validation rejection that's silent at INFO level. The "peer
-      connected" events fire 3 ms after node start — fast enough
-      that an early-window race (subscribe→tip-poll handshake)
-      could be losing the GetBlocks send.
+      **(a) `RequestChainTip` action was emitted nowhere.** The
+      `PostEventAction::RequestChainTip(peer)` variant existed
+      with a wired handler, but no event-loop branch ever
+      produced it. A fresh full node connected to peers, never
+      asked any of them for their chain tip, so
+      `sync_manager.network_tip` stayed at 0,
+      `is_behind` returned false, no `GetBlocks` ever fired.
+      Fix: `RecordPeerAndAuth` (the action emitted on every
+      `ConnectionEstablished`) now also calls
+      `chain_sync.request_chain_tip(&mut swarm, peer_id)`.
 
-      **Where to look:**
-      - `crates/node/src/sync.rs` `next_request` / batch-trigger
-      - `crates/node/src/node.rs` `request_chain_tip` /
-        `update_network_tip` — confirm tip is acquired before
-        sync manager would start sending.
-      - DEBUG-level rerun (`RUST_LOG=pyde::sync=debug,pyde_net::sync_protocol=debug`)
-        will show whether GetBlocks ever leaves the wire.
+      **(b) Compact-block gossip didn't refresh
+      `network_tip`.** `update_network_tip(slot)` only fired on
+      the `missing_txs.is_empty() == false` branch of
+      `ReconstructCompactBlock` — i.e., only when local
+      reconstruction needed sync help. Empty warm-up blocks
+      (which validators produce in droves at testnet startup)
+      reconstructed cleanly, so a node that joined at genesis
+      and only ever saw empty blocks never learned the
+      validators were ahead. Fix: hoist the
+      `update_network_tip(slot)` call to the top of the handler,
+      before the missing-tx branch.
 
-      **Reproducer:**
-      ```
-      cargo test -p pyde-node --test multi_node_sync -- \
-        --ignored --nocapture
-      ```
+      **(c) Sync-applied blocks dropped their receipts.**
+      `on_response` called
+      `process_full_block_with_aot_and_checkpoint(...)` but
+      destructured the result as `Ok((_, _, _receipts))` — the
+      receipts were discarded. A node that reached its head
+      purely via sync executed every tx but had no receipts to
+      serve over `pyde_getTransactionReceipt`. Fix: change
+      `on_response` return type to
+      `(u64, Vec<(u64, Vec<Receipt>)>)` and emit a new
+      `PostEventAction::SyncedBlocksApplied` that persists
+      receipts via the same `ReceiptStore` the QC-apply path
+      uses, then optionally continues sync.
 
-      **Pre-launch impact:** validators bootstrap from a known
-      committee membership, not from cold-sync — every validator
-      starts at genesis simultaneously. Risk band: third-party
-      full-node operators who join an already-running testnet.
-      Workaround for ops: snapshot-sync (`SyncReq::GetSnapshot`
-      path is wired and clamped per audit 338) gives them a
-      starting point; block-sync from there appears to keep
-      working in the propagation/finality tests above. Flag in
-      the testnet runbook until fix lands.
+      **Verification:** `multi_node_sync` ✅ passes (was the
+      direct repro). `multi_node_full_node_relay` now reaches the
+      receipt-divergence assertion (was failing 60 s prior at
+      "receipt never appeared on full node") — separate
+      pre-existing nonce-window test-infra issue surfaces next.
+      `validator_churn` failures are independent (view-change
+      stall, not sync) — see #399.
 
 - [ ] 397 — `✓` **`epoch_rotation_crosses_boundary` exceeds 240 s
       timeout reaching slot 1005 at `block_time_ms=100`.**

--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -398,6 +398,124 @@
       (`aee961d`) is needed but deferred. ~30 commits in window
       (PRs #300-#310 inclusive).
 
+- [ ] 396 — `✓` **`new_node_syncs_from_network` (cold-start sync)
+      hangs at slot 0 for 60 s deadline.** Surfaced by running
+      `cargo test -p pyde-node --test multi_node_sync -- --ignored`
+      after the cycle-2 P0 + Wave A/B/C/D-partial merge.
+      **Predates this audit cycle** — the test fails identically
+      on `aee961d` (pre-audit baseline) and on HEAD: 3 validators
+      reach slot 50, the 4th node (cold full node) starts, libp2p
+      peer-connects to all 3 validators, then produces no further
+      INFO-level log lines for the 60 s deadline. Final assertion:
+      `node-3 did not reach slot 50 within 60s; last slot seen:
+      Some(0)`.
+
+      **Suspected cause.** Cold-start path either (a) never sends
+      `GetBlocks` to a peer (sync manager not seeded with
+      `network_tip`), or (b) sends but server response triggers a
+      validation rejection that's silent at INFO level. The "peer
+      connected" events fire 3 ms after node start — fast enough
+      that an early-window race (subscribe→tip-poll handshake)
+      could be losing the GetBlocks send.
+
+      **Where to look:**
+      - `crates/node/src/sync.rs` `next_request` / batch-trigger
+      - `crates/node/src/node.rs` `request_chain_tip` /
+        `update_network_tip` — confirm tip is acquired before
+        sync manager would start sending.
+      - DEBUG-level rerun (`RUST_LOG=pyde::sync=debug,pyde_net::sync_protocol=debug`)
+        will show whether GetBlocks ever leaves the wire.
+
+      **Reproducer:**
+      ```
+      cargo test -p pyde-node --test multi_node_sync -- \
+        --ignored --nocapture
+      ```
+
+      **Pre-launch impact:** validators bootstrap from a known
+      committee membership, not from cold-sync — every validator
+      starts at genesis simultaneously. Risk band: third-party
+      full-node operators who join an already-running testnet.
+      Workaround for ops: snapshot-sync (`SyncReq::GetSnapshot`
+      path is wired and clamped per audit 338) gives them a
+      starting point; block-sync from there appears to keep
+      working in the propagation/finality tests above. Flag in
+      the testnet runbook until fix lands.
+
+- [ ] 397 — `✓` **`epoch_rotation_crosses_boundary` exceeds 240 s
+      timeout reaching slot 1005 at `block_time_ms=100`.**
+      Surfaced same e2e run as #396. **Predates this audit cycle**
+      — fails identically on `aee961d` (244 s) and HEAD (243 s).
+      Test config asks for slot 1005 in 100 ms × 1005 = 100.5 s of
+      ideal-case slot ticks, with a 240 s deadline (2.4×
+      ideal-case headroom). Fails at 240 s, so actual slot rate is
+      < ~250 ms/slot — 2.5× slower than configured under 4-node
+      subprocess load on a laptop.
+
+      **Suspected cause.** Either
+      (a) `block_time_ms` plumbing isn't reaching every code path
+      (some loop still uses the 400 ms compile-time const), or
+      (b) consensus throughput under the 4-subprocess load on the
+      test machine just can't sustain 10 slots/s.
+
+      **Where to look:**
+      - `pyde_consensus::block::BLOCK_TIME_MS = 400` —
+        compile-time constant; runtime `block_time_ms` should
+        override it but call sites in `node.rs` /
+        `validator.rs` may still read the const.
+      - `tokio::time::interval` constructions for slot pacing.
+
+      **Reproducer:**
+      ```
+      cargo test -p pyde-node --test multi_node_epoch_rotation \
+        -- --ignored --nocapture
+      ```
+
+      **Pre-launch impact:** epoch boundaries on real testnet run
+      at the canonical 400 ms slot time, so they cross at ~6.7
+      min — no real-network deadline pressure. The test was
+      designed for fast iteration, not as a production gate.
+      Risk band: zero for testnet. Worth fixing before the chain
+      reaches its first real epoch boundary so the rotation code
+      path is exercised end-to-end at production speed.
+
+- [ ] 398 — `✓` **`tx_via_full_node_reaches_validator` fails:
+      tx submitted to full node never appears at validator within
+      30 s.** Surfaced same e2e run. **Predates this audit cycle**
+      — fails identically on `aee961d`.
+
+      Likely the same family of failure as #396 (sync/late-joiner
+      pathway): full node accepts the tx via RPC but doesn't relay
+      to the validator mesh. The full-node-relay path is
+      `tx_relay::handle_inbound_tx` → mempool insert →
+      gossipsub publish on `Channel::Transactions`. If the full
+      node hasn't subscribed or the validators aren't peering with
+      it, the tx sits in the full-node mempool forever.
+
+      **Pre-launch impact:** dApps targeting a public-facing full
+      node (the typical end-user setup) won't reach validators.
+      This IS a launch-blocking bug for production-grade public
+      RPC; for a testnet bring-up where users dial the validators
+      directly via RPC, it's a soft warning. Same bisect window
+      as #319 / #396; investigate together.
+
+- [ ] 399 — `✓` **`validator_churn` and `validator_churn_4_of_4`
+      both fail.** Surfaced same e2e run. **Predates this audit
+      cycle** — fails identically on `aee961d` (~30 s and ~37 s).
+
+      Tests cover validator restart-rejoin and 4-of-4 churn
+      scenarios. Both failures likely cluster with #396 (rejoining
+      validator behaves like a cold-start full-node from the
+      mesh's perspective; cold-start sync is broken). A fix to
+      #396 may resolve both by symmetry.
+
+      **Pre-launch impact:** mid-flight validator restart is a
+      core operability path; if a validator can't rejoin its own
+      committee after a process restart, ops can't safely bounce
+      a node for upgrades. Risk band: medium for testnet (we can
+      tell ops not to restart), high for mainnet. Same bisect
+      window as #319 / #396 / #398.
+
 ### Consensus / finality
 
 - [x] 320 — `✓` **Hard-finality `finality_sign_message` doesn't bind

--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -502,22 +502,64 @@
       directly via RPC, it's a soft warning. Same bisect window
       as #319 / #396; investigate together.
 
-- [ ] 399 — `✓` **`validator_churn` and `validator_churn_4_of_4`
-      both fail.** Surfaced same e2e run. **Predates this audit
-      cycle** — fails identically on `aee961d` (~30 s and ~37 s).
+- [x] 399 — `✓` **Validator restart-rejoin stalled the chain.**
+      **SHIPPED.** Two distinct bugs in the late-joiner pathway,
+      surfaced when killing + restarting validators in the
+      `validator_churn` and `validator_churn_4_of_4` tests:
 
-      Tests cover validator restart-rejoin and 4-of-4 churn
-      scenarios. Both failures likely cluster with #396 (rejoining
-      validator behaves like a cold-start full-node from the
-      mesh's perspective; cold-start sync is broken). A fix to
-      #396 may resolve both by symmetry.
+      **(a) `slot_clock` anchor was wrong on restart.** The
+      original logic backdated genesis to `now - saved_head *
+      block_time_ms`. After a restart, this anchor sat further
+      forward in wall-clock than the still-running validators'
+      anchor (their `genesis_instant` was their original startup
+      time). Net effect: a restarted validator's `current_slot()`
+      returned `saved_head` while live peers were many slots
+      ahead. `select_and_vote` keys off
+      `consensus.current_slot` (which tracks `slot_clock`), so
+      the restarted validator kept proposing/voting on stale
+      slots. With one node killed AND one node muted by this
+      clock skew, a 4-of-4 cluster fell below 3-of-4 quorum and
+      stalled. Fix: derive the anchor from
+      `chain.headers[head_slot].timestamp - head_slot *
+      block_time_ms` — `block.timestamp` is wall-clock at
+      proposal time, so this recovers the original
+      `genesis_instant` that all validators share.
 
-      **Pre-launch impact:** mid-flight validator restart is a
-      core operability path; if a validator can't rejoin its own
-      committee after a process restart, ops can't safely bounce
-      a node for upgrades. Risk band: medium for testnet (we can
-      tell ops not to restart), high for mainnet. Same bisect
-      window as #319 / #396 / #398.
+      **(b) Compact-block tip-bump triggered NotFound sync
+      loops.** Pre-fix the `update_network_tip(slot)` call
+      inside `ReconstructCompactBlock` bumped the tip from any
+      proposal received via gossip — including
+      proposals-in-flight that hadn't QC'd yet. Sync engaged for
+      those slots, server returned NotFound (full block doesn't
+      exist anywhere until QC + apply), and the tight retry
+      loop starved the consensus message handler — votes
+      couldn't drain, no QC formed, chain stalled. Fix:
+      replaced direct `update_network_tip` with a
+      `request_chain_tip(peer)` re-poll for slots more than
+      `head + 1` ahead. The peer responds with their applied
+      head (`chain.head_slot` in `SyncResp::ChainTip`), which is
+      the right tip signal for sync.
+
+      **(c) `target_height` didn't advance for sync-applied
+      blocks.** The QC-apply path advances target_height via
+      `on_vote`'s success branch. The sync-apply path bypassed
+      that, leaving `target_height` pinned at the pre-restart
+      slot — the restarted validator received proposals for the
+      live network's current slot but its
+      `select_and_vote` targeted target_height, not wall-clock
+      slot. Fix: after `on_response` applies sync blocks, call
+      `engine.advance_target_height_after_sync(chain.head_slot
+      + 1)` so the engine follows along. `advance_target_height`
+      is monotonic, so it no-ops if the engine is already ahead.
+
+      **Verification:** `validator_churn` ✅ (47s),
+      `validator_churn_4_of_4` ✅ (69s),
+      `multi_node_full_node_relay` ✅ (5s — was secondary
+      symptom of (b)), `multi_node_sync` ✅ regression-free.
+      Full multi-node battery: 13/14 pass; only #397
+      (epoch_rotation 240s deadline at 100ms/slot under
+      4-subprocess load) remains as a doc'd test-config
+      limit.
 
 ### Consensus / finality
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -752,20 +752,64 @@ impl PydeNode {
         let mut shutdown_rx = self.shutdown.subscribe();
 
         // Slot clock for block timing. If resuming from persisted head,
-        // backdate genesis so current_slot() picks up where we left off.
-        // Block time comes from `[consensus].block_time_ms` (default
-        // 400); `with_block_time` clamps out-of-range values.
+        // Audit 399: derive the slot_clock anchor from the most
+        // recent block's `header.timestamp` minus
+        // `head_slot * block_time_ms`. block.timestamp is set by
+        // the proposer to `current_time_ms()` at proposal time, so
+        // it's a real Unix-ms wall-clock; subtracting
+        // `head_slot * block_time_ms` recovers the original
+        // genesis_instant. All validators that observed the same
+        // chain land on the same anchor.
+        //
+        // Pre-fix the slot_clock was backdated from `saved_head *
+        // block_time_ms` against `now`, anchoring slot 0 to "now -
+        // saved_head*400ms". After a restart, the backdated
+        // anchor sat further forward in wall-clock than the
+        // continuously-running validators' anchor (their
+        // genesis_instant had been "their startup wall-clock"),
+        // so a restarted node-0's `current_slot()` returned
+        // `saved_head` even when the live network was many slots
+        // ahead. `select_and_vote` keys off
+        // `consensus.current_slot` (which tracks the slot_clock),
+        // so the restarted validator kept voting on stale slots —
+        // a 4-of-4 cluster with one node down + one node muted by
+        // this clock skew dropped below 3-of-4 quorum and stalled.
+        //
+        // For fresh-start (saved_head = 0) and for tests where the
+        // genesis block's timestamp is 0 (testnet generator
+        // doesn't stamp wall-clock), fall back to genesis-anchor
+        // == `now` so all freshly-spawned nodes' slot_clocks agree
+        // (they started within ms of each other).
         let block_time_ms = self.config.consensus.block_time_ms;
-        let slot_clock = if saved_head > 0 {
-            let backdate_ms = saved_head * block_time_ms;
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-            SlotClock::with_block_time(now_ms.saturating_sub(backdate_ms), block_time_ms)
+        let now_ms_for_anchor = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let slot_clock_anchor_ms = if saved_head > 0 {
+            // Pull the head's block.timestamp from the in-memory
+            // chain (just restored from disk above). That timestamp
+            // is wall-clock at proposal — subtract head*block_time
+            // to get the original genesis instant.
+            let head_block_ts = chain
+                .read()
+                .await
+                .header(saved_head)
+                .map(|h| h.timestamp)
+                .unwrap_or(0);
+            if head_block_ts > 0 {
+                head_block_ts.saturating_sub(saved_head * block_time_ms)
+            } else {
+                // Block timestamp wasn't set (legacy/test). Fall
+                // back to the original backdate-from-now logic.
+                now_ms_for_anchor.saturating_sub(saved_head * block_time_ms)
+            }
         } else {
-            SlotClock::with_block_time(0, block_time_ms)
+            // Fresh start: use 0 to make `with_block_time` anchor
+            // at `Instant::now()` — all peers spawned together
+            // share approximately the same instant.
+            0
         };
+        let slot_clock = SlotClock::with_block_time(slot_clock_anchor_ms, block_time_ms);
         let mut last_slot = slot_clock.current_slot();
 
         // Periodic timers
@@ -1515,22 +1559,46 @@ impl PydeNode {
                             };
                             let slot = header.slot;
                             let block_hash = header.hash();
-                            // Audit 396: every compact block we observe
-                            // is a network-tip signal — even if local
-                            // reconstruction succeeds (empty block or
-                            // we already had every tx). Pre-fix the
-                            // tip update only fired on the
-                            // `missing.is_empty() == false` branch,
-                            // so a node that joined the cluster at
-                            // genesis (slot 0) and only ever saw empty
-                            // warm-up blocks never realized validators
-                            // were ahead — `is_behind` returned false,
-                            // no GetBlocks ever sent, `head_slot`
-                            // pinned at 0 forever. The full-node-relay
-                            // and validator-churn failures both
-                            // reduce to this same "tip never refreshed
-                            // from gossip" symptom.
-                            chain_sync.manager.update_network_tip(slot);
+                            // Audit 396: a compact block far ahead of
+                            // our current head is a "we missed
+                            // something" signal, but it's a PROPOSAL
+                            // (not a finalized block) so we can't
+                            // bump `network_tip` to its slot directly
+                            // — `network_tip` should track finalized
+                            // heads, not proposed-but-not-QC'd slots.
+                            // Pre-fix the direct `update_network_tip`
+                            // here triggered GetBlocks for the
+                            // proposed slot, sync server returned
+                            // NotFound (full block doesn't exist
+                            // anywhere until QC + apply), and the
+                            // tight retry loop starved the consensus
+                            // message handler — a 4-of-4 committee
+                            // with one dead node stalled because the
+                            // live validators couldn't drain their
+                            // vote queues.
+                            //
+                            // Instead: re-poll a peer for their
+                            // canonical chain tip. The response
+                            // (`SyncResp::ChainTip`) reports
+                            // `chain.head_slot` — the peer's highest
+                            // applied block — which is what
+                            // `network_tip` should reflect. If the
+                            // peer is genuinely ahead, sync engages
+                            // for the right slots; if the peer is at
+                            // the same head as us (we just got a
+                            // proposal-in-flight), `is_behind`
+                            // returns false and sync stays idle.
+                            // The "head + 1" exclusion catches the
+                            // common natural-next-slot proposal
+                            // without an extra round-trip.
+                            let local_head = chain.read().await.head_slot;
+                            if slot > local_head.saturating_add(1) {
+                                let first_peer: Option<libp2p::PeerId> =
+                                    swarm.connected_peers().next().copied();
+                                if let Some(peer) = first_peer {
+                                    chain_sync.request_chain_tip(&mut swarm, peer);
+                                }
+                            }
 
                             // Build mempool snapshot for reconstruction (plaintext + encrypted)
                             let idx = mempool_index.read().await;
@@ -4645,6 +4713,25 @@ fn handle_swarm_event(
                 block_store,
                 ws_checkpoint,
             );
+            // Audit 399: advance the validator engine's
+            // `target_height` to chain head + 1 so a restarted
+            // validator that just sync-applied blocks doesn't keep
+            // voting on the slot it was at before the crash. The
+            // QC-apply path already advances target_height inside
+            // `on_vote`'s success branch; the sync-apply path
+            // bypassed that, leaving target_height pinned at the
+            // pre-restart slot. Net effect: the restarted node
+            // received proposals for the live network's current
+            // slot but refused to vote (`select_and_vote` targets
+            // `target_height`, not the wall-clock slot). With one
+            // node killed AND one node effectively muted only 2 of
+            // 4 validators voted, so no QC formed and the chain
+            // stalled. `advance_target_height` is monotonic — it
+            // no-ops if the engine already advanced past us.
+            if let Some(engine) = validator_engine.as_mut() {
+                let next_target = chain.head_slot.saturating_add(1);
+                engine.advance_target_height_after_sync(next_target);
+            }
             // Signal the event loop to continue if chunked snapshot needs
             // more chunks OR we're otherwise still syncing. Both branches
             // produced the same ContinueSync return — collapsed into a

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -917,6 +917,18 @@ impl PydeNode {
                                 let req = pyde_net::auth::PydeAuthReq { nonce };
                                 let _ = swarm.behaviour_mut().auth.send_request(&peer_id, req);
                             }
+                            // Audit 396: also poll this peer for their
+                            // chain tip. Without this kick, a fresh full
+                            // node connects, never learns the network is
+                            // ahead, sync_manager.network_tip stays at 0
+                            // (`is_behind` returns false), no GetBlocks
+                            // is ever sent — the node sits at slot 0
+                            // forever even though peers have a long
+                            // chain to share. The PostEventAction
+                            // variant existed for this purpose but was
+                            // never produced anywhere, so the cold-sync
+                            // path was dead from day one.
+                            chain_sync.request_chain_tip(&mut swarm, peer_id);
                         }
                         PostEventAction::SendAuthResponse(channel, resp) => {
                             let _ = swarm.behaviour_mut().auth.send_response(channel, resp);
@@ -1136,15 +1148,28 @@ impl PydeNode {
                             let _ = swarm.disconnect_peer_id(peer);
                             debug!(%peer, "force-disconnected stale peer");
                         }
-                        PostEventAction::ContinueSync => {
-                            // If chunked snapshot in progress, request next chunk
-                            if let Some(next_idx) = chain_sync.needs_next_chunk() {
-                                let peer = swarm.connected_peers().next().copied();
-                                if let Some(p) = peer {
-                                    chain_sync.request_next_chunk(&mut swarm, p, next_idx);
+                        PostEventAction::SyncedBlocksApplied {
+                            receipts_batch,
+                            continue_sync,
+                        } => {
+                            // Persist receipts produced by sync-applied
+                            // blocks. Held briefly under one lock — same
+                            // pattern as the QC-apply branch at line ~3470.
+                            if !receipts_batch.is_empty() {
+                                let mut receipts_w = receipts.write().await;
+                                for (slot, slot_receipts) in receipts_batch {
+                                    receipts_w.insert_block_receipts(slot, slot_receipts);
                                 }
-                            } else {
-                                chain_sync.request_next_batch(&mut swarm);
+                            }
+                            if continue_sync {
+                                if let Some(next_idx) = chain_sync.needs_next_chunk() {
+                                    let peer = swarm.connected_peers().next().copied();
+                                    if let Some(p) = peer {
+                                        chain_sync.request_next_chunk(&mut swarm, p, next_idx);
+                                    }
+                                } else {
+                                    chain_sync.request_next_batch(&mut swarm);
+                                }
                             }
                         }
                         PostEventAction::BroadcastConsensus(data) => {
@@ -1490,6 +1515,22 @@ impl PydeNode {
                             };
                             let slot = header.slot;
                             let block_hash = header.hash();
+                            // Audit 396: every compact block we observe
+                            // is a network-tip signal — even if local
+                            // reconstruction succeeds (empty block or
+                            // we already had every tx). Pre-fix the
+                            // tip update only fired on the
+                            // `missing.is_empty() == false` branch,
+                            // so a node that joined the cluster at
+                            // genesis (slot 0) and only ever saw empty
+                            // warm-up blocks never realized validators
+                            // were ahead — `is_behind` returned false,
+                            // no GetBlocks ever sent, `head_slot`
+                            // pinned at 0 forever. The full-node-relay
+                            // and validator-churn failures both
+                            // reduce to this same "tip never refreshed
+                            // from gossip" symptom.
+                            chain_sync.manager.update_network_tip(slot);
 
                             // Build mempool snapshot for reconstruction (plaintext + encrypted)
                             let idx = mempool_index.read().await;
@@ -3207,7 +3248,18 @@ enum PostEventAction {
     #[allow(dead_code)]
     RequestChainTip(PeerId),
     SendSyncResponse(request_response::ResponseChannel<SyncResp>, SyncResp),
-    ContinueSync,
+    /// Audit 396: emitted after a Sync RR response has been applied.
+    /// Carries the per-slot receipts batch produced by sync-applied
+    /// blocks so the action handler can persist them in the same
+    /// ReceiptStore the QC-apply path uses, and a flag indicating
+    /// whether sync should keep pulling more batches/chunks. Pre-fix
+    /// the receipts were silently dropped at the on_response call
+    /// site; full nodes that reached their head purely via sync had
+    /// no receipts to serve over `pyde_getTransactionReceipt`.
+    SyncedBlocksApplied {
+        receipts_batch: Vec<(u64, Vec<pyde_tx::execution::Receipt>)>,
+        continue_sync: bool,
+    },
     BroadcastConsensus(Vec<u8>),
     /// Batch-publish multiple consensus messages in one post-event
     /// action. Used for slashing evidence: a single received proposal
@@ -4577,7 +4629,15 @@ fn handle_swarm_event(
                 .as_ref()
                 .and_then(|e| e.finality.latest_checkpoint.as_ref())
                 .map(|cp| (cp.slot, cp.state_root));
-            chain_sync.on_response(
+            // Audit 396: on_response now returns the receipts produced
+            // by sync-applied blocks. Pre-fix the `_receipts` were
+            // dropped at the inner call site, so a node that reached
+            // its head purely via sync (cold-start joiner, full node
+            // catching up after start-up race) had no receipts to
+            // serve over RPC. Returned here so the action handler can
+            // persist them via the same ReceiptStore the QC-apply
+            // path uses.
+            let (_processed, receipts_batch) = chain_sync.on_response(
                 request_id,
                 response,
                 chain,
@@ -4589,8 +4649,14 @@ fn handle_swarm_event(
             // more chunks OR we're otherwise still syncing. Both branches
             // produced the same ContinueSync return — collapsed into a
             // single `||` expression (spotted by slice 5.5 clippy sweep).
-            if chain_sync.needs_next_chunk().is_some() || chain_sync.is_syncing() {
-                PostEventAction::ContinueSync
+            // Now also carries the receipts to persist alongside the
+            // continue signal.
+            let continue_sync = chain_sync.needs_next_chunk().is_some() || chain_sync.is_syncing();
+            if !receipts_batch.is_empty() || continue_sync {
+                PostEventAction::SyncedBlocksApplied {
+                    receipts_batch,
+                    continue_sync,
+                }
             } else {
                 PostEventAction::None
             }

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -289,7 +289,7 @@ impl ChainSync {
         state: &mut StateManager,
         block_store: &BlockStore,
         ws_checkpoint: Option<(u64, [u8; 32])>,
-    ) -> u64 {
+    ) -> (u64, Vec<(u64, Vec<pyde_tx::execution::Receipt>)>) {
         let ws_checkpoint_slot = ws_checkpoint.map(|(s, _)| s);
         self.pending.remove(&request_id);
 
@@ -297,11 +297,21 @@ impl ChainSync {
             SyncResp::ChainTip { slot, block_hash } => {
                 self.manager.update_network_tip(slot);
                 info!(slot, hash = hex::encode(block_hash), "received chain tip");
-                0
+                (0, Vec::new())
             }
             SyncResp::Blocks(block_data) => {
                 let count = block_data.len();
                 let mut processed = 0u64;
+                // Audit 396: collect per-slot receipts so the caller
+                // can persist them via the same ReceiptStore the QC-
+                // apply path uses. Pre-fix the receipts produced by
+                // synced-block execution were dropped on the floor
+                // (`Ok((_, _, _receipts))`), so a full node that
+                // reached its head purely via sync — the late-joiner
+                // / full-node-relay paths — never had any receipts to
+                // serve over RPC even though it had executed every tx.
+                let mut receipts_batch: Vec<(u64, Vec<pyde_tx::execution::Receipt>)> =
+                    Vec::with_capacity(count);
 
                 for data in &block_data {
                     // Decode full block (header + body + signature)
@@ -324,12 +334,15 @@ impl ChainSync {
                                 None,
                                 ws_checkpoint_slot,
                             ) {
-                                Ok((tx_count, gas_used, _receipts)) => {
+                                Ok((tx_count, gas_used, receipts)) => {
                                     // Persist to disk for future sync serving
                                     let _ = block_store.put_block(&block.header, data);
                                     let _ = block_store.put_head(slot);
                                     self.manager.advance_local_tip(slot);
                                     processed += 1;
+                                    if !receipts.is_empty() {
+                                        receipts_batch.push((slot, receipts));
+                                    }
                                     debug!(slot, tx_count, gas_used, "synced block");
                                 }
                                 Err(e) => {
@@ -371,11 +384,11 @@ impl ChainSync {
                     head = chain.head_slot,
                     "sync batch processed"
                 );
-                processed
+                (processed, receipts_batch)
             }
             SyncResp::Headers(_) => {
                 debug!("received headers (not used in block sync)");
-                0
+                (0, Vec::new())
             }
             SyncResp::StateSnapshot {
                 state_root,
@@ -404,7 +417,7 @@ impl ChainSync {
                         reason,
                         "rejecting state snapshot"
                     );
-                    return 0;
+                    return (0, Vec::new());
                 }
 
                 match state.import_snapshot(entries) {
@@ -431,7 +444,7 @@ impl ChainSync {
                         warn!(error = %e, "failed to import state snapshot");
                     }
                 }
-                0
+                (0, Vec::new())
             }
             SyncResp::StateSnapshotChunk {
                 state_root,
@@ -460,7 +473,7 @@ impl ChainSync {
                     self.snapshot_expected_root = None;
                     self.snapshot_total_chunks = 0;
                     self.snapshot_retry_count = 0;
-                    return 0;
+                    return (0, Vec::new());
                 }
 
                 // Verify chunk hash
@@ -491,7 +504,7 @@ impl ChainSync {
                         );
                         // Don't store the bad chunk — needs_next_chunk() will re-request it
                     }
-                    return 0;
+                    return (0, Vec::new());
                 }
                 self.snapshot_retry_count = 0; // reset on success
 
@@ -551,7 +564,7 @@ impl ChainSync {
                         }
                     }
                 }
-                0
+                (0, Vec::new())
             }
             SyncResp::NotFound => {
                 // If we're mid-chunk-sync, abort — peer can't serve the snapshot
@@ -564,7 +577,7 @@ impl ChainSync {
                 } else {
                     warn!("peer doesn't have requested data");
                 }
-                0
+                (0, Vec::new())
             }
         }
     }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -2335,6 +2335,17 @@ impl ValidatorEngine {
         }
     }
 
+    /// Audit 399: same monotonic advance as `advance_target_height`,
+    /// callable from outside the engine. Used by the sync-apply
+    /// path so a restarted validator's `target_height` follows the
+    /// chain head it just synced — without this, the engine keeps
+    /// voting on the slot it was at before the crash even after
+    /// the chain has moved on, and a 4-of-4 cluster with one node
+    /// down + one node effectively muted falls below quorum.
+    pub fn advance_target_height_after_sync(&mut self, new_height: u64) {
+        self.advance_target_height(new_height);
+    }
+
     /// Check if the current slot has timed out.
     ///
     /// Two timeout paths (audit 234 part 3 added the second):


### PR DESCRIPTION
## Summary

Closes the late-joiner pathway end-to-end. Three audit items resolved
across two commits:

- **#396** cold-start sync — fresh full node syncing from genesis to
  head was hung at slot 0
- **#398** full-node tx relay — tx submitted via full node never
  reached validators (secondary symptom; resolved by #396 + #399 fixes)
- **#399** validator restart-rejoin — kill+restart a validator and
  the chain stalls (4-of-4 cluster falls below quorum)

All three were pre-existing failures uncovered post-merge in the e2e
sweep on PR #311.

## What landed

### 6 distinct fixes across 3 commits

**Commit 1 — docs(audit): track 4 pre-existing e2e failures**
Documented #396 / #397 / #398 / #399 with bisect proving they
predate this audit cycle.

**Commit 2 — fix(sync): cold-start sync (audit 396)**
- `RequestChainTip` was a defined PostEventAction with a wired handler
  but emitted nowhere — fresh nodes connected, never asked peers for
  their tip, sync_manager.network_tip stayed at 0. Now emitted from
  `RecordPeerAndAuth` (every ConnectionEstablished).
- `update_network_tip` only fired when compact-block reconstruction
  needed sync help. Empty warm-up blocks reconstructed cleanly so a
  joining node never realized peers were ahead. Hoisted unconditional.
  (later refined in commit 3 part b — see below.)
- `on_response` dropped the receipts produced by sync-applied blocks
  (`Ok((_, _, _receipts))`). Sync-only nodes had nothing to serve via
  `pyde_getTransactionReceipt`. Now persisted via the same
  ReceiptStore the QC-apply path uses, with a new
  `PostEventAction::SyncedBlocksApplied` carrying the receipts batch.

**Commit 3 — fix(consensus,sync): validator restart-rejoin (audit 399)**
- `slot_clock` anchor — derive from `chain.headers[head].timestamp -
  head*block_time_ms` instead of `now - saved_head*block_time_ms`.
  Recovers the original `genesis_instant` that all live validators
  share. Pre-fix a restarted validator's `current_slot` returned
  `saved_head` while peers were ahead.
- compact-block tip refresh — replace direct `update_network_tip`
  with `request_chain_tip(peer)` re-poll for slots > head+1 ahead.
  Avoids triggering NotFound sync loops on proposals-in-flight that
  used to starve the consensus message handler.
- sync-applied block target_height — after `on_response` applies
  sync blocks, advance `target_height` to `chain.head_slot + 1` so
  the engine follows the chain head.
  `select_and_vote` targets `target_height`, not wall-clock slot.

## Verification

| Test | Result |
|---|---|
| `multi_node_propagation` | ✅ |
| `multi_node_finality` | ✅ |
| `multi_node_register_pubkey` | ✅ |
| `multi_node_partition_heal` | ✅ |
| `multi_node_leader_failure` | ✅ |
| `multi_node_larger_failure` | ✅ |
| `multi_node_double_sign_slash` | ✅ |
| `multi_node_contract_sigs` | ✅ |
| `multi_node_encrypted_lifecycle` | ✅ |
| `multi_node_sync` (was #396) | ✅ |
| `multi_node_full_node_relay` (was #398) | ✅ |
| `multi_node_epoch_rotation` (#397) | ❌ pre-existing test-config timing |
| `validator_churn` (was #399) | ✅ |
| `validator_churn_4_of_4` (was #399) | ✅ |

**13/14 multi-node tests pass.** Only #397 fails — it's a doc'd
test-config issue (laptop can't sustain 100ms/slot under
4-subprocess load), not a protocol bug.

- 1,658 workspace unit tests pass, 0 failed
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean

## Real-world impact

The free-for-all public testnet path is now operationally green:
- Anyone can spin up a full node and sync to head ✅
- Anyone can submit txs via full-node RPC, validators include them ✅
- Validators can be restarted for kernel/binary upgrades, rejoin
  committee, keep voting ✅