### PR TITLE
state: Wave G durability — atomic JMT commit, fsync, decrypted-tx through overlay+undo (audit 330+331+332)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -680,13 +680,37 @@
       commodity SSDs, well within the 400 ms slot budget. Combined
       with audit-330's atomic batch, the per-block commit is now a
       true crash-consistent durable write.
-- [ ] 332 — `⚠` **Decrypted-tx execution writes directly to SMT
-      bypassing cache + undo log.**
-      `crates/node/src/block_processor.rs:984` (try_decrypt_and_execute)
-      and `crates/node/src/node.rs:2732-2747` (single-node decrypt).
-      Reorg cannot revert decrypted-tx state; cache reads stale.
-      Funnel through `update_batch_deferred` and append a third
-      undo batch to `record_block_undo`.
+- [x] 332 — `⚠` **Decrypted-tx execution writes directly to SMT
+      bypassing cache + undo log.** **SHIPPED.** Both call sites
+      that executed decrypted txs (`block_processor::try_decrypt_and_execute`
+      and the single-node decrypt path in `node.rs`) used to call
+      `execute_transaction(dtx, &mut *state.smt_mut(), &block_ctx)`,
+      writing straight into the underlying JMT and bypassing the
+      StateManager's cache + undo log. Two consequences:
+      1. Cache reads returned stale pre-decrypt values until the
+         next invalidation.
+      2. `revert_to(slot - 1)` (reorg path, audit 231) only
+         walked the undo log and rolled back plaintext writes,
+         leaving decrypted-tx state stuck — silent state
+         divergence between the chain head and the data on disk.
+
+      Post-fix both paths route through a `StateOverlay` over the
+      StateManager, then commit via `update_batch_deferred` +
+      `record_block_undo` (matching the plaintext path). The
+      block_processor side already calls `record_block_undo(slot,
+      ...)` once for plaintext during apply; decrypted-tx execution
+      now appends a SECOND `(slot, undo)` tuple — `revert_to` walks
+      both together when rolling the slot back. Added explicit
+      `flush_pending()` before `refresh_root()` since
+      `update_batch_deferred` doesn't immediately push writes to
+      the underlying SMT.
+
+      Removed the `smt_mut()` escape hatch entirely so future
+      callers can't re-introduce the same skip-the-cache-and-undo
+      bug class. 298 node binary tests pass. The
+      `multi_node_encrypted_lifecycle` e2e test still passes after
+      the refactor (validators converge on the same post-decrypt
+      state root).
 
 ### Net
 

--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -651,17 +651,35 @@
 
 ### State
 
-- [ ] 330 — `⚠` **JMT commit non-atomic across two `db.write` calls.**
-      `crates/state/src/jmt_store.rs:474-479`. Crash between writes
-      leaves nodes for `next_version` persisted while
-      `META_LATEST_VERSION` still points at the old version. Combine
-      both writes into a single `rocksdb::WriteBatch`.
-- [ ] 331 — `⚠` **No fsync on per-block JMT writes.**
-      `crates/state/src/jmt_store.rs:343-344`,
-      `crates/state/src/backend.rs:599`. Default `WriteOptions`;
-      power loss in the WAL window can lose state. Add
-      `WriteOptions::set_sync(true)` (or `flush_wal(true)`) at the
-      block-final commit point.
+- [x] 330 — `⚠` **JMT commit non-atomic across two `db.write` calls.**
+      **SHIPPED.** New `JmtRocksStore::commit_atomic(node_batch,
+      next_version)` builds a single `rocksdb::WriteBatch` containing
+      nodes + values + rightmost-leaf marker AND
+      `META_LATEST_VERSION` together; one `db.write_opt(batch)`
+      lands them all-or-nothing. Pre-fix `update_all` issued two
+      sequential `db.write` / `db.put` calls and a crash between
+      them left nodes persisted for `next_version` while the
+      version pointer still referenced the previous version —
+      orphaned tree pages permanently leaked storage and the
+      reopened validator resumed at the OLD version. Removed the
+      now-unused `set_latest_version` helper. The trait-required
+      `TreeWriter::write_node_batch` impl stays for the JMT
+      crate's snapshot-restore path, with a doc-comment warning
+      callers not to use it directly. 2 new tests
+      (`audit_330_atomic_commit_advances_version_pointer_atomically`,
+      `audit_330_commit_atomic_writes_full_set_in_one_batch`); 81
+      state tests pass.
+- [x] 331 — `⚠` **No fsync on per-block JMT writes.** **SHIPPED.**
+      `commit_atomic` (JMT) and `BufferedWriteBackend::flush`
+      (legacy SMT) now use `WriteOptions::set_sync(true)` so the
+      RocksDB WAL is fdatasync'd before the call returns. Pre-fix
+      the default `sync=false` left a ~1 s WAL window during which
+      a power loss / VM crash silently rolled back the last
+      committed block, putting the recovered validator behind the
+      live network on restart. ~1-5 ms cost per commit on
+      commodity SSDs, well within the 400 ms slot budget. Combined
+      with audit-330's atomic batch, the per-block commit is now a
+      true crash-consistent durable write.
 - [ ] 332 — `⚠` **Decrypted-tx execution writes directly to SMT
       bypassing cache + undo log.**
       `crates/node/src/block_processor.rs:984` (try_decrypt_and_execute)

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -1080,16 +1080,56 @@ pub fn try_decrypt_and_execute(
         dev_skip_signature: true,
         block_sigs_pre_verified: false,
     };
+    // Audit 332: route decrypted-tx execution through a
+    // `StateOverlay` over the StateManager so writes accumulate
+    // in the same write-cache + undo-log machinery the plaintext
+    // path uses. Pre-fix `execute_transaction(dtx, &mut
+    // *state.smt_mut(), &block_ctx)` wrote DIRECTLY into the
+    // underlying JMT, which:
+    //   1. Skipped the StateManager's overlay write-cache, so
+    //      subsequent reads via the cache returned stale pre-
+    //      decrypt values until the next cache invalidation.
+    //   2. Skipped `record_block_undo` entirely. A subsequent
+    //      `revert_to(slot - 1)` call (reorg path, audit 231)
+    //      would roll back the plaintext writes from the same
+    //      block but leave the decrypted-tx state in place,
+    //      producing a chain head with NEITHER the old nor the
+    //      new state — silent divergence.
+    //
+    // Post-fix: execute against an overlay whose `base` is the
+    // current StateManager view, then commit the overlay's
+    // writes via `update_batch_deferred` and append the undo
+    // entries via `record_block_undo`. The plaintext path
+    // already called `record_block_undo(slot, ...)` once for
+    // this slot during block apply; the second call here pushes
+    // a separate undo tuple that `revert_to` walks together with
+    // the first when rolling the slot back.
     let mut receipts = Vec::with_capacity(decrypted_txs.len());
-    for (i, dtx) in decrypted_txs.iter().enumerate() {
-        if !verified_enc_indices.contains(&i) {
-            continue;
+    {
+        use pyde_state::smt::StateAccess;
+        let mut overlay = pyde_state::smt::StateOverlay::new(state as &dyn StateAccess);
+        for (i, dtx) in decrypted_txs.iter().enumerate() {
+            if !verified_enc_indices.contains(&i) {
+                continue;
+            }
+            match execute_transaction(dtx, &mut overlay, &block_ctx) {
+                Ok(r) => receipts.push(r),
+                Err(e) => warn!(slot, error = ?e, "decrypted tx execution failed"),
+            }
         }
-        match execute_transaction(dtx, &mut *state.smt_mut(), &block_ctx) {
-            Ok(r) => receipts.push(r),
-            Err(e) => warn!(slot, error = ?e, "decrypted tx execution failed"),
+        let (writes, undo) = overlay.into_writes_with_undo();
+        if !writes.is_empty() {
+            let _ = state.update_batch_deferred(writes);
+        }
+        if !undo.is_empty() {
+            state.record_block_undo(slot, undo);
         }
     }
+    // Flush the deferred batch into the underlying JMT before
+    // recomputing root. Pre-fix the writes went directly to the
+    // SMT so refresh_root saw them immediately; post-fix they
+    // accumulate in `pending_writes` and need an explicit flush.
+    let _ = state.flush_pending();
     state.refresh_root();
 
     DecryptOutcome::Executed {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2855,31 +2855,68 @@ impl PydeNode {
                                                                                 dev_skip_signature: false,
                                                                                 block_sigs_pre_verified: false,
                                                                             };
+                                                                            // Audit 332: same overlay+undo
+                                                                            // discipline as the block_processor
+                                                                            // path. Pre-fix this loop wrote each
+                                                                            // decrypted tx directly into
+                                                                            // `state_w.smt_mut()`, bypassing the
+                                                                            // StateManager write-cache and
+                                                                            // skipping `record_block_undo`. A
+                                                                            // reorg via `revert_to(slot - 1)`
+                                                                            // would leave decrypted-tx state
+                                                                            // applied even after rolling the
+                                                                            // surrounding block back, producing
+                                                                            // a divergent state.
+                                                                            use pyde_state::smt::StateAccess;
+                                                                            let mut overlay =
+                                                                                pyde_state::smt::StateOverlay::new(
+                                                                                    &*state_w as &dyn StateAccess,
+                                                                                );
+                                                                            let mut tx_receipts = Vec::with_capacity(
+                                                                                decrypted_txs.len(),
+                                                                            );
                                                                             for dtx in &decrypted_txs {
-                                                                                // Bind the execute_transaction result BEFORE the
-                                                                                // match so the `state_w.smt_mut()` MutexGuard
-                                                                                // temporary is dropped at this semicolon. Without
-                                                                                // this binding the guard lives through the match
-                                                                                // body, which includes `receipts.write().await` —
-                                                                                // the tokio scheduler could move the future to
-                                                                                // another thread holding a std Mutex guard, a
-                                                                                // well-known deadlock / UB pattern. Surfaced by
-                                                                                // slice 5.5 clippy sweep.
                                                                                 let exec_result = pyde_tx::pipeline::execute_transaction(
                                                                                     dtx,
-                                                                                    &mut *state_w.smt_mut(),
+                                                                                    &mut overlay,
                                                                                     &block_ctx,
                                                                                 );
                                                                                 match exec_result {
-                                                                                    Ok(receipt) => {
-                                                                                        let mut receipts_w = receipts.write().await;
-                                                                                        receipts_w.insert_block_receipts(current_slot, vec![receipt]);
-                                                                                    }
+                                                                                    Ok(receipt) => tx_receipts.push(receipt),
                                                                                     Err(e) => {
                                                                                         warn!(error = ?e, "failed to execute decrypted tx");
                                                                                     }
                                                                                 }
                                                                             }
+                                                                            let (writes, undo) =
+                                                                                overlay.into_writes_with_undo();
+                                                                            if !writes.is_empty() {
+                                                                                let _ = state_w
+                                                                                    .update_batch_deferred(writes);
+                                                                            }
+                                                                            if !undo.is_empty() {
+                                                                                state_w.record_block_undo(
+                                                                                    current_slot, undo,
+                                                                                );
+                                                                            }
+                                                                            // Persist receipts after the overlay
+                                                                            // commit so the caller sees them
+                                                                            // alongside the new state.
+                                                                            if !tx_receipts.is_empty() {
+                                                                                let mut receipts_w =
+                                                                                    receipts.write().await;
+                                                                                receipts_w.insert_block_receipts(
+                                                                                    current_slot,
+                                                                                    tx_receipts,
+                                                                                );
+                                                                            }
+                                                                            // Flush deferred writes before
+                                                                            // recomputing root; the overlay
+                                                                            // path buffers via
+                                                                            // `update_batch_deferred` so the
+                                                                            // SMT/JMT root only reflects them
+                                                                            // after `flush_pending`.
+                                                                            let _ = state_w.flush_pending();
                                                                             state_w.refresh_root();
                                                                         }
                                                                         Err(e) => warn!(error = %e, "decryption failed"),

--- a/crates/node/src/state_manager.rs
+++ b/crates/node/src/state_manager.rs
@@ -321,11 +321,19 @@ impl StateManager {
         }
     }
 
-    /// Get mutable SMT access. Returns MutexGuard (deref to PersistentJMT).
-    /// Only used during genesis/startup — not during pipelined execution.
-    pub fn smt_mut(&self) -> std::sync::MutexGuard<'_, PersistentJMT> {
-        self.smt.lock().expect("smt lock poisoned")
-    }
+    // Audit 332: `smt_mut()` was the escape hatch that let the
+    // decrypted-tx execution path bypass the StateManager's
+    // write-cache and undo-log machinery, silently breaking
+    // reorg consistency. Removed alongside the audit-332 fix —
+    // every state write now goes through `update_batch_deferred`
+    // (with `record_block_undo` for revertibility), and reads
+    // through the cache-aware `StateAccess` impl on
+    // `StateManager`. Adding a new `smt_mut`-style raw escape
+    // hatch should be considered a regression: the next caller
+    // will re-introduce the same skip-the-cache-and-undo-log
+    // bug class. Use `StateOverlay` for transactional execution
+    // contexts and `update_batch_deferred` for direct buffered
+    // writes.
 
     /// Get immutable SMT access. Returns MutexGuard.
     #[allow(dead_code)]

--- a/crates/state/src/backend.rs
+++ b/crates/state/src/backend.rs
@@ -594,9 +594,21 @@ impl BufferedWriteBackend {
             }
         }
 
+        // Audit 331: per-block flush is the durability boundary —
+        // fsync the WAL before returning. Default WriteOptions
+        // (sync=false) meant a power loss inside RocksDB's WAL
+        // window (~1 s) silently rolled back the last committed
+        // block, leaving the validator behind the network on
+        // restart. `set_sync(true)` forces an fdatasync per flush;
+        // ~1-5 ms cost on commodity SSDs, well within slot budget.
+        // The legacy SMT path is preserved during the JMT
+        // migration (audit 215); both paths fsync at the per-block
+        // commit point now.
+        let mut opts = rocksdb::WriteOptions::default();
+        opts.set_sync(true);
         self.inner
             .db
-            .write(batch)
+            .write_opt(batch, &opts)
             .map_err(|e| BackendError::RocksDB(e.to_string()))
     }
 }

--- a/crates/state/src/jmt_store.rs
+++ b/crates/state/src/jmt_store.rs
@@ -189,9 +189,101 @@ impl JmtRocksStore {
         }
     }
 
-    fn set_latest_version(&self, version: Version) -> anyhow::Result<()> {
-        let key = Self::meta_key(META_LATEST_VERSION);
-        self.db.put(&key, version.to_be_bytes())?;
+    /// Audit 330: atomic commit that fuses the JMT node/value writes,
+    /// the rightmost-leaf marker, and the `META_LATEST_VERSION`
+    /// pointer into a single `rocksdb::WriteBatch`. RocksDB
+    /// guarantees all-or-nothing application of a write batch, so a
+    /// crash between the JMT-data writes and the version pointer is
+    /// no longer possible.
+    ///
+    /// Pre-fix `update_all` issued two sequential `db.write` /
+    /// `db.put` calls — `write_node_batch(&batch.node_batch)` then
+    /// `set_latest_version(next_version)`. A power loss / `kill -9` /
+    /// OOM between them left nodes for the new version persisted
+    /// while `META_LATEST_VERSION` still pointed at the old version,
+    /// permanently leaking the orphaned node-tree until a future
+    /// successful commit overwrote those slots. Worse: on restart
+    /// the recovered root was the OLD version's, but if anything
+    /// downstream was racing on already-published nodes it could
+    /// momentarily see a state ahead of the canonical version
+    /// pointer.
+    pub(crate) fn commit_atomic(
+        &self,
+        node_batch: &NodeBatch,
+        next_version: Version,
+    ) -> anyhow::Result<()> {
+        let mut batch = rocksdb::WriteBatch::default();
+
+        // Nodes — same write set the trait impl produces.
+        let mut node_cache = self.node_cache.lock().unwrap();
+        for (node_key, node) in node_batch.nodes() {
+            let key = Self::node_key_bytes(node_key);
+            let value = borsh::to_vec(node).map_err(|e| anyhow::anyhow!("node encode: {}", e))?;
+            batch.put(&key, &value);
+            node_cache.put(node_key.clone(), Some(node.clone()));
+        }
+        drop(node_cache);
+
+        // Values.
+        let mut value_cache = self.value_cache.lock().unwrap();
+        for ((version, key_hash), maybe_value) in node_batch.values() {
+            let key = Self::value_key_bytes(*version, key_hash);
+            match maybe_value {
+                Some(bytes) if !bytes.is_empty() => {
+                    batch.put(&key, bytes);
+                    value_cache.put(*key_hash, Some(bytes.clone()));
+                }
+                _ => {
+                    batch.put(&key, []);
+                    value_cache.put(*key_hash, None);
+                }
+            }
+        }
+        drop(value_cache);
+
+        // Rightmost leaf — only present when the batch contains
+        // leaves; preserve the old "best in this batch" semantics.
+        let mut rightmost: Option<(NodeKey, jmt::storage::LeafNode)> = None;
+        for (node_key, node) in node_batch.nodes() {
+            if let Node::Leaf(leaf) = node {
+                let candidate = (node_key.clone(), leaf.clone());
+                rightmost = Some(match rightmost {
+                    None => candidate,
+                    Some(ref cur) if candidate.0.nibble_path() >= cur.0.nibble_path() => candidate,
+                    Some(cur) => cur,
+                });
+            }
+        }
+        if let Some(rm) = rightmost {
+            let bytes =
+                borsh::to_vec(&rm).map_err(|e| anyhow::anyhow!("rightmost encode: {}", e))?;
+            batch.put(Self::meta_key(META_RIGHTMOST), bytes);
+        }
+
+        // The atomicity-critical step: META_LATEST_VERSION goes into
+        // the SAME batch so it lands iff the nodes/values land.
+        batch.put(
+            Self::meta_key(META_LATEST_VERSION),
+            next_version.to_be_bytes(),
+        );
+
+        // Audit 331: fsync the WAL before returning. Pre-fix the
+        // default `WriteOptions` had `sync = false`, so a power
+        // loss / VM crash within RocksDB's WAL window (typically
+        // up to ~1 s) lost the most recent committed block —
+        // validators reopened at the previous version, every other
+        // node had moved on, and the recovering validator stalled
+        // until snapshot-sync caught it up. `set_sync(true)`
+        // forces an `fdatasync()` per commit; on commodity SSDs
+        // this adds ~1-5 ms of latency per block, well within the
+        // 400 ms slot budget. Combined with the audit-330 atomic
+        // batch, this turns the per-block commit into a true
+        // crash-consistent durable write.
+        let mut opts = rocksdb::WriteOptions::default();
+        opts.set_sync(true);
+        self.db
+            .write_opt(batch, &opts)
+            .map_err(|e| anyhow::anyhow!("rocksdb atomic commit: {}", e))?;
         Ok(())
     }
 }
@@ -289,6 +381,14 @@ impl HasPreimage for JmtRocksStore {
 }
 
 impl TreeWriter for JmtRocksStore {
+    /// Trait-required write entry. Application code should NOT call
+    /// this directly — it writes nodes/values without updating
+    /// `META_LATEST_VERSION`, leaving the version pointer stale.
+    /// The atomic commit path (`commit_atomic`) is the only callable
+    /// that bumps both together (audit 330). This impl exists so
+    /// the JMT crate's snapshot-restore path (`tree.restore_*`) can
+    /// stream node batches in; the caller is expected to set the
+    /// version pointer separately at the end of restore.
     fn write_node_batch(&self, node_batch: &NodeBatch) -> anyhow::Result<()> {
         let mut batch = rocksdb::WriteBatch::default();
 
@@ -471,12 +571,18 @@ impl PersistentJMT {
             .put_value_set(value_set, next_version)
             .map_err(|_| "JMT put_value_set failed")?;
 
+        // Audit 330: atomic commit — nodes, values, rightmost
+        // marker, AND `META_LATEST_VERSION` go into the same
+        // RocksDB WriteBatch. Pre-fix the two sequential writes
+        // (`write_node_batch` then `set_latest_version`) had a
+        // crash window between them: a power loss left orphaned
+        // node-tree pages persisted at `next_version` while the
+        // version pointer still referenced the previous version,
+        // permanently leaking storage until a later commit wrote
+        // over the same slots.
         self.store
-            .write_node_batch(&batch.node_batch)
-            .map_err(|_| "JMT write_node_batch failed")?;
-        self.store
-            .set_latest_version(next_version)
-            .map_err(|_| "JMT set_latest_version failed")?;
+            .commit_atomic(&batch.node_batch, next_version)
+            .map_err(|_| "JMT atomic commit failed")?;
 
         *version_guard = next_version;
         *self.current_root.lock().unwrap() = new_root;
@@ -579,5 +685,78 @@ mod tests {
         let r2 = jmt2.root();
 
         assert_eq!(r1, r2);
+    }
+
+    /// Audit 330: after a successful `update_all`, the
+    /// `META_LATEST_VERSION` pointer that
+    /// `JmtRocksStore::latest_version()` reads MUST match the
+    /// version the in-memory tracker advanced to. Pre-fix the two
+    /// were updated by separate `db.write` calls, so a crash
+    /// between them left the on-disk pointer stale; reopening the
+    /// store would resume at the OLD version even though the new
+    /// version's nodes were durable. This test confirms the post-
+    /// fix atomic commit keeps both halves in lockstep on the
+    /// happy path. (Crash-injection regression coverage requires
+    /// process-kill harness — captured separately in MAINNET_PLAN.)
+    #[test]
+    fn audit_330_atomic_commit_advances_version_pointer_atomically() {
+        let mut jmt = PersistentJMT::open_tmp().unwrap();
+        // Fresh store: latest_version is None.
+        assert!(jmt.store.latest_version().is_none());
+
+        jmt.insert(key_from_bytes(b"k1"), b"v1".to_vec()).unwrap();
+        let after_first = jmt.store.latest_version();
+        assert_eq!(after_first, Some(0), "first commit must publish v=0");
+
+        jmt.insert(key_from_bytes(b"k2"), b"v2".to_vec()).unwrap();
+        let after_second = jmt.store.latest_version();
+        assert_eq!(after_second, Some(1), "second commit must publish v=1");
+
+        // The version pointer and the readable tree state agree:
+        // every key inserted across the two commits is present at
+        // the latest version.
+        let tree = JellyfishMerkleTree::<_, Poseidon2JmtHasher>::new(&jmt.store);
+        let v = after_second.unwrap();
+        let kh1 = KeyHash(<[u8; 32]>::try_from(key_from_bytes(b"k1").as_slice()).unwrap());
+        let kh2 = KeyHash(<[u8; 32]>::try_from(key_from_bytes(b"k2").as_slice()).unwrap());
+        assert_eq!(tree.get(kh1, v).unwrap().as_deref(), Some(b"v1".as_ref()));
+        assert_eq!(tree.get(kh2, v).unwrap().as_deref(), Some(b"v2".as_ref()));
+    }
+
+    /// Audit 330: confirm the WriteBatch path on `commit_atomic`
+    /// covers nodes + values + version + rightmost together. We
+    /// can't peek at RocksDB's on-disk WAL from a unit test, but
+    /// we can pre-construct a non-trivial node batch and check
+    /// the post-commit reads agree with the version pointer.
+    #[test]
+    fn audit_330_commit_atomic_writes_full_set_in_one_batch() {
+        let mut jmt = PersistentJMT::open_tmp().unwrap();
+        // 3-leaf batch to exercise inner nodes + rightmost.
+        let entries = vec![
+            (key_from_bytes(b"a"), b"1".to_vec()),
+            (key_from_bytes(b"b"), b"2".to_vec()),
+            (key_from_bytes(b"c"), b"3".to_vec()),
+        ];
+        let root_before = jmt.root();
+        jmt.update_all(entries.clone()).unwrap();
+        let root_after = jmt.root();
+        assert_ne!(root_before, root_after);
+
+        // After commit_atomic, all three components reflect the
+        // new commit:
+        //   1. version pointer advanced (read via latest_version)
+        //   2. tree readable at the new version (get returns values)
+        //   3. rightmost-leaf marker present (get_rightmost_leaf
+        //      returns Some — required for snapshot-restore code)
+        use jmt::storage::TreeReader;
+        assert_eq!(jmt.store.latest_version(), Some(0));
+        for (k, v) in &entries {
+            assert_eq!(jmt.get(k).as_deref(), Some(&v[..]));
+        }
+        let rm = jmt.store.get_rightmost_leaf().unwrap();
+        assert!(
+            rm.is_some(),
+            "rightmost leaf must be persisted in same atomic batch"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes Wave G (state durability) of `AUDIT_FINDINGS_2.md`. Three
crash-consistency fixes that were the difference between "validator
that crashes mid-block recovers cleanly" and "validator that crashes
mid-block needs operator intervention".

## Commits

### 330+331 — atomic + fsync per-block commit (`36b4dc5`)
- **330**: New `JmtRocksStore::commit_atomic(node_batch, version)` builds
  a single `rocksdb::WriteBatch` containing nodes + values + rightmost
  marker AND `META_LATEST_VERSION` together. One `db.write_opt(batch)`
  lands them all-or-nothing. Pre-fix two sequential writes meant a
  crash between them left orphaned tree pages persisted at the new
  version while the version pointer still referenced the old one.
- **331**: Both `commit_atomic` (JMT) and `BufferedWriteBackend::flush`
  (legacy SMT) use `WriteOptions::set_sync(true)` → fdatasync per
  commit. ~1-5 ms cost on commodity SSDs, well within the 400 ms slot
  budget. Pre-fix a power loss in the WAL window (~1 s) silently
  rolled back the last committed block.

### 332 — decrypted-tx through overlay + undo log (`f5e735e`)
Both decrypted-tx execution sites used to call
`execute_transaction(dtx, &mut *state.smt_mut(), &block_ctx)` —
writing directly into the underlying JMT and bypassing the
StateManager's write-cache + per-block undo log. Two consequences:
1. Cache reads returned stale pre-decrypt values until invalidation.
2. `revert_to(slot - 1)` (reorg) walked plaintext undo only —
   decrypted-tx state survived the rollback, leaving a chain head
   with neither old nor new state.

Both paths now route through `StateOverlay::new(state)` →
`update_batch_deferred(writes)` + `record_block_undo(slot, undo)`,
matching the plaintext path. The `smt_mut()` escape hatch is removed
so future callers can't re-introduce the same bug class.

## Verification

- 1,679 workspace unit tests pass / 0 failed (15 crates)
- 298 pyde-node binary tests pass
- multi_node_encrypted_lifecycle integration test passes (validators
  converge on same post-decrypt state root)
- 81 state tests pass (incl. 2 new audit-330 atomicity tests)
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean