### PR TITLE
fix(account,rpc): nonce-window arithmetic safe at u64::MAX (audit 386)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1485,9 +1485,24 @@
 - [ ] 385 — `prune_expired` clears + rebuilds `seen_hashes` on
       eviction. `crates/mempool/src/pool.rs:443-451`. Track removed
       hashes incrementally.
-- [ ] 386 — Encrypted nonce-window check at RPC ingress can
+- [x] 386 — Encrypted nonce-window check at RPC ingress can
       overflow on near-`u64::MAX` base. `crates/node/src/rpc.rs:1365`,
       `crates/account/src/nonce.rs:53`. Use `checked_add`.
+      **SHIPPED.** Four arithmetic sites converted to overflow-safe
+      forms: `NonceState::validate` (window-end), `NonceState::advance`
+      (base increment), `NonceState::max_nonce` (display upper bound),
+      and `send_raw_encrypted_transaction` ingress check. Pre-fix, a
+      base near `u64::MAX` would panic in debug or wrap in release; the
+      wrap caused valid nonces to be rejected and bogus ones near the
+      wrap boundary to be accepted. Post-fix semantics: when the math
+      overflows, the window naturally clamps at `u64::MAX` (no nonces
+      exist beyond it), so every nonce in `[base, u64::MAX]` is
+      in-window and the upper-bound check is skipped. The `advance`
+      loop now checks the addition *before* shifting the bit out of
+      `used` — otherwise it would consume the slot from the bitmap
+      without moving `base`, leaving the same nonce reusable. Four
+      regression tests cover `validate` at u64::MAX-near and exact
+      base, `advance` at u64::MAX, and `max_nonce` saturation.
 - [ ] 387 — `prompt_password` echoes input.
       `crates/pyde-dev/src/wallet.rs:291-298`. Use `rpassword`.
 - [ ] 388 — `is_localhost` uses `String::contains`.

--- a/crates/account/src/nonce.rs
+++ b/crates/account/src/nonce.rs
@@ -50,8 +50,19 @@ impl NonceState {
         if nonce < self.base {
             return Err(NonceError::BelowWindow);
         }
-        if nonce >= self.base + WINDOW_SIZE {
-            return Err(NonceError::AboveWindow);
+        // Audit 386: `self.base + WINDOW_SIZE` overflows once `base` is
+        // within `WINDOW_SIZE` of `u64::MAX`. In debug builds that's a
+        // panic on a hot validation path; in release it wraps and the
+        // resulting comparison rejects valid nonces while accepting
+        // bogus ones near the wrap boundary. The right semantics:
+        // when the window would extend past `u64::MAX`, all remaining
+        // nonces in `[base, u64::MAX]` are still valid (there is no
+        // nonce greater than `u64::MAX` to reject), so a `checked_add`
+        // failure means "no upper-bound rejection."
+        if let Some(window_end) = self.base.checked_add(WINDOW_SIZE) {
+            if nonce >= window_end {
+                return Err(NonceError::AboveWindow);
+            }
         }
         let bit = (nonce - self.base) as u8;
         if self.used & (1 << bit) != 0 {
@@ -72,15 +83,31 @@ impl NonceState {
     /// Advance the window: skip over consecutive used nonces at the base.
     /// E.g., if base=100 and bits 0,1,2 are set, advance to base=103.
     fn advance(&mut self) {
+        // Audit 386: `self.base += 1` panics when `base == u64::MAX`. In
+        // practice this is unreachable (would require `u64::MAX` consumed
+        // nonces on a single account), but a bounded loop keeps the
+        // function total. Crucially we check the addition *before*
+        // shifting the bit out — otherwise we'd consume the slot from
+        // `used` without moving `base`, leaving the same nonce reusable.
         while self.used & 1 == 1 {
-            self.used >>= 1;
-            self.base += 1;
+            match self.base.checked_add(1) {
+                Some(b) => {
+                    self.used >>= 1;
+                    self.base = b;
+                }
+                None => break,
+            }
         }
     }
 
     /// The highest valid nonce in the current window.
     pub fn max_nonce(&self) -> u64 {
-        self.base + WINDOW_SIZE - 1
+        // Audit 386: `saturating_add` clamps the displayed upper bound
+        // at `u64::MAX` when `base` is within `WINDOW_SIZE - 1` of it.
+        // Used in the InvalidNonce error message rendered by
+        // `validate_nonce`, so the wallet sees a meaningful bound
+        // instead of a wrapped value.
+        self.base.saturating_add(WINDOW_SIZE - 1)
     }
 
     /// Number of available (unused) slots in the window.
@@ -287,5 +314,54 @@ mod tests {
     fn max_nonce() {
         let ns = NonceState::with_base(100);
         assert_eq!(ns.max_nonce(), 115);
+    }
+
+    // ========== Audit 386: u64::MAX overflow safety ==========
+
+    #[test]
+    fn validate_does_not_overflow_at_u64_max_base() {
+        // Pre-fix: `self.base + WINDOW_SIZE` panics in debug and wraps
+        // in release. Post-fix: `checked_add` returns `None`, the
+        // upper-bound check is skipped, and every nonce in
+        // `[base, u64::MAX]` is treated as in-window.
+        let ns = NonceState::with_base(u64::MAX - 5);
+        // Every nonce in [u64::MAX-5, u64::MAX] is valid (6 slots).
+        for n in (u64::MAX - 5)..=u64::MAX {
+            assert!(ns.is_valid(n), "nonce {} should be valid", n);
+        }
+        // Below-window still rejects.
+        assert_eq!(ns.validate(u64::MAX - 6), Err(NonceError::BelowWindow));
+    }
+
+    #[test]
+    fn validate_at_exact_u64_max_base() {
+        // Edge case: base == u64::MAX. Only u64::MAX itself is in window.
+        let ns = NonceState::with_base(u64::MAX);
+        assert!(ns.is_valid(u64::MAX));
+        assert_eq!(ns.validate(u64::MAX - 1), Err(NonceError::BelowWindow));
+    }
+
+    #[test]
+    fn advance_does_not_overflow_at_u64_max() {
+        // Pre-fix: `self.base += 1` panics when base reaches u64::MAX
+        // mid-advance. Post-fix: the loop breaks instead.
+        let mut ns = NonceState::with_base(u64::MAX);
+        ns.use_nonce(u64::MAX).unwrap();
+        // Base stays at u64::MAX (can't advance further), but the bit
+        // is consumed.
+        assert_eq!(ns.base, u64::MAX);
+        // Re-using the same nonce is still rejected.
+        assert_eq!(ns.validate(u64::MAX), Err(NonceError::AlreadyUsed));
+    }
+
+    #[test]
+    fn max_nonce_saturates_at_u64_max() {
+        // Pre-fix: `self.base + WINDOW_SIZE - 1` overflows.
+        // Post-fix: saturates at u64::MAX.
+        let ns = NonceState::with_base(u64::MAX - 5);
+        assert_eq!(ns.max_nonce(), u64::MAX);
+
+        let ns = NonceState::with_base(u64::MAX);
+        assert_eq!(ns.max_nonce(), u64::MAX);
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1417,16 +1417,24 @@ impl PydeApiServer for RpcServer {
         // (`WINDOW_SIZE = 16` per sender) instead of the wall-clock
         // submission rate.
         if let Some(ns) = &nonce_state_opt {
-            if enc_tx.nonce >= ns.base + pyde_account::nonce::WINDOW_SIZE {
-                return Err(rpc_err(
-                    -32008,
-                    format!(
-                        "encrypted-tx nonce {} is past the in-flight window [{}, {}); submit when prior nonces commit",
-                        enc_tx.nonce,
-                        ns.base,
-                        ns.base + pyde_account::nonce::WINDOW_SIZE,
-                    ),
-                ));
+            // Audit 386: `ns.base + WINDOW_SIZE` panics in debug and
+            // wraps in release once `base` is within `WINDOW_SIZE` of
+            // `u64::MAX`. `checked_add` returning `None` means the
+            // window naturally extends to `u64::MAX`, so every nonce
+            // `>= base` is in-window and we skip the upper-bound
+            // rejection.
+            if let Some(window_end) = ns.base.checked_add(pyde_account::nonce::WINDOW_SIZE) {
+                if enc_tx.nonce >= window_end {
+                    return Err(rpc_err(
+                        -32008,
+                        format!(
+                            "encrypted-tx nonce {} is past the in-flight window [{}, {}); submit when prior nonces commit",
+                            enc_tx.nonce,
+                            ns.base,
+                            window_end,
+                        ),
+                    ));
+                }
             }
             if enc_tx.nonce < ns.base {
                 return Err(rpc_err(


### PR DESCRIPTION
## Summary
- Replaces `base + WINDOW_SIZE` / `base + 1` arithmetic with
  `checked_add` (or `saturating_add` for display) at four sites:
  `NonceState::{validate, advance, max_nonce}` and the
  `send_raw_encrypted_transaction` RPC ingress check.
- Pre-fix, a base near `u64::MAX` would panic in debug or wrap in
  release. The wrap caused valid nonces to be rejected and bogus
  ones near the wrap boundary to be accepted.
- Post-fix, when the math overflows the window naturally clamps at
  `u64::MAX` (no nonces beyond it), so every nonce in
  `[base, u64::MAX]` is in-window. The `advance` loop also reorders
  to check the addition before shifting the bit, preventing slot
  reuse at u64::MAX.
- Four new regression tests in `nonce.rs` cover the boundary cases.

Closes audit item 386.