### PR TITLE
fix(crypto): rejection-sample Goldilocks randomness paths (audit 391)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1584,11 +1584,42 @@
 - [ ] 390 — `NonceState::from_bytes` silently returns
       `Self::new()` on invalid input; should be `Option<Self>`.
       `crates/account/src/nonce.rs:100-113`.
-- [ ] 391 — Goldilocks bias: `gl(u64::from_le_bytes(...))` reduces
+- [x] 391 — Goldilocks bias: `gl(u64::from_le_bytes(...))` reduces
       mod p, biasing values in `[p, 2^64)`.
       `crates/crypto/src/threshold.rs:55, 199, 238, 381, 484, 653,
       822`. Use rejection sampling for randomness paths; document
       the silent-remap on Kyber-seed reconstruction.
+      **SHIPPED.** Pre-fix `gl()` silently reduced any input ≥ p
+      (`p = 2^64 - 2^32 + 1`) by subtracting p, making values in
+      `[0, 2^32)` ≈ 2x more likely than values in `[2^32, p)` for
+      hash-derived inputs. Post-fix categorizes the seven cited
+      sites and applies the appropriate fix per category:
+      *(a) Randomness paths* — `random_goldilocks` (Shamir
+      polynomial coefficients) and `derive_blinding_mask`
+      (per-share unblinding mask) now rejection-sample by
+      re-hashing with an attempt counter folded into the hash
+      input. Per-attempt rejection is `(2^32 - 1) / 2^64 ≈ 2^-32`,
+      so the loop terminates after one attempt with overwhelming
+      probability. Determinism in the public arguments is
+      preserved (cross-validator agreement on shares + masks).
+      *(b) Kyber-seed reconstruction* — `threshold_keygen`
+      keeps the silent remap (rejection-sampling there would
+      mean re-running Kyber keygen, breaking the protocol's
+      determinism on the produced sk). The non-injective
+      round-trip is now documented inline with collision
+      probability bounds (≈ 2^-29 per keygen) and the operator
+      recovery path (re-keygen on first failed decap).
+      *(c) Deserialization paths* — `KeyShare::from_bytes`,
+      `DecryptionShare::from_bytes`, and
+      `RefreshContribution::from_bytes` keep the silent remap
+      (honest serialization is canonical via `gl_to_u64()`; the
+      remap only affects malformed inputs, which the downstream
+      MAC catches). Documented inline. Three regression tests
+      (`audit_391_random_goldilocks_is_canonical_and_deterministic`,
+      `audit_391_derive_blinding_mask_is_canonical_and_deterministic`,
+      `audit_391_threshold_roundtrip_after_rejection_sampling`)
+      pin the canonical-output, determinism, and end-to-end
+      decryption invariants.
 - [ ] 392 — `Hash256::from_slice` silently truncates/pads.
       `crates/crypto/src/hash.rs:24-29`. Return `Option<Hash256>`.
 - [ ] 393 — VRF input domain reuse: `VRF_DOMAIN_OUTPUT` used for

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -52,6 +52,16 @@ fn zeroize_goldilocks_vec_vec(v: &mut Vec<Vec<Goldilocks>>) {
 
 // --- Goldilocks field arithmetic helpers ---
 
+/// The Goldilocks prime modulus: `2^64 - 2^32 + 1`.
+///
+/// Audit 391: callers that derive a Goldilocks element from
+/// hash output must rejection-sample against this prime to avoid
+/// the small distribution bias that `gl()`'s silent reduction
+/// introduces over the range `[p, 2^64)`. Pre-fix, values in
+/// `[0, 2^32)` were ~2x more likely to be produced than values
+/// in `[2^32, p)`.
+const GOLDILOCKS_PRIME: u64 = 0xFFFF_FFFF_0000_0001;
+
 fn gl(val: u64) -> Goldilocks {
     PrimeCharacteristicRing::from_u64(val)
 }
@@ -77,16 +87,35 @@ struct FieldShare {
 }
 
 /// Generate random Goldilocks element from entropy.
+///
+/// Audit 391: rejection-sample so candidates in `[p, 2^64)` are
+/// re-drawn instead of silently mapping to `[0, 2^32)`. The
+/// per-attempt rejection probability is
+/// `(2^64 - p) / 2^64 = (2^32 - 1) / 2^64 ≈ 2^-32`, so the loop
+/// terminates after one attempt with overwhelming probability.
+/// Domain-separating each attempt by an attempt counter keeps
+/// the function deterministic in `(entropy, index)` while making
+/// the value uniform over `[0, p)` — important for Shamir
+/// polynomial coefficients, where a biased coefficient
+/// distribution narrows the share-space an attacker has to
+/// search.
 fn random_goldilocks(entropy: &[u8], index: usize) -> Goldilocks {
-    let mut input = Vec::with_capacity(entropy.len() + 8);
-    input.extend_from_slice(entropy);
-    input.extend_from_slice(&(index as u64).to_le_bytes());
-    let hash = poseidon2_hash(&input);
-    let bytes = hash.as_bytes();
-    let mut val_bytes = [0u8; 8];
-    val_bytes.copy_from_slice(&bytes[0..8]);
-    let val = u64::from_le_bytes(val_bytes);
-    gl(val)
+    let mut attempt: u64 = 0;
+    loop {
+        let mut input = Vec::with_capacity(entropy.len() + 16);
+        input.extend_from_slice(entropy);
+        input.extend_from_slice(&(index as u64).to_le_bytes());
+        input.extend_from_slice(&attempt.to_le_bytes());
+        let hash = poseidon2_hash(&input);
+        let bytes = hash.as_bytes();
+        let mut val_bytes = [0u8; 8];
+        val_bytes.copy_from_slice(&bytes[0..8]);
+        let val = u64::from_le_bytes(val_bytes);
+        if val < GOLDILOCKS_PRIME {
+            return gl(val);
+        }
+        attempt += 1;
+    }
 }
 
 /// Split a single field element into n shares with threshold t.
@@ -248,6 +277,14 @@ impl KeyShare {
                 data[off + 6],
                 data[off + 7],
             ]);
+            // Audit 391: `gl()` silently reduces values in
+            // `[p, 2^64)`. Honestly produced shares always
+            // serialize via `gl_to_u64()` (canonical, in `[0, p)`),
+            // so this remap only fires on malformed input.
+            // Treating malformed values as their canonical
+            // equivalents keeps deserialization total — the
+            // downstream MAC check inside `combine_shares` rejects
+            // the resulting bad keystream.
             shares.push(gl(val));
         }
         Some(Self { index, shares })
@@ -308,6 +345,9 @@ impl DecryptionShare {
         for i in 0..count {
             let off = 12 + i * 8;
             let val = u64::from_le_bytes(data[off..off + 8].try_into().ok()?);
+            // Audit 391: see `KeyShare::from_bytes` — silent
+            // remap on malformed input is fine because the
+            // downstream MAC compare rejects bad keystreams.
             shares.push(gl(val));
         }
         Some(Self { index, shares })
@@ -481,7 +521,26 @@ pub fn threshold_keygen(
 
     let (pk, sk) = kyber_keygen()?;
 
-    // Convert 64-byte seed to 8 Goldilocks elements
+    // Convert 64-byte seed to 8 Goldilocks elements.
+    //
+    // Audit 391: each 8-byte chunk of the Kyber secret key is
+    // raw random bytes (not a canonical Goldilocks-element
+    // serialization), so any chunk in `[p, 2^64)` is silently
+    // remapped to `chunk - p` by `gl()`. On reconstruction the
+    // same chunk goes back through `gl_to_u64()`, yielding the
+    // remapped value `chunk - p` rather than the original
+    // `chunk` — for those chunks the round-trip is non-injective
+    // and the recovered Kyber secret is wrong. We accept this
+    // here rather than rejection-sampling because rejecting a
+    // Kyber sk byte chunk would mean re-running Kyber keygen
+    // (different sk), and the cross-validator share split has
+    // already been committed to the produced sk. Per-chunk
+    // collision probability is `(2^32 - 1) / 2^64 ≈ 2^-32`, and
+    // with 8 chunks the per-keygen failure rate is ≈ 2^-29 — low
+    // enough that we trade a vanishing failure rate for keygen
+    // determinism. If an unlucky keygen produces a corrupted
+    // round-trip, the resulting threshold key fails decapsulation
+    // on first use; the operator re-runs keygen.
     let seed_bytes = sk.as_bytes();
     let seed_elements: Vec<Goldilocks> = (0..SEED_ELEMENTS)
         .map(|i| {
@@ -580,20 +639,38 @@ fn ciphertext_binding_hash(ct: &ThresholdCiphertext) -> [u8; 32] {
 }
 
 /// Derive the blinding mask for a specific share element.
-/// mask = H(ct_hash || validator_index || element_index) interpreted as a Goldilocks field element.
+/// mask = H(ct_hash || validator_index || element_index || attempt)
+/// rejection-sampled into `[0, p)` and interpreted as a Goldilocks
+/// field element.
+///
+/// Audit 391: rejection-sample so the per-share mask distribution
+/// is exactly uniform over the Goldilocks field. Pre-fix the
+/// implementation took the first 8 bytes of a Poseidon2 digest and
+/// silently reduced mod `p` — biasing values in `[0, 2^32)` ~2x
+/// over `[2^32, p)`. The same correlation showed up between the
+/// share-creation side (validators applying the mask) and the
+/// reconstruction side (`combine_shares` subtracting it). Mask
+/// determinism in `(ct_hash, validator_index, elem_index)` is
+/// preserved by hashing in an attempt counter.
 fn derive_blinding_mask(
     ct_hash: &[u8; 32],
     validator_index: usize,
     elem_index: usize,
 ) -> Goldilocks {
-    let mut buf = Vec::with_capacity(48);
-    buf.extend_from_slice(ct_hash);
-    buf.extend_from_slice(&(validator_index as u64).to_le_bytes());
-    buf.extend_from_slice(&(elem_index as u64).to_le_bytes());
-    let hash = poseidon2_hash(&buf);
-    // Take first 8 bytes as u64 — gl() reduces mod Goldilocks prime automatically
-    let val = u64::from_le_bytes(hash.to_bytes()[..8].try_into().unwrap());
-    gl(val)
+    let mut attempt: u64 = 0;
+    loop {
+        let mut buf = Vec::with_capacity(56);
+        buf.extend_from_slice(ct_hash);
+        buf.extend_from_slice(&(validator_index as u64).to_le_bytes());
+        buf.extend_from_slice(&(elem_index as u64).to_le_bytes());
+        buf.extend_from_slice(&attempt.to_le_bytes());
+        let hash = poseidon2_hash(&buf);
+        let val = u64::from_le_bytes(hash.to_bytes()[..8].try_into().unwrap());
+        if val < GOLDILOCKS_PRIME {
+            return gl(val);
+        }
+        attempt += 1;
+    }
 }
 
 /// Combine decryption shares to recover the plaintext.
@@ -836,6 +913,12 @@ impl RefreshContribution {
             let mut v = Vec::with_capacity(elems);
             for _ in 0..elems {
                 let val = u64::from_le_bytes(data[off..off + 8].try_into().ok()?);
+                // Audit 391: see `KeyShare::from_bytes` — silent
+                // remap on malformed input is fine. Honest
+                // refresh contributions serialize via canonical
+                // `gl_to_u64()`; tampering with delta bytes only
+                // corrupts the recipient's share, caught when
+                // decryption fails the MAC.
                 v.push(gl(val));
                 off += 8;
             }
@@ -1938,5 +2021,78 @@ mod tests {
             contrib.sub_shares.is_empty(),
             "resharing contribution sub_shares not cleared post-zeroize"
         );
+    }
+
+    // ========== Audit 391: rejection sampling ==========
+
+    /// Audit 391: `random_goldilocks` is deterministic in
+    /// `(entropy, index)` and always produces a canonical
+    /// Goldilocks element. The post-fix loop adds an attempt
+    /// counter, so the *value* differs from the pre-fix
+    /// implementation; this test pins the canonical-form
+    /// invariant.
+    #[test]
+    fn audit_391_random_goldilocks_is_canonical_and_deterministic() {
+        let entropy = b"audit-391-test-entropy";
+        for index in 0..256usize {
+            let a = random_goldilocks(entropy, index);
+            let b = random_goldilocks(entropy, index);
+            assert_eq!(
+                a.as_canonical_u64(),
+                b.as_canonical_u64(),
+                "determinism: same (entropy, index) must yield same value"
+            );
+            assert!(
+                a.as_canonical_u64() < GOLDILOCKS_PRIME,
+                "canonical: value must be in [0, p)"
+            );
+        }
+    }
+
+    /// Audit 391: `derive_blinding_mask` is deterministic in
+    /// `(ct_hash, validator_index, elem_index)` so every validator
+    /// computes the same mask and `combine_shares` can subtract
+    /// it. Post-fix the inner loop hashes an attempt counter, but
+    /// the function's external contract is unchanged.
+    #[test]
+    fn audit_391_derive_blinding_mask_is_canonical_and_deterministic() {
+        let ct_hash = [7u8; 32];
+        for validator_index in 1..16usize {
+            for elem_index in 0..SEED_ELEMENTS {
+                let a = derive_blinding_mask(&ct_hash, validator_index, elem_index);
+                let b = derive_blinding_mask(&ct_hash, validator_index, elem_index);
+                assert_eq!(
+                    a.as_canonical_u64(),
+                    b.as_canonical_u64(),
+                    "determinism: same inputs must yield same mask"
+                );
+                assert!(
+                    a.as_canonical_u64() < GOLDILOCKS_PRIME,
+                    "canonical: mask must be in [0, p)"
+                );
+            }
+        }
+    }
+
+    /// Audit 391: an end-to-end smoke test that the new
+    /// rejection-sampled `random_goldilocks` and
+    /// `derive_blinding_mask` still produce a working
+    /// threshold-encryption pipeline. If the rejection loops were
+    /// non-deterministic (e.g., the attempt counter wasn't
+    /// folded into the hash input), the share-side and
+    /// reconstruction-side masks would diverge and decryption
+    /// would fail the MAC.
+    #[test]
+    fn audit_391_threshold_roundtrip_after_rejection_sampling() {
+        let (pk, shares) = threshold_keygen(5, 3).expect("keygen");
+        let msg = b"audit-391 roundtrip";
+        let ct = threshold_encrypt(&pk, msg).expect("encrypt");
+        let dec_shares: Vec<_> = shares
+            .iter()
+            .take(3)
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let recovered = combine_shares(&dec_shares, 3, &ct).expect("combine");
+        assert_eq!(recovered, msg);
     }
 }


### PR DESCRIPTION
## Summary
- `gl(u64::from_le_bytes(...))` silently reduced inputs in
  `[p, 2^64)` by subtracting p (Goldilocks prime), biasing
  hash-derived values in `[0, 2^32)` ~2x over `[2^32, p)`.
- Categorizes the seven cited sites and applies the right fix
  per category:
  - **Randomness paths** (`random_goldilocks`,
    `derive_blinding_mask`) now rejection-sample with an
    attempt counter folded into the hash input.
    Per-attempt rejection is ~ 2^-32; loop terminates in one
    attempt with overwhelming probability. Determinism in
    public args preserved.
  - **Kyber-seed reconstruction** keeps the silent remap
    (rejecting there would break Kyber-keygen determinism).
    Documented inline with collision probability bounds and
    operator recovery path.
  - **Deserialization paths** keep the silent remap (canonical
    serialization is always in `[0, p)`; remap only affects
    malformed inputs, caught by downstream MAC). Documented.
- Three new regression tests pin canonical-output and
  determinism on rejection-sampled paths plus an end-to-end
  decryption round-trip.

Closes audit item 391.