### PR TITLE
docs(rpc,deploy): public-RPC operator playbook + nginx template

### DIFF
--- a/deploy/nginx-pyde-rpc.conf.example
+++ b/deploy/nginx-pyde-rpc.conf.example
@@ -1,0 +1,208 @@
+# Pyde public RPC reverse-proxy template.
+#
+# Architecture this is designed for:
+#
+#   internet → nginx (this config)
+#                 ↓ rate-limited, TLS-terminated, headers-normalized
+#               pyde --role full-node (loopback :8545 / :8546)
+#                 ↑ pulls block / state from validator peers via libp2p
+#
+# Validators MUST NOT have their JSON-RPC bound to a public interface;
+# this nginx fronts a *separate* full-node fleet. See `docs/public-rpc.md`
+# for the full topology + operator playbook.
+#
+# Fill in the CHANGE_ME tokens below before deploying:
+#   - server_name (your public DNS)
+#   - ssl_certificate / ssl_certificate_key (your TLS cert chain)
+#   - upstream pyde_rpc / pyde_ws addresses if you're load-balancing more
+#     than one full-node behind this proxy
+#
+# Pairs with audit 348: this config sets a single trusted X-Forwarded-For
+# entry that the pyde faucet / RPC ingress can read for per-IP
+# rate-limiting. The proxy STRIPS any inbound XFF before adding its own
+# (otherwise an attacker can forge their client IP).
+
+# ────────────────────────────────────────────────────────────────────
+# Rate-limit zones — sized for ~10K active users / public testnet.
+# ────────────────────────────────────────────────────────────────────
+#
+# Method classes:
+#   • Cheap read   (getBalance, getNonce, blockNumber, chainId, …):
+#     stateless, sub-ms response. 100 req/s/IP burst-200.
+#   • Medium read  (getBlockByNumber, getReceipt, getLogs):
+#     touches block store. 30 req/s/IP burst-60.
+#   • Expensive    (call, estimateGas, createAccessList):
+#     runs the VM against current state. 10 req/s/IP burst-20.
+#   • Write        (sendRawTransaction, sendRawEncryptedTransaction):
+#     hits mempool ingress + relay. 10 req/s/IP burst-20.
+#       Note: encrypted-tx ingress already does its own per-sender
+#       rate-limit at the mempool layer (audit 027). This zone is the
+#       outer wall against IP-level flooding.
+#   • Subscription (WebSocket /ws): 1 req/s/IP burst-3 — opening a
+#     subscription is cheap but each long-lived connection holds
+#     resources. Connection cap below tightens this further.
+#
+# Tuning: bump zone sizes if you exceed ~10K unique IPs in a 60s
+# window. Each zone entry costs ~64 bytes; 1m = ~16K entries.
+limit_req_zone $binary_remote_addr zone=rpc_cheap:1m   rate=100r/s;
+limit_req_zone $binary_remote_addr zone=rpc_medium:1m  rate=30r/s;
+limit_req_zone $binary_remote_addr zone=rpc_expensive:1m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=rpc_write:1m    rate=10r/s;
+limit_req_zone $binary_remote_addr zone=rpc_subscribe:1m rate=1r/s;
+
+# Per-IP concurrent connection cap. WebSocket subscriptions count
+# here, so a misbehaved client can't open 1000s of long-lived sockets.
+limit_conn_zone $binary_remote_addr zone=conn_per_ip:1m;
+
+# ────────────────────────────────────────────────────────────────────
+# Upstream — replace with your full-node fleet IPs/hostnames.
+# ────────────────────────────────────────────────────────────────────
+upstream pyde_rpc {
+    # least_conn is the right policy for JSON-RPC: requests vary in
+    # cost (cheap balance reads vs expensive eth_call), and least_conn
+    # routes new requests to whichever upstream is least busy.
+    least_conn;
+    server 127.0.0.1:8545 max_fails=3 fail_timeout=10s;
+    # server CHANGE_ME_FULLNODE_2:8545 max_fails=3 fail_timeout=10s;
+    # server CHANGE_ME_FULLNODE_3:8545 max_fails=3 fail_timeout=10s;
+    keepalive 32;
+}
+
+upstream pyde_ws {
+    least_conn;
+    # WebSocket lives on rpc_port + 1 (audit 398's stride-2 layout).
+    server 127.0.0.1:8546 max_fails=3 fail_timeout=10s;
+    # server CHANGE_ME_FULLNODE_2:8546 max_fails=3 fail_timeout=10s;
+    keepalive 32;
+}
+
+# ────────────────────────────────────────────────────────────────────
+# JSON-RPC method classifier — a $rpc_zone variable is computed from
+# the request body so we can route different methods to different
+# rate-limit zones with one server block. Reads the JSON body on the
+# fly via `map` + `set_request_body` is not nginx-native; instead we
+# match by URI prefix or by the X-Pyde-Method client-supplied hint.
+#
+# Operators who want method-level rate-limiting should use the OpenResty
+# extension or front the upstream with a small shim that sets the
+# zone as a header. For the basic config below we apply a single
+# rate-limit (rpc_cheap) at the top level; tighten per-method limits
+# at the application layer (validator node already enforces them).
+# ────────────────────────────────────────────────────────────────────
+
+# ────────────────────────────────────────────────────────────────────
+# HTTPS server block.
+# ────────────────────────────────────────────────────────────────────
+server {
+    listen 443 ssl http2;
+    server_name CHANGE_ME_RPC_HOST;  # e.g. rpc.testnet.pyde.network
+
+    # TLS — use Let's Encrypt + certbot, or your CA's chain.
+    ssl_certificate     /etc/letsencrypt/live/CHANGE_ME_RPC_HOST/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/CHANGE_ME_RPC_HOST/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:TLS:10m;
+    ssl_session_tickets off;
+
+    # ────────────── Hardening defaults ──────────────
+
+    # Body-size cap. The encrypted-tx wire format (audit 301) is at
+    # most ~12 KB (Kyber-768 ciphertext + FALCON sig + access list).
+    # Plaintext txs are smaller. 64K leaves comfortable headroom for
+    # eth_call requests with calldata, well below "attacker streams
+    # GB to OOM the server."
+    client_max_body_size 64k;
+    client_body_buffer_size 64k;
+    client_body_timeout 10s;
+
+    # Request line + header caps. Default nginx caps are higher;
+    # tightening reduces reflection/amplification surface.
+    large_client_header_buffers 4 16k;
+    client_header_timeout 10s;
+
+    # Slowloris defenses. Keep-alive timeout pairs with the upstream
+    # `keepalive 32` — long enough for connection reuse, short enough
+    # that idle attackers can't pin sockets indefinitely.
+    keepalive_timeout 30s;
+    send_timeout 30s;
+
+    # Per-IP concurrent connection cap. 50 covers a single user with
+    # multiple browser tabs + a wallet doing background polling.
+    # Past 50 = scripting / abuse. Adjust upward if you support
+    # high-fanout dapps.
+    limit_conn conn_per_ip 50;
+
+    # Hide nginx version + tighten common header reflection.
+    server_tokens off;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # ────────────── X-Forwarded-For for audit 348 ──────────────
+    #
+    # The pyde faucet / RPC ingress reads the rightmost untrusted hop
+    # in `X-Forwarded-For` as the client IP for rate-limiting (audit
+    # 348). For that to be safe, this proxy MUST strip any inbound
+    # `X-Forwarded-For` header from the client and add its own.
+    # Otherwise an attacker can fake their client IP and bypass
+    # per-IP rate limits.
+    proxy_set_header X-Forwarded-For $remote_addr;  # override, do not append
+    proxy_set_header X-Real-IP       $remote_addr;
+    proxy_set_header Host            $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # ────────────── JSON-RPC over HTTPS ──────────────
+    location / {
+        # Default zone — most requests are cheap reads. Operators
+        # who need method-level limits can add an OpenResty/Lua
+        # classifier here. The validator node enforces stricter
+        # caps at the application layer.
+        limit_req zone=rpc_cheap burst=200 nodelay;
+
+        # Health-check whitelist — let load-balancer probes through
+        # without rate-limit collisions.
+        if ($request_uri = "/health") {
+            return 200 "ok\n";
+        }
+
+        proxy_pass http://pyde_rpc;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        # Read timeout — covers slow `eth_call` execution. The
+        # validator's per-call gas budget bounds wall time, but
+        # encrypted-tx submission paths involve threshold ops
+        # that can take ~50ms. 30s is comfortable.
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_connect_timeout 5s;
+    }
+
+    # ────────────── WebSocket subscriptions ──────────────
+    location /ws {
+        limit_req zone=rpc_subscribe burst=3 nodelay;
+
+        proxy_pass http://pyde_ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # WebSocket connections are long-lived; loosen the read
+        # timeout. Heartbeats from the client / `pyde_subscribe`
+        # confirmations from the server keep the channel active.
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+}
+
+# ────────────────────────────────────────────────────────────────────
+# HTTP → HTTPS redirect.
+# ────────────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    server_name CHANGE_ME_RPC_HOST;
+    return 301 https://$host$request_uri;
+}

--- a/docs/public-rpc.md
+++ b/docs/public-rpc.md
@@ -1,0 +1,311 @@
+# Public RPC Operator Guide
+
+Operator runbook for running a Pyde public RPC fleet — the
+internet-facing endpoint that wallets, dapps, and explorers hit.
+Audience: whoever is setting up the public RPC behind your testnet
+(often the coordinator + 1-2 dedicated full-node operators).
+
+If you're a validator operator, you want
+[`run-validator.md`](./run-validator.md) instead. **Validators MUST
+NOT expose JSON-RPC publicly** — see [§ Topology](#topology) below.
+
+## Topology
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  internet                                                        │
+│     │                                                            │
+│     ▼                                                            │
+│  ┌──────────────┐    rate-limited, TLS,                          │
+│  │ nginx :443   │ ── XFF-normalized, body-cap ──▶               │
+│  └──────────────┘                                                │
+│     │                                                            │
+│     ▼                                                            │
+│  ┌──────────────────────────────────────────┐                    │
+│  │ pyde --role full-node     :8545 / :8546  │                    │
+│  │   (loopback-bound, no public exposure)   │                    │
+│  └──────────────────────────────────────────┘                    │
+│     │                                                            │
+│     ▼ libp2p                                                     │
+│  ┌──────────────────────────────────────────┐                    │
+│  │ validator fleet (private network only)   │                    │
+│  └──────────────────────────────────────────┘                    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Three rules that hold this topology together:
+
+1. **Validators run with `--role validator`** and bind RPC to
+   loopback (the default in the testnet bundle's `config.toml`).
+   They participate in consensus and never serve public traffic.
+
+2. **Public RPC fleet runs `--role full-node`** on separate hosts
+   (or at minimum separate processes / containers). Full nodes
+   replicate state from the validator gossip mesh but don't sign
+   blocks. A misbehaved RPC client can DoS a full-node — that's
+   acceptable; it can't DoS consensus.
+
+3. **nginx fronts the full-node fleet** for TLS, rate-limiting,
+   header normalization, and load balancing. The full-node's
+   JSON-RPC port stays on `127.0.0.1` even on the host running
+   nginx.
+
+## What's in `deploy/nginx-pyde-rpc.conf.example`
+
+- TLS termination (Let's Encrypt-friendly cert paths)
+- Per-IP rate-limit zones for read / write / subscribe traffic
+- Per-IP concurrent-connection cap (default 50)
+- 64 KB body-size cap (encrypted-tx wire format is ~12 KB; plaintext
+  smaller; 64 KB leaves headroom for `pyde_call` calldata)
+- Slowloris defenses (header / body / keepalive timeouts)
+- WebSocket upgrade for `pyde_subscribe*` channels
+- `X-Forwarded-For` rewrite that pairs with audit 348's trust
+  mechanism — see [§ X-Forwarded-For pairing](#x-forwarded-for-pairing)
+- HTTP → HTTPS redirect
+
+## Setup steps
+
+### 1. Provision a full-node host
+
+```sh
+# On the full-node host:
+mkdir -p /var/lib/pyde
+# Drop in the bundle's genesis.toml + the public-RPC node config.
+# (The bundle's per-node config.toml is for VALIDATORS — for a
+#  full-node, generate a custom config or take the bundle's
+#  template and set role = "full".)
+cat > /var/lib/pyde/config.toml <<EOF
+[node]
+role = "full"
+chain_id = 7331
+datadir = "/var/lib/pyde"
+
+[network]
+port = 30303
+max_peers = 100
+bootstrap_peers = [
+  # paste the testnet's validator multiaddrs from genesis.toml
+]
+
+[rpc]
+enabled = true
+listen = "127.0.0.1"   # loopback only — nginx fronts it
+port = 8545
+
+[storage]
+db_path = "state"
+cache_size = 524288    # 512 MB; bump for high read traffic
+EOF
+
+# Start the full node.
+pyde run --role full --config /var/lib/pyde/config.toml --datadir /var/lib/pyde
+```
+
+### 2. Install + configure nginx
+
+```sh
+# Install nginx + certbot (Debian/Ubuntu):
+apt-get update && apt-get install -y nginx certbot python3-certbot-nginx
+
+# Get a TLS cert. Replace rpc.testnet.pyde.network with your DNS:
+certbot certonly --nginx -d rpc.testnet.pyde.network
+
+# Drop in the template:
+cp /path/to/pyde/deploy/nginx-pyde-rpc.conf.example /etc/nginx/sites-available/pyde-rpc
+ln -s /etc/nginx/sites-available/pyde-rpc /etc/nginx/sites-enabled/pyde-rpc
+
+# Edit /etc/nginx/sites-enabled/pyde-rpc:
+#   - replace CHANGE_ME_RPC_HOST with your DNS
+#   - confirm ssl_certificate paths match certbot's output
+#   - if load-balancing across multiple full-nodes, add them to the
+#     `upstream pyde_rpc` and `upstream pyde_ws` blocks
+
+# Sanity-check the config and reload:
+nginx -t
+systemctl reload nginx
+```
+
+### 3. Tell the full-node to trust the proxy's XFF header
+
+When the proxy sets `X-Forwarded-For: <client_ip>`, the full-node's
+faucet path needs to be told to trust it. From your faucet command:
+
+```sh
+pyde faucet \
+  --rpc http://127.0.0.1:8545 \
+  --from 0x... \
+  --private-key /path/to/faucet.key \
+  --trust-x-forwarded-for     # ← only when behind a proxy
+```
+
+**Do NOT set `--trust-x-forwarded-for`** if the faucet is exposed
+directly to the public internet — clients can fake `X-Forwarded-For`
+and bypass per-IP rate limits.
+
+### 4. Verify
+
+```sh
+# Plain JSON-RPC works:
+curl -s https://rpc.testnet.pyde.network -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_blockNumber","params":[],"id":1}'
+# → {"jsonrpc":"2.0","id":1,"result":"0x..."}
+
+# Body-size cap works:
+curl -s https://rpc.testnet.pyde.network -X POST \
+  -H 'Content-Type: application/json' \
+  --data-binary @/tmp/100kb-blob
+# → 413 Request Entity Too Large
+
+# Rate-limit works (run from a single IP — should start 503-ing):
+for i in $(seq 1 500); do
+  curl -s https://rpc.testnet.pyde.network -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","method":"pyde_blockNumber","params":[],"id":1}' \
+    > /dev/null &
+done
+wait
+# Some requests return 503 once the burst window is exceeded.
+```
+
+## X-Forwarded-For pairing
+
+Audit 348 added per-IP rate-limit support to the faucet's HTTP
+ingress with a configurable trust mode for `X-Forwarded-For`. The
+full picture:
+
+```
+client (203.0.113.5) ──HTTP──▶ nginx ──HTTP──▶ pyde --role full-node
+                                      │
+                                      └── X-Forwarded-For: 203.0.113.5
+                                          (overridden by nginx, NOT appended)
+```
+
+The pyde faucet, when started with `--trust-x-forwarded-for`,
+reads the **rightmost** entry in XFF as the client IP for
+rate-limiting. Because nginx OVERRIDES (not appends) any inbound
+XFF, the rightmost entry is always the real client IP.
+
+If nginx APPENDED (the default before this template), an attacker
+sending `X-Forwarded-For: 1.2.3.4` would get nginx to append:
+`X-Forwarded-For: 1.2.3.4, 203.0.113.5`. The faucet's rightmost-
+hop policy would still resolve the right IP — but a poorly-
+configured proxy might use the leftmost. **Always override XFF at
+the trust boundary** to avoid that whole class of mistake.
+
+The template at `deploy/nginx-pyde-rpc.conf.example` does the
+override correctly:
+
+```nginx
+proxy_set_header X-Forwarded-For $remote_addr;  # OVERRIDE, not append
+```
+
+## Method-level rate limits
+
+The template applies a single zone (`rpc_cheap` at 100 r/s/IP) to
+all `/` traffic. For finer-grained limits per method class, you
+have two options:
+
+1. **Application-layer (recommended)**: the validator node already
+   rate-limits at the mempool ingress (audit 027 — 10 enc-tx/s/sender,
+   100 concurrent-tx/sender). RPC reads are stateless and cheap; a
+   single global zone is usually fine.
+
+2. **Proxy-layer (advanced)**: drop in OpenResty + a small Lua
+   handler that parses the JSON-RPC body's `method` field and sets
+   a `$rpc_zone` variable used by `limit_req`. The template
+   reserves zones (`rpc_medium`, `rpc_expensive`, `rpc_write`,
+   `rpc_subscribe`) for this — uncomment / wire them up if you need
+   per-method enforcement at the proxy.
+
+For a launch-day public testnet the application-layer limits are
+sufficient. Method-level proxy limits are an upgrade path if a
+specific method class becomes a hot abuse target.
+
+## Common pitfalls
+
+### "Health checks are getting rate-limited"
+
+The template whitelists `/health` ahead of the rate-limit. If your
+load-balancer probes a different path, add it:
+
+```nginx
+if ($request_uri = "/your-probe-path") {
+    return 200 "ok\n";
+}
+```
+
+### "Subscriptions disconnect after 60s"
+
+Default nginx `proxy_read_timeout` is 60s. The template raises it
+to 1h for the `/ws` location, but if you front the proxy with
+*another* proxy (CDN, AWS ALB), each layer has its own timeout.
+Configure each one to keep WebSocket connections alive.
+
+### "Faucet is rate-limiting everyone to one IP"
+
+You forgot `--trust-x-forwarded-for` on the faucet. Without it,
+every request looks like it's coming from `127.0.0.1` (the
+nginx → faucet hop), so the IP rate-limit zone collapses to a
+single bucket. Set the flag and restart.
+
+### "TLS handshake fails with `unable to get local issuer certificate`"
+
+Cert chain incomplete. `certbot --nginx` should set
+`ssl_certificate` to `fullchain.pem` (NOT `cert.pem`). If you
+see only `cert.pem`, switch to `fullchain.pem`.
+
+## Monitoring this layer
+
+The full-node already exposes Prometheus metrics on `:9090`. Add an
+nginx-exporter sidecar (e.g.,
+[nginxinc/nginx-prometheus-exporter](https://github.com/nginxinc/nginx-prometheus-exporter))
+to surface proxy-layer metrics — request rate, 4xx/5xx ratios,
+upstream connection pool — alongside the chain metrics.
+
+Key panels to watch:
+
+- 5xx ratio > 1% → upstream issue (full-node down, slow query)
+- 429/503 ratio sustained → legit user demand or DoS attempt;
+  raise zone limits if legit
+- Connection-pool exhaustion → bump `keepalive 32` in the upstream
+  blocks
+- TLS handshake failures → cert expiry approaching
+
+## Recovery
+
+### Full-node falls behind
+
+Symptom: `pyde_syncing` returns true; clients get stale balance
+reads. Cause: usually a slow RocksDB compaction or a libp2p peer
+churn event.
+
+```sh
+# Check sync state on the loopback (skip nginx):
+curl -s http://127.0.0.1:8545 -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_syncing","params":[],"id":1}'
+```
+
+If lagging by < 100 blocks, wait — full-nodes catch up via the
+validator gossip mesh in seconds. If lagging by > 1000 blocks for
+more than a minute, restart the full-node and let it re-bootstrap.
+
+### A full-node deadlocks
+
+Symptom: requests time out; `pyde_blockNumber` stops responding.
+
+```sh
+# Take the upstream out of rotation:
+# Edit /etc/nginx/sites-enabled/pyde-rpc, comment out the affected
+# `server` line in `upstream pyde_rpc`, then:
+nginx -s reload
+
+# Restart the full-node:
+systemctl restart pyde-fullnode
+
+# Verify it's caught up before adding back to the pool:
+curl -s http://that-host:8545 -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"pyde_blockNumber","params":[],"id":1}'
+```

--- a/docs/testnet-bringup.md
+++ b/docs/testnet-bringup.md
@@ -225,8 +225,11 @@ Once smoke passes:
 
 1. Stand up a public RPC fleet. Validator RPCs are loopback-bound by
    default. Run **separate full nodes** behind a load balancer with
-   TLS — never expose validator RPCs publicly. See
-   `crates/node/src/cli.rs` `Command::Run` `--role full-node`.
+   TLS — never expose validator RPCs publicly. The complete operator
+   playbook (topology, nginx template, X-Forwarded-For pairing,
+   recovery procedures) is at [`docs/public-rpc.md`](./public-rpc.md);
+   a drop-in nginx config is at
+   `deploy/nginx-pyde-rpc.conf.example`.
 2. Spin up the [pyde-explorer](../../pyde-explorer/) — its backend
    indexer needs `PYDE_RPC_URL` pointed at one full node, frontend
    `NEXT_PUBLIC_API_URL` pointed at the backend.


### PR DESCRIPTION
## Summary
- Adds `deploy/nginx-pyde-rpc.conf.example`: drop-in TLS reverse
  proxy with per-IP rate-limit zones, body-size cap (64 KB),
  WebSocket support, and X-Forwarded-For override that pairs
  with audit 348's trust mechanism.
- Adds `docs/public-rpc.md`: full operator playbook covering
  topology, setup, verification, monitoring, and recovery.
- Updates the testnet bring-up runbook to point at both.
- No code change. Pre-launch operator polish.