### PR TITLE
fix(crypto): Hash256::from_slice rejects wrong-length input (audit 392)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1620,8 +1620,24 @@
       `audit_391_threshold_roundtrip_after_rejection_sampling`)
       pin the canonical-output, determinism, and end-to-end
       decryption invariants.
-- [ ] 392 — `Hash256::from_slice` silently truncates/pads.
+- [x] 392 — `Hash256::from_slice` silently truncates/pads.
       `crates/crypto/src/hash.rs:24-29`. Return `Option<Hash256>`.
+      **SHIPPED.** Pre-fix the function silently zero-padded short
+      slices and silently truncated long ones — both behaviors hide
+      programming bugs (a 31-byte hash compared equal to a real
+      `Hash256(...)` whose 32nd byte was zero, and a 33-byte payload
+      had its trailing byte dropped without surfacing the size
+      mismatch). Post-fix returns `Option<Self>`, returning `None`
+      for any length other than exactly 32. Updated all three
+      callers in `MerkleVerify` (vm.rs:1485, 1494, 1500) to
+      `.ok_or(Trap::MemoryFault)?` — defensive since each upstream
+      `checked_read_slice(_, 32)` call always produces a 32-byte
+      buffer, so `None` here is a host invariant violation rather
+      than a guest-reachable case. Three regression tests
+      (`from_slice_exact_length`,
+      `audit_392_from_slice_short_returns_none`,
+      `audit_392_from_slice_long_returns_none`) pin the
+      reject-on-mismatch contract at slice boundaries.
 - [ ] 393 — VRF input domain reuse: `VRF_DOMAIN_OUTPUT` used for
       both `sk_input` and `output_input`.
       `crates/crypto/src/vrf.rs:15-16, 49-62`. Split into

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -21,11 +21,20 @@ impl Hash256 {
         self.0
     }
 
-    pub fn from_slice(slice: &[u8]) -> Self {
-        let mut bytes = [0u8; 32];
-        let len = slice.len().min(32);
-        bytes[..len].copy_from_slice(&slice[..len]);
-        Self(bytes)
+    /// Construct a `Hash256` from a 32-byte slice.
+    ///
+    /// Audit 392: returns `None` for any other length. Pre-fix the
+    /// function silently zero-padded short slices and silently
+    /// truncated long ones — both behaviors hide programming bugs
+    /// (a malformed 31-byte hash compared equal to a real
+    /// `Hash256(...)` whose 32nd byte was zero, and a 33-byte
+    /// payload had its trailing byte dropped on the floor without
+    /// surfacing the size mismatch). Callers that genuinely need
+    /// truncation/padding should do it explicitly at the call
+    /// site.
+    pub fn from_slice(slice: &[u8]) -> Option<Self> {
+        let bytes: [u8; 32] = slice.try_into().ok()?;
+        Some(Self(bytes))
     }
 }
 
@@ -81,11 +90,29 @@ mod tests {
     }
 
     #[test]
-    fn from_slice_short() {
-        let h = Hash256::from_slice(&[1, 2, 3]);
-        let mut expected = [0u8; 32];
-        expected[..3].copy_from_slice(&[1, 2, 3]);
-        assert_eq!(h.to_bytes(), expected);
+    fn from_slice_exact_length() {
+        let bytes = [42u8; 32];
+        let h = Hash256::from_slice(&bytes).expect("32-byte slice is accepted");
+        assert_eq!(h.to_bytes(), bytes);
+    }
+
+    #[test]
+    fn audit_392_from_slice_short_returns_none() {
+        // Pre-fix this silently zero-padded; post-fix the size
+        // mismatch surfaces as None so the caller decides what
+        // to do.
+        assert!(Hash256::from_slice(&[1, 2, 3]).is_none());
+        assert!(Hash256::from_slice(&[]).is_none());
+        assert!(Hash256::from_slice(&[0u8; 31]).is_none());
+    }
+
+    #[test]
+    fn audit_392_from_slice_long_returns_none() {
+        // Pre-fix this silently truncated; post-fix it returns
+        // None so the trailing bytes can't be lost without the
+        // caller noticing.
+        assert!(Hash256::from_slice(&[7u8; 33]).is_none());
+        assert!(Hash256::from_slice(&[7u8; 64]).is_none());
     }
 
     #[test]

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1474,8 +1474,15 @@ impl Vm {
                     return Err(Trap::OutOfGas);
                 }
 
-                // Walk the proof: hash leaf with each sibling up to root
-                let mut current = pyde_crypto::hash::Hash256::from_slice(&leaf_bytes);
+                // Walk the proof: hash leaf with each sibling up to root.
+                // Audit 392: `Hash256::from_slice` now returns
+                // `Option<Self>`; the source `checked_read_slice(_, 32)`
+                // calls always produce 32-byte buffers, so `None`
+                // here is a host-side invariant violation rather
+                // than a guest-reachable case. Map to MemoryFault
+                // defensively.
+                let mut current =
+                    pyde_crypto::hash::Hash256::from_slice(&leaf_bytes).ok_or(Trap::MemoryFault)?;
                 for i in 0..proof_len {
                     let sib_offset = desc_ptr
                         .checked_add(72 + (i as u32) * 32)
@@ -1484,11 +1491,13 @@ impl Vm {
                         .memory
                         .checked_read_slice(sib_offset, 32)
                         .map_err(|_| Trap::MemoryFault)?;
-                    let sibling = pyde_crypto::hash::Hash256::from_slice(&sib_bytes);
+                    let sibling = pyde_crypto::hash::Hash256::from_slice(&sib_bytes)
+                        .ok_or(Trap::MemoryFault)?;
                     current = pyde_crypto::poseidon2::poseidon2_pair(current, sibling);
                 }
 
-                let root = pyde_crypto::hash::Hash256::from_slice(&root_bytes);
+                let root =
+                    pyde_crypto::hash::Hash256::from_slice(&root_bytes).ok_or(Trap::MemoryFault)?;
                 let verified = current == root;
                 self.cpu.write_gp(d.rd, if verified { 1 } else { 0 });
                 self.pc += 4;


### PR DESCRIPTION
## Summary
- `Hash256::from_slice` silently zero-padded short slices and
  silently truncated long ones. Both behaviors hide programming
  bugs at the call site.
- Changes the signature to `Option<Self>`, returning `None` for
  any length other than exactly 32. Updates the three
  `MerkleVerify` callers in `vm.rs` to `.ok_or(Trap::MemoryFault)?`.
- Three new regression tests pin the boundary contract.

Closes audit item 392.