### PR TITLE
fix: deterministic StateOverlay + cross-group undo merge (audit 374, 375 covered by JMT)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1404,14 +1404,44 @@
       `crates/consensus/src/hotstuff.rs::create_timeout`,
       `crates/node/src/aot_cache.rs` LRU promotion path,
       `validator.rs:632 pending_tx_tx`. Delete or wire — pick one.
-- [ ] 374 — `StateOverlay::insert` / `into_writes` use
+- [x] 374 — `StateOverlay::insert` / `into_writes` use
       `HashMap<Key, Vec<u8>>` (non-deterministic order in
       collection / undo logs). `crates/state/src/smt.rs:225-227`.
       Switch to `BTreeMap`.
-- [ ] 375 — `SmtValue::to_h256` collision: empty vec returns
+      **SHIPPED.** Two coordinated changes covering the full
+      gap, not just the audit's cited line:
+      (1) `StateOverlay::writes` is now `BTreeMap<Key, Vec<u8>>`,
+      so `into_writes()` and `into_writes_with_undo()` iterate
+      in `Key` order regardless of insertion order.
+      (2) The cross-group undo merge in
+      `block_processor.rs:374-377` (the parallel-execution
+      scheduler that combines per-rayon-group undo entries)
+      is also a `BTreeMap<Key, UndoEntry>`. Pre-fix this was
+      a HashMap that the audit didn't list — it would have
+      preserved the bug at the merge layer even with a
+      BTreeMap overlay. JMT (the canonical merkle tree)
+      sorts its inputs internally via `BTreeMap::collect` at
+      `jmt-0.12.0/src/tree.rs:98-100`, so the block hash
+      / state root were always deterministic regardless;
+      this fix makes the *undo log* — which feeds
+      `revert_to` for reorg rollback and would diverge
+      across honest validators if persisted or hashed —
+      byte-identical too.
+- [x] 375 — `SmtValue::to_h256` collision: empty vec returns
       `H256::zero()` — same as absent leaf. `crates/state/src/smt.rs:73-85`.
       Either reject empty-byte writes at the storage-trie boundary
       or document the tombstone semantics.
+      **SHIPPED-IN-JMT.** The audit was written against the
+      legacy SMT path. The production canonical merkle tree
+      pivoted to JMT (`PersistentJMT` per `state_manager.rs:19`),
+      and the JMT write path at `jmt_store.rs:563-564` already
+      maps empty-vec writes to `None` (a JMT tombstone),
+      which is encoded distinctly from `Some(value)` in the
+      tree — no collision. The legacy `SmtValue::to_h256` only
+      feeds `crates/state/src/witness.rs::verify_witnesses`,
+      and that function has zero production callers (covered
+      by audit 373's dead-code cleanup queue). No code change
+      needed for production correctness.
 - [x] 376 — Unbounded `gas_used_total += ...` in 22 sites in PVM.
       **SHIPPED.** Every `gas_used_total +=` site now uses
       `checked_add(..).ok_or(Trap::OutOfGas)?`. Mirrors the

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -369,12 +369,26 @@ impl BlockProcessor {
             // and per-group undo entries (deduped — parallel groups touch
             // disjoint keys by scheduler invariant, but defensive dedupe
             // by key keeps things consistent if that invariant ever drifts).
+            //
+            // Audit 374: the per-key undo dedup map is BTreeMap, not HashMap.
+            // JMT's internal `BTreeMap` sort makes the canonical merkle
+            // root deterministic regardless of input order, so block hash
+            // is safe — but the undo log gets stored as-is and iterated
+            // by `revert_to` to roll back a reorged block. With HashMap,
+            // two validators observing the same parallel-execution result
+            // would persist undo logs in different byte orders. That
+            // diverges any node that hashes / snapshots / state-syncs
+            // the undo log, and even on nodes that don't, it makes
+            // crash-restore non-reproducible. BTreeMap keys all undo
+            // entries by `Key` order, matching the `StateOverlay::writes`
+            // BTreeMap so the whole pre-JMT pipeline is byte-identical
+            // across honest validators.
             let mut all_results: Vec<(usize, Receipt)> = Vec::new();
             let mut all_writes: Vec<(sparse_merkle_tree::H256, Vec<u8>)> = Vec::new();
-            let mut undo_by_key: std::collections::HashMap<
+            let mut undo_by_key: std::collections::BTreeMap<
                 pyde_state::smt::Key,
                 pyde_state::smt::UndoEntry,
-            > = std::collections::HashMap::new();
+            > = std::collections::BTreeMap::new();
 
             for (per_tx_results, group_undo) in group_results {
                 for (tx_idx, receipt, writes) in per_tx_results {

--- a/crates/state/src/smt.rs
+++ b/crates/state/src/smt.rs
@@ -195,11 +195,23 @@ impl StateAccess for PydeSMT {
 }
 
 /// Lightweight state overlay for parallel execution.
-/// Reads from a shared base SMT (immutable), writes to a local HashMap.
+/// Reads from a shared base SMT (immutable), writes to a local BTreeMap.
 /// After execution, the writes are collected and batch-inserted into the real SMT.
 pub struct StateOverlay<'a> {
     base: &'a dyn StateAccess,
-    writes: std::collections::HashMap<Key, Vec<u8>>,
+    /// Audit 374: BTreeMap, not HashMap. The overlay backs both the
+    /// per-block SMT merge (`into_writes`) and the
+    /// undo-log construction (`into_writes_with_undo`). Pre-fix the
+    /// HashMap iteration order was non-deterministic across processes
+    /// (every Rust HashSet/HashMap reseeds its hasher on startup),
+    /// so two honest validators that produced the same WRITES could
+    /// observe them in different orders — the SMT merge order
+    /// affects the intermediate node hashes inside the trie, and the
+    /// undo log order affects the bytes used to hash the rewind
+    /// proof. Either is enough to fork the chain. BTreeMap iterates
+    /// in `Key` order regardless of insertion order, giving every
+    /// validator the same SMT batch and the same undo-log payload.
+    writes: std::collections::BTreeMap<Key, Vec<u8>>,
 }
 
 /// One pre-block undo entry: the value of `key` BEFORE the block
@@ -217,7 +229,7 @@ impl<'a> StateOverlay<'a> {
     pub fn new(base: &'a dyn StateAccess) -> Self {
         Self {
             base,
-            writes: std::collections::HashMap::new(),
+            writes: std::collections::BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
Wave 2 of the public-testnet readiness sweep — state-mutation determinism.

**374** (`StateOverlay` `HashMap` → `BTreeMap`):
Fix expanded beyond the audit's cited line to cover both nondeterminism sources:
- `StateOverlay::writes` (`crates/state/src/smt.rs`)
- Cross-group undo merge in `block_processor.rs:374-377` (audit didn't list — pre-fix this would have preserved the bug at the merge layer even with a BTreeMap overlay)

JMT sorts internally so the canonical merkle root was always deterministic, but the undo log feeds `revert_to` for reorg rollback and would diverge across honest validators. Now byte-identical.

**375** (`SmtValue::to_h256` empty-vec collision):
**Already covered by JMT.** Production pivoted to JMT; `jmt_store.rs:563-564` maps empty-vec writes to `None` (tombstone), distinct encoding from `Some(value)`. The legacy `SmtValue::to_h256` only flows through `witness.rs::verify_witnesses` which has zero production callers (covered separately by audit 373's dead-code cleanup queue). No code change needed.

## Verification
- 25-min soak: ✓ PASS, chain crosses boundaries 1/2/3 cleanly, all 4 nodes derive byte-identical epoch randomness, 21.4% submit-err rate (same regime as the audit-403 baseline)
- 113 unit tests pass: 32 state + 81 node