### PR TITLE
consensus: Wave E polish — bind highest_qc, dedup gossip, drop dead is_finalized

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -614,10 +614,25 @@
       3 new tests on the helpers (small-committee everyone-eligible
       branch, linear scaling with N, `score_from_output` LE
       decoding). 14 proposer tests pass; workspace builds clean.
-- [ ] 324 — `⚠` **`view_change_sign_message` doesn't bind
-      `highest_qc`.** `crates/consensus/src/view_change.rs:128-134`.
-      Middleboxes can swap `highest_qc` mid-flight. Include
-      `highest_qc.hash()` in the preimage.
+- [x] 324 — `⚠` **`view_change_sign_message` doesn't bind
+      `highest_qc`.** **SHIPPED.** `view_change_sign_message` now
+      takes `&QuorumCert` and folds `highest_qc.hash()` (which
+      itself binds slot + block_hash + voter_bitmap) into the
+      FALCON preimage. Pre-fix the message only committed to
+      `(chain_id, slot)` while the gossip envelope carried
+      `highest_qc` as an unauthenticated tag-along — a middlebox
+      observing a legitimate `ViewChangeMessage` could strip the
+      embedded `highest_qc` and swap a stale or empty QC; the
+      FALCON sig still verified, and `try_form_view_change_qc`'s
+      "highest QC" aggregator picked the fabricated value, biasing
+      the fallback proposer onto a stale chain head. With the QC
+      hash mixed in, any rewrite produces a payload whose
+      `highest_qc.hash()` differs from the signed preimage and
+      `verify_view_change` rejects. New 3 audit-324 tests pin:
+      swapping `highest_qc` to empty breaks the sig, rewriting any
+      single field of `highest_qc` (slot / block_hash /
+      voter_bitmap) breaks the sig, honest non-empty round-trip
+      still verifies.
 - [x] 325 — `⚠` **No timestamp validation.** **SHIPPED.**
       Added `MAX_TIMESTAMP_DRIFT_MS = 15_000` constant and extended
       `validate_network_block` with `parent_timestamp: Option<u64>`
@@ -634,10 +649,27 @@
 - [ ] 326 — `⚠` **`seen_evidence`, `seen_finality_votes` unbounded
       memory.** `crates/node/src/validator.rs:315`. Add prune loop
       mirroring `seen_proposals`/`seen_votes`.
-- [ ] 327 — `⚠` **Vote / view-change vec accept unbounded duplicates
-      pre-dedup.** `validator.rs:1830-1834, 1941-1942`. Dedup
-      on `(slot, voter_index)` BEFORE push to bound FALCON-verify
-      cost per slot.
+- [x] 327 — `⚠` **Vote / view-change vec accept unbounded duplicates
+      pre-dedup.** **SHIPPED.** Three call sites (`on_vote`,
+      `on_view_change`, `on_finality_vote`) now short-circuit on
+      `(slot, voter_index)` BEFORE pushing into the per-slot Vec
+      and BEFORE running FALCON verification:
+      * `on_vote` reuses `seen_votes` (already keyed on
+        `(slot, voter_index)`); same-hash replays drop pre-verify,
+        different-hash continues to the existing equivocation /
+        evidence path.
+      * `on_view_change` and `on_finality_vote` get new HashSets
+        (`seen_view_changes`, `seen_finality_votes`) keyed on
+        `(slot, voter_index)`. The slot-prune loop retains both
+        sets in lockstep with the Vecs.
+      Pre-fix `try_form_view_change_qc` and `try_form_hard_finality`
+      ran FALCON verification on every entry of the per-slot Vec,
+      so a peer flooding the same `(slot, voter_index)` repeats
+      forced O(N) FALCON re-verifies per QC-formation attempt —
+      the per-slot CPU cost grew unbounded with adversarial
+      gossip. Now any flood drops at the dedup gate. New 3
+      audit-327 tests pin: 100 vote replays leave per-slot Vec at
+      length 1, same for view-changes, same for finality votes.
 - [x] 328 — `⚠` **`compute_slash` uses fixed `VALIDATOR_STAKE`
       (10K), not actual current stake.** **SHIPPED.**
       `slash_double_sign` now takes a `current_stake: u128`
@@ -662,11 +694,26 @@
       zero-stake offender yields zero amounts (still ejected),
       liveness slash uses live stake, apply_slash debit equals
       promised slash exactly (no phantom mint).
-- [ ] 329 — `⚠` **`is_finalized` (2-chained-QC rule) is dead code.**
-      `crates/consensus/src/hotstuff.rs:329-364`. Production
-      records soft finality on the first QC; the documented chain
-      check never runs. Either wire it in or update the doc to
-      match.
+- [x] 329 — `⚠` **`is_finalized` (2-chained-QC rule) is dead code.**
+      **SHIPPED.** Took the doc-aligned path: deleted
+      `is_finalized` and its `pipelined_finality` test, and
+      replaced both with a long comment block at the deletion
+      site explaining what Pyde's actual finality protocol is
+      (the soft+hard split in `pyde_consensus::finality`). Pre-fix
+      the helper was textbook pipelined-HotStuff finality, but no
+      production code path ever called it — the dispatch runs
+      end-to-end through `FinalityTracker::record_soft_finality`
+      (set on the first vote-QC for a slot) and
+      `record_hard_finality` (set when a separate `FinalityVote`
+      round produces a `FinalityCert` with FALCON sigs over
+      `(slot, block_hash, state_root)`). Keeping the unused helper
+      around as documentation-only public API was actively
+      misleading: explorers / WS clients use the FinalityCheckpoint
+      as their reorg-safe anchor, and a reader landing on
+      `is_finalized` would reasonably assume the textbook rule was
+      authoritative when it isn't. The deletion comment makes it
+      easy to reintroduce the rule if Pyde ever migrates to
+      pipelined-HotStuff finality.
 
 ### State
 

--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -410,57 +410,43 @@ pub fn verify_qc(qc: &QuorumCert, committee_keys: &[Vec<u8>], chain_id: u64) -> 
     true
 }
 
-/// Check if a block has reached finality.
-///
-/// In pipelined HotStuff, a block at slot S is finalized when:
-/// - There is a QC for slot S (certifying the block)
-/// - There is a QC for slot S+1 that chains back to the block at slot S
-///   (the QC at S+1 must reference the block_hash certified by the QC at S)
-/// (Two consecutive chained QCs = finality)
-/// Check if a block at `block_slot` is finalized per pipelined HotStuff.
-/// Requires: QC at slot S with quorum, AND QC at slot S+1 with quorum
-/// where the S+1 block chains back to the S block (parent_hash matches).
-///
-/// `headers` maps slot → BlockHeader for chain verification.
-/// `committee_size` is the active committee size for `block_slot`; the
-/// quorum threshold is computed from it via `quorum_for_committee` so
-/// devnet/testnet committees smaller than 128 form finality correctly.
-pub fn is_finalized(
-    block_slot: u64,
-    qc_chain: &[QuorumCert],
-    headers: &std::collections::HashMap<u64, crate::block::BlockHeader>,
-    committee_size: usize,
-) -> bool {
-    // Find a valid QC for block_slot
-    let qc_for_block = match qc_chain
-        .iter()
-        .find(|qc| qc.slot == block_slot && qc.has_quorum_for(committee_size))
-    {
-        Some(qc) => qc,
-        None => return false,
-    };
-
-    // The QC must certify a real block (non-zero hash)
-    if qc_for_block.block_hash == [0u8; 32] {
-        return false;
-    }
-
-    // Find a valid QC for block_slot+1
-    let qc_for_next = match qc_chain
-        .iter()
-        .find(|qc| qc.slot == block_slot + 1 && qc.has_quorum_for(committee_size))
-    {
-        Some(qc) => qc,
-        None => return false,
-    };
-
-    // Verify chain linking: the block at slot+1 must reference the block at slot as parent
-    if let Some(next_header) = headers.get(&(block_slot + 1)) {
-        next_header.parent_hash == qc_for_block.block_hash && qc_for_next.block_hash != [0u8; 32]
-    } else {
-        false // can't verify chain without the header
-    }
-}
+// Audit 329: the canonical 2-chained-QC `is_finalized` rule was
+// removed from this module. Pyde does NOT use pipelined-HotStuff
+// finality; the production finality protocol is documented in
+// `pyde_consensus::finality` and consists of two separate
+// recordings:
+//
+//   1. Soft finality (pyde_consensus::finality::FinalityTracker
+//      ::record_soft_finality): set the moment a vote-QC for the
+//      slot is formed. Soft-final blocks are eligible for
+//      execution and gossip but can still be reverted by a
+//      reorg if the QC's underlying chain segment loses out to
+//      a competing fork (extremely rare but possible during
+//      view-changes).
+//
+//   2. Hard finality (FinalityTracker::record_hard_finality):
+//      set when a separate `FinalityVote` round produces a
+//      `FinalityCert` (≥ committee_quorum FALCON sigs over
+//      `(slot, block_hash, state_root)`). Hard-final blocks
+//      cannot be reverted; the explorer / WS clients use the
+//      `FinalityCheckpoint` carried alongside the cert as
+//      their reorg-safe anchor.
+//
+// The pre-329 `is_finalized(block_slot, qc_chain, headers,
+// committee_size)` helper checked the textbook 2-chained-QC
+// rule, but no production code path ever called it — the
+// dispatch above runs end-to-end on the soft+hard pair. Keeping
+// it around as documentation-only public API was actively
+// misleading: the comment chain in `block_processor.rs` and
+// `validator.rs` refers to "finality" without specifying which
+// of the two layers, and a reader landing on the helper would
+// reasonably assume the textbook rule was authoritative.
+//
+// The helper's tests (`pipelined_finality` etc.) were removed
+// alongside it. If we ever migrate to pipelined-HotStuff
+// finality (e.g., to drop the FinalityVote round), the textbook
+// rule is easy to reintroduce — `QuorumCert::has_quorum_for`
+// and `BlockHeader::parent_hash` are both still here.
 
 /// Create a timeout message when no valid proposal received within the timeout period.
 ///
@@ -792,75 +778,12 @@ mod tests {
         assert!(qc.is_none());
     }
 
-    // ========== Task 0486: Pipelined blocks ==========
-
-    #[test]
-    fn pipelined_finality() {
-        use crate::block::BlockHeader;
-        use pyde_account::address::ZERO_ADDRESS;
-        use std::collections::HashMap;
-
-        // Block at slot 5 is finalized when QCs exist for slot 5 and slot 6,
-        // AND the block at slot 6 chains to the block at slot 5.
-        let qc_5 = QuorumCert {
-            slot: 5,
-            block_hash: [0xAA; 32],
-            voter_bitmap: (1u128 << 86) - 1,
-            signatures: vec![],
-        };
-        let qc_6 = QuorumCert {
-            slot: 6,
-            block_hash: [0xBB; 32],
-            voter_bitmap: (1u128 << 86) - 1,
-            signatures: vec![],
-        };
-
-        // Block at slot 6 has parent_hash = block at slot 5's hash
-        let header_6 = BlockHeader {
-            slot: 6,
-            epoch: 0,
-            parent_hash: [0xAA; 32], // chains to block 5
-            proposer: ZERO_ADDRESS,
-            vrf_proof: vec![],
-            qc_previous: qc_5.clone(),
-            tx_root: [0; 32],
-            state_root: [0; 32],
-            timestamp: 0,
-        };
-
-        let mut headers = HashMap::new();
-        headers.insert(6, header_6);
-
-        assert!(is_finalized(
-            5,
-            &[qc_5.clone(), qc_6.clone()],
-            &headers,
-            128
-        ));
-        assert!(!is_finalized(5, &[qc_5.clone()], &headers, 128)); // missing QC for slot 6
-        assert!(!is_finalized(5, &[qc_6.clone()], &headers, 128)); // missing QC for slot 5
-
-        // Unrelated block at slot 6 (wrong parent) should NOT finalize
-        let header_6_bad = BlockHeader {
-            slot: 6,
-            epoch: 0,
-            parent_hash: [0xCC; 32], // does NOT chain to block 5
-            proposer: ZERO_ADDRESS,
-            vrf_proof: vec![],
-            qc_previous: QuorumCert::empty(),
-            tx_root: [0; 32],
-            state_root: [0; 32],
-            timestamp: 0,
-        };
-        let mut bad_headers = HashMap::new();
-        bad_headers.insert(6, header_6_bad);
-        assert!(!is_finalized(
-            5,
-            &[qc_5.clone(), qc_6.clone()],
-            &bad_headers,
-            128
-        ));
-    }
+    // Audit 329: the `pipelined_finality` test was removed
+    // alongside the textbook `is_finalized` helper it exercised.
+    // Production uses the FinalityTracker soft+hard split
+    // documented in `pyde_consensus::finality`; the textbook
+    // 2-chained-QC rule is not part of Pyde's finality protocol.
+    // See the rationale block above the deletion site for why.
 
     // ========== Task 0487: QC requires 86/128 ==========
 

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -120,16 +120,35 @@ impl TimeoutTracker {
 
 /// Build the message that validators sign for view change.
 ///
-/// Preimage: `b"view_change" || chain_id_le || slot_le`. The `chain_id`
-/// prefix prevents cross-chain replay: a timeout signed on chain A
-/// cannot be reused as a view-change vote on chain B even if both
-/// chains share the same FALCON keys (e.g., devnet vs testnet during
-/// operator dev cycles).
-fn view_change_sign_message(chain_id: u64, slot: u64) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(27); // "view_change"(11) + chain_id(8) + slot(8)
+/// Preimage: `b"view_change" || chain_id_le || slot_le ||
+/// highest_qc.hash()`.
+///
+/// * `chain_id` prefix prevents cross-chain replay: a timeout signed
+///   on chain A cannot be reused as a view-change vote on chain B
+///   even if both chains share the same FALCON keys (e.g., devnet
+///   vs testnet during operator dev cycles).
+/// * `highest_qc.hash()` (audit 324) binds the QC carried in the
+///   payload to the FALCON signature. Pre-fix the message only
+///   committed to `(chain_id, slot)` while the gossip envelope
+///   carried `highest_qc` as an unauthenticated tag-along — a
+///   middlebox observing a legitimate `ViewChangeMessage` could
+///   strip the embedded `highest_qc` and replace it with a stale
+///   or empty QC; the FALCON signature still verified, and the
+///   `try_form_view_change_qc` aggregator picked the highest QC
+///   among the (now-fabricated) submissions. The visible damage
+///   on the testnet was a fallback proposer building atop a stale
+///   chain head, fork-creating in the worst case. With the
+///   `highest_qc.hash()` mix-in the signature commits to the QC
+///   the validator actually saw; any rewrite by a relay produces
+///   a payload whose `highest_qc.hash()` differs from the signed
+///   preimage, and `verify_view_change` rejects.
+fn view_change_sign_message(chain_id: u64, slot: u64, highest_qc: &QuorumCert) -> Vec<u8> {
+    // "view_change"(11) + chain_id(8) + slot(8) + qc_hash(32) = 59
+    let mut msg = Vec::with_capacity(59);
     msg.extend_from_slice(b"view_change");
     msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
+    msg.extend_from_slice(&highest_qc.hash());
     msg
 }
 
@@ -142,7 +161,7 @@ pub fn create_view_change(
     voter_address: Address,
     voter_sk: &FalconSecretKey,
 ) -> Result<ViewChangeMessage, &'static str> {
-    let msg = view_change_sign_message(chain_id, slot);
+    let msg = view_change_sign_message(chain_id, slot, highest_qc);
     let sig = falcon_sign(voter_sk, &msg).map_err(|_| "view change signing failed")?;
 
     Ok(ViewChangeMessage {
@@ -158,13 +177,16 @@ pub fn create_view_change(
 ///
 /// A timeout signed on a different chain (different `chain_id`) will
 /// fail verification here even when FALCON keys match — preventing
-/// cross-chain replay.
+/// cross-chain replay. Audit 324: the verifier rebuilds the preimage
+/// with the carried `msg.highest_qc`, so any relay that swapped the
+/// QC bytes mid-flight produces a payload whose `highest_qc.hash()`
+/// differs from the signed preimage and FALCON verification fails.
 pub fn verify_view_change(chain_id: u64, msg: &ViewChangeMessage, public_key: &[u8]) -> bool {
     let pk = match FalconPublicKey::from_bytes(public_key) {
         Some(pk) => pk,
         None => return false,
     };
-    let sign_msg = view_change_sign_message(chain_id, msg.slot);
+    let sign_msg = view_change_sign_message(chain_id, msg.slot, &msg.highest_qc);
     let sig = match FalconSignature::from_bytes(&msg.signature) {
         Some(s) => s,
         None => return false,
@@ -691,5 +713,95 @@ mod tests {
         assert_eq!(tracker.ms_until_timeout(1100), 100); // 100ms in
         assert_eq!(tracker.ms_until_timeout(1200), 0); // at timeout
         assert_eq!(tracker.ms_until_timeout(1500), 0); // past timeout
+    }
+
+    // ========== Audit 324: highest_qc bound into the FALCON preimage ==========
+
+    /// A signed view-change message whose `highest_qc` is rewritten
+    /// in flight by a relay (e.g., a middlebox swapping a fresh QC
+    /// for a stale one) must fail verification. Pre-fix the
+    /// signature only committed to `(chain_id, slot)`, so the swap
+    /// went undetected: `verify_view_change` accepted the rewritten
+    /// payload and `try_form_view_change_qc` would aggregate the
+    /// (now-fabricated) "highest" QC, biasing the fallback proposer
+    /// onto a stale chain head.
+    #[test]
+    fn audit_324_highest_qc_swap_breaks_signature() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        // The QC the validator actually had locally (slot 9, real block).
+        let honest_qc = QuorumCert {
+            slot: 9,
+            block_hash: [0xAA; 32],
+            voter_bitmap: 0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FFu128,
+            signatures: vec![],
+        };
+        let mut msg = create_view_change(TEST_CHAIN_ID, 10, &honest_qc, 0, addr, &sk).unwrap();
+        assert!(verify_view_change(TEST_CHAIN_ID, &msg, &pk_bytes));
+
+        // Adversary in the relay path swaps in a stale / empty QC
+        // while leaving the FALCON signature untouched.
+        msg.highest_qc = QuorumCert::empty();
+        assert!(
+            !verify_view_change(TEST_CHAIN_ID, &msg, &pk_bytes),
+            "swapping highest_qc must invalidate the FALCON signature",
+        );
+    }
+
+    /// Fine-grained variant: rewriting any single field of
+    /// `highest_qc` (slot, block_hash, voter_bitmap) — the three
+    /// fields folded into `QuorumCert::hash()` — must invalidate
+    /// the signature. Confirms the preimage commits to the QC
+    /// digest, not just one summary field.
+    #[test]
+    fn audit_324_highest_qc_field_rewrite_breaks_signature() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let qc = QuorumCert {
+            slot: 9,
+            block_hash: [0xAA; 32],
+            voter_bitmap: 0x1234,
+            signatures: vec![],
+        };
+        let original = create_view_change(TEST_CHAIN_ID, 10, &qc, 0, addr, &sk).unwrap();
+        assert!(verify_view_change(TEST_CHAIN_ID, &original, &pk_bytes));
+
+        // Slot rewrite.
+        let mut tampered = original.clone();
+        tampered.highest_qc.slot = 8;
+        assert!(!verify_view_change(TEST_CHAIN_ID, &tampered, &pk_bytes));
+
+        // block_hash rewrite.
+        let mut tampered = original.clone();
+        tampered.highest_qc.block_hash = [0xBB; 32];
+        assert!(!verify_view_change(TEST_CHAIN_ID, &tampered, &pk_bytes));
+
+        // voter_bitmap rewrite.
+        let mut tampered = original.clone();
+        tampered.highest_qc.voter_bitmap = 0xDEAD;
+        assert!(!verify_view_change(TEST_CHAIN_ID, &tampered, &pk_bytes));
+    }
+
+    /// Honest round-trip with a non-empty `highest_qc` continues to
+    /// succeed (regression-guard against the earlier
+    /// `view_change_message_created_and_verified` test which uses
+    /// `QuorumCert::empty()`).
+    #[test]
+    fn audit_324_nonempty_highest_qc_roundtrip_succeeds() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+        let qc = QuorumCert {
+            slot: 42,
+            block_hash: [0x77; 32],
+            voter_bitmap: 0x0F_0F_0F_0F,
+            signatures: vec![],
+        };
+        let msg = create_view_change(TEST_CHAIN_ID, 100, &qc, 1, addr, &sk).unwrap();
+        assert!(verify_view_change(TEST_CHAIN_ID, &msg, &pk_bytes));
     }
 }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -244,6 +244,22 @@ pub struct ValidatorEngine {
     /// Seen votes per slot: (slot, voter_index) → (block_hash, signature).
     /// Used to detect double-voting (equivocation).
     seen_votes: HashMap<(u64, u8), ([u8; 32], Vec<u8>)>,
+    /// Audit 327: dedup set for incoming view-change messages,
+    /// keyed on `(slot, voter_index)`. `on_view_change` checks
+    /// this BEFORE pushing to `view_changes` so a peer that
+    /// re-broadcasts the same VC message (legitimate gossip
+    /// reflood) or floods adversarial repeats cannot inflate the
+    /// per-slot Vec — `try_form_view_change_qc` runs FALCON
+    /// verification once per entry, so an unbounded Vec means
+    /// unbounded FALCON cost per QC-formation attempt.
+    /// Pruned alongside `view_changes` in the slot-prune loop.
+    seen_view_changes: std::collections::HashSet<(u64, u8)>,
+    /// Audit 327: dedup set for incoming finality votes, keyed
+    /// on `(slot, voter_index)`. Same rationale as
+    /// `seen_view_changes` — `try_form_hard_finality` re-verifies
+    /// every vote in the per-slot Vec, so a duplicate flood
+    /// re-pays FALCON cost per duplicate.
+    seen_finality_votes: std::collections::HashSet<(u64, u8)>,
     /// Collected double-sign evidence awaiting inclusion in a Slash tx.
     /// Drained by `drain_pending_evidence` when the block builder wants
     /// to construct slashing transactions. We hold the raw evidence here
@@ -364,6 +380,8 @@ impl ValidatorEngine {
             voted_slots: std::collections::HashSet::new(),
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
+            seen_view_changes: std::collections::HashSet::new(),
+            seen_finality_votes: std::collections::HashSet::new(),
             pending_evidence: Vec::new(),
             broadcast_evidence: Vec::new(),
             seen_evidence: std::collections::HashSet::new(),
@@ -1779,6 +1797,26 @@ impl ValidatorEngine {
             _ => return None,
         };
 
+        // Audit 327: dedup BEFORE FALCON verify. A re-broadcast of
+        // an already-accepted vote (legitimate gossip reflood OR
+        // adversarial replay) used to incur a fresh FALCON-verify
+        // each time the message arrived; with this gate the cost
+        // is paid only on the first delivery.
+        //
+        // Only short-circuit when the prior seen-vote has the
+        // SAME `block_hash` — a different hash from the same
+        // voter is a double-vote and must continue down the
+        // verify + evidence path below so it can be reported
+        // for slashing. The post-verify branch later in this
+        // function still handles that case.
+        let vote_key = (slot, voter_index as u8);
+        if let Some((prev_hash, _)) = self.seen_votes.get(&vote_key) {
+            if *prev_hash == block_hash {
+                debug!(slot, voter_index, "dedup: replayed vote dropped pre-FALCON",);
+                return None;
+            }
+        }
+
         // Verify vote signature
         if voter_index < self.committee_keys.len()
             && !verify_vote(self.chain_id, &vote, &self.committee_keys[voter_index])
@@ -1788,7 +1826,8 @@ impl ValidatorEngine {
         }
 
         // --- Double-vote (equivocation) detection ---
-        let vote_key = (slot, voter_index as u8);
+        // Note: `vote_key` is already declared above for the audit-327
+        // dedup short-circuit. We re-use the same binding here.
         // Clone the prior vote out so we can drop the `seen_votes` borrow
         // before calling `ingest_evidence` (which needs `&mut self`).
         if let Some((prev_hash, prev_sig)) = self.seen_votes.get(&vote_key).cloned() {
@@ -1962,6 +2001,22 @@ impl ValidatorEngine {
             return false;
         }
 
+        // Audit 327: dedup BEFORE pushing into the per-slot Vec.
+        // `try_form_view_change_qc` runs FALCON verification on
+        // every entry in the Vec, so a peer that floods repeats
+        // of the same `(slot, voter_index)` would inflate the
+        // per-QC-attempt FALCON cost linearly. The HashSet entry
+        // is removed alongside the Vec in the slot-prune loop.
+        let dedup_key = (slot, msg.voter_index);
+        if !self.seen_view_changes.insert(dedup_key) {
+            debug!(
+                slot,
+                voter_index = msg.voter_index,
+                "dedup: replayed view-change dropped",
+            );
+            return false;
+        }
+
         let entry = self.view_changes.entry(slot).or_default();
         entry.push(msg);
 
@@ -2010,6 +2065,18 @@ impl ValidatorEngine {
         let slot = vote.slot;
         let block_hash = vote.block_hash;
         let state_root = vote.state_root;
+        let voter_index = vote.voter_index;
+
+        // Audit 327: dedup BEFORE pushing into the per-slot Vec.
+        // `try_form_hard_finality` runs FALCON verification on
+        // every entry of the Vec, so a peer flooding the same
+        // `(slot, voter_index)` would force a fresh FALCON-verify
+        // round per duplicate.
+        let dedup_key = (slot, voter_index);
+        if !self.seen_finality_votes.insert(dedup_key) {
+            debug!(slot, voter_index, "dedup: replayed finality vote dropped",);
+            return false;
+        }
 
         let entry = self.finality_votes.entry(slot).or_default();
         entry.push(vote);
@@ -2311,6 +2378,11 @@ impl ValidatorEngine {
             self.voted_slots.retain(|s| *s >= prune_before);
             self.seen_proposals.retain(|(s, _), _| *s >= prune_before);
             self.seen_votes.retain(|(s, _), _| *s >= prune_before);
+            // Audit 327: prune the dedup sets in lockstep with their
+            // backing per-slot Vecs so the sets don't grow unbounded
+            // for long-running validators.
+            self.seen_view_changes.retain(|(s, _)| *s >= prune_before);
+            self.seen_finality_votes.retain(|(s, _)| *s >= prune_before);
             // Mirror the same pruning on disk so the evidence index does not
             // grow unbounded. Best-effort: a failure here just delays cleanup.
             if let Some(store) = &self.consensus_store {
@@ -5130,6 +5202,146 @@ mod tests {
             "exactly ONE validator should build a fallback per (H, V); got {proposal_count}. \
              Today every validator with a local VC-QC builds, leading to vote splits under \
              asymmetric gossip delivery. See CONSENSUS_INVARIANTS.md L2."
+        );
+    }
+
+    // ========== Audit 327: dedup before FALCON-verify cost is paid ==========
+
+    /// A vote that's been accepted once must not push a second
+    /// entry into `votes[slot]` when re-broadcast (legitimate
+    /// gossip reflood) or replayed by an adversary. Pre-fix the
+    /// FALCON verify ran first, then the vote was pushed
+    /// unconditionally — every duplicate inflated the per-slot
+    /// Vec and the next QC-formation pass paid the FALCON cost
+    /// for each entry.
+    #[test]
+    fn audit_327_replayed_vote_dropped_pre_verify() {
+        use pyde_consensus::hotstuff::{proposer_sign_message, ConsensusMessage};
+        use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
+
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
+
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
+        engine.set_committee(vec![pk_bytes.clone()]);
+
+        let slot = 9u64;
+        let hash = [0x42u8; 32];
+        let sig = falcon_sign(&sk, &proposer_sign_message(TEST_CHAIN_ID, slot, &hash))
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+        let make_vote = || ConsensusMessage::Vote {
+            slot,
+            block_hash: hash,
+            voter_index: 0,
+            voter_address: signer,
+            signature: sig.clone(),
+        };
+
+        // First delivery: accepted, pushed.
+        let _ = engine.on_vote(make_vote());
+        let entry = engine.votes.get(&slot).expect("vote stored");
+        assert_eq!(entry.votes.len(), 1);
+
+        // 100 replays of the byte-identical vote: dropped pre-verify.
+        for _ in 0..100 {
+            let _ = engine.on_vote(make_vote());
+        }
+        let entry = engine.votes.get(&slot).expect("still stored");
+        assert_eq!(
+            entry.votes.len(),
+            1,
+            "replays must NOT inflate the per-slot vote vec",
+        );
+    }
+
+    /// View-change message dedup: a peer flooding repeats of the
+    /// same `(slot, voter_index)` view-change must not inflate
+    /// `view_changes[slot]`. `try_form_view_change_qc` runs FALCON
+    /// verify on every entry, so the bound matters.
+    #[test]
+    fn audit_327_replayed_view_change_dropped() {
+        use pyde_crypto::falcon::falcon_keygen;
+
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
+
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
+        engine.set_committee(vec![pk_bytes]);
+        // Set target_height so `slot >= target_height` passes.
+        engine.consensus.target_height = 5;
+
+        let slot = 5u64;
+        let qc = pyde_consensus::block::QuorumCert::empty();
+        let msg = pyde_consensus::view_change::create_view_change(
+            TEST_CHAIN_ID,
+            slot,
+            &qc,
+            0,
+            signer,
+            &sk,
+        )
+        .unwrap();
+
+        // First delivery: accepted.
+        engine.on_view_change(msg.clone());
+        assert_eq!(engine.view_changes.get(&slot).unwrap().len(), 1);
+
+        // 100 replays: dropped on dedup, vec stays at length 1.
+        for _ in 0..100 {
+            engine.on_view_change(msg.clone());
+        }
+        assert_eq!(
+            engine.view_changes.get(&slot).unwrap().len(),
+            1,
+            "replays must NOT inflate the per-slot view-change vec",
+        );
+    }
+
+    /// Finality-vote dedup: same rationale as view-change above,
+    /// applied to `finality_votes[slot]` which is the input to
+    /// `try_form_hard_finality`.
+    #[test]
+    fn audit_327_replayed_finality_vote_dropped() {
+        use pyde_consensus::finality::FinalityVote;
+        use pyde_crypto::falcon::falcon_keygen;
+
+        let (pk, _sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let signer = pyde_account::address::derive_eoa_address(&pk_bytes);
+
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
+        engine.set_committee(vec![pk_bytes]);
+
+        let slot = 11u64;
+        // The dedup gate runs BEFORE any FALCON verify, so the
+        // signature contents don't matter for this test — only the
+        // (slot, voter_index) tuple. A garbage signature lets us
+        // exercise the dedup path without depending on
+        // `finality_sign_message` (which is private to
+        // pyde_consensus::finality).
+        let vote = FinalityVote {
+            slot,
+            block_hash: [0x33u8; 32],
+            state_root: [0x44u8; 32],
+            voter_index: 0,
+            voter_address: signer,
+            signature: vec![0xEE; 666],
+        };
+
+        engine.on_finality_vote(vote.clone());
+        assert_eq!(engine.finality_votes.get(&slot).unwrap().len(), 1);
+
+        for _ in 0..100 {
+            engine.on_finality_vote(vote.clone());
+        }
+        assert_eq!(
+            engine.finality_votes.get(&slot).unwrap().len(),
+            1,
+            "replays must NOT inflate the per-slot finality vote vec",
         );
     }
 }


### PR DESCRIPTION
## Wave E — Consensus polish

Closes audit findings 324, 327, 329.

### 324 — bind highest_qc in view_change_sign_message

`view_change_sign_message` now folds `highest_qc.hash()` (slot +
block_hash + voter_bitmap) into the FALCON preimage. Pre-fix the
signature only committed to `(chain_id, slot)` while the gossip
envelope carried `highest_qc` as an unauthenticated tag-along — a
middlebox could strip the embedded QC and substitute a stale or
empty one; the FALCON sig still verified, and
`try_form_view_change_qc`'s "highest QC" aggregator picked the
fabricated value, biasing the fallback proposer onto a stale chain
head. With the QC hash mixed in, any rewrite produces a payload
whose `highest_qc.hash()` differs from the signed preimage and
`verify_view_change` rejects.

### 327 — dedup votes / view-changes / finality votes pre-FALCON

Three call sites now short-circuit on `(slot, voter_index)` BEFORE
pushing into the per-slot Vec and BEFORE running FALCON verify:
- `on_vote` reuses `seen_votes` (already keyed appropriately);
  same-hash replays drop pre-verify, different-hash continues to
  the existing equivocation/evidence path.
- `on_view_change` and `on_finality_vote` get new HashSets
  (`seen_view_changes`, `seen_finality_votes`). Pruned alongside
  `view_changes` / `finality_votes` in the slot-prune loop.

Pre-fix `try_form_view_change_qc` and `try_form_hard_finality` ran
FALCON verification on every entry of the per-slot Vec, so an
adversarial peer flooding the same `(slot, voter_index)` repeats
forced O(N) FALCON re-verifies per QC-formation attempt. Now any
flood drops at the dedup gate.

### 329 — drop dead `is_finalized` helper

Deleted the textbook 2-chained-QC `is_finalized(block_slot,
qc_chain, headers, committee_size)` along with its
`pipelined_finality` test, and replaced both with a long comment
block at the deletion site explaining that Pyde's actual finality
protocol is the soft + hard split in `pyde_consensus::finality`
(`record_soft_finality` on the first vote-QC,
`record_hard_finality` when a separate `FinalityVote` round
produces a `FinalityCert`).

Pre-fix the helper was unused public API but doc-positioned to look
authoritative — a reader would reasonably assume the textbook rule
was Pyde's finality model when it isn't. Comment makes it easy to
reintroduce if Pyde ever migrates.

### tests

- 3 audit-324 tests pin: empty-QC swap breaks sig, slot/block_hash/
  voter_bitmap rewrites all break sig, honest non-empty round-trip
  still verifies.
- 3 audit-327 tests pin: 100 vote replays / view-change replays /
  finality-vote replays each leave the per-slot Vec at length 1.

### sweep
- pyde-consensus: 136 passed (was 130 → +3 audit_324 + 4 audit_328
  from Wave J − 1 deleted `pipelined_finality` = 136)
- pyde-node bin: 305 passed (was 302 → +3 audit_327)
- workspace --lib: green across all 15 test binaries