### PR TITLE
fix(consensus): proposer candidacy uses epoch_randomness_for_slot (audit 402 follow-up)

### DIFF
--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -1248,10 +1248,21 @@ impl ValidatorEngine {
         let slot = self.consensus.current_slot;
         let committee_size = self.committee_keys.len();
 
+        // Audit 402: same boundary-aware lookup as the verify path.
+        // Pre-fix this used `self.epoch_randomness` directly, which
+        // could be a stale value (the buffered next-epoch randomness
+        // hadn't been swapped in yet) or the wrong epoch's value.
+        // Result: proposers generated VRF proofs against a different
+        // randomness than verifiers used → every VRF check failed
+        // → view-change fallback fired every 20-50 slots → chain
+        // ran at ~25% throughput post-boundary. Routing through
+        // `epoch_randomness_for_slot(slot)` makes generator and
+        // verifier agree on the same input.
+        let randomness = self.epoch_randomness_for_slot(slot);
         match compute_candidacy(
             &identity.public_key,
             &identity.secret_key,
-            &self.epoch_randomness,
+            &randomness,
             slot,
             identity.address,
         ) {


### PR DESCRIPTION
## Summary
- Single-line follow-up to PR #343: route the proposer's
  VRF candidacy check through `epoch_randomness_for_slot()`
  instead of `self.epoch_randomness` so generator and
  verifier use the exact same epoch-aware lookup.
- Symmetric with the verifier-side fix landed in #343.
- Verified: 9-min soak crosses epoch 0→1 boundary,
  produces 1513 unique QC slots over 606s = 2.5 QC/sec
  (design rate). Chain is healthy.