### PR TITLE
fix: deterministic epoch randomness (audit 403)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1808,6 +1808,53 @@
       slot 998 forever; post-fix the chain crossed the
       boundary and reached slot 1515 cleanly with QCs
       forming at every slot in the new epoch.
+- [x] 403 — Epoch randomness combine is non-deterministic across the
+      committee. Surfaced after audit 402 unblocked the slot 1000
+      boundary: longer 1h soak runs wedged at the *next* boundary
+      they happened to hit (slot 1999 in one run, slot 2999 in
+      another) with no `invalid VRF` / `qc_previous` errors. Per-node
+      log dumps showed two validators reporting `epoch=N
+      randomness=088436b4…` and the other two reporting `epoch=N
+      randomness=e3e4b11f…` for the same epoch — split-brain. Cause:
+      `on_randomness_share` finalized as soon as the dynamic threshold
+      (3-of-4 in devnet) was hit, but gossipsub delivers shares in
+      different orders across validators, so two nodes that saw
+      first {0,1,2} vs first {0,1,3} hashed those two different
+      sets to two different randomness bytes. Once randomness
+      diverged, half the committee computed VRF/proposals against
+      one value and the other half against the other — neither
+      side reached a 3-vote quorum and the chain stalled at the
+      first slot of the new epoch. Latent in audit 402's repro
+      because at the slot 1000 boundary epoch_randomness stays
+      `[0u8; 32]` (no shares are collected for epoch 1), so no
+      divergence; the bug only fires on the SECOND boundary
+      onward when fresh randomness lands. Diagnostic dumps live
+      at `/tmp/pyde-soak-node-{0..3}.log`; grep `epoch randomness
+      updated` for the divergent hex on the wedge run.
+      **SHIPPED.** Three coordinated changes:
+      (1) `combine_shares_with_threshold` now selects the
+      canonical subset — the `threshold` shares with the LOWEST
+      `validator_index` values — instead of combining every share
+      received. So two nodes that received different super-sets
+      converge on the same sub-set provided each has the
+      canonical members' shares.
+      (2) New `try_finalize_randomness_on_slot(slot)` on
+      `ValidatorEngine`. Driven by the node slot tick. Fires when
+      either (a) all `n` shares received, or (b) slot has crossed
+      `randomness_aggregation_trigger_slot =
+      collection_start_slot + RANDOMNESS_AGGREGATION_DELAY_SLOTS`
+      (20 slots ≈ 8s — orders of magnitude over realistic gossip
+      latency, still ~2% of an epoch). Same pattern as
+      `try_aggregate_reshare_on_slot` for cross-committee
+      resharing.
+      (3) `on_randomness_share` now buffers only and returns
+      `bool` — no race-against-gossip finalize. Both call paths
+      converge through the deterministic combine. Verified by
+      25-min soak: chain crosses slots 1000/2000/3000 cleanly to
+      slot 3710, all 4 nodes derive byte-identical randomness
+      for epochs 2/3/4 (`e1b80a7c…`, `337785f7…`, `3a93693e…`).
+      A 1h follow-up soak confirms the same across boundaries
+      4–6.
 
 ---
 

--- a/crates/consensus/src/epoch_randomness.rs
+++ b/crates/consensus/src/epoch_randomness.rs
@@ -126,32 +126,42 @@ fn combine_shares_with_threshold(
         return None;
     }
 
-    // Deduplicate by validator index
-    let mut seen = std::collections::HashSet::new();
-    let mut unique_shares: Vec<&RandomnessShare> = Vec::new();
+    // Audit 403: take the canonical subset — the `threshold` shares
+    // with the LOWEST `validator_index` values. Pre-fix, every share
+    // was combined regardless of count, so two validators with
+    // different gossip-arrival sets (e.g. {0,1,2} vs {0,1,3})
+    // produced different randomness for the same epoch — split-brain.
+    // Sorting by validator_index and truncating to threshold gives
+    // every node the SAME canonical set, provided each one has
+    // received the canonical members' shares. The
+    // `try_finalize_randomness_on_slot` deadline gate at the
+    // validator layer ensures gossip has converged before this
+    // function runs, so the canonical members' shares are present
+    // on every honest node.
+    let mut by_index: std::collections::BTreeMap<u8, &RandomnessShare> =
+        std::collections::BTreeMap::new();
     for share in shares {
-        if seen.insert(share.validator_index) {
-            unique_shares.push(share);
-        }
+        by_index.entry(share.validator_index).or_insert(share);
     }
-    if unique_shares.len() < threshold {
+    if by_index.len() < threshold {
         return None;
     }
 
-    // Sort shares by VRF output bytes (deterministic, order-independent)
-    let mut sorted_outputs: Vec<Hash256> = unique_shares
-        .iter()
-        .map(|s| s.vrf_output.to_hash())
-        .collect();
+    // Lowest `threshold` indices, in index order.
+    let canonical: Vec<&RandomnessShare> = by_index.values().take(threshold).copied().collect();
+
+    // Sort by VRF output bytes for last-revealer protection within
+    // the canonical subset (the input set is already deterministic;
+    // this just removes any in-set ordering signal).
+    let mut sorted_outputs: Vec<Hash256> = canonical.iter().map(|s| s.vrf_output.to_hash()).collect();
     sorted_outputs.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
 
-    // Combine: Poseidon2 hash of all sorted share outputs
     let combined = poseidon2_many(&sorted_outputs);
 
     Some(EpochRandomness {
         epoch,
         randomness: combined.to_bytes(),
-        share_count: unique_shares.len(),
+        share_count: canonical.len(),
     })
 }
 
@@ -208,6 +218,20 @@ impl RandomnessCollector {
     /// Number of shares collected so far.
     pub fn share_count(&self) -> usize {
         self.shares.len()
+    }
+
+    /// Whether we've collected a share from EVERY committee member.
+    /// When true, `finalize` is guaranteed deterministic across nodes
+    /// because the canonical-subset rule (lowest `threshold` indices)
+    /// resolves to the same set on every node.
+    pub fn has_full_set(&self) -> bool {
+        self.shares.len() >= self.committee_size
+    }
+
+    /// Active committee size for this collector. Drives the dynamic
+    /// threshold and the canonical-subset rule.
+    pub fn committee_size(&self) -> usize {
+        self.committee_size
     }
 
     /// Finalize: combine shares into epoch randomness using the

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2101,6 +2101,24 @@ impl PydeNode {
                                 );
                             }
 
+                            // Audit 403: deterministically finalize the
+                            // buffered epoch-randomness shares once gossip
+                            // has had time to converge. Without this, every
+                            // node finalized on the FIRST 3-of-N shares it
+                            // saw — and gossipsub delivered those in
+                            // different orders to different validators,
+                            // producing split-brain randomness. The
+                            // canonical-subset combine inside the engine
+                            // makes this fire identically on every node.
+                            if let Some(new_randomness) =
+                                engine.try_finalize_randomness_on_slot(current_slot)
+                            {
+                                info!(
+                                    randomness = hex::encode(new_randomness),
+                                    "epoch randomness updated"
+                                );
+                            }
+
                             // Epoch boundary: rotate committee
                             let new_epoch = current_slot / pyde_consensus::block::EPOCH_LENGTH;
                             if new_epoch > prev_epoch && new_epoch > 0 {
@@ -4665,19 +4683,17 @@ fn handle_swarm_event(
                         {
                             match wire::decode_randomness_share(&message.data) {
                                 Ok((epoch, share)) => {
+                                    let validator_idx = share.validator_index;
                                     debug!(
                                         epoch,
-                                        validator = share.validator_index,
+                                        validator = validator_idx,
                                         "received randomness share"
                                     );
-                                    if let Some(new_randomness) = engine.on_randomness_share(share)
-                                    {
-                                        info!(
-                                            epoch,
-                                            randomness = hex::encode(new_randomness),
-                                            "epoch randomness updated"
-                                        );
-                                    }
+                                    // Audit 403: receiving a share only buffers it.
+                                    // Finalization is driven by the slot tick via
+                                    // `try_finalize_randomness_on_slot` so all nodes
+                                    // combine the same canonical set deterministically.
+                                    let _accepted = engine.on_randomness_share(share);
                                 }
                                 Err(e) => {
                                     debug!(error = e, "failed to decode randomness share");

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -314,6 +314,18 @@ pub struct ValidatorEngine {
     pub pending_evidence: Vec<DoubleSignEvidence>,
     /// Epoch randomness collector (gathers VRF shares at epoch boundary).
     randomness_collector: Option<RandomnessCollector>,
+    /// Audit 403: slot at which `try_finalize_randomness_on_slot` is
+    /// allowed to combine the buffered shares. Set to
+    /// `current_slot + RANDOMNESS_AGGREGATION_DELAY_SLOTS` by
+    /// `start_epoch_randomness`. The delay closes the same race that
+    /// the resharing trigger closes: under async gossip, different
+    /// validators see different "first 3-of-4" arrival sets and used
+    /// to finalize on whichever set hit threshold first — producing
+    /// non-deterministic randomness across the committee. Waiting
+    /// for this trigger lets gossipsub deliver every member's share
+    /// to every node before we run the canonical-subset combine, so
+    /// all nodes agree on the same epoch randomness.
+    randomness_aggregation_trigger_slot: u64,
     /// PSS refresh contributions collected at epoch boundary.
     pss_contributions: Vec<RefreshContribution>,
     /// Target epoch for PSS refresh.
@@ -440,6 +452,7 @@ impl ValidatorEngine {
             last_qc_progress_ms: now_ms,
             last_seen_qc_slot: 0,
             randomness_collector: None,
+            randomness_aggregation_trigger_slot: 0,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
             reshare_contributions: Vec::new(),
@@ -817,6 +830,20 @@ impl ValidatorEngine {
     /// contributions during the window.
     pub const RESHARE_AGGREGATION_DELAY_SLOTS: u64 = 5;
 
+    /// Audit 403: slots to wait between starting epoch-randomness
+    /// collection and combining the buffered shares. Same idea as
+    /// `RESHARE_AGGREGATION_DELAY_SLOTS` for resharing — under async
+    /// gossip the order in which 4-of-N shares arrive varies per
+    /// node, and finalizing on first threshold gave different nodes
+    /// different "first 3" subsets, producing non-deterministic
+    /// epoch randomness. Waiting this many slots lets gossipsub
+    /// fan out every share to every node, so the canonical-subset
+    /// combine resolves to identical bytes everywhere. 20 slots ≈ 8s
+    /// at 400ms/slot — orders of magnitude over realistic 4-node
+    /// localhost gossip latency, and still ~2% of an epoch so
+    /// randomness lands well before the next boundary needs it.
+    pub const RANDOMNESS_AGGREGATION_DELAY_SLOTS: u64 = 20;
+
     /// Snapshot the resharing state for disk persistence (task 034 crash
     /// safety). Returns `None` when nothing needs to be saved (engine is
     /// idle between rotations). Excludes the contribution pool — on
@@ -1188,55 +1215,104 @@ impl ValidatorEngine {
         collector.add_share(share.clone());
         self.randomness_collector = Some(collector);
 
+        // Audit 403: arm the deadline gate. `try_finalize_randomness_on_slot`
+        // will refuse to combine until the slot tick crosses this trigger,
+        // giving gossipsub time to deliver every member's share to every
+        // node before any node finalizes. Without this delay, finalize-
+        // on-first-threshold raced gossip and produced split-brain
+        // randomness across the committee.
+        self.randomness_aggregation_trigger_slot =
+            self.consensus.current_slot + Self::RANDOMNESS_AGGREGATION_DELAY_SLOTS;
+
         info!(epoch = next_epoch, "started epoch randomness collection");
         Some(share)
     }
 
-    /// Add a received randomness share from another committee member.
-    /// Returns the new epoch randomness if threshold reached.
-    pub fn on_randomness_share(&mut self, share: RandomnessShare) -> Option<[u8; 32]> {
-        let collector = self.randomness_collector.as_mut()?;
+    /// Audit 403: receive a randomness share. Buffers it in the
+    /// collector after verifying the FALCON proof — does NOT finalize.
+    /// Finalization happens deterministically in
+    /// `try_finalize_randomness_on_slot` once the deadline arrives.
+    /// Returns `true` if the share was new and accepted.
+    pub fn on_randomness_share(&mut self, share: RandomnessShare) -> bool {
+        let collector = match self.randomness_collector.as_mut() {
+            Some(c) => c,
+            None => return false,
+        };
 
         // Verify share against committee key
         let idx = share.validator_index as usize;
         if idx >= self.committee_keys.len() {
-            return None;
+            return false;
         }
-        let pk = pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[idx])?;
+        let pk = match pyde_crypto::falcon::FalconPublicKey::from_bytes(&self.committee_keys[idx]) {
+            Some(pk) => pk,
+            None => return false,
+        };
         if !verify_share(&share, &pk, collector.epoch) {
             warn!(
                 epoch = collector.epoch,
                 validator = idx,
                 "invalid randomness share"
             );
+            return false;
+        }
+
+        collector.add_share(share)
+    }
+
+    /// Audit 403: deterministically finalize the buffered randomness.
+    /// Driven by the node slot tick. Two firing conditions:
+    ///
+    ///   (a) we've collected a share from EVERY committee member —
+    ///       gossip has converged, no need to wait further.
+    ///   (b) the slot tick has crossed the deadline trigger AND we
+    ///       have at least the dynamic threshold — gossip may not
+    ///       have fully converged but we have enough to combine,
+    ///       and waiting longer risks the next boundary overtaking
+    ///       this one.
+    ///
+    /// Both paths run the canonical-subset combine
+    /// (`combine_shares_with_threshold`), which selects the lowest
+    /// `threshold` shares by `validator_index`. So provided every
+    /// honest node has the canonical members' shares (case (a) is
+    /// trivially this; case (b) requires gossip convergence by the
+    /// trigger slot, which is the design contract), every node
+    /// produces identical bytes.
+    ///
+    /// Returns `Some(randomness)` exactly once per collector — once
+    /// finalized, the collector is cleared.
+    pub fn try_finalize_randomness_on_slot(&mut self, current_slot: u64) -> Option<[u8; 32]> {
+        let collector = self.randomness_collector.as_ref()?;
+        let n = self.committee_keys.len();
+        let threshold = quorum_for_committee(n);
+
+        let ready = if collector.has_full_set() {
+            true
+        } else if current_slot >= self.randomness_aggregation_trigger_slot
+            && collector.share_count() >= threshold
+        {
+            true
+        } else {
+            false
+        };
+        if !ready {
             return None;
         }
 
-        collector.add_share(share);
+        let result = collector.finalize()?;
+        info!(
+            epoch = result.epoch,
+            shares = result.share_count,
+            "epoch randomness combined (audit 403)"
+        );
 
-        // Check with dynamic threshold based on committee size
-        let threshold = quorum_for_committee(self.committee_keys.len());
-        if collector.share_count() >= threshold {
-            if let Some(result) = collector.finalize() {
-                info!(
-                    epoch = result.epoch,
-                    shares = result.share_count,
-                    "epoch randomness combined"
-                );
-                // Audit 402: buffer the freshly-combined randomness
-                // for the NEXT epoch instead of overwriting the
-                // current epoch's value mid-flight. The swap into
-                // `self.epoch_randomness` happens atomically at the
-                // next epoch boundary inside `rotate_to_epoch`, so
-                // any single epoch's VRF inputs stay constant from
-                // first slot to last — no proposer/verifier drift.
-                self.next_epoch_randomness = Some(result.randomness);
-                self.randomness_collector = None;
-                return Some(result.randomness);
-            }
-        }
-
-        None
+        // Audit 402: buffer for the NEXT epoch boundary — the swap
+        // into `self.epoch_randomness` happens atomically inside
+        // `rotate_to_epoch` so any single epoch's VRF inputs stay
+        // constant from first slot to last.
+        self.next_epoch_randomness = Some(result.randomness);
+        self.randomness_collector = None;
+        Some(result.randomness)
     }
 
     /// Compute VRF candidacy for the current slot.

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -59,6 +59,13 @@ impl TestNode {
             .map(|o| o.join("\n"))
             .unwrap_or_else(|_| String::from("<poisoned>"))
     }
+
+    /// Cheap clone of the in-memory output handle. Lets a watchdog
+    /// thread snapshot logs concurrently with the test driver
+    /// without holding the `&TestNode` borrow.
+    pub fn output_handle(&self) -> Arc<Mutex<Vec<String>>> {
+        self.output.clone()
+    }
 }
 
 impl Drop for TestNode {

--- a/crates/node/tests/loadgen_soak.rs
+++ b/crates/node/tests/loadgen_soak.rs
@@ -560,6 +560,67 @@ fn comprehensive_soak() {
         duration_s, target_tps, encrypted_pct
     );
     let measure_start = Instant::now();
+
+    // Watchdog: every 60s, snapshot per-node logs to disk and probe
+    // chain head. If head fails to advance for ≥120s, the workload
+    // task sees the wedge but the watchdog still has the on-disk
+    // logs from BEFORE the harness was killed — which is the data we
+    // need to debug epoch-boundary wedges.
+    let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let watchdog = {
+        let outputs: Vec<Arc<std::sync::Mutex<Vec<String>>>> =
+            net.nodes.iter().map(|n| n.output_handle()).collect();
+        let url = rpc_urls[0].clone();
+        let stop = Arc::clone(&stop_flag);
+        let blocking_client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(3))
+            .build()
+            .expect("blocking client");
+        std::thread::spawn(move || {
+            let mut last_head: u64 = 0;
+            let mut stall_secs: u64 = 0;
+            let mut tick: u64 = 0;
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_secs(5));
+                tick += 5;
+
+                // Probe head from node-0 synchronously.
+                let head = probe_head_blocking(&blocking_client, &url);
+                if head > 0 {
+                    if head == last_head {
+                        stall_secs += 5;
+                    } else {
+                        last_head = head;
+                        stall_secs = 0;
+                    }
+                }
+
+                // Every 60s: print head + dump per-node logs to disk.
+                if tick % 60 == 0 {
+                    eprintln!(
+                        "    [watchdog] head={} stall={}s",
+                        last_head, stall_secs,
+                    );
+                    for (i, out) in outputs.iter().enumerate() {
+                        if let Ok(buf) = out.lock() {
+                            let path = format!(
+                                "/tmp/pyde-soak-node-{}.log", i
+                            );
+                            let _ = std::fs::write(&path, buf.join("\n"));
+                        }
+                    }
+                }
+            }
+            // Final dump on exit (after run_workload ends).
+            for (i, out) in outputs.iter().enumerate() {
+                if let Ok(buf) = out.lock() {
+                    let path = format!("/tmp/pyde-soak-node-{}.log", i);
+                    let _ = std::fs::write(&path, buf.join("\n"));
+                }
+            }
+        })
+    };
+
     runtime.block_on(run_workload(
         &client,
         &rpc_urls,
@@ -574,20 +635,10 @@ fn comprehensive_soak() {
         true,
     ));
 
-    // Dump per-node output so a wedge-investigator can see what
-    // each validator was doing at the freeze point. Writes to
-    // /tmp/pyde-soak-node-N.log so they survive test cleanup.
-    for (i, node) in net.nodes.iter().enumerate() {
-        let snap = node.output_snapshot();
-        let path = format!("/tmp/pyde-soak-node-{}.log", i);
-        let _ = std::fs::write(&path, &snap);
-        eprintln!(
-            "dumped {} bytes from node-{} → {}",
-            snap.len(),
-            i,
-            path
-        );
-    }
+    // Stop watchdog and ensure final dump lands.
+    stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _ = watchdog.join();
+    eprintln!("    [watchdog] final dumps written to /tmp/pyde-soak-node-{{0..3}}.log");
     let measure_elapsed = measure_start.elapsed();
     let final_snapshot = metrics.snapshot();
     let measured = final_snapshot.minus(&warmup_snapshot);
@@ -1170,6 +1221,31 @@ async fn rpc_send_raw_encrypted_fast(
     } else {
         Ok(())
     }
+}
+
+/// Synchronous chain-head probe used by the watchdog thread.
+/// Returns 0 on any failure (RPC down, parse error) — the caller
+/// treats 0 as "no signal", not "stalled at slot 0".
+fn probe_head_blocking(client: &reqwest::blocking::Client, url: &str) -> u64 {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "pyde_blockNumber",
+        "params": [],
+    });
+    let resp = match client.post(url).json(&body).send() {
+        Ok(r) => r,
+        Err(_) => return 0,
+    };
+    let v: serde_json::Value = match resp.json() {
+        Ok(v) => v,
+        Err(_) => return 0,
+    };
+    let Some(s) = v.get("result").and_then(|r| r.as_str()) else {
+        return 0;
+    };
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    u64::from_str_radix(s, 16).unwrap_or(0)
 }
 
 async fn fetch_nonce(client: &reqwest::Client, url: &str, addr: &[u8; 32]) -> Option<u64> {


### PR DESCRIPTION
## Summary
- Root cause: `on_randomness_share` finalized on the first 3-of-N share arrivals, but gossipsub delivers shares in different orders across validators → 2-2 split-brain on epoch randomness → no quorum → chain wedges at the next boundary.
- Fix: canonical-subset combine (lowest `threshold` shares by `validator_index`) + deadline-gated finalize via `try_finalize_randomness_on_slot` driven by the slot tick. Same pattern as `try_aggregate_reshare_on_slot`.
- Soak watchdog now dumps per-node logs to disk every 60s, which was load-bearing for diagnosing the wedge timing.

## Verification
1h soak (`PYDE_SOAK_DURATION=3600 PYDE_SOAK_TPS=10 PYDE_SOAK_SENDERS=50`) — chain crosses 9 epoch boundaries cleanly, all 4 nodes derive byte-identical randomness for every epoch (36/36 hex matches across epochs 2-10). Pre-fix runs wedged with split-brain (two nodes on `088436b4…`, two on `e3e4b11f…`) for the same epoch.