### PR TITLE
fix(node): anchor slot_clock to genesis_timestamp_ms (audit 400)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1685,6 +1685,40 @@
       re-keys the validator. `crates/node/src/node.rs:5181-5224`.
       Refuse on non-devnet `chain_id` unless explicit
       `--init-validator-key` flag.
+- [x] 400 — Slot clocks diverge by per-node startup wall-clock when
+      operators boot apart. `crates/node/src/genesis.rs:972`,
+      `crates/node/src/node.rs:846-869`.
+      **SHIPPED.** Surfaced by walking `docs/testnet-bringup.md`
+      end-to-end with a deliberate operator stagger. Pre-fix the
+      generator wrote `timestamp = 0` into `genesis.toml`, and
+      `node.rs`'s fresh-start branch returned `slot_clock_anchor_ms
+      = 0`, so `SlotClock::with_block_time` fell back to anchoring
+      slot 0 at each node's per-host `Instant::now()`. A 4-minute
+      stagger between operators became ~600 slots of permanent skew:
+      each node's `current_slot()` walked from a different
+      wall-clock origin, votes covered different
+      `(slot, block_hash)` tuples than what neighbors expected, the
+      "invalid vote signature" path fired hundreds of times per
+      second, and the chain silently stalled even though every node
+      individually looked healthy (peers connected, threshold key
+      loaded, RPC up). **Real-world severity**: any public testnet
+      where operators don't start within ~ms of each other would
+      silently fail to make progress — the runbook does not
+      mandate that. Post-fix the generator stamps
+      `genesis.timestamp = current_time_ms()`, every node anchors
+      its slot_clock to that absolute Unix-ms (regardless of
+      individual boot time), and `current_slot()` is the same
+      function of wall-clock across the network. Verified on a
+      4-validator local run with a 60-second deliberate stagger:
+      pre-fix saw 670+ "invalid vote signature" warnings and a
+      stuck chain at block 0; post-fix all four nodes anchored
+      identically (`slot_clock_anchor_ms=1777952611407`) and
+      produced 2.5 blocks/sec in lockstep with zero signature
+      errors. Adds `audit_400_generator_stamps_genesis_timestamp`
+      regression in the generator and an operational
+      "slot_clock initialized" info-log on every node startup so
+      operators can quickly confirm their anchor matches the
+      coordinator-supplied genesis timestamp.
 
 ---
 

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -967,9 +967,24 @@ pub fn generate_testnet(
         vesting: None,
     });
 
+    // Stamp the genesis with the bundle-generation wall-clock. Every
+    // validator's slot_clock anchors slot 0 to this absolute Unix-ms
+    // timestamp, so operators who boot their nodes minutes or hours
+    // apart still agree on `current_slot()` at any moment of wall-
+    // clock. Pre-fix this was hardcoded to 0, which made the node
+    // startup path fall back to anchoring slot 0 at the per-node
+    // `Instant::now()` — a 4-minute stagger between operators became
+    // 600 slots of permanent skew, votes failed signature
+    // verification because they covered different (slot, block_hash)
+    // tuples than what neighbors expected, and the chain silently
+    // stalled even though every node looked individually healthy.
+    let genesis_timestamp_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
     let genesis_config = GenesisConfig {
         chain_id,
-        timestamp: 0,
+        timestamp: genesis_timestamp_ms,
         allocations,
         validators,
         initial_supply: String::new(),
@@ -1612,6 +1627,47 @@ mod tests {
         let err = generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, 1, 400, Some(&addrs))
             .unwrap_err();
         assert!(err.contains("entries but expected"), "got: {err}");
+    }
+
+    /// Audit 400: the generator must stamp a real wall-clock
+    /// timestamp into `genesis.toml`. Pre-fix this was hardcoded to
+    /// 0, which made `node.rs` fall back to anchoring slot_clock at
+    /// per-node `Instant::now()` — staggered operator boots became
+    /// permanent slot-counter divergence and votes failed
+    /// signature verification because they covered different
+    /// (slot, block_hash) tuples than what neighbors expected.
+    #[test]
+    fn audit_400_generator_stamps_genesis_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let before_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, 31337, 400, None).unwrap();
+        let after_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let genesis_str = std::fs::read_to_string(tmp.path().join("genesis.toml")).unwrap();
+        let ts_line = genesis_str
+            .lines()
+            .find(|l| l.starts_with("timestamp"))
+            .expect("timestamp field present");
+        let ts: u64 = ts_line
+            .split('=')
+            .nth(1)
+            .and_then(|v| v.trim().parse().ok())
+            .expect("timestamp parses as u64");
+
+        assert!(
+            ts >= before_ms && ts <= after_ms,
+            "genesis timestamp {} should be in [{}, {}] (the wall-clock window of the call)",
+            ts,
+            before_ms,
+            after_ms,
+        );
+        assert!(ts > 0, "genesis timestamp must not regress to 0");
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -833,41 +833,59 @@ impl PydeNode {
         // a 4-of-4 cluster with one node down + one node muted by
         // this clock skew dropped below 3-of-4 quorum and stalled.
         //
-        // For fresh-start (saved_head = 0) and for tests where the
-        // genesis block's timestamp is 0 (testnet generator
-        // doesn't stamp wall-clock), fall back to genesis-anchor
-        // == `now` so all freshly-spawned nodes' slot_clocks agree
-        // (they started within ms of each other).
+        // Audit 400: anchor the slot_clock to the genesis timestamp
+        // for BOTH fresh-start and resume paths. The previous
+        // fresh-start branch returned `0`, which made
+        // `SlotClock::with_block_time` fall back to anchoring slot 0
+        // at the per-node `Instant::now()` — a stagger between
+        // operators (4 minutes is enough) became hundreds of slots
+        // of permanent skew because each node's `current_slot()`
+        // walked from a different wall-clock origin. With genesis
+        // now stamped at bundle-generation time (see
+        // `generate_testnet`), every node can anchor its
+        // slot_clock at the SAME absolute Unix-ms regardless of
+        // when its host booted.
+        //
+        // Resume: prefer the head block's `header.timestamp` minus
+        // `head_slot * block_time_ms` (audit-399); fall back to
+        // `now - head_slot * block_time_ms` if the header was
+        // unstamped. Fresh start: read `genesis_config.timestamp`
+        // (`chain.header(0)` returns None because the genesis block
+        // isn't inserted into the chain's `headers` map). Final
+        // fallback ("anchor at now") only fires for legacy bundles
+        // with an unstamped genesis AND no saved head — i.e., the
+        // dev-loop / in-process-test case.
         let block_time_ms = self.config.consensus.block_time_ms;
         let now_ms_for_anchor = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
-        let slot_clock_anchor_ms = if saved_head > 0 {
-            // Pull the head's block.timestamp from the in-memory
-            // chain (just restored from disk above). That timestamp
-            // is wall-clock at proposal — subtract head*block_time
-            // to get the original genesis instant.
-            let head_block_ts = chain
+        let head_block_ts = if saved_head > 0 {
+            chain
                 .read()
                 .await
                 .header(saved_head)
                 .map(|h| h.timestamp)
-                .unwrap_or(0);
-            if head_block_ts > 0 {
-                head_block_ts.saturating_sub(saved_head * block_time_ms)
-            } else {
-                // Block timestamp wasn't set (legacy/test). Fall
-                // back to the original backdate-from-now logic.
-                now_ms_for_anchor.saturating_sub(saved_head * block_time_ms)
-            }
+                .unwrap_or(0)
         } else {
-            // Fresh start: use 0 to make `with_block_time` anchor
-            // at `Instant::now()` — all peers spawned together
-            // share approximately the same instant.
+            genesis_config.timestamp
+        };
+        let slot_clock_anchor_ms = if head_block_ts > 0 {
+            head_block_ts.saturating_sub(saved_head * block_time_ms)
+        } else if saved_head > 0 {
+            now_ms_for_anchor.saturating_sub(saved_head * block_time_ms)
+        } else {
             0
         };
         let slot_clock = SlotClock::with_block_time(slot_clock_anchor_ms, block_time_ms);
+        info!(
+            saved_head,
+            head_block_ts,
+            slot_clock_anchor_ms,
+            now_ms = now_ms_for_anchor,
+            initial_slot = slot_clock.current_slot(),
+            "slot_clock initialized"
+        );
         let mut last_slot = slot_clock.current_slot();
 
         // Periodic timers


### PR DESCRIPTION
## Summary
- Surfaced by walking `docs/testnet-bringup.md` end-to-end with a
  deliberate operator stagger.
- Pre-fix the generator wrote `timestamp = 0`, and `node.rs`'s
  fresh-start branch returned `slot_clock_anchor_ms = 0`, so
  every node anchored slot 0 at its own `Instant::now()`. A
  stagger between operators became permanent slot-counter
  divergence; votes covered different `(slot, block_hash)`
  tuples than neighbors expected, signature verification
  failed silently, and the chain stalled even though each node
  individually looked healthy.
- Real-world severity: any public testnet with staggered
  operator boots would silently fail to produce blocks.
- Fix:
  - `generate_testnet` stamps `current_time_ms()` into
    `genesis.toml` (matches the ETH / Solana / Cosmos
    genesis-time anchor pattern).
  - `node.rs` reads `genesis_config.timestamp` on fresh start
    instead of hardcoding the slot_clock anchor to 0.
- Verified on a 4-validator local run with a 60s stagger:
  pre-fix had 670+ invalid-signature warnings and a stuck
  chain at block 0; post-fix all four anchored identically
  (`slot_clock_anchor_ms=1777952611407`) and produced 2.5
  blocks/sec in lockstep with zero signature errors.
- Adds a regression test and a `slot_clock initialized`
  startup info-log so operators can verify their anchor
  matches the coordinator's at a glance.

Closes audit item 400.

## Discovered runbook gaps (deferred to follow-up PR)
- `accounts.json` undocumented in Phase 3 distribution
- generated `run.sh` instructs operators to pass
  `--bootstrap "<node-0-multiaddr>"` even though configs have
  `bootstrap_peers` baked in
- legacy validator.key warning fires on every restart until
  `PYDE_VALIDATOR_PASSPHRASE` is set; runbook says "single
  deprecation warning"
- smoke 5.2's `jq '.result | length'` returns 2 (object field
  count), should be `.result.count`