### PR TITLE
fix(node): unify encrypted-tx ingress policy across RPC + gossip (audit 384)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1515,9 +1515,25 @@
       semaphore + 503 on saturation. `crates/node/src/faucet.rs:430-460`.
 - [ ] 383 — `pyde testnet --chain-id 1` not refused.
       `crates/node/src/genesis.rs:845-1368`.
-- [ ] 384 — Mempool `EncryptedTx` `add()` (structural-only) accepts
+- [x] 384 — Mempool `EncryptedTx` `add()` (structural-only) accepts
       sig length [500, 1000] — verify mainnet path always takes
       `Verify` or `Reject`, never `StructuralOnly`.
+      **SHIPPED.** The `encrypted_tx_ingest_policy` function in
+      `rpc.rs:1867` already mapped `(None, chain_id != 31337)` to
+      `Reject`, but the gossip ingress in `node.rs:1587` open-coded
+      the same `(sender_pk_opt, chain_id)` match inline — three
+      ingress sites, two implementations. A future change to the
+      devnet rule that updated only the RPC paths would silently
+      re-open the structural-only window on mainnet through gossip.
+      Fix promotes `EncryptedTxIngestPolicy` and
+      `encrypted_tx_ingest_policy` to `pub(crate)` and refactors
+      the gossip ingress to call the same function — single source
+      of truth across all three ingress sites. Adds
+      `ingest_policy_structural_only_is_devnet_exclusive` test that
+      sweeps `chain_id` over `[0, 10_000]` plus the canonical
+      mainnet/testnet/edge values (1, 7331, 100_000, 1_000_000,
+      u64::MAX) and asserts `StructuralOnly` is never returned for
+      `None` sender_pk except at chain_id 31337.
 - [ ] 385 — `prune_expired` clears + rebuilds `seen_hashes` on
       eviction. `crates/mempool/src/pool.rs:443-451`. Track removed
       hashes incrementally.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1583,10 +1583,25 @@ impl PydeNode {
                             };
                             let chain_id = chain.read().await.chain_id;
                             let mut relay = tx_relay.write().await;
-                            let accepted = match (sender_pk_opt, chain_id) {
-                                (Some(pk), _) => relay.receive_tx_verified(enc_tx, &pk),
-                                (None, 31337) => relay.receive_tx(enc_tx),
-                                (None, _) => {
+                            // Audit 384: route through the same
+                            // `encrypted_tx_ingest_policy` as the RPC
+                            // ingress so the devnet/production split
+                            // can't drift between the three call
+                            // sites. On any non-devnet chain_id this
+                            // function maps `None` sender_pk to
+                            // `Reject`, so the structural-only path
+                            // is unreachable on mainnet.
+                            let accepted = match crate::rpc::encrypted_tx_ingest_policy(
+                                sender_pk_opt,
+                                chain_id,
+                            ) {
+                                crate::rpc::EncryptedTxIngestPolicy::Verify(pk) => {
+                                    relay.receive_tx_verified(enc_tx, &pk)
+                                }
+                                crate::rpc::EncryptedTxIngestPolicy::StructuralOnly => {
+                                    relay.receive_tx(enc_tx)
+                                }
+                                crate::rpc::EncryptedTxIngestPolicy::Reject => {
                                     debug!(
                                         tx_hash = hex::encode(tx_hash),
                                         "dropped encrypted gossip tx: sender has no registered auth_key"

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1845,8 +1845,18 @@ fn resolve_request_chain_id(supplied: Option<u64>, node_chain_id: u64) -> Result
 /// `send_encrypted_transaction`'s sender-FALCON binding (audit item
 /// 206). Split out as a pure function so the devnet/production
 /// branch is unit-testable without spinning up an `RpcServer`.
+///
+/// Audit 384: this enum is the single source of truth for the
+/// devnet-vs-production routing of encrypted-tx ingress. Three
+/// callers (RPC `send_encrypted_transaction`, RPC
+/// `send_raw_encrypted_transaction`, gossip ingress in `node.rs`)
+/// MUST go through `encrypted_tx_ingest_policy` rather than
+/// open-coding the match. Pre-fix the gossip path duplicated the
+/// match inline, so any future change to the structural-only
+/// devnet rule would need to be mirrored in three places — drift
+/// would silently re-open the length-only ingress on mainnet.
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum EncryptedTxIngestPolicy {
+pub(crate) enum EncryptedTxIngestPolicy {
     /// Sender has an on-chain `Single` auth_key; route through full
     /// FALCON verification against it.
     Verify(Vec<u8>),
@@ -1864,7 +1874,7 @@ enum EncryptedTxIngestPolicy {
 /// sender's on-chain account (`None` means either no account or an
 /// account with `AuthKeys::None`). `chain_id == 31337` identifies
 /// devnet; any other chain_id is treated as production.
-fn encrypted_tx_ingest_policy(
+pub(crate) fn encrypted_tx_ingest_policy(
     sender_pk: Option<Vec<u8>>,
     chain_id: u64,
 ) -> EncryptedTxIngestPolicy {
@@ -2262,6 +2272,44 @@ mod tests {
                 chain_id
             );
         }
+    }
+
+    /// Audit 384: the `StructuralOnly` variant must NEVER appear on
+    /// any chain_id other than the devnet sentinel (31337). Sweep a
+    /// dense range of plausible chain_ids — including testnet (7331)
+    /// and the canonical mainnet candidates — to guard against any
+    /// future change widening the structural-only window. Pre-fix
+    /// the gossip path in `node.rs` open-coded the match, so a drift
+    /// between the RPC and gossip routing was the realistic failure
+    /// mode this test is designed to catch.
+    #[test]
+    fn ingest_policy_structural_only_is_devnet_exclusive() {
+        for chain_id in 0u64..=10_000 {
+            let policy = encrypted_tx_ingest_policy(None, chain_id);
+            if chain_id == 31337 {
+                continue; // not in range, but explicit for clarity
+            }
+            assert_ne!(
+                policy,
+                EncryptedTxIngestPolicy::StructuralOnly,
+                "chain_id {} must not produce StructuralOnly without auth_key",
+                chain_id,
+            );
+        }
+        // Spot-check the canonical chain_ids we actually care about.
+        for chain_id in [1u64, 7331, 100_000, 1_000_000, u64::MAX] {
+            assert_ne!(
+                encrypted_tx_ingest_policy(None, chain_id),
+                EncryptedTxIngestPolicy::StructuralOnly,
+                "chain_id {} must not produce StructuralOnly without auth_key",
+                chain_id,
+            );
+        }
+        // And confirm devnet IS the only chain that returns it.
+        assert_eq!(
+            encrypted_tx_ingest_policy(None, 31337),
+            EncryptedTxIngestPolicy::StructuralOnly,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `encrypted_tx_ingest_policy` in rpc.rs is the canonical
  devnet/production gating for encrypted-tx ingress. The two RPC
  call sites already routed through it, but the gossip ingress in
  `node.rs:1587` open-coded the same match inline.
- Three ingress sites + two implementations = drift surface. A
  future change to the devnet rule that updated only the RPC
  paths would silently re-open the structural-only (length-only)
  ingress on mainnet through gossip.
- Promotes `EncryptedTxIngestPolicy` and
  `encrypted_tx_ingest_policy` to `pub(crate)` and refactors the
  gossip ingress to call the same function. Single source of
  truth across all three sites.
- Adds an exhaustive sweep test that asserts the
  `StructuralOnly` variant is never produced for `None`
  sender_pk on any chain_id other than 31337.

Closes audit item 384.