### PR TITLE
fix(security): wave 1 — CSPRNG, no-echo password, localhost match, multisig dedup, validator.key guard (audits 381/387/388/389/395)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1508,9 +1508,17 @@
 - [ ] 380 — Heartbeat 400ms (matches slot time). Bump to 1 s once
       peer scoring + peer-book restoration stabilize the mesh
       post-restart. `crates/net/src/node.rs:118`.
-- [ ] 381 — `propagation::rand_nonce` uses SystemTime, not CSPRNG.
+- [x] 381 — `propagation::rand_nonce` uses SystemTime, not CSPRNG.
       `crates/net/src/propagation.rs:117-124`. Switch to
       `getrandom::getrandom` (already a dep).
+      **SHIPPED.** Now reads 8 bytes from `getrandom::getrandom`
+      and panics on OS CSPRNG failure (unrecoverable for
+      consensus security). Pre-fix the short-ID nonce was
+      trivially predictable from a wall-clock estimate; an
+      off-path peer could pre-compute a tx whose short ID
+      collides with another peer's tx, forcing fallback
+      `GetBlockTxs` round-trips and amplifying compact-block
+      bandwidth.
 - [ ] 382 — Faucet `signing_lock` doesn't bound queue length;
       semaphore + 503 on saturation. `crates/node/src/faucet.rs:430-460`.
 - [ ] 383 — `pyde testnet --chain-id 1` not refused.
@@ -1573,14 +1581,41 @@
       without moving `base`, leaving the same nonce reusable. Four
       regression tests cover `validate` at u64::MAX-near and exact
       base, `advance` at u64::MAX, and `max_nonce` saturation.
-- [ ] 387 — `prompt_password` echoes input.
+- [x] 387 — `prompt_password` echoes input.
       `crates/pyde-dev/src/wallet.rs:291-298`. Use `rpassword`.
-- [ ] 388 — `is_localhost` uses `String::contains`.
+      **SHIPPED.** Switched to `rpassword::prompt_password`,
+      which puts the TTY into no-echo mode for the duration
+      of the read. Pre-fix the wallet passphrase rendered to
+      the screen as it was typed — anyone over the operator's
+      shoulder, on a shared screen, or scrubbing a terminal
+      recording could recover the passphrase verbatim.
+- [x] 388 — `is_localhost` uses `String::contains`.
       `crates/pyde-dev/src/signer.rs:178-184`. Parse with
       `url::Url::host_str` and exact-match.
-- [ ] 389 — `account::auth::validate_signature` for MultiSig
+      **SHIPPED.** Now parses with `url::Url::parse` and
+      exact-matches the host component against the loopback
+      set `{localhost, 127.0.0.1, 0.0.0.0, [::1], ::1}`.
+      Pre-fix `String::contains("localhost")` matched
+      attacker URLs like `http://attacker.example/?ref=localhost`
+      or `http://127.0.0.1.attacker.example/`, which would
+      unlock the devnet-auto-key fallback against an
+      attacker-controlled RPC.
+- [x] 389 — `account::auth::validate_signature` for MultiSig
       doesn't dedup keys. `crates/account/src/auth.rs:60-94`.
       Cross-with #304 fix: invariant check at construction.
+      **SHIPPED.** Two coordinated changes:
+      (1) `validate_signature` now tracks which public-key
+      bytes already counted toward the quorum and skips
+      subsequent positions whose key is a repeat. With
+      positional matching, a `keys: vec![k1, k1, k2]` slate
+      previously let a single `(k1, sig)` pair satisfy two
+      threshold positions — collapsing 2-of-3 into 1-of-1
+      whenever k1 appeared twice. (2) `AuthKeys::from_bytes`
+      now refuses to deserialize a `MultiSig` variant whose
+      key list contains duplicates, so persisted state can
+      never carry an unsafe slate. Two regression tests
+      pinned (`multisig_duplicate_key_does_not_double_credit_audit_389`,
+      `authkeys_from_bytes_rejects_duplicate_multisig_keys_audit_389`).
 - [x] 390 — `NonceState::from_bytes` silently returns
       `Self::new()` on invalid input; should be `Option<Self>`.
       `crates/account/src/nonce.rs:100-113`.
@@ -1681,10 +1716,23 @@
       gate; deferred. Tests `verify_all_with_all_valid_returns_true`
       and `verify_all_with_one_invalid_returns_false` (renamed
       from the old `batch_verify_*` names) still pin behavior.
-- [ ] 395 — `validator.key` regeneration on missing file silently
+- [x] 395 — `validator.key` regeneration on missing file silently
       re-keys the validator. `crates/node/src/node.rs:5181-5224`.
       Refuse on non-devnet `chain_id` unless explicit
       `--init-validator-key` flag.
+      **SHIPPED.** `load_validator_identity` now takes
+      `chain_id` and refuses to mint a fresh keypair when
+      the file is missing on any non-devnet chain unless the
+      operator explicitly opts in via
+      `PYDE_INIT_VALIDATOR_KEY=1`. Pre-fix, a deleted /
+      mis-restored / never-provisioned `validator.key` would
+      silently mint a NEW keypair under a different identity —
+      the chain saw a different validator with a different
+      derived address that couldn't sign on behalf of the
+      original stake position, quietly degrading the network
+      to N-1 effective validators with no log signal.
+      Devnet (`chain_id == 31337`) keeps the silent-generate
+      ergonomics for laptop test infra.
 - [x] 400 — Slot clocks diverge by per-node startup wall-clock when
       operators boot apart. `crates/node/src/genesis.rs:972`,
       `crates/node/src/node.rs:846-869`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,12 +3644,14 @@ dependencies = [
  "pyde-vm",
  "rand 0.8.6",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "tokio",
  "toml",
+ "url",
  "zeroize",
 ]
 
@@ -4204,6 +4206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,6 +4232,16 @@ dependencies = [
  "nix",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/account/src/auth.rs
+++ b/crates/account/src/auth.rs
@@ -10,6 +10,7 @@
 use crate::types::{Account, AuthKeys};
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 use pyde_crypto::poseidon2::poseidon2_hash;
+use std::collections::BTreeSet;
 
 /// Authentication result.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -65,6 +66,19 @@ pub fn validate_signature(account: &Account, message: &[u8], signatures: &[Vec<u
                 return AuthResult::Invalid;
             }
 
+            // Audit 389: dedup keys defensively. The `MultiSig` variant
+            // has public fields (no constructor invariant), so any
+            // caller could build a `keys: vec![k1, k1, k2]` set. With
+            // positional matching, that lets a single (k1, sig) pair
+            // satisfy two threshold positions — a 2-of-3 multisig
+            // collapses to 1-of-1 if k1 appears twice. We track which
+            // public-key bytes already counted toward the quorum and
+            // skip subsequent positions whose key is a repeat. The
+            // `from_bytes` constructor below also rejects duplicate
+            // keys at the deserialization boundary so stored state
+            // can never carry a duplicate; this dedup is the in-memory
+            // safety net.
+            let mut counted: BTreeSet<&[u8]> = BTreeSet::new();
             let mut valid_count = 0u32;
             for (i, pk_bytes) in keys.iter().enumerate() {
                 if i >= signatures.len() {
@@ -72,6 +86,11 @@ pub fn validate_signature(account: &Account, message: &[u8], signatures: &[Vec<u
                 }
                 if signatures[i].is_empty() {
                     continue; // skip non-signers
+                }
+                if !counted.insert(pk_bytes.as_slice()) {
+                    // duplicate key at a different position — already
+                    // counted, do not double-credit.
+                    continue;
                 }
                 let pk = match FalconPublicKey::from_bytes(pk_bytes) {
                     Some(pk) => pk,
@@ -206,6 +225,66 @@ mod tests {
         // 2 of 3 signatures — should pass
         let result = validate_signature(&account, message, &[sig1, sig2, vec![]]);
         assert_eq!(result, AuthResult::Valid);
+    }
+
+    /// Audit 389 regression: a `MultiSig` slate with the same key
+    /// repeated twice and threshold 2 must NOT validate when only
+    /// one signature is provided (with the same sig pasted into two
+    /// positions). Pre-fix, positional matching counted the (k1, sig)
+    /// pair twice and accepted the slate as 2-of-3 quorum. Post-fix,
+    /// the dedup-by-pubkey gate inside `validate_signature` only
+    /// credits k1 once even if it appears at multiple positions.
+    #[test]
+    fn multisig_duplicate_key_does_not_double_credit_audit_389() {
+        let (pk1, sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
+
+        let mut account = Account::new_eoa(pk1.as_bytes());
+        account.auth_keys = AuthKeys::MultiSig {
+            keys: vec![
+                pk1.as_bytes().to_vec(),
+                pk1.as_bytes().to_vec(), // duplicate
+                pk2.as_bytes().to_vec(),
+            ],
+            threshold: 2,
+        };
+
+        let message = b"multisig tx";
+        let sig1 = falcon_sign(&sk1, message).unwrap().as_bytes().to_vec();
+
+        // Same sig pasted into positions 0 AND 1 (both bound to pk1).
+        // Should be rejected because pk1 only counts once.
+        let result =
+            validate_signature(&account, message, &[sig1.clone(), sig1, vec![]]);
+        assert_eq!(
+            result,
+            AuthResult::Invalid,
+            "audit 389: duplicate key positions must not satisfy threshold"
+        );
+    }
+
+    /// Audit 389 regression: `AuthKeys::MultiSig::from_bytes` must
+    /// refuse a slate with duplicate keys at the deserialization
+    /// boundary, so persisted state can't carry an unsafe slate.
+    #[test]
+    fn authkeys_from_bytes_rejects_duplicate_multisig_keys_audit_389() {
+        let (pk1, _sk1) = falcon_keygen().unwrap();
+        let (pk2, _sk2) = falcon_keygen().unwrap();
+
+        let unsafe_slate = AuthKeys::MultiSig {
+            keys: vec![
+                pk1.as_bytes().to_vec(),
+                pk1.as_bytes().to_vec(), // duplicate
+                pk2.as_bytes().to_vec(),
+            ],
+            threshold: 2,
+        };
+        let bytes = unsafe_slate.to_bytes();
+        let decoded = AuthKeys::from_bytes(&bytes);
+        assert!(
+            decoded.is_none(),
+            "audit 389: from_bytes must reject MultiSig with duplicate keys"
+        );
     }
 
     #[test]

--- a/crates/account/src/types.rs
+++ b/crates/account/src/types.rs
@@ -103,6 +103,19 @@ impl AuthKeys {
                     keys.push(data[offset..offset + klen].to_vec());
                     offset += klen;
                 }
+                // Audit 389: refuse duplicate keys at the
+                // deserialization boundary. With positional matching
+                // in `validate_signature`, duplicate keys in the slate
+                // would let one signer's (key, sig) pair count toward
+                // multiple threshold positions. Keys are FALCON-512
+                // public keys, so a "duplicate" is byte-equal pubkey
+                // bytes. Sort + adjacent-compare is O(N log N), fine
+                // for the tens-of-keys multisigs the variant supports.
+                let mut sorted: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
+                sorted.sort();
+                if sorted.windows(2).any(|w| w[0] == w[1]) {
+                    return None;
+                }
                 Some(AuthKeys::MultiSig { keys, threshold })
             }
             _ => None,

--- a/crates/net/src/propagation.rs
+++ b/crates/net/src/propagation.rs
@@ -114,13 +114,22 @@ impl CompactBlock {
 }
 
 /// Generate a random nonce for short ID computation.
+///
+/// Audit 381: pre-fix this hashed `SystemTime::now()`, which is
+/// trivially predictable (an off-path observer with a rough clock
+/// can guess the nonce within microseconds). The short-ID hash is
+/// what protects compact-block transmission from collision attacks
+/// — a predictable nonce lets a Byzantine peer pre-compute a tx
+/// whose short ID collides with another peer's tx, forcing
+/// fallback `GetBlockTxs` round-trips and amplifying bandwidth.
+/// Now backed by the OS CSPRNG via `getrandom`, which is already
+/// a transitive dep through `rand` and exposed directly here.
 fn rand_nonce() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let t = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
-    // Mix timestamp with a counter for uniqueness
-    t.as_nanos() as u64 ^ (t.as_secs().wrapping_mul(0x517cc1b727220a95))
+    let mut buf = [0u8; 8];
+    // OS CSPRNG failure is unrecoverable for consensus security;
+    // panic rather than fall back to a predictable source.
+    getrandom::getrandom(&mut buf).expect("OS CSPRNG must be available for short-id nonce");
+    u64::from_le_bytes(buf)
 }
 
 /// Block body request: request missing transactions by short ID.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -177,7 +177,10 @@ impl PydeNode {
 
         // 1. Load validator identity early (needed for genesis funding)
         let early_validator_identity = if is_validator {
-            Some(load_validator_identity(datadir)?)
+            Some(load_validator_identity(
+                datadir,
+                self.config.node.chain_id,
+            )?)
         } else {
             None
         };
@@ -5738,7 +5741,25 @@ fn handle_swarm_event(
 /// The new key is saved encrypted iff `PYDE_VALIDATOR_PASSPHRASE`
 /// is set; otherwise it falls back to the legacy raw format
 /// (preserving devnet ergonomics).
-fn load_validator_identity(datadir: &Path) -> Result<ValidatorIdentity, String> {
+///
+/// Audit 395: silent regeneration on non-devnet chain_ids was an
+/// operator footgun. If a validator's `validator.key` got deleted,
+/// moved during a backup restore, or never made it into a fresh
+/// VM image, the node would silently mint a NEW keypair and
+/// rejoin under a different identity. From the chain's perspective
+/// this is a different validator (new pubkey → new
+/// derived address) — it can't sign on behalf of the original
+/// stake position, so the original validator stops voting and the
+/// chain quietly degrades to N-1 effective validators with no log
+/// signal that something is wrong. We now refuse to silently
+/// generate on non-devnet chain_ids and require the operator to
+/// explicitly opt in via `PYDE_INIT_VALIDATOR_KEY=1`. Devnet
+/// (`chain_id == 31337`) keeps the silent-generate ergonomics so
+/// laptop test infra doesn't have to set the env var.
+fn load_validator_identity(
+    datadir: &Path,
+    chain_id: u64,
+) -> Result<ValidatorIdentity, String> {
     let key_path = datadir.join("validator.key");
     let passphrase = std::env::var("PYDE_VALIDATOR_PASSPHRASE").ok();
 
@@ -5780,6 +5801,31 @@ fn load_validator_identity(datadir: &Path) -> Result<ValidatorIdentity, String> 
             (pk, sk)
         }
     } else {
+        // Audit 395: refuse to mint a fresh keypair on non-devnet
+        // chains unless the operator explicitly opted in. Devnet
+        // (`chain_id == 31337`) preserves the silent-generate
+        // ergonomics for laptop test infra.
+        let is_devnet = chain_id == pyde_net::discovery::DEVNET_CHAIN_ID;
+        let opted_in = std::env::var("PYDE_INIT_VALIDATOR_KEY")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false);
+        if !is_devnet && !opted_in {
+            return Err(format!(
+                "validator.key missing at {} on chain_id={} — refusing \
+                 to silently generate a NEW validator identity (audit 395). \
+                 If this is a fresh validator that should mint a new key, \
+                 re-run with PYDE_INIT_VALIDATOR_KEY=1. If this is an \
+                 existing validator whose key was lost or moved, restore \
+                 the original `validator.key` from backup before starting \
+                 — silently regenerating produces a new pubkey/address \
+                 the chain doesn't recognize as your stake position, \
+                 quietly degrading the network to N-1 effective \
+                 validators.",
+                key_path.display(),
+                chain_id
+            ));
+        }
+
         // Generate new validator key
         let (pk, sk) = pyde_crypto::falcon::falcon_keygen()
             .map_err(|e| format!("failed to generate validator key: {}", e))?;

--- a/crates/pyde-dev/Cargo.toml
+++ b/crates/pyde-dev/Cargo.toml
@@ -32,6 +32,10 @@ hex = "0.4"
 # Wallet encryption
 aes-gcm = "0.10"
 rand = "0.8"
+# Audit 387: silent terminal input for password prompts so the
+# typed passphrase isn't echoed onto the operator's screen
+# (shoulder-surf / screencast leak).
+rpassword = "7"
 # Memory-hard KDF for keystore passphrases (audit 306).
 argon2 = "0.5"
 # Audit 358: Zeroizing<[u8; 32]> for the AES key derived from
@@ -44,6 +48,8 @@ pyde-tx = { path = "../tx" }
 # Deploy (RPC)
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+# Audit 388: exact-match host parsing for dev-key gate.
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/pyde-dev/src/signer.rs
+++ b/crates/pyde-dev/src/signer.rs
@@ -175,12 +175,24 @@ fn load_wallet_signer(name: &str) -> Result<Signer, String> {
 }
 
 /// Check if an RPC URL points to localhost.
+///
+/// Audit 388: pre-fix this used `String::contains` on the
+/// lowercased URL, so `http://attacker.example/?ref=localhost`,
+/// `http://127.0.0.1.attacker.example/`, or
+/// `http://evil.example/127.0.0.1` all matched as localhost
+/// — which would unlock the devnet-auto-key fallback against
+/// an attacker-controlled RPC. We now parse the URL and exact-
+/// match the host component against the loopback set; anything
+/// that fails to parse is conservatively treated as non-local.
 fn is_localhost(url: &str) -> bool {
-    let lower = url.to_lowercase();
-    lower.contains("localhost")
-        || lower.contains("127.0.0.1")
-        || lower.contains("0.0.0.0")
-        || lower.contains("[::1]")
+    let parsed = match url::Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    match parsed.host_str() {
+        Some(host) => matches!(host, "localhost" | "127.0.0.1" | "0.0.0.0" | "[::1]" | "::1"),
+        None => false,
+    }
 }
 
 fn home_dir() -> std::path::PathBuf {

--- a/crates/pyde-dev/src/wallet.rs
+++ b/crates/pyde-dev/src/wallet.rs
@@ -323,13 +323,17 @@ fn load_keystore(name: &str) -> Result<Keystore, String> {
 }
 
 /// Prompt for password from stdin (no echo).
+///
+/// Audit 387: pre-fix this used `stdin().read_line` after a plain
+/// prompt write, which left the terminal in echoing mode — every
+/// keystroke of the wallet passphrase rendered to the screen.
+/// Anyone over the operator's shoulder, on a shared screen, or
+/// scrubbing back through a terminal recording could recover the
+/// passphrase verbatim. `rpassword::prompt_password` puts the TTY
+/// into no-echo mode for the duration of the read and restores
+/// afterwards, matching `sudo` / `ssh` UX.
 pub fn prompt_password(prompt: &str) -> Result<String, String> {
-    eprint!("{}", prompt);
-    let mut password = String::new();
-    std::io::stdin()
-        .read_line(&mut password)
-        .map_err(|e| format!("cannot read password: {}", e))?;
-    Ok(password.trim().to_string())
+    rpassword::prompt_password(prompt).map_err(|e| format!("cannot read password: {}", e))
 }
 
 /// Load a wallet by name, prompt for password, return the address hex.


### PR DESCRIPTION
## Summary
Wave 1 of the public-testnet readiness sweep — five small, security-relevant audit fixes batched into one PR.

| # | What | Where |
|---|---|---|
| 381 | Compact-block short-ID nonce: SystemTime → CSPRNG | `crates/net/src/propagation.rs` |
| 387 | Wallet `prompt_password` echo → `rpassword` (no-echo TTY) | `crates/pyde-dev/src/wallet.rs` |
| 388 | `is_localhost`: `String::contains` → URL parse + host exact-match | `crates/pyde-dev/src/signer.rs` |
| 389 | MultiSig key dedup (validate_signature + from_bytes) | `crates/account/src/{auth,types}.rs` |
| 395 | `validator.key` silent regen → refuse on non-devnet without opt-in | `crates/node/src/node.rs` |

## Verification
All affected unit-test suites pass: 114 crypto + 141 consensus + 58 account (+2 new audit-389 regression tests) + 250 tx + 46 net.