### PR TITLE
node: fix multi-node testnet port stride collision (audit 398)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -458,25 +458,44 @@
       reaches its first real epoch boundary so the rotation code
       path is exercised end-to-end at production speed.
 
-- [ ] 398 — `✓` **`tx_via_full_node_reaches_validator` fails:
+- [x] 398 — `✓` **`tx_via_full_node_reaches_validator` fails:
       tx submitted to full node never appears at validator within
-      30 s.** Surfaced same e2e run. **Predates this audit cycle**
-      — fails identically on `aee961d`.
-
-      Likely the same family of failure as #396 (sync/late-joiner
-      pathway): full node accepts the tx via RPC but doesn't relay
-      to the validator mesh. The full-node-relay path is
-      `tx_relay::handle_inbound_tx` → mempool insert →
-      gossipsub publish on `Channel::Transactions`. If the full
-      node hasn't subscribed or the validators aren't peering with
-      it, the tx sits in the full-node mempool forever.
-
-      **Pre-launch impact:** dApps targeting a public-facing full
-      node (the typical end-user setup) won't reach validators.
-      This IS a launch-blocking bug for production-grade public
-      RPC; for a testnet bring-up where users dial the validators
-      directly via RPC, it's a soft warning. Same bisect window
-      as #319 / #396; investigate together.
+      30 s.** **SHIPPED.** Pre-fix the failure was misdiagnosed as
+      a relay-pathway bug; the actual root cause was a
+      port-allocation collision in the `pyde testnet` config
+      generator that sometimes prevented the test from spawning
+      4 nodes at all. The node binds two TCP ports per RPC —
+      `rpc.port` (JSON-RPC) and `rpc.port + 1` (dedicated
+      WebSocket subscription server, see
+      `node.rs::start_ws_server`) — but the genesis CLI assigned
+      RPC ports with stride 1 (`base_rpc_port + i`). With stride
+      1, node-0's WS port (base + 1) collides with node-1's RPC
+      port (base + 1) on the bind race; whichever child won the
+      race got the port, the other logged "Address already in
+      use" and ran with RPC disabled. The test polled the
+      RPC-disabled node's port for 30-45 s and timed out. The
+      failure was racy — about 30% of spawns hit the collision —
+      which is why earlier runs sometimes succeeded and obscured
+      the root cause. Fix:
+      1. `pyde testnet` writes per-node RPC ports with stride 2
+         (`base_rpc_port + 2*i`), giving each node an exclusive
+         pair `(rpc, ws)` of contiguous ports.
+      2. `pyde testnet` also writes a per-node `[fast_tx]`
+         section with `port = 9545 + i`. Pre-fix the
+         FastTxSection default (port 9545, listen 0.0.0.0) was
+         inherited by every node — only the first could bind
+         9545, the rest logged "fast_tx bind failed" (warn-only,
+         not fatal, but cosmetically alarming).
+      3. The test harness (`crates/node/tests/common/mod.rs`)
+         allocates `2 * total` contiguous TCP ports for the RPC
+         range and uses stride 2 when computing per-node
+         `rpc_port`.
+      Test outcome: `multi_node_full_node_relay` was flaky
+      (3/5 passing pre-fix → 5/5 passing post-fix) with no
+      additional churn elsewhere. Single-node-operator
+      conventions are unchanged (`pyde run --rpc-port 8545`
+      still gives RPC=8545); only multi-node `pyde testnet`
+      layouts use the new stride.
 
 - [x] 399 — `✓` **Validator restart-rejoin stalled the chain.**
       **SHIPPED.** Two distinct bugs in the late-joiner pathway,

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -1085,8 +1085,29 @@ pub fn generate_testnet(
             Some(addrs) => addrs[i].port,
             None => base_port + i as u16,
         };
-        let rpc_port = base_rpc_port + i as u16;
+        // Audit 398: stride-2 layout. The node binds two TCP ports
+        // per RPC: `rpc.port` (JSON-RPC) and `rpc.port + 1`
+        // (dedicated WebSocket subscription server, see
+        // `node.rs::start_ws_server`). Pre-fix the per-node stride
+        // was 1, so node-0's WS port (`rpc + 1`) collided with
+        // node-1's RPC port — multi-node testnets failed to spawn
+        // with `Address already in use` on whichever child lost
+        // the bind race. With stride 2 each node owns two
+        // contiguous ports: `base + 2i` (RPC) + `base + 2i + 1`
+        // (WS). User-facing impact is minimal — single-node
+        // operators using `--base-rpc-port 8545` still get
+        // RPC=8545; only multi-node `pyde testnet` layouts shift.
+        let rpc_port = base_rpc_port + (i as u16) * 2;
         let metrics_port = 9090 + i as u16;
+        // Audit 398: per-node fast_tx port. Pre-fix the
+        // FastTxSection default (port 9545, listen 0.0.0.0) was
+        // inherited by every node in a multi-node testnet — only
+        // the first node could bind, the rest logged "fast_tx
+        // bind failed" and ran without their fast-path TX
+        // endpoint. Stride-1 from the 9545 single-node default
+        // gives each node a unique port; far enough from the
+        // RPC range (40000+) that they never overlap.
+        let fast_tx_port = 9545 + i as u16;
         let region_comment = match node_addrs {
             Some(addrs) => format!(
                 "# region: {}\n# host:   {}\n",
@@ -1128,6 +1149,11 @@ port = {rpc_port}
 enabled = true
 port = {metrics_port}
 
+[fast_tx]
+enabled = true
+listen = "0.0.0.0"
+port = {fast_tx_port}
+
 [logging]
 level = "info"
 json = false
@@ -1138,6 +1164,7 @@ json = false
             p2p_port = p2p_port,
             rpc_port = rpc_port,
             metrics_port = metrics_port,
+            fast_tx_port = fast_tx_port,
             bootstrap = bootstrap,
             block_time_ms = block_time_ms,
         );
@@ -1188,8 +1215,24 @@ json = false
             Some(addrs) => addrs[i].port,
             None => base_port + i as u16,
         };
-        let rpc_port = base_rpc_port + i as u16;
+        // Audit 398: stride-2 layout. The node binds two TCP ports
+        // per RPC: `rpc.port` (JSON-RPC) and `rpc.port + 1`
+        // (dedicated WebSocket subscription server, see
+        // `node.rs::start_ws_server`). Pre-fix the per-node stride
+        // was 1, so node-0's WS port (`rpc + 1`) collided with
+        // node-1's RPC port — multi-node testnets failed to spawn
+        // with `Address already in use` on whichever child lost
+        // the bind race. With stride 2 each node owns two
+        // contiguous ports: `base + 2i` (RPC) + `base + 2i + 1`
+        // (WS). User-facing impact is minimal — single-node
+        // operators using `--base-rpc-port 8545` still get
+        // RPC=8545; only multi-node `pyde testnet` layouts shift.
+        let rpc_port = base_rpc_port + (i as u16) * 2;
         let metrics_port = 9090 + i as u16;
+        // Audit 398: per-node fast_tx port. See validator-config
+        // block above for rationale (audit-398 multi-node bind
+        // collision on the default 9545).
+        let fast_tx_port = 9545 + i as u16;
         let region_comment = match node_addrs {
             Some(addrs) => format!(
                 "# region: {}\n# host:   {}\n",
@@ -1231,6 +1274,11 @@ port = {rpc_port}
 enabled = true
 port = {metrics_port}
 
+[fast_tx]
+enabled = true
+listen = "0.0.0.0"
+port = {fast_tx_port}
+
 [logging]
 level = "info"
 json = false
@@ -1241,6 +1289,7 @@ json = false
             p2p_port = p2p_port,
             rpc_port = rpc_port,
             metrics_port = metrics_port,
+            fast_tx_port = fast_tx_port,
             bootstrap = bootstrap,
             block_time_ms = block_time_ms,
         );
@@ -1256,7 +1305,19 @@ json = false
 
     for i in 0..num_validators {
         let p2p_port = base_port + i as u16;
-        let rpc_port = base_rpc_port + i as u16;
+        // Audit 398: stride-2 layout. The node binds two TCP ports
+        // per RPC: `rpc.port` (JSON-RPC) and `rpc.port + 1`
+        // (dedicated WebSocket subscription server, see
+        // `node.rs::start_ws_server`). Pre-fix the per-node stride
+        // was 1, so node-0's WS port (`rpc + 1`) collided with
+        // node-1's RPC port — multi-node testnets failed to spawn
+        // with `Address already in use` on whichever child lost
+        // the bind race. With stride 2 each node owns two
+        // contiguous ports: `base + 2i` (RPC) + `base + 2i + 1`
+        // (WS). User-facing impact is minimal — single-node
+        // operators using `--base-rpc-port 8545` still get
+        // RPC=8545; only multi-node `pyde testnet` layouts shift.
+        let rpc_port = base_rpc_port + (i as u16) * 2;
         let node_dir = out_dir.join(format!("node-{}", i));
 
         if i == 0 {
@@ -1356,12 +1417,14 @@ json = false
     println!("  genesis.toml        — shared genesis");
     println!("  faucet.key          — faucet signing key");
     for i in 0..num_validators {
+        // Audit 398: stride-2 layout — keep the operator-printed
+        // RPC matching what's actually written into config.toml.
         println!(
             "  node-{}/config.toml  — node {} config (P2P:{}, RPC:{})",
             i,
             i,
             base_port + i as u16,
-            base_rpc_port + i as u16
+            base_rpc_port + (i as u16) * 2,
         );
         println!("  node-{}/validator.key — node {} signing key", i, i);
     }

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -201,8 +201,20 @@ impl TestNetwork {
         // `base_port + i`, so the range must be contiguous + free at
         // startup for EVERY node (validators + full nodes). We probe by
         // binding then immediately releasing.
+        //
+        // Audit 398: RPC range needs `2 * total` slots because each
+        // node binds two TCP ports — `rpc.port` (JSON-RPC) and
+        // `rpc.port + 1` (dedicated WS subscription server). The
+        // genesis CLI assigns the per-node RPC at `base + 2 * i`, so
+        // node-0 owns base + 0..=1, node-1 owns base + 2..=3, etc.
+        // Pre-fix the harness allocated only `total` slots and
+        // `pyde testnet` used stride 1, causing node-0's WS port
+        // (base + 1) to collide with node-1's RPC port (base + 1)
+        // — multi-node testnet spawns failed intermittently with
+        // "Address already in use" depending on which child won
+        // the bind race.
         let (p2p_base, mut p2p_holders) = allocate_contiguous_udp_ports(total)?;
-        let (rpc_base, mut rpc_holders) = allocate_contiguous_tcp_ports(total)?;
+        let (rpc_base, mut rpc_holders) = allocate_contiguous_tcp_ports(2 * total)?;
 
         // Run `pyde testnet` to set up genesis + per-node configs.
         run_testnet_cli(
@@ -232,7 +244,11 @@ impl TestNetwork {
         for i in 0..total {
             let role: &'static str = if i < validators { "validator" } else { "full" };
             let node_dir = net_dir.join(format!("node-{}", i));
-            let rpc_port = rpc_base + i as u16;
+            // Audit 398: per-node RPC port follows the stride-2
+            // layout (`rpc_base + 2 * i`) so node-i's RPC + WS
+            // (which lives at rpc_port + 1) never collides with
+            // node-(i+1)'s RPC.
+            let rpc_port = rpc_base + (i as u16) * 2;
             let p2p_port = p2p_base + i as u16;
             let mut n = TestNode {
                 index: i,
@@ -244,16 +260,25 @@ impl TestNetwork {
                 output: Arc::new(Mutex::new(Vec::new())),
             };
             // Take this node's holders out of the shared vec.
+            // Audit 398: each node owns 2 contiguous TCP ports
+            // (RPC + WS), so consume both holders per node.
             let udp = p2p_holders.remove(0);
             let tcp = rpc_holders.remove(0);
+            let tcp_ws = rpc_holders.remove(0);
             if i < first_deferred_idx {
                 // Drop holders, then spawn — the OS releases the ports
                 // immediately and the child grabs them on startup.
                 drop(udp);
                 drop(tcp);
+                drop(tcp_ws);
                 start_node(&mut n, &pyde_bin, dev)?;
             } else {
                 // Keep them reserved until start_deferred() is called.
+                // The deferred-holder struct holds onto only the RPC
+                // slot (the WS slot is also reserved but goes to a
+                // throwaway — both will be reissued when the child
+                // process actually binds them on `start_deferred`).
+                drop(tcp_ws);
                 deferred_port_holders.insert(
                     i,
                     DeferredPortHolder {


### PR DESCRIPTION
## Audit 398 — full-node tx propagation

Closes audit finding 398.

The \`tx_via_full_node_reaches_validator\` test was failing
intermittently with \"RPC at http://127.0.0.1:NNNNN never came up:
no HTTP body separator\". Pre-fix the failure was misdiagnosed as a
relay-pathway bug; the actual root cause was a port-allocation
collision in the \`pyde testnet\` config generator that sometimes
prevented the test from spawning N nodes at all.

### root cause

The node binds two TCP ports per RPC:
- \`rpc.port\` (JSON-RPC)
- \`rpc.port + 1\` (dedicated WebSocket subscription server, per
  \`node.rs::start_ws_server\`)

But the genesis CLI assigned per-node RPC ports with stride 1
(\`base_rpc_port + i\`). With stride 1, node-0's WS port (base + 1)
collides with node-1's RPC port (base + 1) on the bind race;
whichever child won the race got the port, the other logged
\"Address already in use\" and ran with RPC disabled. The harness
polled the RPC-disabled node's port for 30-45s and timed out.

The failure was racy — about 30-40% of spawns hit the collision —
which is why earlier runs sometimes succeeded and obscured the
root cause.

### fix

1. **\`pyde testnet\` writes per-node RPC ports with stride 2**
   (\`base_rpc_port + 2*i\`), giving each node an exclusive pair
   \`(rpc, ws)\` of contiguous ports.

2. **\`pyde testnet\` writes a per-node \`[fast_tx]\` section** with
   \`port = 9545 + i\`. Pre-fix the FastTxSection default (port
   9545, listen 0.0.0.0) was inherited by every node — only the
   first could bind 9545, the rest logged \"fast_tx bind failed\"
   (warn-only, not fatal, but obscured root cause analysis).

3. **The test harness** (\`crates/node/tests/common/mod.rs\`)
   allocates \`2 * total\` contiguous TCP ports for the RPC range
   and uses stride 2 when computing per-node \`rpc_port\`.

### test outcome

\`multi_node_full_node_relay\`: 5/5 stable passes (was 3/5 pre-fix).

Single-node-operator conventions are unchanged (\`pyde run
--rpc-port 8545\` still gives RPC=8545); only multi-node
\`pyde testnet\` layouts use the new stride.

### sweep
- workspace --lib: green across all 15 test binaries