### PR TITLE
fix(faucet,genesis): bound signing-queue depth + refuse mainnet chain_id (audits 382, 383)

### DIFF
--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1549,10 +1549,32 @@
       collides with another peer's tx, forcing fallback
       `GetBlockTxs` round-trips and amplifying compact-block
       bandwidth.
-- [ ] 382 — Faucet `signing_lock` doesn't bound queue length;
+- [x] 382 — Faucet `signing_lock` doesn't bound queue length;
       semaphore + 503 on saturation. `crates/node/src/faucet.rs:430-460`.
-- [ ] 383 — `pyde testnet --chain-id 1` not refused.
+      **SHIPPED.** Added `signing_capacity:
+      Arc<tokio::sync::Semaphore>` with `MAX_FAUCET_QUEUE = 16`
+      permits alongside the existing `signing_lock`. Each
+      handler calls `try_acquire_owned` before waiting on the
+      lock; if no permit is available the request is shed
+      with HTTP 503 (`{"error":"faucet queue saturated, retry
+      shortly"}`). Worst-case waiter count is bounded to 16
+      → single-digit MB of queued tokio-task RAM under DoS,
+      vs unbounded growth pre-fix.
+- [x] 383 — `pyde testnet --chain-id 1` not refused.
       `crates/node/src/genesis.rs:845-1368`.
+      **SHIPPED.** `generate_testnet` now rejects
+      `chain_id == MAINNET_CHAIN_ID (1)` with an explicit
+      error directing the operator to the canonical testnet
+      id (7331) or the dedicated mainnet genesis ceremony.
+      Pre-fix an operator could silently mint a fake mainnet
+      genesis with arbitrary validator keys + a faucet pre-
+      funded address; anything signed against that genesis
+      carried the real mainnet `chain_id` and could be
+      replayed onto mainnet later. Two existing tests updated
+      to use `TESTNET_CHAIN_ID` instead of the hardcoded `1`,
+      plus a new regression test
+      (`generate_testnet_refuses_mainnet_chain_id_audit_383`)
+      pins the refusal contract.
 - [x] 384 — Mempool `EncryptedTx` `add()` (structural-only) accepts
       sig length [500, 1000] — verify mainnet path always takes
       `Verify` or `Reject`, never `StructuralOnly`.

--- a/crates/node/src/faucet.rs
+++ b/crates/node/src/faucet.rs
@@ -46,6 +46,15 @@ use tokio::net::TcpListener;
 /// peak (entry size ≈ 100B at the worst case) stays bounded.
 const RATE_LIMITER_MAX_ENTRIES: usize = 50_000;
 
+/// Audit 382: ceiling on the number of in-flight requests that are
+/// allowed to be waiting on the signing-serialization lock at any
+/// moment. Beyond this, new requests get an immediate HTTP 503
+/// rather than queueing further. The signing path is intrinsically
+/// sequential (per-faucet nonce race) so adding queue capacity
+/// trades only memory; this cap pins the worst-case to single-digit
+/// MB even under sustained DoS.
+const MAX_FAUCET_QUEUE: usize = 16;
+
 /// Audit 347: a syntactically valid Pyde address is exactly
 /// `0x` + 64 hex digits (case-insensitive). Anything else is a
 /// malformed request and must be rejected BEFORE the rate-limiter
@@ -606,6 +615,22 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
     // in `send_faucet_tx` for the mempool-dedup interaction.
     let signing_lock: Arc<tokio::sync::Mutex<()>> = Arc::new(tokio::sync::Mutex::new(()));
 
+    // Audit 382: bound the queue depth on the signing serialization.
+    // The `signing_lock` mutex itself is unbounded — under DoS, every
+    // request that survives the per-IP and per-address rate limits
+    // queues on this mutex, and the queue grows linearly in spawned
+    // tokio tasks plus their captured Arc state until the runtime
+    // OOMs. The signing serialization is sequential by design (nonce
+    // race), so the only valid backpressure is to refuse new work
+    // when the queue is already deep. `signing_capacity` is a
+    // `Semaphore` with `MAX_FAUCET_QUEUE` permits; each handler
+    // calls `try_acquire_owned` before waiting on `signing_lock` and
+    // returns 503 if no permit is available. With `MAX_FAUCET_QUEUE
+    // = 16`, the worst-case queue depth on the lock is 16 (one
+    // active signer + 15 waiters), bounding RAM at single-digit MB.
+    let signing_capacity: Arc<tokio::sync::Semaphore> =
+        Arc::new(tokio::sync::Semaphore::new(MAX_FAUCET_QUEUE));
+
     let trust_xff = config.trust_x_forwarded_for;
 
     loop {
@@ -620,6 +645,7 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
         let from = from.clone();
         let signer = signer.clone();
         let signing_lock = signing_lock.clone();
+        let signing_capacity = signing_capacity.clone();
 
         tokio::spawn(async move {
             handle_connection(
@@ -632,6 +658,7 @@ pub async fn run_faucet(config: FaucetConfig) -> Result<(), String> {
                 amount,
                 signer,
                 signing_lock,
+                signing_capacity,
                 chain_id,
                 trust_xff,
             )
@@ -651,6 +678,7 @@ async fn handle_connection(
     amount: u64,
     signer: Arc<Option<FaucetSigner>>,
     signing_lock: Arc<tokio::sync::Mutex<()>>,
+    signing_capacity: Arc<tokio::sync::Semaphore>,
     chain_id: u64,
     trust_xff: bool,
 ) {
@@ -771,6 +799,7 @@ async fn handle_connection(
                     amount,
                     signer.as_ref().as_ref(),
                     &signing_lock,
+                    &signing_capacity,
                     chain_id,
                 )
                 .await
@@ -807,6 +836,7 @@ async fn handle_connection(
                         amount,
                         signer.as_ref().as_ref(),
                         &signing_lock,
+                        &signing_capacity,
                         chain_id,
                     )
                     .await
@@ -831,6 +861,7 @@ async fn serve_dispense(
     amount: u64,
     signer: Option<&FaucetSigner>,
     signing_lock: &tokio::sync::Mutex<()>,
+    signing_capacity: &Arc<tokio::sync::Semaphore>,
     chain_id: u64,
 ) -> String {
     // Both rate limits must pass. Check before dispense; record only
@@ -851,6 +882,25 @@ async fn serve_dispense(
             &format!(r#"{{"error":"ip rate limited","retryAfter":{}}}"#, secs),
         );
     }
+    // Audit 382: bound queue depth on the signing-serialization lock.
+    // `try_acquire_owned` is non-blocking; if the queue is full
+    // (`MAX_FAUCET_QUEUE` requests already waiting on `signing_lock`),
+    // shed load with HTTP 503 rather than letting tokio tasks pile
+    // up holding their captured Arc state.
+    let _queue_permit = match signing_capacity.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!(
+                to = %address,
+                ip = %ip_key,
+                "faucet queue saturated — returning 503 (audit 382)"
+            );
+            return json_response(
+                503,
+                r#"{"error":"faucet queue saturated, retry shortly"}"#,
+            );
+        }
+    };
     match send_faucet_tx(rpc, from, address, amount, signer, signing_lock, chain_id).await {
         Ok(tx_hash) => {
             addr_limiter.record(address);

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -886,6 +886,26 @@ pub fn generate_testnet(
     if num_full_nodes > 16 {
         return Err("full_nodes must be 0..=16".into());
     }
+    // Audit 383: refuse to generate testnet artifacts for the
+    // mainnet chain_id. The `pyde testnet` command is intended
+    // for local devnets and the canonical public testnet
+    // (`chain_id == 7331`); accepting `chain_id == 1` would
+    // let an operator silently mint a fake mainnet genesis with
+    // arbitrary validator keys and a faucet pre-funded address.
+    // Anything signed against that genesis would carry the real
+    // mainnet chain_id and could be replayed onto mainnet later.
+    if chain_id == pyde_net::discovery::MAINNET_CHAIN_ID {
+        return Err(format!(
+            "refusing to generate testnet artifacts for chain_id={} \
+             (the canonical mainnet id) — `pyde testnet` is for \
+             devnets and the canonical public testnet \
+             (chain_id={}). Pick a different chain_id, or use the \
+             dedicated mainnet genesis ceremony when launching \
+             mainnet (audit 383).",
+            chain_id,
+            pyde_net::discovery::TESTNET_CHAIN_ID,
+        ));
+    }
 
     let total_nodes = num_validators + num_full_nodes;
     if let Some(addrs) = node_addrs {
@@ -1587,7 +1607,10 @@ mod tests {
                 port: 30305,
             },
         ];
-        generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, 1, 400, Some(&addrs)).unwrap();
+        // Audit 383: chain_id=1 (mainnet) is now refused by
+        // `generate_testnet`. Use the canonical testnet id for
+        // tests that exercise the distributed-write surface.
+        generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, pyde_net::discovery::TESTNET_CHAIN_ID, 400, Some(&addrs)).unwrap();
 
         // node-0's config must:
         //  - carry its own region/host as a comment header
@@ -1631,9 +1654,47 @@ mod tests {
             port: 1,
         }];
         // 4 validators but only 1 addr → mismatch
-        let err = generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, 1, 400, Some(&addrs))
-            .unwrap_err();
+        // Audit 383: avoid chain_id=1 (mainnet) which is now refused.
+        let err = generate_testnet(
+            tmp.path(),
+            4,
+            0,
+            30303,
+            8545,
+            true,
+            pyde_net::discovery::TESTNET_CHAIN_ID,
+            400,
+            Some(&addrs),
+        )
+        .unwrap_err();
         assert!(err.contains("entries but expected"), "got: {err}");
+    }
+
+    /// Audit 383 regression: `pyde testnet --chain-id 1` (the canonical
+    /// mainnet id) must be refused. Pre-fix an operator could
+    /// silently mint a fake mainnet genesis with arbitrary validator
+    /// keys + a faucet pre-funded address; signed txs against it
+    /// could be replayed onto real mainnet later.
+    #[test]
+    fn generate_testnet_refuses_mainnet_chain_id_audit_383() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = generate_testnet(
+            tmp.path(),
+            4,
+            0,
+            30303,
+            8545,
+            true,
+            pyde_net::discovery::MAINNET_CHAIN_ID,
+            400,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("refusing to generate testnet artifacts"),
+            "expected mainnet refusal, got: {err}"
+        );
+        assert!(err.contains("audit 383"), "expected audit 383 ref, got: {err}");
     }
 
     /// Audit 400: the generator must stamp a real wall-clock


### PR DESCRIPTION
## Summary
Wave 3 of the public-testnet readiness sweep — operator hardening.

**382** Faucet `signing_lock` queue bound:
- New `signing_capacity` semaphore with `MAX_FAUCET_QUEUE = 16` permits
- `try_acquire_owned` before the existing `signing_lock`; HTTP 503 on saturation
- Worst-case waiter count bounded to 16, vs unbounded pre-fix

**383** Refuse `pyde testnet --chain-id 1`:
- `generate_testnet` rejects mainnet chain_id with an explicit error pointing operators at `TESTNET_CHAIN_ID = 7331` or the dedicated mainnet genesis ceremony
- Pre-fix an operator could silently mint a fake mainnet genesis (replay-attackable)
- Existing tests updated to use `TESTNET_CHAIN_ID`; new regression test pins the contract

## Verification
318 `pyde-node` tests pass (+1 new audit-383 regression test).