### PR TITLE
rename(crypto): falcon_batch_verify → falcon_verify_all (audit 394)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1642,11 +1642,26 @@
       both `sk_input` and `output_input`.
       `crates/crypto/src/vrf.rs:15-16, 49-62`. Split into
       `VRF_FINGERPRINT_DOMAIN` and `VRF_OUTPUT_DOMAIN`.
-- [ ] 394 — `falcon_batch_verify` is a sequential `.all(...)`,
+- [x] 394 — `falcon_batch_verify` is a sequential `.all(...)`,
       not algebraic batch verification.
       `crates/crypto/src/falcon.rs:118-122`. Rename to
       `falcon_verify_all` until upstream supports a true batch
       API, OR wire to the upstream batch path if available.
+      **SHIPPED.** Audit's two-option recommendation: rename or
+      wire to upstream. Upstream `falcon-rs` 0.2.x (the version
+      we depend on) has no batch API (verified by grepping
+      `~/.cargo/registry/src/.../falcon-rs-0.2.4` for any
+      `batch`/`verify_batch` symbol — zero hits). Renamed
+      `falcon_batch_verify` → `falcon_verify_all` to communicate
+      the actual semantics: a `forall` short-circuit over
+      `falcon_verify`, NOT an algebraic batch scheme that
+      amortizes work across signatures (Ed25519/BLS-style).
+      Updated all callers (the standalone `falcon_bench` and
+      two unit tests). The `pyde-crypto` crate is `no_std`, so
+      rayon-parallelism would require a separate `std`-feature
+      gate; deferred. Tests `verify_all_with_all_valid_returns_true`
+      and `verify_all_with_one_invalid_returns_false` (renamed
+      from the old `batch_verify_*` names) still pin behavior.
 - [ ] 395 — `validator.key` regeneration on missing file silently
       re-keys the validator. `crates/node/src/node.rs:5181-5224`.
       Refuse on non-devnet `chain_id` unless explicit

--- a/crates/crypto/benches/falcon_bench.rs
+++ b/crates/crypto/benches/falcon_bench.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use pyde_crypto::falcon::{falcon_batch_verify, falcon_keygen, falcon_sign, falcon_verify};
+use pyde_crypto::falcon::{falcon_keygen, falcon_sign, falcon_verify, falcon_verify_all};
 
 fn bench_keygen() {
     println!("=== FALCON-512 keygen ===\n");
@@ -58,8 +58,8 @@ fn bench_verify() {
     );
 }
 
-fn bench_batch_verify() {
-    println!("\n=== FALCON-512 batch verify ===\n");
+fn bench_verify_all() {
+    println!("\n=== FALCON-512 verify_all (sequential N×verify) ===\n");
     let (pk, sk) = falcon_keygen().unwrap();
 
     for count in [100, 1000] {
@@ -74,7 +74,7 @@ fn bench_batch_verify() {
             .collect();
 
         let start = Instant::now();
-        std::hint::black_box(falcon_batch_verify(&items));
+        std::hint::black_box(falcon_verify_all(&items));
         let elapsed = start.elapsed();
 
         println!(
@@ -90,6 +90,6 @@ fn main() {
     bench_keygen();
     bench_sign();
     bench_verify();
-    bench_batch_verify();
+    bench_verify_all();
     println!();
 }

--- a/crates/crypto/src/falcon.rs
+++ b/crates/crypto/src/falcon.rs
@@ -122,9 +122,20 @@ pub fn falcon_verify(pk: &FalconPublicKey, msg: &[u8], sig: &FalconSignature) ->
     .is_ok()
 }
 
-/// Batch verify multiple FALCON-512 signatures.
+/// Verify a list of FALCON-512 signatures sequentially.
 /// Returns true only if ALL signatures are valid.
-pub fn falcon_batch_verify(items: &[(&FalconPublicKey, &[u8], &FalconSignature)]) -> bool {
+///
+/// Audit 394: name is `_verify_all`, not `_batch_verify`, because
+/// this is a `forall` short-circuit over `falcon_verify`, NOT an
+/// algebraic batch-verification scheme that amortizes work
+/// across signatures (the way Ed25519 / BLS batch verifiers do).
+/// Pre-rename the `falcon_verify_all` name implied a
+/// per-signature cost lower than `falcon_verify` × N, which
+/// upstream `falcon-rs` (0.2.x) does not provide. Rename
+/// communicates the actual semantics. If/when upstream adds a
+/// real batch API, this function rewires under the same
+/// `_verify_all` name; callers don't need to change.
+pub fn falcon_verify_all(items: &[(&FalconPublicKey, &[u8], &FalconSignature)]) -> bool {
     items
         .iter()
         .all(|(pk, msg, sig)| falcon_verify(pk, msg, sig))
@@ -229,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_verify_all_valid() {
+    fn verify_all_with_all_valid_returns_true() {
         let (pk, sk) = falcon_keygen().unwrap();
         let msgs: &[&[u8]] = &[b"msg1", b"msg2", b"msg3"];
         let sigs: Vec<FalconSignature> =
@@ -239,11 +250,11 @@ mod tests {
             .zip(sigs.iter())
             .map(|(m, s)| (&pk, *m, s))
             .collect();
-        assert!(falcon_batch_verify(&items));
+        assert!(falcon_verify_all(&items));
     }
 
     #[test]
-    fn batch_verify_one_invalid() {
+    fn verify_all_with_one_invalid_returns_false() {
         let (pk, sk) = falcon_keygen().unwrap();
         let sig1 = falcon_sign(&sk, b"msg1").unwrap();
         let sig2 = falcon_sign(&sk, b"msg2").unwrap();
@@ -254,7 +265,7 @@ mod tests {
             (&pk, b"wrong", &sig2),
             (&pk, b"msg3", &sig3),
         ];
-        assert!(!falcon_batch_verify(&items));
+        assert!(!falcon_verify_all(&items));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `falcon_batch_verify` was a `forall` short-circuit over
  `falcon_verify` — not an algebraic batch-verification scheme.
  The pre-rename name implied a per-signature cost lower than
  `falcon_verify` × N, which upstream `falcon-rs` 0.2.x does not
  offer (no `batch`/`verify_batch` symbol in the upstream
  source).
- Renamed to `falcon_verify_all`. Updates the bench and two
  unit tests. If/when upstream adds a real batch API, this
  function rewires under the same name without touching callers.
- `pyde-crypto` is `no_std`; rayon-style parallelism would
  require a `std`-feature gate, deferred.

Closes audit item 394.