### PR TITLE
fix: audits 404-408 + TPL-201 + whitepaper v0.9 draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ MAINNET_PLAN.md
 BENCH_PLAN.md
 BENCH_CONTRACTS.md
 EXPLORER_PLAN.md
+TESTNET_LAUNCH_TRACKER.md
 
 # cargo-fuzz artefacts (task 053). Crate lives outside the workspace
 # and has its own Cargo.lock + target/ dir + corpus dir which we don't

--- a/AUDIT_FINDINGS_2.md
+++ b/AUDIT_FINDINGS_2.md
@@ -1967,6 +1967,139 @@
       for epochs 2/3/4 (`e1b80a7c…`, `337785f7…`, `3a93693e…`).
       A 1h follow-up soak confirms the same across boundaries
       4–6.
+- [x] 404 — `otic::compile_all` silently bypasses the frontend
+      (resolve + typecheck + safety), so production callers and
+      test fixtures that didn't run the frontend separately got
+      a "lex + parse + lower + codegen" pipeline that accepted
+      contracts the strict typechecker rejects. Surfaced while
+      writing the bombard suite for a multi-laptop network
+      stress test: the same `SUITE_SRC` that compiled cleanly
+      via `compile_all` (the path the local soak takes) failed
+      under `pyde-dev build` with two distinct errors —
+      "signed integer type `i64` is not supported (audit 354)"
+      and "address() expects 'self' or an Address, found
+      Helper". Audit 354 already documents the codegen issue
+      (no signed-int ISA opcodes; `<`, `>`, `/`, `%`, `>>` on
+      i64/i128/i256 silently produce wrong results), and the
+      typechecker rejects those types at the AST level — but
+      the lax `compile_all` path skipped the typechecker, so
+      `loadgen_soak.rs` happily compiled `signed_val: i64` +
+      `checked_signed(delta: i64)` for hours of soak runtime
+      while reporting `ok=735 err=0` for the bucket against
+      bytecode whose comparisons were silently broken
+      (additions wrap correctly in two's complement; the
+      `assert!(self.signed_val > -1000)` line ran an unsigned
+      comparison that gave the right answer by coincidence
+      for the test's input range). The same bypass also let
+      `pyde-dev script` (the production developer toolchain)
+      compile scripts with undefined identifiers, multi-
+      constructor contracts, view functions that write state,
+      and audit-356 selector collisions — all of which the
+      typechecker / safety pass would have caught.
+
+      Production leak surface: `crates/pyde-dev/src/script.rs`
+      called `compile_all` without first running the frontend.
+      Every other production caller (`pyde-dev build`, `otic`
+      CLI) explicitly ran the frontend first.
+
+      **SHIPPED.** Three coordinated changes:
+
+      (1) `crates/otic/src/lib.rs` — split the public API.
+      `compile_all_unchecked` retains the old lex+parse+
+      lower+codegen behaviour for compiler-internal tests
+      (`crates/otic/src/codegen.rs` codegen self-tests, AOT
+      cache tests, `pyde-dev build` and `otic` CLI which run
+      the frontend explicitly first). The new strict
+      `compile_all` runs lex → parse → resolve → typecheck →
+      safety → lower → codegen and returns
+      `Result<Vec<...>, String>` with formatted diagnostics
+      on any frontend failure. Production callers that don't
+      separately run the frontend now route through this
+      path.
+
+      (2) `crates/pyde-dev/src/script.rs` — migrated to the
+      strict `compile_all`. Bubbles diagnostics up as a
+      formatted error for the operator. Pre-fix this was the
+      only production toolchain that silently accepted
+      audit-354 violations and selector collisions.
+
+      (3) `crates/node/tests/loadgen_soak.rs` — SUITE_SRC
+      cleaned of patterns the strict typechecker rejects.
+      `signed_val: i64` + `checked_signed(delta: i64)` are
+      gone (broken arithmetic per audit 354; reintroduce
+      post-codegen-signed-int-support). The `Spawner.spawn()`
+      method no longer captures the deployed child's address
+      via `address(deploy!(Helper))` (which the strict path
+      rejects); it calls `child.ping()` instead, still
+      exercising CREATE → constructor → runtime install
+      end-to-end. The default workload drops from 9 to 8
+      buckets (no more `SignedMath`).
+
+      Test files using `compile_all` in fixtures stayed on
+      the renamed `compile_all_unchecked` (`crates/tx/src/
+      pipeline.rs` test code, `crates/node/tests/*.rs`,
+      `crates/aot/src/lib.rs` AOT cache tests). They probe
+      chain pipeline behaviour against simple contracts that
+      should pass the strict frontend; migrating each one
+      individually to `compile_all` is a follow-up to
+      surface any latent contract bugs in those fixtures.
+
+      Verified by extracting the cleaned `SUITE_SRC` to a
+      `pyde-dev` project and running `pyde-dev build`:
+      Helper (135 instructions), MegaContract (951
+      instructions), Spawner (1036 instructions), all three
+      compile cleanly through the full frontend. 1714 / 1714
+      workspace lib tests pass post-fix. 25-min soak confirms
+      end-to-end: chain crosses boundaries 1/2/3 cleanly, all
+      4 nodes derive byte-identical epoch randomness, 8/8
+      workload buckets exercised, 21.1% submit err (same
+      regime as the audit-403 baseline).
+- [x] 405 — `address(<contract or interface handle>)` rejected
+      by the strict typechecker, blocking the canonical factory
+      pattern (`Spawner::spawn() -> Address` returning the
+      deployed child's address). The shape compiled silently via
+      the lax `compile_all_unchecked` path and produced WRONG
+      bytecode: the lower pass for `address(...)` always emitted
+      `BuiltinOp::AddressOfSelf` regardless of argument, so
+      `let child = deploy!(Helper); address(child)` returned the
+      factory's OWN address instead of the deployed child's.
+      `simple_factory.oti` (the otic test suite's canonical
+      factory fixture) shipped with this exact pattern; its
+      `lower_simple_factory` test passed because it only checks
+      that the IR is non-empty + Display doesn't panic, not that
+      the emitted opcodes do the right thing.
+
+      **SHIPPED.** Two coordinated changes:
+
+      (1) `crates/otic/src/typecheck.rs::call` — `address(arg)`
+      now accepts `Ty::Contract(_)` and `Ty::Interface(_)` in
+      addition to `self`, `Ty::Address`, `Ty::Unknown`, and
+      `Ty::Error`. The error message updates to
+      "expects 'self', an Address, or a Contract/Interface
+      handle".
+
+      (2) `crates/otic/src/lower.rs::Expr::Call` — the
+      `address(...)` arm differentiates by argument shape:
+      `address(self)` still emits `BuiltinOp::AddressOfSelf`,
+      but for any other argument we emit
+      `Inst::Cast(dst, src, Ty::Address)`. Codegen lowers the
+      Wide → Wide cast to a `Wmov` (or no-op if the register
+      allocator picks `dst == src`), preserving the 32-byte
+      address bits — Contract / Interface handles + Address
+      all share the same wide-register layout, so the copy is
+      bit-exact.
+
+      Regression test
+      `check_address_of_contract_handle_audit_405` in
+      `typecheck::tests` pins the typechecker rule. The full
+      otic test suite (387 unit + integration tests) is
+      green post-fix. The same 25-min soak that verified
+      audit 404 also verified this fix end-to-end (the
+      cleaned SUITE_SRC's Spawner exercises CREATE +
+      constructor + runtime install per spawn; future re-
+      introduction of the canonical
+      `address(deploy!(Helper))` capture will compile via
+      strict).
 
 ---
 

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -1,0 +1,1863 @@
+# Pyde
+
+**A Post-Quantum Layer 1 with Native MEV Protection**
+
+Version 0.9 — May 2026
+Zarah Systems
+Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+---
+
+## Abstract
+
+Crypto is approaching a transition. The cryptography that secures every major Layer 1 in production today — secp256k1, Ed25519, BLS12-381 — falls to a quantum computer running Shor's algorithm, and the timeline for cryptographically-relevant quantum compresses every year. The MEV market on incumbent chains has hardened into a multi-billion-dollar extraction surface paid by retail users to validator-builder coalitions. The chains chasing throughput have made validation a Wall Street business; the chains chasing decentralization have made throughput unusable. The next default Layer 1 — the chain crypto runs on for the decade after this one — will need to be post-quantum-secure, MEV-free at the protocol layer, sub-second-final, and decentralized on commodity hardware. **No chain in production today is all four.** The major incumbents — Ethereum, Solana, Aptos, Sui, Cardano, Bitcoin — are working on the missing properties through migration roadmaps that are honest multi-year coordinated upgrades across deployed contracts, entrenched wallets, and trillions of dollars of value at risk. NIST's 2024 standardization of FALCON, ML-DSA, and ML-KEM unblocked the cryptographic primitives the field had been waiting for, but the cost of retrofitting them into a live chain is structural, not technological. Pyde is the chain built greenfield to ship every property as the default from genesis. Every signature uses FALCON-512. Every mempool transaction is encrypted under a Kyber-768 threshold key held by a 128-validator committee. Sandwich attacks, frontrunning, and proposer extraction become structurally impossible — not policed, not auctioned, not made more efficient, but eliminated. Validators run on 8 cores and 16 GB of RAM with one vote each regardless of stake; cross-network interactions — calling functions on other chains, querying oracles, requesting off-chain compute — happen through a permissionless parachain layer of decentralized infrastructure providers that follow a Pyde-published spec, stake PYDE, and earn the gas fees from the contracts that call them, with no slot auctions and no separate token to hold. The execution layer is a register-based virtual machine with parallel scheduling driven by declared access lists; the design target is 12,500 sustained TPS at 400 ms slot time, with 4,000 TPS sustained / 7,000 TPS burst measured today on a four-validator laptop devnet against real FALCON signatures at 100 % inclusion. The window for a greenfield chain to occupy the post-quantum, MEV-free, commodity-validated category is open and time-bound. Pyde is the chain built to occupy it.
+
+---
+
+## Executive Summary
+
+### What Pyde is
+
+Pyde is the chain built for what comes after the current generation of L1s. It is a monolithic Layer 1 — consensus and execution share a single binary — built around four properties that the next default Layer 1 will need to have, that no chain in production today has all of, and that this paper defends in technical detail. Each claim below is falsifiable; each is anchored in shipped code in the current branch.
+
+**1. Post-quantum security is the default, not an upgrade.** The major L1s have not been blind to the quantum threat. Ethereum has tracked post-quantum migration in research and roadmap discussions since 2020; Solana, Cardano, and Bitcoin have active working groups exploring migration paths; NIST's 2024 standardization of FALCON, ML-DSA, and ML-KEM has unblocked the cryptographic primitives the field had been waiting for. The structural challenge is retrofitting post-quantum signatures onto chains with deployed contracts, entrenched wallets, and historical signed state — a multi-year coordinated upgrade across every node, every wallet, every signing library, and every contract that hard-codes a key format. Pyde's claim is not that incumbents have ignored the problem. It is that a chain built greenfield does not pay the migration cost. Every signature that secures consensus, every key that authorizes a transaction, every encryption used to hide a transaction's contents from validators uses NIST-standardized lattice-based cryptography from the genesis block. FALCON-512 (NIST FIPS 206) signs consensus votes, transaction authorizations, and validator key registrations. Kyber-768 / ML-KEM (NIST FIPS 203) encrypts mempool transactions. Poseidon2 over the Goldilocks field hashes blocks, transactions, and Merkle nodes. Ed25519 appears only in libp2p's noise transport for peer routing; an attacker who breaks Ed25519 learns which IP addresses validators connect to but cannot forge a block, decrypt a transaction, or steal an account. The chain that ships post-quantum signatures as the default — at production scale, on commodity hardware, with no migration tax — establishes the cryptographic baseline for the era after the one we are currently in. The migration cost the incumbents face is the moat that protects that position.
+
+**2. MEV is removed at the protocol layer.** Transactions enter the mempool encrypted under a threshold public key held jointly by the 128-validator committee. The block proposer publishes a Poseidon2 commitment to the ordering of those encrypted transactions before any of the validators releases a decryption share. After 86 of 128 shares converge, the validators jointly decrypt and execute the block — but the order is already locked, and every decrypted transaction up to the gas limit must appear in the sealed block. A proposer who reorders, drops, or front-runs a transaction is detectable and slashable. Sandwich attacks and frontrunning become ill-defined operations rather than market activities. Every billion dollars extracted via MEV from retail users on incumbent chains is a billion dollars of users learning that the chain they use is not built for them. The chain that removes that tax structurally — not by auctioning it more efficiently — is the chain those users move to as soon as a credible alternative exists.
+
+**3. Sub-second finality with a credible throughput target.** A modified pipelined HotStuff consensus protocol with VRF-based proposer selection produces blocks every 400 ms. Hard finality — an 86-of-128 FALCON quorum certificate on a finality cert — typically lands within one or two slots. Today's measured throughput on a four-validator devnet is 4 K TPS sustained × 10 min and 7 K TPS burst × 30 s, both at 100 % inclusion against full FALCON signature verification. The design target on cloud-class hardware is 12,500 sustained TPS / 50,000 peak; the gas-model ceiling — 400 M target block gas at ~52 K average gas per transaction in a realistic mixed workload — implies ~19 K theoretical TPS, leaving headroom above the design target. Sub-second finality at retail-scale throughput is a category, not a feature. The chain that holds the category becomes the default surface for the consumer applications, payment systems, and high-frequency dApps that today's chains are still bottlenecked behind multi-minute finality or unstable peak throughput from serving.
+
+**4. True decentralization at three layers.** Pyde's mainnet validator hardware spec is 8 cores, 16 GB of RAM, 500 GB of NVMe SSD, and 100 Mbps symmetric network — a developer workstation, not a data-center node. Every committee member has exactly one vote regardless of stake; the 10,000 PYDE bond is anti-sybil, not a power multiplier. Cross-network interactions — calling a function on Solana, querying an oracle, requesting off-chain compute — happen through a permissionless **parachain layer** of decentralized infrastructure providers who implement a Pyde-published specification, stake PYDE as their bond, and earn gas fees from the contracts that call them via the `cross_call!` macro. There are no slot auctions, no parachain-team gatekeeping, no permissioned inclusion; the spec is the contract, the implementations are open source and competitive. Combined gas (Pyde-side + parachain-side) is computed at call time and billed in one transaction, so the parachain layer is invisible to the user. The combined effect is that participation in Pyde — running a node, validating, building or operating a parachain — is a function of will and a small fixed bond, not of access to data-center capital, governance lobbying, or auction proceeds. Decentralization is the asymmetric property: a chain that has become a data-center business cannot become a workstation business without breaking its own validator set. Pyde gets to make this choice once. Incumbents get to fight it forever.
+
+### State of build
+
+Of the 143-task mainnet readiness plan derived from the April 2026 internal audit, 86 are complete, 6 are partial, and 51 are open. What is shipped:
+
+- All 15 production Rust crates compile, test, and run as a single binary.
+- Multi-node consensus reaches finality, recovers from leader failure, slashes double-signers, and rotates committees at epoch boundaries (verified across a 4-node devnet).
+- The encrypted mempool round-trip — submit, threshold-encrypt, ordering commitment, threshold decrypt, seal — passes end-to-end with state roots converging across all nodes.
+- 4 K TPS sustained × 10 min at 100 % inclusion on a four-validator laptop devnet with full FALCON signatures.
+- Hardened transaction decoders (audit 301), pinned chain-id RPC and faucet (audits 302, 303), production-rejected dev-mode signature paths (audit 304), Argon2id keystore encryption shared across node, SDK, and developer tools (audit 306).
+
+What runs today is consensus-correct and survives partition-and-heal, double-sign, and 2-of-7 validator-offline tests. What remains for mainnet is the cloud-validated throughput run at the 12.5 K target, a five-track external audit programme, an incentivized testnet, and the 128-validator genesis ceremony.
+
+### What's deferred to post-mainnet
+
+Mainnet ships with committee-only finality. Validators execute every block they vote on, and finality is the FALCON quorum certificate. The post-mainnet roadmap is substantial and deliberately staged: the **parachain layer** for cross-chain routing, oracle networks, indexers, and off-chain compute (~ + 6-to-12 months); **programmable accounts** and **native session keys** for full account abstraction; **STARK execution proofs** as a parallel finality path (~ + 18-30 months); **ZK proofs as a parachain attestation mode** (~ + 24-36 months), unifying Pyde and its parachain layer into a verifiable computation network where every operation can be cryptographically proved when the cost-benefit ratio justifies it; signed mempool censorship commitments with cryptographic slashing; expanded TypeScript SDK coverage. Two-chamber on-chain governance was explicitly evaluated and rejected (§14.2). Section 19 catalogues every post-mainnet item honestly. Investors and auditors who read the original architecture proposals will notice that mainnet ships less than the original ambition contemplated and that the post-mainnet roadmap is on a credible path; we'd rather frame both than be caught by either.
+
+### Tokenomics in one paragraph
+
+PYDE has a 1 billion token genesis supply with a decreasing inflation schedule (5 % year 1 → 3 % → 2 % → 1 %, fixed thereafter). Each validator stakes 10,000 PYDE — one bond per committee seat, 128 seats — and earns from a two-tier reward stream: protocol inflation, plus a 20 % share of every transaction's base fee. Of each base fee, 70 % is burned, 20 % goes to the validator, and 10 % accrues to a multisig-controlled treasury. The fee model is EIP-1559 with elastic 4× blocks and no priority tips — there is no priority signal because the encrypted mempool eliminates the information asymmetry that priority fees price. The combined effect — high blockspace supply at the design target, no priority tips, no MEV tax on the all-in cost, no separate token to hold for oracle or cross-chain calls — is structurally low effective transaction cost at every utilization level (§12.6).
+
+### Governance in one paragraph
+
+Pyde's governance is deliberately off-chain. Protocol changes go through Pyde Improvement Proposals (PIPs) — a public, versioned process modeled on Bitcoin's BIPs and Ethereum's EIPs, ratified by PIP-0001. There is no on-chain stake-weighted voting on protocol upgrades; validators upgrade voluntarily, hard forks happen by social consensus, and the chain that retains 67 %+ of stake is the legitimate continuation. On-chain governance is restricted to treasury spending and emergency operations, both gated by an M-of-N FALCON multisig with a 30-day-bounded emergency-pause primitive.
+
+### UX and DX as protocol surface
+
+Pyde treats user and developer experience as protocol surface, not application work. **Multisig is a native account mode**, not a contract every project re-deploys against subtly different security assumptions. **Programmable accounts** ship as a post-mainnet extension of the same account model — opt-in, sandboxed PVM bytecode policies that express spend limits, time locks, allow-listed recipients, tiered authorization, and recovery flows without a separate account-abstraction stack. **Native session keys** ship alongside, giving dApps the ability to act on a user's behalf within a registered scope (specific contracts, capped spend, slot-bounded duration) without a wallet popup per action — the missing primitive for gaming, AI agents, and consumer apps that has been a hand-rolled retrofit on every major chain to date. **First-class Rust and TypeScript SDKs** ship from day one — the TypeScript SDK is at ethers-equivalent maturity today (provider, FALCON-aware wallet, ABI-aware contract layer, WASM-compiled crypto). The **Otigen smart-contract language** ships with reentrancy blocked by default, checked arithmetic, and protocol-aware primitives. The **`pyde-dev` CLI** mirrors the Foundry / Hardhat developer loop (`build`, `test`, `deploy`, cheatcodes, scripted deployments). The full validator binary is a single executable with one config file. Where other chains require an ecosystem to materialize the developer surface, Pyde ships the surface.
+
+### Use of capital, in shape
+
+The path from this paper to mainnet runs through, in order:
+
+1. Cloud-validated stress testing of the 12.5 K sustained / 50 K peak TPS targets on server-class hardware (the laptop devnet has thermal-bound the test).
+2. A five-track external audit programme covering consensus, the PVM, the post-quantum cryptography, networking, and the otic compiler. Each track engages a separate specialist firm; the consolidated programme is the dominant pre-mainnet line item.
+3. A 3+ month incentivized testnet with reference dApps (DEX, lending market, NFT marketplace), a fully-funded bug bounty, and remediation of all critical and high findings before launch.
+4. A 128-validator genesis ceremony, geo-distributed, with hardware-benchmarked operators who participated in the incentivized testnet.
+
+This whitepaper is the technical credibility document for the testnet-to-mainnet capital deployment. It is not a fundraise prospectus.
+
+---
+
+## 1. Introduction
+
+### 1.1 What L1s left on the table
+
+Seventeen years after Bitcoin's genesis block and eleven years after Ethereum's smart-contract launch, Layer 1 blockchains carry four open architectural debts that the industry has learned to live with but has not solved.
+
+**Quantum risk.** Every major L1 in production today secures consensus signatures with elliptic-curve cryptography — Ed25519 in Solana, Aptos, Sui, and Cardano; secp256k1 in Bitcoin and Ethereum execution; BLS12-381 in Ethereum's beacon chain. All three fall to a sufficiently large quantum computer running Shor's algorithm.
+
+The major L1s have not been blind to this. Ethereum's research community has tracked post-quantum migration since 2020; Vitalik Buterin and others have published on lattice-based signatures and post-quantum-friendly account abstraction, and the broader Ethereum roadmap pre-positions for PQ via state expiry, account abstraction, and Verkle-tree groundwork. Solana has explored PQ alternatives in working groups. Cardano has shipped hash-based signature primitives as building blocks. The Bitcoin community has multiple BIP drafts proposing migration paths. NIST's 2024 standardization of FALCON, ML-DSA (Dilithium), and ML-KEM (Kyber) finalized the cryptographic primitives the entire field had been waiting for. The question is no longer "do we have post-quantum signatures?" — it is "how do we deploy them across chains with deployed contracts, entrenched wallets, signing libraries, and historical signed state already at billions of dollars of value at risk?"
+
+The honest answer for incumbent L1s is migration: a multi-year coordinated upgrade across every node, every wallet, every smart contract that hard-codes a key format, and every historical signature that needs to remain verifiable. Bitcoin's secp256k1-to-anything migration would require coordinating every running node and every UTXO on a chain with hundreds of billions of dollars of market value. Ethereum's path requires consensus-layer changes, wallet support across an enormous EIP surface, and likely a multi-fork transition. These efforts are realistic and underway, and the major L1 teams are competent and well-funded; the constraint is the shape of the problem, not the seriousness of the response. Migration takes years and cannot be rushed without leaving users behind.
+
+Pyde's claim is not that incumbent chains have ignored the problem. It is that a chain built greenfield does not pay the migration cost. Every signature in Pyde is FALCON from the genesis block. Every account address derives from a FALCON public key. Every encryption uses Kyber-768 / ML-KEM. There is no historical secp256k1 or Ed25519 signature to validate, no pre-quantum-derived address to migrate, no deployed contract that hard-codes a pre-quantum key format. The chain is post-quantum because nothing else has ever existed on it, and that property is structural — it cannot be lost without breaking the chain.
+
+The forecast for cryptographically-relevant quantum computers compresses each year. Recent work on lattice reductions has narrowed the timeline. The window in which it is reasonable to launch a new L1 on pre-quantum cryptography is closing; the window in which an existing L1 can finish migration before facing the threat is the harder constraint.
+
+**MEV.** Flashbots quantified MEV on Ethereum at hundreds of millions of dollars extracted per year, and the field's response has been to make the MEV market more efficient — proposer-builder separation, MEV-Boost on Ethereum, Jito on Solana, sealed-bid auction designs in the broader research literature. These are defensible engineering choices given the constraints of existing chains with deployed contracts, entrenched proposer behavior, and validator economics that already depend on MEV revenue; the work going into those designs is serious work, and the field is genuinely better for it. The alternative — removing the underlying information asymmetry at the protocol level rather than auctioning the surplus — requires consensus-protocol changes that are easier to ship at the genesis of a new chain than to retrofit into a live one. Threshold-encrypted mempools have existed in academic literature since 2018 and in research projects since shortly after; the constraint on shipping one as a default has been the cost of changing the proposer's information set on a chain that did not start out that way.
+
+The case for the protocol-level removal — Pyde's choice — is a user case. Every retail swap on a public AMM pays a sandwich tax measurable in basis points; every liquidation on a public lending market is contestable by the proposer; every NFT mint is racing against bots that can read the mempool. The aggregate cost — the surplus extracted from users to fund the sophistication of searchers and to compensate validators for not extracting it themselves — is real money, and it is the user's money. The market-design and protocol-level approaches answer different questions: PBS asks "how should this surplus be distributed?" Pyde asks "is there a protocol that does not produce the surplus in the first place?" Both questions are legitimate. Pyde's bet is that, for a greenfield chain, the second question has a cleaner answer.
+
+**Throughput at finality.** The industry has produced two extremes. Ethereum prioritizes finality at the cost of throughput — roughly 15 sustained TPS at the L1, with finality measured in minutes. Solana prioritizes throughput at the cost of stability — high peak throughput, but seven major outages between 2021 and 2024, several attributed to mempool overload and resource exhaustion. The chains in between — Aptos, Sui, Avalanche — have published throughput claims in lab settings but have not yet demonstrated sustained 12,500 TPS at sub-second hard finality on adversarial mixed workloads in production.
+
+**Validator centralization on premium hardware.** A quieter problem, related to the throughput one, is that the chains optimizing hardest for throughput have ended up making validation a premium-hosting business. Solana's effective real-world validator spec runs to 12 + cores and 256 + GB of RAM, with stated requirements that have grown over time as the chain has scaled — a coherent engineering response to the throughput target Solana set itself. The aggregate effect is that running a Solana validator at production performance is meaningfully a data-center operation, and a smaller number of professional operators run a disproportionate share of stake than the original validator-decentralization vision contemplated. Polkadot's parachain slots are auctioned because shared-security parachains depend on relay-chain validator capacity, which is a finite resource that has to be allocated — a coherent solution to the resource-allocation problem, but one that ends up concentrating slot ownership in well-capitalized parachain teams. Ethereum's L2 ecosystem ships scaling at the cost of fragmenting the user surface across L2s, each with its own sequencer, its own bridge, and its own decentralization timeline. Each of these is a sensible local optimization given the chain's starting position and the constraint set its team was working against; in aggregate, the field has been trading decentralization for throughput at rates the user-facing communication does not always make explicit. A user who picks a chain on the basis of throughput often does not see the implied trust model behind it. None of this is anyone's bad faith — it is what happens when scaling decisions get made one chain at a time and the cumulative cost lands on the user.
+
+These four problems are not independent items on a punch list. They converge in time. NIST's 2024 cryptographic standardization unblocked the post-quantum primitives at the same moment that the MEV literature matured into quantified user-cost numbers; at the same moment that Solana's stability work made the cost of premium-hardware validation visible; at the same moment that the L2 ecosystem's sequencer-trust assumptions started attracting serious public scrutiny. The industry is staring at a four-axis problem, and most of the production answers were architected for a different era — for an era when the quantum threat was theoretical, when MEV was a footnote in academic papers, when Solana's hardware spec was 4 cores and 16 GB, when the only L1 anyone needed was Ethereum. The architecture that wins the next decade does not have to be the one that won the last one. It has to be the one built for what crypto becomes next.
+
+Pyde's premise is that all four are protocol-level problems and all four are best addressed at genesis. Post-quantum cryptography can be migrated into a live chain — Ethereum, Solana, Cardano, and Bitcoin are all on that path — but the migration is a multi-year coordinated upgrade across every running validator, every wallet, every signing library, every contract that hard-codes a key format, and every historical signature that needs to remain verifiable on the new protocol. Encrypted mempools can be added to a chain whose block-builder market depends on visible order, but the political cost of removing validator MEV revenue is part of what any credible proposal has to absorb, and the existing builder-market participants are organized to defend their position. Parallel execution can be retrofitted onto a globally-serial state model — Ethereum's transient-storage and access-list EIPs are concrete steps in that direction — but the access patterns of deployed contracts were written assuming serialization, and a meaningful fraction of value-locked logic has to be re-examined transaction by transaction. All three migrations are doable. None of them are cheap, and none of them are fast. The cost of getting these properties right at launch is meaningfully smaller than the cost of changing them later, and the chain that ships them right at launch occupies the position that the incumbents are migrating toward.
+
+### 1.2 Four first principles
+
+Pyde's design is governed by four axioms. Every other choice in this paper follows from them.
+
+**Axiom 1 — Post-quantum cryptography is the default.** No application-layer signature, encryption, or hash in Pyde uses pre-quantum primitives. FALCON-512 signs every consensus vote, every transaction, every validator key registration. Kyber-768 / ML-KEM encrypts every transaction in the mempool. Poseidon2 over the Goldilocks field hashes every block, transaction, and Merkle node. Ed25519 and X25519 appear only in libp2p's noise transport for peer routing; consensus-critical messages are gated by FALCON signatures verified at the application layer. A quantum attacker who breaks Ed25519 sees the network topology but cannot forge a single block, decrypt a single transaction, or compromise a single validator key.
+
+The trade-off is signature size: a FALCON-512 signature is 600–900 bytes, against 64 bytes for Ed25519, and a Kyber-768 ciphertext is 1,088 bytes against negligible overhead for plaintext. Pyde absorbs this cost in the budget for every layer that matters and avoids it everywhere it does not.
+
+**Axiom 2 — MEV is a protocol bug.** The block proposer must not be able to see, reorder, or selectively include unconfirmed transactions. This is not a market-design problem ("how should we share MEV with users?"); it is a security property ("the proposer's information set is restricted"). Pyde achieves this with three interlocking mechanisms.
+
+First, transactions enter the mempool encrypted under a threshold public key generated by the 128-validator committee. No single validator can decrypt the payload; 86 of 128 must cooperate.
+
+Second, the proposer publishes a Poseidon2 commitment to the ordering of encrypted transactions in the proposed block before any decryption share is released by any validator. The ordering is binding by hash; once the commitment is in the proposed block header, the proposer cannot change it without producing a different block.
+
+Third, after the threshold of 86 decryption shares is reached and the block is decrypted, every successfully decrypted transaction up to the gas limit must appear in the sealed block in the committed order. A validator who detects a missing transaction or a reordered transaction rejects the block; under HotStuff's safety property, false positives cost liveness, not safety. A proposer caught violating mandatory inclusion is slashable.
+
+The net effect: a proposer cannot front-run because they cannot read the mempool; they cannot back-run because the ordering is committed before decryption; they cannot drop because dropped transactions are detectable and slashable; they cannot sandwich because they cannot insert their own transaction into a position they have not committed to in advance.
+
+**Axiom 3 — Throughput requires parallel execution and a monolithic binary.** A monolithic chain — consensus and execution sharing a single process, no separate proving network or auxiliary services — minimizes coordination cost. A parallel scheduler — driven by declared access lists, executing non-conflicting transactions concurrently — minimizes per-transaction wall time. The combination targets 12,500 sustained TPS at 400 ms slot time. The design ceiling is set by the gas model: 400 M target / 1.6 B max block gas, against ~52 K average gas per transaction in a realistic mixed workload of ERC20 transfers (50 %), AMM swaps (25 %), NFT mints (15 %), and plain transfers (10 %). The arithmetic gives ~19 K theoretical TPS at the gas ceiling, leaving 50 % headroom above the design target.
+
+The monolithic-binary choice is contested. Multi-chain ecosystems (Cosmos, Polkadot) and modular stacks (Celestia, EigenLayer) argue that disaggregating execution, consensus, settlement, and data availability lets each layer scale independently. Pyde's counter-argument is that disaggregation is a tax on the application: every cross-layer interaction is an additional protocol surface, an additional trust boundary, an additional latency. Modular wins on heterogeneity; monolithic wins on coherence. For an L1 whose target is high-throughput, low-latency, MEV-free execution at the base layer, coherence is more valuable than heterogeneity. Cross-chain interoperability is added back as a separate, permissionless layer above the coherent base — the parachain layer described under Axiom 4 — rather than as a structural premise that fragments the chain at genesis.
+
+**Axiom 4 — Decentralization is the protocol's burden, not the user's.** A chain is decentralized when the cost to participate as a validator, full node, or extension chain is low enough that participation is open to anyone with an ordinary computer and an internet connection. Pyde holds this property at three layers, by design.
+
+*Validators run on commodity hardware.* Pyde's mainnet validator spec is 8 cores, 16 GB of RAM, 500 GB of NVMe SSD, and 100 Mbps symmetric network — a developer workstation, not a data-center node. The CPU bound during a slot is FALCON signature verification on 86 of 128 incoming committee votes plus Poseidon2 hashing during JMT updates; both are CPU-bound but neither requires a high-end server. A validator can be self-hosted at home or on a low-cost cloud instance with no operational disadvantage versus a professional operator. The contrast with chains that have raised validator hardware specs repeatedly under load is deliberate: when validation becomes a premium-hosting business, decentralization becomes a function of capital, not of will.
+
+*Every validator has exactly one vote.* The 10,000 PYDE validator stake is an anti-sybil cost, not a power multiplier. To gain a second vote, a token holder must register a second validator with separate identity, separate FALCON key material, and separate slashing exposure — economically and operationally identical to recruiting an entirely independent operator. The committee is 128 validators with equal voting weight, and the threshold for hard finality is 86 of 128. There is no chain operation in which a validator with 10,000 PYDE has less voice than a validator with 10 million.
+
+*Parachains are permissionless decentralized infrastructure, not auctioned slots.* Cross-network interactions in Pyde — calling a function on Solana, querying an oracle, requesting off-chain compute, indexing on-chain data — happen through a parachain layer of operators who implement a Pyde-published specification. Any developer can implement the spec in any programming language; any operator who stakes PYDE and runs a conforming implementation can join the operator set for a category. There are no slot auctions, no parachain-team gatekeeping, no permissioned inclusion. The parachain spec is the protocol-level contract; the implementations are public, open source, and competitive. A Pyde contract that uses a parachain via the `cross_call!` macro pays one combined gas fee — covering both Pyde-side execution and parachain-side execution — and parachain operators earn their share of the fee. Cross-chain interaction becomes seamless from the user's perspective and trust-minimized at the protocol level: a permissionless infrastructure layer with on-chain rules, PYDE-staked operators, and on-chain slashing, in place of custodial multisig bridges and oracle-and-relayer trust assumptions. The parachain layer ships post-mainnet on a + 6-to-+ 12-month horizon (Section 19), but the protocol-level surface — the `cross_call!` macro, the `HardFinalityCert` primitive, the unified gas model — is settled at genesis.
+
+The combined effect of the three layers is that the cost of participating in Pyde — running a node, validating, building a parachain — is a function of will and a small fixed bond, not of access to data-center capital, governance lobbying, or auction proceeds. Decentralization in Pyde is built into the architecture rather than added back through tokenomics or social process.
+
+### 1.3 Why this window is open and closing
+
+The strategic window for a greenfield chain to occupy the post-quantum, MEV-free, commodity-validated category rests on three time-bound facts.
+
+**First, NIST's 2024 cryptographic standardization is still recent.** The toolkit is now mature, the primitives are vetted, and the field has the parts it needs to build a post-quantum chain. But no major L1 has shipped a post-quantum-default protocol. That gap will close — Ethereum will eventually ship PQ migration, Solana will eventually rebuild around lattice signatures, the field will converge — but the migration timelines for incumbents are honestly multi-year, and the chain that establishes itself as the post-quantum default before that closure earns the position permanently. Migration cost is symmetric: it protects whoever holds the position as much as it constrains whoever needs to take it. The first chain to ship post-quantum at production scale is the post-quantum chain for the next decade.
+
+**Second, the MEV market on incumbent chains has hardened into a structural extraction.** The user discontent is real and growing — every public AMM swap, every public liquidation, every NFT mint is now visibly contestable by sophisticated searchers — but the incumbents' incentive structure (validators capture MEV revenue, builder markets share it back) makes structural removal politically expensive. A protocol-level fix on Ethereum is not just a code change; it is a renegotiation of who gets what. Pyde does not have that constraint. The chain ships MEV-removed at genesis, so there is no political coalition to overturn, no validator revenue to compensate, no auction market to dismantle. The chain that arrives without the political baggage is the chain that gets to remove the tax cleanly.
+
+**Third, the cost of running validators on premium hardware is now visible and politically expensive.** The Solana validator hardware creep is documented, the data-center concentration is measurable, and the question "who actually validates this chain?" is increasingly being asked by users, regulators, and journalists. The chains that have made validation a professional-operator business cannot become commodity-hardware chains without breaking their own validator set. Pyde gets to make the decentralization choice once. Incumbents get to fight it forever.
+
+These three facts do not stay true forever. Quantum forecasts compress; an incumbent will eventually ship a credible PQ migration; the political cost of MEV will eventually force someone to absorb it; the hardware-cost question will eventually be answered, one way or another. The window is the period between when these problems became visible at the same time and when they get solved one way or another. Inside that window, the chain that ships all four properties first establishes the position the industry's open problems define. The chain that occupies the position becomes the default Layer 1 of the post-quantum, post-MEV-as-market era of crypto.
+
+This paper is the technical case that Pyde is the chain built to occupy it.
+
+### 1.4 What follows
+
+The rest of this paper specifies how the protocol implements each axiom, what is built today, what is honestly deferred, and where Pyde's design diverges from the major L1s.
+
+- **Section 2** — Architecture overview: the single-binary structure, the validator and full-node roles, the commodity-hardware spec, the transaction lifecycle from submit to hard finality.
+- **Sections 3–5** — Consensus, cryptography, and MEV protection. The headline mechanisms.
+- **Sections 6–9** — The Pyde Virtual Machine, the Otigen smart-contract language, the state model, parallel execution, and networking.
+- **Section 10** — Cross-chain interactions and the parachain architecture: hard-finality certificates as bridge inputs, the parachain specification, the unified gas model, the permissionless decentralized-infrastructure model. Architecture established at genesis; spec, reference implementations, and bridges ship post-mainnet on a + 6-to-12-month horizon.
+- **Sections 11–13** — The account model, gas and fee model, and tokenomics.
+- **Section 14** — Governance and the PIP process.
+- **Section 15** — Security: attack surface, defenses, deliberate scope-limits.
+- **Section 16** — Performance: measured numbers, methodology, the path to the design target.
+- **Section 17** — Comparisons to Ethereum, Solana, Aptos, Sui, Polkadot, Cosmos, and Avalanche.
+- **Section 18** — Launch roadmap.
+- **Section 19** — Post-mainnet appendix: STARK execution proofs and the verifiable computation network roadmap, parachain specification, programmable accounts, session keys, signed mempool commitments, native bridges, expanded TypeScript SDK coverage.
+- **Sections 20–21** — Constants reference and glossary.
+
+The document is written to be skimmable at the section level and rigorous within each section. A reader interested in MEV protection can read Section 5 and the threshold-encryption portions of Section 4 and have a complete picture. A reader interested in the decentralization story can read Sections 2 (commodity hardware), 4 (equal voting in consensus), and 10 (permissionless parachains). A reader doing technical diligence should read it end-to-end.
+
+---
+
+## 2. Architecture Overview
+
+### 2.1 Single binary, two roles
+
+Pyde ships as a single Rust binary, `pyde`, built from a workspace of fifteen library crates plus the binary itself. There is no separate execution-layer service, no proving-network sidecar, no auxiliary indexer required for chain operation. A node operator runs one process, configures it as a validator or a full node via TOML, and points it at a genesis file. Everything that happens on the chain — consensus, transaction execution, mempool management, state commitment, RPC, peer discovery, gossip — happens inside that process.
+
+The motivation is operational simplicity. Distributed systems with N coupled services have N + (N choose 2) failure modes; a chain that ships as one process has one. The motivation is also performance: in-process function calls are cheaper than IPC or network calls, and a JIT-compiled smart contract can call into the state backend with no serialization round-trip. Solana made the same architectural choice; Ethereum's separation of consensus and execution clients is a reflection of its history, not an endorsement of the modular pattern.
+
+The two operational roles, validator and full node, share the same binary and the same execution code path. The differences are local:
+
+| Capability | Validator | Full node |
+| --- | --- | --- |
+| Receives proposals | Yes | Yes |
+| Executes blocks | Yes | Yes |
+| Maintains state | Yes | Yes |
+| Serves RPC | Optional | Yes |
+| Releases threshold-decryption shares | Yes | No |
+| Signs and broadcasts FALCON votes | Yes | No |
+| Eligible to propose blocks (1/128 slots) | Yes | No |
+| Aggregates votes into a quorum certificate | When proposer | No |
+| Earns block rewards and fee share | Yes | No |
+
+A full node performs every piece of execution work that a validator does — it has to, in order to maintain the chain — minus the consensus participation. The hardware footprint is therefore comparable; the only validator-specific cost is the per-slot fsync of vote and proposal state to disk (measured at 25.5 µs per write on Apple Silicon NVMe, a 4.2× overhead over async writes), which a full node does not pay.
+
+### 2.2 Hardware spec
+
+The mainnet validator hardware target is:
+
+```
+CPU:  8+ cores, modern x86_64 or ARM64
+RAM:  16 GB (mempool + JMT in-memory caches + execution state)
+Disk: 500 GB NVMe SSD (RocksDB state + receipt store + consensus log)
+Net:  100 Mbps symmetric, low jitter (decryption shares + gossipsub)
+```
+
+This is a developer workstation, not a data-center node. The CPU bound during a slot is FALCON signature verification (when batching 86+ committee votes) and Poseidon2 hashing during JMT updates; both are CPU-bound but neither requires high-end server hardware. A self-hosted mini-PC, a low-cost cloud instance, or a residential machine on a fiber connection all meet the spec. The contrast with chains that have raised validator requirements upward under load is deliberate: hardware creep is the slow erosion of decentralization, and Pyde absorbs that pressure by building the protocol to fit the budget rather than by raising the budget when the protocol gets heavy.
+
+A full node has the same compute and storage shape minus the per-vote fsync overhead. Lighter participation modes — light clients, RPC-only nodes, archive nodes — are out of scope for mainnet but trivially supported by the same binary with different configuration.
+
+### 2.3 The pyde binary subcommand surface
+
+```
+pyde run              # Run as validator or full node
+pyde testnet          # Generate a multi-validator testnet directory
+pyde default-config   # Print a default node config TOML
+pyde default-genesis  # Print a default devnet genesis TOML
+pyde faucet           # Run a public faucet HTTP server
+```
+
+The subcommand surface is intentionally small. `run` is the production path; the others are bootstrapping tools. Configuration is TOML; genesis is a separate TOML file with validator registration, vesting schedules, airdrop Merkle roots, and protocol constants. A four-validator local devnet bootstraps in under ten seconds:
+
+```
+$ pyde testnet --validators 4 --out ./devnet --dev
+$ cd devnet && ./run.sh
+```
+
+A 16-validator three-region cross-host testnet bootstraps from a published address manifest:
+
+```
+$ pyde testnet \
+    --validators 16 \
+    --out ./testnet \
+    --node-addrs ./crates/node/testdata/testnet-16v-3region.toml
+```
+
+Both paths use the same code as a mainnet deployment.
+
+### 2.4 Workspace map
+
+The fifteen library crates that compose the binary, in dependency order:
+
+| Crate | Role |
+| --- | --- |
+| `crypto` | FALCON-512, Kyber-768, Poseidon2, threshold, VRF, PSS — the post-quantum primitives. |
+| `slashing` | Slashing constants and evidence types shared across `tx` and `consensus` to break the dependency cycle. |
+| `pvm` | The Pyde Virtual Machine: 32-bit ISA, 16 GP + 8 wide registers, 4 MB address space, 62 opcodes. |
+| `aot` | Cranelift-based ahead-of-time JIT compiler. PVM bytecode → native at deploy time. |
+| `state` | Jellyfish Merkle Tree state, RocksDB backend, witnesses, undo logs. |
+| `account` | Accounts, addresses (Poseidon2 of FALCON pubkey), nonce-window bitmap. |
+| `tx` | Transaction types, fee market (EIP-1559), gas, parallel execution scheduler, fee distribution. |
+| `mempool` | Encrypted mempool, ordering commitment, decryption-share aggregation, block construction. |
+| `consensus` | Modified HotStuff, VRF proposer selection, finality certificates, slashing rules. |
+| `net` | libp2p transport, gossipsub channels, peer discovery, FALCON peer authentication. |
+| `otic` | Otigen smart-contract compiler: lex → parse → typecheck → IR → optimize → codegen → artifact. |
+| `node` | The binary entry point: RPC, validator process, genesis, faucet, persistence stores. |
+| `pyde-dev` | Developer CLI: build, test, deploy, format, wallet management. |
+| `pyde-rust-sdk` | Rust client library for application developers. |
+| `pyde-crypto-wasm` | WASM bindings for browser dApps and JS/TS wallets. |
+
+Dependencies flow downward. `consensus` depends on `mempool`, `mempool` on `tx`, `tx` on `account` and `state`, all of them on `crypto`. The slashing constants live in their own leaf crate (`slashing`) so that `tx` and `consensus` can both reference them without forming a cycle. The SDK and dev tools live above the production stack and are not loaded into the validator binary at runtime.
+
+### 2.5 Transaction lifecycle, end to end
+
+A transaction's life from submission to hard finality runs through eight stages:
+
+1. **Construct.** The client (wallet, dApp, dev tool) builds a `Transaction` with sender, recipient, value, calldata, gas limit, nonce, chain ID, and access list. The transaction is FALCON-512-signed by the sender's authorization key.
+
+2. **Encrypt (default for MEV-sensitive paths).** The client wraps the transaction in an `EncryptedTx` envelope: it generates a Kyber-768 ciphertext under the committee's threshold public key, binds the ciphertext to the sender's FALCON public key via a Poseidon2 MAC, and signs the envelope. Plaintext transactions remain valid but are visible to validators in the mempool; encrypted is the default for any transaction touching a public AMM, lending market, or other MEV-sensitive surface.
+
+3. **Submit.** The client sends the (encrypted) transaction to a full node's RPC endpoint via `pyde_sendRawTransaction` or `pyde_sendRawEncryptedTransaction`. The receiving node validates wire format, FALCON signature, chain ID, nonce window, balance ≥ gas + value, gas limit, deadline, access list, and tx size — at the RPC boundary, before the transaction is added to the mempool or gossiped.
+
+4. **Gossip.** A validated transaction is added to the mempool and gossiped on the `pyde/tx-gossip/1` channel (plaintext) or `pyde/encrypted-tx-gossip/1` channel (encrypted). All committee members and full nodes subscribe; the mempool reaches a consistent view within mesh-convergence time (typically under 200 ms on the laptop devnet).
+
+5. **Propose.** When the per-slot VRF selects a proposer, the proposer reads from its local mempool view, applies global / per-sender / TTL caps, sorts by gas-then-FIFO, and assembles a candidate block. For encrypted transactions, the proposer publishes a Poseidon2 commitment to the ordered set of `(encrypted_tx_hash)` in the block header, and broadcasts the proposal to the committee.
+
+6. **Decrypt.** Each committee member, on receiving the proposal, verifies the ordering commitment is well-formed and releases its threshold-decryption share for every encrypted transaction in the proposed block. The shares are gossiped on the consensus channel. Once 86 of 128 shares converge for each ciphertext, the validator decrypts the inner transaction.
+
+7. **Execute and vote.** The validator executes the decrypted block via the parallel scheduler (transactions with disjoint access lists run concurrently; conflicts run serially). The validator computes the post-block state root via the JMT, verifies that the proposer's mandatory-inclusion invariant is satisfied (every successfully decrypted tx up to the gas limit appears in the sealed block in committed order), and signs FALCON-512 votes for the block at the prepare, pre-commit, and commit phases of HotStuff.
+
+8. **Finalize.** Once 86 of 128 commit votes are aggregated by the next proposer into a quorum certificate, the block is hard-finalized. A `HardFinalityCert` carrying the 86 FALCON signatures, the voter bitmap, and the state root is the cross-chain-portable proof of finality. Hard finality typically lands within one or two slot periods of inclusion (~400 – 800 ms).
+
+The only step that introduces latency beyond pure consensus is the threshold-decryption round-trip; this is the cost of MEV protection. On the four-validator devnet, the encrypted-path tax adds ~150 – 300 ms to typical hard-finality latency over the plaintext-path baseline.
+
+---
+
+## 3. Consensus
+
+### 3.1 Modified pipelined HotStuff
+
+Pyde's consensus is a variant of pipelined HotStuff (Yin et al., 2019) chosen for three properties: O(n) message complexity per slot (versus O(n²) for PBFT), responsive optimistic finality (a block can finalize in three message rounds when the network is well-connected), and a clean view-change protocol that does not require an external timing oracle. The Pyde variant adds VRF-based proposer selection, multi-proposer fallback for missed slots, post-quantum FALCON-512 signatures on every vote, and threshold-encrypted mempool integration.
+
+The committee is fixed at 128 validators per epoch. The Byzantine fault tolerance threshold is f ≤ 42; the quorum threshold for safety is 2f + 1 = 86. A block is hard-finalized when 86 of 128 committee members have signed a FALCON commit vote, aggregated into a quorum certificate.
+
+Slot duration is 400 ms. Within a slot, the protocol runs:
+
+```
+T = 0       Proposer broadcasts proposed block (with ordering commitment)
+T = 0+ε    Validators verify proposal, release decryption shares
+T = ε      Validators aggregate shares, decrypt, execute, sign prepare vote
+T = 2ε     Next proposer aggregates prepare QC, broadcasts pre-commit
+T = 3ε     Committee signs pre-commit votes, aggregated into commit QC
+T = 400ms  Slot boundary, next slot begins
+```
+
+Hard finality typically lands within one or two slot periods (400 – 800 ms) of block inclusion. Soft finality — the block is included in a chain backed by at least one quorum certificate — lands within the slot itself.
+
+### 3.2 VRF proposer selection
+
+Each slot, every committee member independently computes a VRF score over the input `(epoch_randomness || slot)`. The lowest score wins; that validator is the proposer. The score is unforgeable (only a validator with the secret key can compute it) and verifiable (any party can verify the proof against the public key). No one can predict another validator's score in advance, which means a targeted DoS attack against the next proposer is infeasible — the proposer's identity is unknown until the proof is revealed in the proposed block.
+
+This single-shot selection is augmented with a fallback rule: if the primary proposer fails to broadcast within `PROPOSAL_TIMEOUT_MS = 200`, the validator with the second-lowest VRF score takes over as the fallback proposer for that slot. This means a single validator outage does not trigger a full HotStuff view-change in the typical case — the remaining quorum still covers every slot.
+
+`epoch_randomness` is computed at the epoch boundary by aggregating FALCON signatures from at least `RANDOMNESS_THRESHOLD = 85` of 128 committee members on the input string `"pyde-epoch-randomness-v1" || epoch_number`. The aggregated signature is hashed via Poseidon2 to produce a 256-bit randomness output. Because no individual validator's signature is unique enough to predict the aggregated output without ≥ 85 cooperating, no validator can manipulate the next epoch's proposer schedule.
+
+### 3.3 Hard finality
+
+A finalized block carries a `HardFinalityCert`:
+
+```rust
+struct HardFinalityCert {
+    slot:         u64,
+    block_hash:   Hash,
+    state_root:   Hash,
+    voter_bitmap: u128,                     // 128-bit bitmap, 86+ bits set
+    signatures:   Vec<FalconSignature>,     // 86+ FALCON-512 sigs
+}
+```
+
+The certificate is the cross-chain-portable proof that "block N was hard-finalized on Pyde at state root R." Verifying it requires the active committee's FALCON public keys (refreshed at epoch boundaries), 86 FALCON verifications (each ~1 ms on commodity hardware), and a single Merkle path verification from the state root to the data of interest. The total verification cost is ~86 ms per accepted finality cert — non-trivial but feasible on any chain with a reasonable VM. This is the surface that makes future light-client bridges to Pyde possible (Section 10).
+
+Hard finality is irreversible under the BFT assumption (f ≤ 42). A reorg of a hard-finalized block requires either > 42 validators to double-sign (slashable, see §3.4) or a long-range attack on a stale validator set (defended by weak-subjectivity, see §3.5).
+
+### 3.4 Slashing
+
+Pyde's slashing rules cover four offense classes with calibrated penalties:
+
+| Offense | Penalty | Detection |
+| --- | --- | --- |
+| Double-sign (two votes at same height for different blocks) | 100 % of stake (10 000 PYDE) + ejection | Cryptographic evidence (two FALCON-signed votes); any party can submit |
+| Invalid proposal (proposer broadcasts block violating consensus rules) | 50 % of stake | Validator-detected; evidence is the proposed block plus violated rule |
+| Liveness-major (validator absent for > 50 % of an epoch) | 5 % of stake | Per-epoch participation accounting |
+| Liveness-minor (validator absent for > 10 % of an epoch) | 1 % of stake | Per-epoch participation accounting |
+| Decryption withhold (validator does not release threshold share within 2 slots) | 2 % of stake per offense | Threshold-share gossip tracking |
+
+A 10 % finder's fee on slashed stake goes to the party that submitted the evidence transaction. Evidence is gossiped on the consensus channel (`pyde/consensus/1`); any validator can act on equivocations they did not witness directly.
+
+Slashing is a first-class on-chain operation. `TransactionType::Slash` (type 8) carries the evidence; the handler verifies the evidence cryptographically, debits the offender's stake, credits the finder's fee, marks the validator `Exited`, and removes them from the active set. A validator who has been slashed can no longer claim rewards or unstake; the slashed stake is split between the finder, the burn pool, and the treasury per the standard fee distribution.
+
+### 3.5 Long-range attacks and weak subjectivity
+
+The classic long-range attack on a proof-of-stake chain is for a coalition of historically-staked-but-now-exited validators to use their old keys to sign an alternate chain that diverges from the canonical chain at a point in deep history. Without a defense, a new node syncing from genesis cannot distinguish the two chains.
+
+Pyde defends with weak-subjectivity checkpoints. At regular intervals (every 64 epochs ≈ 7 hours), a checkpoint is published containing the slot, block hash, state root, and the committee's FALCON public keys at that point. A new node syncing from cold starts at the most recent published checkpoint, not at genesis, and follows the chain forward. Old validator keys cannot sign alternate history because the new node will not accept any chain that diverges from the trusted checkpoint.
+
+Checkpoints are published on the consensus channel and gossiped to every node. They are also signed by the active committee at the time of publication (86 + FALCON signatures), so a node syncing from cold can verify authenticity by validating the signatures against the previous checkpoint's committee. The chain of trust runs forward from a single trusted checkpoint that the operator chooses.
+
+### 3.6 Committee rotation and PSS
+
+The committee rotates at every epoch boundary (every 1,000 slots ≈ 6.6 minutes). Validators register for committee participation by submitting a `StakeDeposit` transaction (type 4) carrying their FALCON public key and 10,000 PYDE bond; they enter the active set at the next epoch boundary. Validators leave by submitting a `StakeWithdraw` transaction (type 5); their stake is locked for the unbonding period (3,024,000 slots ≈ 14 days) and released after that.
+
+The threshold key for mempool encryption rotates with the committee. The protocol uses Proactive Secret Sharing (PSS): at each epoch boundary, the current committee runs a resharing protocol that produces a new sharing of the same secret distributed across the new committee's members. A validator who joins at epoch e + 1 receives a new share of the same secret that was held by the epoch-e committee. The threshold pubkey is unchanged across rotations; in-flight encrypted transactions submitted during epoch e remain decryptable at epoch e + 1.
+
+PSS resharing uses a deterministic aggregation trigger (`RESHARE_AGGREGATION_DELAY_SLOTS = 5`) so that all new committee members aggregate the same set of contributions, preventing the async-arrival convergence failure that an early implementation had (caught and fixed during internal audit). A future post-mainnet upgrade adds Pedersen / KZG commitments to verify that each contribution's constant term matches its claimed share value, defending against committee-member compromise (currently mitigated by detection — a corrupt resharing causes ciphertexts to stop decrypting at the new epoch, which is observable within one slot).
+
+---
+
+## 4. Cryptography
+
+### 4.1 The post-quantum stack
+
+Pyde's cryptography is the lattice-based stack standardized by NIST in 2024:
+
+| Primitive | Algorithm | Standard | Use |
+| --- | --- | --- | --- |
+| Signatures | FALCON-512 | NIST FIPS 206 | Consensus votes, transaction authorization, validator registration |
+| Public-key encryption | Kyber-768 / ML-KEM | NIST FIPS 203 | Threshold-encrypted mempool |
+| Hash | Poseidon2 (Goldilocks field) | Academic standard | Block hashes, transaction hashes, Merkle nodes, address derivation |
+| VRF | Lattice-based (Goldilocks) | Pyde construction | Proposer selection, epoch randomness |
+| Threshold encryption | Shamir over Goldilocks + Kyber + Poseidon2 MAC | Pyde construction | Mempool encryption, decryption-share aggregation |
+| Proactive secret sharing | PSS over the threshold encryption | Pyde construction | Committee rotation, key refresh at epoch boundaries |
+| Key derivation | Argon2id | RFC 9106 | Keystore encryption (wallet, validator key) |
+
+Ed25519 / X25519 appear in libp2p's noise transport for peer-to-peer routing. They are not part of the consensus or application security model: a quantum attacker who breaks Ed25519 learns which IP addresses validators connect to, but cannot forge a block, decrypt a transaction, or steal an account.
+
+### 4.2 FALCON-512: signatures
+
+FALCON-512 is a lattice-based signature scheme based on the NTRU lattice problem. It produces signatures of variable length (typically 600 – 900 bytes, hard upper bound 1280 bytes), against 64 bytes for Ed25519 — a roughly 10 – 15× signature-size overhead. Public keys are 897 bytes. Verification cost is ~1 ms on commodity hardware, ~3 – 5× slower than Ed25519 verification but well within a per-vote latency budget at 400 ms slot time.
+
+Pyde signs with FALCON-512 at three layers:
+
+- **Consensus votes.** Every prepare, pre-commit, and commit vote in HotStuff is a FALCON-512 signature over the vote's payload (slot, block hash, phase). Aggregation is the union of signatures into a `voter_bitmap` plus a vector of signatures; there is no signature-aggregation scheme like BLS, because no post-quantum BLS analog has matured yet. This is a deliberate cost: the QC bandwidth is higher than a BLS-aggregated chain by roughly the signature-count factor, and the mainnet bandwidth budget (100 Mbps validator network) is sized to absorb it.
+
+- **Transaction authorization.** Every transaction submitted to Pyde is FALCON-512-signed by the sender's authorization key. The signature is verified at RPC ingress and again at execution time. Multisig accounts carry M-of-N FALCON signatures (max signers = 16) verified in the same pipeline.
+
+- **Validator key registration.** A validator's identity is its FALCON public key. The address derived from that key (via Poseidon2) is the validator's account address; the private key controls staking, slashing, and reward claims.
+
+### 4.3 Kyber-768: encryption
+
+Kyber-768 (ML-KEM in NIST FIPS 203 nomenclature) is a lattice-based key encapsulation mechanism providing IND-CCA2 security. The underlying hard problem is Module-LWE (Module Learning With Errors). Public keys are 1 184 bytes; ciphertexts are 1 088 bytes; the encapsulated shared secret is 32 bytes.
+
+Pyde uses Kyber-768 in two patterns:
+
+- **Direct encryption (mempool envelope).** A client encrypts a transaction's inner payload under a fresh Kyber-768 ephemeral key, derives a symmetric key from the shared secret, and uses it with AES-GCM to encrypt the payload bytes. The resulting envelope is a Kyber-768 ciphertext plus an AES-GCM ciphertext plus a sender FALCON signature.
+
+- **Threshold encryption.** The committee jointly holds a Kyber-768 secret distributed via Shamir secret sharing over the Goldilocks field. The corresponding public key is the threshold pubkey published at epoch boundaries.
+
+The `ml-kem` dependency is currently pinned at `0.3.0-rc.0` pending an upstream stable release; the pin is tracked as a dependency-watch task. The release-candidate is already a faithful FIPS 203 implementation; the upgrade is a version-string change, not a protocol change.
+
+### 4.4 Poseidon2: hashing
+
+Poseidon2 is an algebraic hash function over the Goldilocks field (p = 2⁶⁴ - 2³² + 1), parameterized for Pyde with state width 8 and 22 internal rounds. It replaces SHA-2 / Keccak in every protocol-internal hash:
+
+- Block hashes (hash of the block header)
+- Transaction hashes (Poseidon2 of the wire-format bytes)
+- Account address derivation (`address = Poseidon2(falcon_public_key)`)
+- Merkle node hashes in the Jellyfish Merkle Tree
+- VRF input hashing
+- Threshold ciphertext binding (`Poseidon2(sender || nonce || gas || chain || ciphertext_hash)`)
+
+The motivation for Poseidon2 over SHA-2 is performance in finite-field operations, which matters for any future ZK extension (post-mainnet) and which is also faster than Keccak on register-based VMs that already operate in 64-bit field arithmetic. The cost is that Poseidon2 is a younger primitive with less cryptanalytic exposure than SHA-2; the counter-argument is that algebraic hashes have been studied actively since 2018 (Poseidon, Reinforced Concrete, Anemoi, Griffin, Poseidon2) and the cryptanalysis literature has not produced practical attacks at Pyde's parameter set. The Argon2id KDF for keystore encryption (§4.7) is a deliberate departure from Poseidon2, applied where memory-hardness is the relevant property.
+
+### 4.5 Threshold encryption
+
+The mempool-encryption protocol decomposes a single Kyber-768 secret into 128 Shamir shares over the Goldilocks field, distributed across the active committee. Reconstruction requires 86 shares (the same 86-of-128 threshold as consensus quorum). The threshold public key is published at every epoch boundary; clients use it as the encryption target for any transaction submitted to the encrypted mempool path.
+
+The encryption side is straightforward: a client calls `Kyber768.encapsulate(threshold_pubkey)` and gets a ciphertext plus shared secret, then uses AES-GCM under the shared secret to encrypt the inner transaction payload.
+
+The decryption side requires cooperative participation from 86 + committee members, each releasing a partial-decryption share for the ciphertext after verifying the proposer's ordering commitment (§5.2). Aggregation of shares uses Lagrange interpolation over Goldilocks; once 86 shares are collected, the original Kyber shared secret is recoverable, the AES-GCM ciphertext can be decrypted, and the inner transaction is revealed.
+
+Two security properties matter:
+
+- **MAC integrity.** The threshold ciphertext carries a Poseidon2 MAC binding the ciphertext to the sender's FALCON public key, preventing relay-inflation spam where a malicious relay re-injects copied ciphertexts under a different sender. The MAC is verified in constant time using `subtle::ConstantTimeEq` to prevent timing-based MAC-forgery attacks; an early-exit comparison in a previous version was caught and fixed during internal audit before testnet.
+
+- **Decryption-withhold detection.** A validator who fails to release decryption shares within 2 slots of a proposal is flagged for the decryption-withhold slashing condition (§3.4, 2 % of stake per offense). This is what makes the cooperative-decryption protocol economically sound: a validator who deliberately slows decryption pays a cost.
+
+### 4.6 VRF and PSS
+
+Pyde's VRF is a lattice-based construction producing a 256-bit pseudorandom output and a proof of computation. The output is unforgeable (only the secret-key holder can produce it) and verifiable (anyone with the public key can verify the proof). The construction operates over the Goldilocks field for performance compatibility with Poseidon2.
+
+The VRF is used at two layers:
+
+- **Proposer selection.** Every committee member computes a VRF score for each slot; the lowest score is the proposer (§3.2).
+- **Epoch randomness.** The aggregated VRF outputs of 85 + committee members at the epoch boundary, hashed via Poseidon2, produce the next epoch's randomness seed.
+
+PSS (Proactive Secret Sharing) is the protocol that rotates the threshold key across committee changes. Each committee member at epoch e produces a "resharing contribution" — a polynomial over Goldilocks whose constant term is their share — and broadcasts the sub-shares to the new committee at epoch e + 1. The new committee aggregates contributions deterministically (after `RESHARE_AGGREGATION_DELAY_SLOTS = 5` slots) and derives new shares of the same threshold secret. The threshold public key is unchanged; in-flight encrypted transactions submitted during epoch e remain decryptable at epoch e + 1.
+
+### 4.7 Argon2id: keystore key derivation
+
+Operator keys (validator FALCON keys, wallet keys, dev-tool keys) are stored encrypted on disk. The keystore uses AES-GCM for the bulk encryption and Argon2id for the password-to-key derivation. Argon2id is parameterized with m = 64 MiB, t = 3 iterations, p = 1 lane, producing a derivation cost of ~250 ms per guess on a single core — sufficient to make brute-force attacks against weak passphrases computationally expensive while keeping interactive unlock latency acceptable.
+
+The Argon2id KDF is shared across the validator binary, the Rust SDK, and the developer CLI tools, so a wallet generated by `pyde-dev` decrypts with the same parameters in `pyde-rust-sdk`. The shared-Argon2id design replaced an earlier single-iteration Poseidon2-based KDF that was too fast against weak passphrases — caught and fixed during internal audit before testnet.
+
+---
+
+## 5. MEV Protection
+
+### 5.1 The headline mechanism
+
+MEV — the profit a block proposer can extract by reordering, censoring, or front-running unconfirmed transactions — is a structural problem on chains where the proposer can see the mempool. Every public AMM swap on Ethereum, every public liquidation on a public lending market, every NFT mint with a published reveal — all are exposed to a sophisticated proposer who can read pending transactions and insert their own to extract value. The major L1s have all engaged with the problem: Ethereum's MEV-Boost / proposer-builder separation, Solana's Jito, Cosmos's threshold-encryption proposals, and a wider literature of fair-ordering and commit-reveal designs are all live. The convergent direction in production has been to make the MEV market more efficient (auction the right to reorder) rather than to remove it from the protocol. Pyde takes the harder path: remove the proposer's ability to see, reorder, or selectively include transactions at all.
+
+The mechanism is three interlocking properties:
+
+1. **Encrypted mempool.** Transactions enter the mempool encrypted under a 86-of-128 threshold public key. No single validator can decrypt the payload; 86 of 128 must cooperate.
+
+2. **Pre-decryption ordering commitment.** The proposer publishes a Poseidon2 commitment to the ordering of encrypted transactions in the proposed block before any decryption share is released. The commitment binds the order to a specific hash; the proposer cannot change it without producing a different block.
+
+3. **Mandatory inclusion.** After 86 of 128 decryption shares converge and the block is decrypted, every successfully decrypted transaction up to the gas limit must appear in the sealed block in the committed order. A proposer who omits, reorders, or front-runs is detectable and slashable.
+
+The combined effect: the proposer cannot front-run because they cannot read the mempool; they cannot back-run because the ordering is committed before decryption; they cannot drop because dropped transactions are detectable; they cannot sandwich because they cannot insert their own transaction into a position they have not committed to in advance.
+
+### 5.2 The encrypted-tx lifecycle, in detail
+
+```
+CLIENT
+  1. Build inner Transaction { from, to, value, data, gas, nonce, ... }
+  2. FALCON-512 sign the inner transaction
+  3. Fetch threshold pubkey via pyde_getThresholdPublicKey
+  4. Kyber768.encapsulate(threshold_pubkey) → (kem_ct, shared_secret)
+  5. AES-GCM-encrypt the inner-tx bytes under shared_secret → aes_ct
+  6. Build EncryptedTx { sender, nonce, gas, chain_id, kem_ct, aes_ct,
+                        poseidon2_mac, falcon_signature }
+  7. Submit via pyde_sendRawEncryptedTransaction
+
+NETWORK
+  8. RPC ingress: validate FALCON sig, sender registration, nonce window,
+     balance >= gas, chain ID, deadline, size, MAC (constant-time)
+  9. Add to encrypted mempool, gossip on pyde/encrypted-tx-gossip/1
+ 10. Mempool reaches consistent view across committee + full nodes
+
+PROPOSER (this slot)
+ 11. Read local encrypted mempool, apply caps + sort, select up to gas-limit
+ 12. ordering_commitment = Poseidon2(tx_hash_1 || tx_hash_2 || ... || tx_hash_n)
+ 13. Build proposed block with ordering_commitment in header
+ 14. Broadcast proposal on pyde/consensus/1
+
+EVERY COMMITTEE MEMBER
+ 15. Verify proposal signature (FALCON), proposer is correct VRF winner
+ 16. Verify ordering_commitment matches local view of pending txs
+     (or accept if proposer's view differs by within tolerance — see §5.4)
+ 17. For each EncryptedTx in proposed block:
+     a. partial_share = Threshold.share_decrypt(my_share, kem_ct)
+     b. Sign and gossip share on pyde/consensus/1
+ 18. Receive partial shares from other committee members
+ 19. Once 86 shares collected for a given EncryptedTx:
+     a. Aggregate via Lagrange interpolation → kyber_shared_secret
+     b. AES-GCM-decrypt → inner Transaction bytes
+     c. Verify inner FALCON signature
+ 20. Execute decrypted block via parallel scheduler
+ 21. Verify mandatory-inclusion invariant: every successfully-decrypted tx
+     up to gas limit appears in the sealed block in committed order
+ 22. Compute post-block state root via JMT
+ 23. Sign FALCON HotStuff prepare/pre-commit/commit votes for the block
+
+PROPOSER (next slot)
+ 24. Aggregate 86+ commit votes into HardFinalityCert
+ 25. Block is hard-finalized
+```
+
+The whole sequence completes in 1 – 2 slot periods (400 – 800 ms wall-clock) under normal operation.
+
+### 5.3 What this prevents
+
+The major MEV families and how Pyde structurally prevents each:
+
+| Attack | Mechanism | Pyde defense |
+| --- | --- | --- |
+| Frontrunning | Proposer sees a profitable pending tx and inserts a copy with higher priority | Proposer cannot read encrypted mempool contents |
+| Back-running | Proposer sees a pending tx and inserts a follow-up that captures the result | Ordering is committed before decryption; no insertion after the fact |
+| Sandwich | Proposer inserts one tx before and one tx after a victim's swap | Both insertion points are pre-committed; victim's tx is invisible until decryption |
+| JIT liquidity | Proposer adds liquidity right before a large swap and removes after | Same as sandwich — insertion points are pre-committed |
+| Time-bandit | Proposer reorganizes finalized blocks to capture historical MEV | Hard finality is a FALCON QC; reorg requires > 42 validators to double-sign (slashable, 100 % stake loss) |
+| Censorship | Proposer drops a tx targeting the proposer's interests | Mandatory inclusion: every decrypted tx up to gas limit must appear |
+| Same-block oracle manipulation | Proposer sees an oracle-update tx and inserts trades that exploit | Oracle-update tx is invisible until decryption |
+
+Two attack vectors are partially mitigated rather than structurally eliminated, and the whitepaper is honest about both:
+
+- **Cross-block MEV.** A proposer with multiple consecutive slots could in principle delay a tx into a block they control. Pyde's per-slot VRF makes consecutive proposer slots low-probability (~1/128² ≈ 0.006 % for two in a row); the multi-proposer fallback further reduces the window. The bound is structural but not zero.
+
+- **Censorship via mempool exclusion.** A proposer who never sees a tx in their local mempool view cannot include it. Mainnet ships with local-view enforcement: a committee member rejects a block whose ordering omits a tx that member has seen. False positives cost liveness, not safety, under HotStuff. Post-mainnet adds signed mempool commitments and cryptographic censorship slashing (§19) — a 2 – 3 slice project deferred from launch.
+
+### 5.4 Per-sender rate limits and DoS resistance
+
+Encrypted transactions are an attractive DoS surface — submitting an unbounded number of cheap-to-verify ciphertexts could starve the mempool. Pyde defends with four caps:
+
+- **Per-sender rate limit:** 10 tx/s, 100 concurrent (`pyde-mempool::pool` constants).
+- **Per-sender mempool cap:** `MEMPOOL_SENDER_CAP = 128`.
+- **Global mempool cap:** `MEMPOOL_GLOBAL_CAP = 100 000` with hard-reject on overflow.
+- **TTL eviction:** `MEMPOOL_TX_TTL = 240 s` (~600 slots), periodic sweep evicts older entries.
+
+A sender who exceeds the rate limit gets RPC error `-32009` (per-sender cap exceeded) or `-32011` (global cap exceeded). Exceeded transactions are dropped at RPC ingress before mempool entry.
+
+Each ciphertext is bound to its sender's FALCON public key via the Poseidon2 MAC, so a relay node cannot inflate spam by re-injecting a copied ciphertext under a different sender. The MAC verification is constant-time.
+
+### 5.5 What ships at mainnet versus post-mainnet
+
+The full encryption + ordering-commitment + mandatory-inclusion pipeline ships at mainnet. The end-to-end multi-node lifecycle test (`multi_node_encrypted_lifecycle`) passes 5 of 5 across a four-validator devnet with state-root convergence. Encrypted-path throughput is currently being instrumented; the plaintext path measures 4 K TPS sustained, and the encrypted path adds Kyber + threshold-decrypt overhead being characterized against the same 10-minute soak structure.
+
+Two MEV-related upgrades are tracked as post-mainnet:
+
+- **Signed mempool commitments + censorship slashing.** Each validator periodically signs a hash-set of encrypted_txs they have seen, gossiped to the committee. Replaces local-view vote-rejection with a cryptographic commitment to the committee's collective mempool view. Allows direct slashing of proposers who exclude a tx that ≥ f + 1 committee members signed. Detailed in §19.4.
+
+- **Pedersen / KZG commitments on PSS resharing.** Adds verifiable secret sharing to the committee resharing protocol (§3.6), defending against a corrupt committee member contributing a polynomial whose constant term ≠ their actual share. Currently mitigated by detection (corrupt resharing causes ciphertexts to stop decrypting at the new epoch); cryptographic upgrade is detailed in §19.5.
+
+---
+
+## 6. The Pyde Virtual Machine
+
+### 6.1 Design choices
+
+The Pyde Virtual Machine (PVM) is a register-based VM with a 32-bit fixed-width instruction encoding, 16 general-purpose 64-bit registers, 8 wide 256-bit registers for cryptographic operations, a 4 MB flat address space, and 62 opcodes. The design choices follow from the four axioms.
+
+A **register architecture, not a stack machine**, because parallel-execution scheduling and ahead-of-time compilation are both significantly simpler against an explicit register file. The EVM's stack model forces the JIT to track stack heights symbolically; a register VM hands the AOT compiler a representation that maps directly to native registers. Cranelift, Pyde's AOT backend, was designed for register IR; the impedance match is small.
+
+A **fixed 32-bit instruction encoding**, because variable-length encoding (the EVM, WebAssembly, eBPF as it stands today) complicates instruction decoding on the hot path and introduces alignment hazards in the AOT path. A 32-bit encoding gives 6 bits of opcode (64 opcodes available, 62 used), 4 bits each of `rd / rs1`, and 18 bits of immediate-or-second-source — enough to express the full ISA without prefix bytes or LEB128 decoding. The cost is a slightly larger bytecode size; the mainnet block-gas budget absorbs this comfortably.
+
+A **fully checked arithmetic semantics with trap-on-error**. Integer overflow in arithmetic, out-of-bounds memory access, division by zero, invalid jump target, malformed wide-register reference, and call-depth exhaustion all produce a trap that aborts the current call with `RESULT_TRAP`. This is opt-in safety at the VM level rather than at the language level; an Otigen contract that wants saturating or wrapping arithmetic must explicitly request it via the assembler's wrap-marked opcode variants. The wrap-on-overflow semantics for the `Addi` immediate-add instruction is parity-tested between the interpreter and the AOT path; the otic compiler relies on it for two's-complement negation and `u64::MAX` materialization.
+
+### 6.2 Memory layout
+
+```
+0x000000  ┌──────────────────┐  Null-page guard (4 KB, traps on access)
+0x001000  ├──────────────────┤  Code segment (read-execute, immutable)
+   ...    │                  │
+0x010000  ├──────────────────┤  Heap (grows up, mutable, page-allocated)
+   ...    │                  │
+0x400000  └──────────────────┘  Stack top (grows down, fixed reservation)
+```
+
+The 4 MB total address space is sized to fit the entire working set of a typical contract call in CPU L2 cache. Page allocation is on first touch; the page-touch is metered as a gas surcharge (`PAGE_ALLOC_GAS = 200`) to prevent O(1) unbounded reads. EIP-2929-style cold-vs-warm access metering applies to repeated reads of the same page within a single call: the first touch pays the page-allocation gas, subsequent touches pay only the per-access constant.
+
+### 6.3 Opcode set
+
+The 62 opcodes group into nine families:
+
+| Family | Count | Examples |
+| --- | --- | --- |
+| Arithmetic (checked) | 14 | `Add`, `Addi`, `Sub`, `Mul`, `Div`, `Mod`, `Shl`, `Shr`, `Sar` |
+| Arithmetic (wide / 256-bit) | 6 | `WideAdd`, `WideMul`, `WideMod`, `WideEq` |
+| Memory | 8 | `Load64`, `Store64`, `Load256`, `Memcpy`, `Memset` |
+| Control flow | 7 | `Jump`, `Branch`, `Call`, `Ret`, `Trap` |
+| Storage | 4 | `Sload`, `Sstore`, `SloadCold`, `SstoreCold` |
+| Cryptographic | 6 | `Poseidon2`, `Poseidon2State`, `MerkleVerify`, `VerifySig`, `Vrf` |
+| External call | 4 | `CallExt`, `Delegate`, `Create`, `Create2` |
+| Logging / events | 3 | `Log`, `LogTopic`, `LogData` |
+| Assertion / abort | 4 | `Assert`, `Revert`, `Trap`, `OutOfGas` |
+| Misc | 6 | block info, sender, value, gas left, chain ID, timestamp |
+
+The wide opcodes operate on the 8 × 256-bit register file and are the machine-level primitives that Otigen lowers `u256` arithmetic onto. Memcpy is a single-instruction bulk copy bound by available gas (the gas cost scales with the byte count, drained on every byte rather than amortized — a parity bug between interpreter and AOT was caught and fixed during internal audit). The cryptographic opcodes hand off to native implementations rather than running Poseidon2 or FALCON-verify in pure interpreted code; this is what keeps the per-tx gas budget realistic for cryptography-heavy contracts.
+
+### 6.4 The AOT compiler
+
+Pyde compiles PVM bytecode to native machine code at deploy time using Cranelift as the codegen backend. The compiled code is cached per contract address; subsequent calls execute the compiled function directly via an `extern "C"` function pointer. There is no per-call interpreter overhead for compiled contracts.
+
+The compile pipeline:
+
+```
+PVM bytecode  →  analyze (extract basic blocks, infer control flow)
+              →  Cranelift IR generation (per-opcode lowering)
+              →  Cranelift codegen (register allocation, instruction selection)
+              →  JIT linking (extern "C" function pointer)
+              →  cache by contract address
+```
+
+The headline correctness invariant is that **the AOT-compiled function and the interpreter must agree on every observable result for every reachable input**. This is enforced by a parity-test suite covering opcode semantics, gas metering, memory page-touch costs, storage surcharges, and log dynamic charges. Six distinct interpreter/AOT divergences were caught and closed by the internal audit — each one is now a parity test that runs in CI. The current parity suite covers the Counter contract, cross-contract Factory + Token, an Events contract, u256 arithmetic, and a Vault contract with deposits and balance reads.
+
+The AOT does not speculate: each compiled function is the literal lowering of the bytecode at deploy time, with no runtime profile-guided optimization, no de-virtualization of `CallExt` targets, and no inlining across contract boundaries. The reasoning is determinism: every validator must produce the same execution trace, and speculative compilation introduces nondeterminism that is hard to reproduce across hardware. The performance left on the table is bounded; the determinism guarantee is unconditional.
+
+### 6.5 Limits and call-depth
+
+```
+MAX_CODE_SIZE        = 60 KB     (per-contract bytecode size)
+MAX_CALLDATA         = 64 KB     (per-call calldata)
+MAX_TX_SIZE          = 128 KB    (full encoded transaction including sig)
+MAX_EXT_CALL_DEPTH   = 64        (cross-contract recursion limit)
+MAX_WITNESS_SIZE     = 1 MB      (per-block state-witness bound)
+PAGE_ALLOC_GAS       = 200       (one-time cost per touched 4 KB page)
+```
+
+The 64-deep external-call limit is lower than the EVM's 1024. The reasoning is that lattice-VRF and FALCON verification overhead per call is non-trivial; a 1024-deep nested-call sequence on Pyde would consume orders of magnitude more wall-clock time than on the EVM. 64 is enough to support every realistic application pattern (proxy-impl-impl chains, cross-AMM routing, escrow-of-escrow) with comfortable headroom.
+
+---
+
+## 7. Otigen: The Smart Contract Language
+
+### 7.1 Why a new language
+
+Pyde could have shipped Solidity-on-PVM, Move-on-PVM, or a Rust-compiles-to-PVM toolchain. It ships Otigen — a purpose-built language with Rust-flavored syntax — because the protocol-level properties that Pyde provides (encrypted mempool, threshold decryption, FALCON signatures, Poseidon2 hashing, parallel execution via access lists) require language-level primitives that none of the existing options express well. Solidity's `tx.origin` semantics encode an MEV-friendly trust model. Move's borrow checker is an excellent fit for resource-tracking but not for the access-list inference Pyde's parallel scheduler needs. Rust's full surface area is too large for an audit budget. A purpose-built language with 30 keywords, narrow surface, and protocol-aware primitives is a more honest tool for the job.
+
+### 7.2 The compile pipeline
+
+```
+contract.oti  →  lex     (tokens)
+              →  parse   (AST)
+              →  resolve (symbol table, type bindings)
+              →  typeck  (type-check, trait satisfaction, overflow analysis)
+              →  safety  (reentrancy, payable guards, bounds)
+              →  IR      (mid-level intermediate representation)
+              →  optimize(constant fold, dead-code elimination)
+              →  codegen (PVM bytecode + ABI JSON)
+              →  artifact (.json file with bytecode + ABI + selector table)
+```
+
+The CLI surface is small:
+
+```
+otic build contract.oti    # Compile to .json artifact (bytecode + ABI)
+otic check contract.oti    # Type check only, no codegen
+otic test contract.oti     # Run #[test] functions on PVM
+otic abi contract.oti      # Output ABI JSON
+otic fmt   contract.oti    # Format
+otic doc   contract.oti    # Generate docs
+```
+
+`otic test` runs the `#[test]`-annotated functions inside a PVM interpreter with cheatcode access (snapshot, warp time, fund, expect-revert). This is the loop a contract developer lives in: write code, run unit tests against the same VM that mainnet runs, deploy.
+
+### 7.3 The type system
+
+Otigen's primitive types are fixed-width integers from `u8` through `u256` (and signed counterparts), `bool`, `Address`, and `String`. Composite types are `Vec<T>`, `Map<K, V>`, `Tuple`, `Array<T, N>`, and user-defined `struct` and `enum`. Generics are parametric for collections; user structs are monomorphic.
+
+The integer types are checked by default: `let x: u64 = a + b;` traps on overflow. Wrapping or saturating semantics are explicit: `let x: u64 = a.wrapping_add(b);`. `u256` is a first-class type that lowers to the wide-register ISA in §6.3. There is no implicit numeric coercion: `u32` to `u64` is an explicit `as u64`.
+
+`Address` is a 32-byte type derived from `Poseidon2(falcon_pubkey)`. There is no plaintext-key pattern in the language; addresses are opaque values produced by key registration.
+
+### 7.4 Storage, structs, and maps
+
+Contract state lives in declared storage slots:
+
+```otigen
+contract Token {
+    storage {
+        owner:       Address,
+        total_supply: u256,
+        balances:    Map<Address, u256>,
+        allowances:  Map<(Address, Address), u256>,
+    }
+    ...
+}
+```
+
+The compiler assigns each storage slot a deterministic hash slot derived from the contract address and the field name. `Map<K, V>` uses `Poseidon2(slot || key_bytes)` to compute the per-key storage location, identical in shape to Solidity's mapping pattern but rooted in Poseidon2 rather than Keccak-256.
+
+Storage reads and writes lower to PVM `Sload` / `Sstore` opcodes. The first touch of a storage slot in a transaction is a "cold" access (`SloadCold`, higher gas); subsequent touches are "warm" (`Sload`, lower gas). This is the same pattern as EIP-2929 in the EVM, ported to Pyde's gas model.
+
+### 7.5 Function attributes
+
+```otigen
+#[constructor]            // Runs once at deploy, never callable again
+#[view]                   // No state writes; safe to call without a tx
+#[payable]                // May receive PYDE
+#[reentrant]              // Explicitly opt-in to reentrancy (default: blocked)
+#[test]                   // Run by `otic test`, not deployed
+```
+
+The `#[reentrant]` attribute is opt-in by design: Pyde's default is non-reentrant function calls, with the runtime tracking re-entry attempts and trapping unless the function is explicitly tagged. This eliminates the entire class of reentrancy bugs (Solidity's most-exploited primitive) by default. The opt-in path exists for the rare cases (typically callback-heavy DeFi composability) where reentrancy is the desired semantics.
+
+### 7.6 Cross-contract calls and selectors
+
+Function selectors are 4-byte FNV-1a hashes of the function name. The encoder produces calldata in the form `[selector:4][argument bytes]`; the dispatcher in the called contract matches on selector and routes to the appropriate function.
+
+Cross-contract calls are typed:
+
+```otigen
+let token = Token::at(token_address);
+let balance = token.balance_of(user);
+```
+
+The compiler extracts function signatures from every contract in a project at compile time, so the call site is type-checked against the actual signature of `Token::balance_of`. The lowered code is a `CallExt` opcode with the encoded selector and arguments.
+
+### 7.7 The `cross_call!` macro
+
+Otigen parses a `cross_call!` macro for cross-chain and oracle interactions through Pyde's parachain layer:
+
+```otigen
+cross_call!(
+    target:   "ethereum",
+    method:   "request_price",
+    args:     (pair, address(self)),
+    callback: "on_price_received",
+);
+```
+
+The macro is asynchronous. The originating transaction completes after marking the call as pending in account state and emitting an event with the call ID; the actual cross-chain or oracle work happens off-chain at a parachain operator set, and the result arrives in a separate callback transaction (often many slots later, depending on the target chain's finality and the parachain's internal consensus). The named `callback` function is invoked on the originating contract with the attested result.
+
+Combined gas — the Pyde-side execution plus the parachain-side execution — is computed at call time and billed in a single transaction; the user pays once. There is no separate token to hold for oracle queries, no separate billing flow for bridge calls. §10 specifies the parachain layer that provides this surface.
+
+At mainnet the macro lowers to a runtime "not yet supported" return — the Otigen surface is in place so that contracts written today work without rewriting when the parachain layer ships post-mainnet (~ + 6 to + 12 months, §10.8).
+
+---
+
+## 8. State Model and Parallel Execution
+
+### 8.1 The Jellyfish Merkle Tree
+
+Pyde's authenticated state lives in a Jellyfish Merkle Tree (JMT) — the same data structure that underpins Aptos's state layer, a sparse Merkle variant optimized for incremental updates. JMT replaced an earlier sparse-merkle-tree implementation during the testnet bringup; the swap measured a roughly 40 × improvement in per-block commit latency, which was the proximate enabler for the 4 K TPS sustained throughput now measured on the laptop devnet.
+
+Every state-touching operation — account balance change, storage write, account creation — produces a JMT update. At block end, the tree's root is the state root included in the block header. A light client or a future bridge (§10) can verify a single state cell by checking a Merkle path from the root to the cell against the published root.
+
+The JMT is hashed throughout with Poseidon2. Internal nodes are `Poseidon2(left_hash || right_hash)`; leaves are `Poseidon2(key || value_bytes)`. The choice of Poseidon2 over Keccak is the same finite-field-friendliness argument from §4.4, with an additional benefit: Poseidon2 hashing is comparable in speed to SHA-2 on the 8-core validator hardware spec when the hash work is bounded by per-block gas.
+
+### 8.2 Witnesses and light-client verification
+
+A witness is the set of Merkle paths sufficient to verify every state cell touched by a block, plus the pre-block and post-block state roots. Witnesses are bounded by `MAX_WITNESS_SIZE = 1 MB` per block; the gate is enforced at the block-validation entry point before any proof verification work happens, so a malformed oversize witness cannot burn validator CPU.
+
+A light client (or a future cross-chain bridge contract) needs only the block header (containing the post-block state root), the witness for the touched cells, and the active committee's FALCON public keys to verify any state mutation. There is no need for the light client to re-execute the block.
+
+### 8.3 RocksDB backend
+
+Pyde persists state to RocksDB. The store is segmented by column family:
+
+| Column family | Contents |
+| --- | --- |
+| `accounts` | Account records (nonce, balance, code hash, storage root) |
+| `storage`  | Per-contract storage (keyed by `Poseidon2(contract_addr || slot)`) |
+| `code`     | Contract bytecode |
+| `jmt_internal` | JMT internal nodes |
+| `jmt_leaves`   | JMT leaves |
+| `receipts` | Transaction receipts |
+| `consensus_log` | Vote log, evidence, checkpoint log (fsync per write) |
+
+LRU caches sit in front of the cold storage tiers (256 K entries each for accounts and storage), absorbing the hot working set in RAM. The 16 GB validator RAM spec is sized to fit the JMT internal-node cache, the LRU layers, the mempool, and the in-flight execution state with comfortable headroom.
+
+Crash safety is guaranteed by `WriteOptions::set_sync(true)` on every consensus-state write (vote log, evidence ingest, checkpoint persistence). The fsync overhead is 25.5 µs per write on Apple Silicon NVMe; the per-slot vote write is a single fsync, the per-slot evidence write happens only on the rare equivocation path. The throughput cost is well under the 12,500 TPS target ceiling.
+
+### 8.4 Parallel execution scheduler
+
+Every Pyde transaction declares an access list — the set of `(contract_address, slot)` storage cells the transaction will read and write. The mempool validates the access list against the actual transaction at ingress (a transaction whose runtime touches a slot not in its declared access list traps); the scheduler uses the declared list to drive parallel execution.
+
+The scheduler builds a directed acyclic graph of conflicts: two transactions conflict if either's write set intersects the other's read or write set. Topologically independent transactions execute concurrently on a worker thread pool sized to the validator's core count; conflict-bound transactions execute serially within their conflict group.
+
+The expected speedup depends on the workload's conflict density. A plaintext-transfer workload (each transaction touches the sender + recipient pair) has a low conflict density and parallelizes well — a stress test of 1,000 parallel non-conflicting transfers completes in 1,000 independent scheduler groups at 100 % commit. An AMM-heavy workload (every swap touches the same pool reserve) has higher conflict density and parallelizes less; the scheduler degrades gracefully to serial execution within the contended group.
+
+### 8.5 The two-phase commit
+
+Block execution runs in two phases. The first phase is the parallel scheduler: transactions execute against a per-block snapshot, producing per-transaction state diffs and receipts. The second phase is the serial finalize: state diffs are applied in canonical order, the JMT updates incrementally, the post-block state root is computed, and the witness is materialized.
+
+The split is deliberate. Parallel execution against a snapshot is cheap; serial JMT update is structured (every leaf update is an O(log N) tree mutation) and runs as fast as a single core can hash. The combination gives parallel throughput where the workload allows, with deterministic state-root computation that every validator independently agrees on.
+
+A per-block undo log captures pre-execution state so that a transaction trap mid-execution can roll back its effects without re-executing prior committed transactions in the block. This is the same pattern as the EVM's journal but rooted in the JMT's per-leaf update model.
+
+---
+
+## 9. Networking
+
+### 9.1 libp2p as the transport
+
+Pyde's peer-to-peer networking is built on libp2p — the same modular networking stack used by Ethereum's beacon chain, Filecoin, IPFS, and Polkadot. The choice is pragmatic: libp2p's gossipsub is the only widely-deployed gossip protocol with the per-topic routing, mesh maintenance, and back-pressure characteristics Pyde needs, and rebuilding the layer would be a multi-engineer-year project against a well-tested incumbent.
+
+The transports are TCP and QUIC, with QUIC preferred where firewall and NAT conditions allow. Connection encryption is the libp2p noise protocol, which uses Ed25519 / X25519 for the transport handshake. As discussed in §4.1, this is the only place pre-quantum crypto appears in Pyde's stack: an attacker who breaks Ed25519 learns the network topology but cannot forge a block, decrypt a transaction, or steal an account. Consensus-critical messages are FALCON-signed at the application layer; encrypted-mempool ciphertexts are Kyber-768 ciphertexts. The libp2p layer carries them, but does not authenticate them.
+
+### 9.2 Channels
+
+Pyde uses five gossipsub topics with distinct subscription and back-pressure characteristics:
+
+| Topic | Subscribers | Content |
+| --- | --- | --- |
+| `pyde/blocks/1` | All nodes | Proposed and finalized blocks |
+| `pyde/consensus/1` | Committee only | Votes, QCs, evidence, decryption shares, checkpoints |
+| `pyde/tx-gossip/1` | All nodes | Plaintext transactions |
+| `pyde/encrypted-tx-gossip/1` | All nodes | Encrypted-mempool ciphertexts |
+| `pyde/sync/1` | Sync requesters + responders | Cold-sync and catch-up block requests |
+
+The committee-only restriction on the consensus channel is enforced cryptographically: a peer that is not a current committee member is dropped from the topic mesh, and any consensus message it broadcasts is rejected at the recipient. This is what makes the gossipsub mesh efficient at 128 validators — committee message volume scales as O(committee × messages_per_slot), not O(network_size × messages_per_slot).
+
+### 9.3 Peer discovery and authentication
+
+Peer discovery uses Kademlia DHT with Pyde-specific bootstrap nodes. New nodes connect to a small set of seed peers from configuration or genesis, exchange peer lists via DHT walk, and form a working peer set within a few seconds.
+
+Peer authentication has two layers. The libp2p noise handshake authenticates each peer's Ed25519 identity at the transport level. The Pyde-specific FALCON handshake binds the libp2p peer ID to a FALCON public key registered on-chain, so that consensus channels can enforce committee membership cryptographically. The FALCON handshake runs once per connection and caches; it does not add per-message overhead. The current design lands the FALCON binding before peer scoring, so a peer that fails the FALCON check is dropped before it can influence the gossip mesh.
+
+### 9.4 Rate limiting and DDoS resistance
+
+Network-layer DDoS resistance is built into the connection lifecycle:
+
+- Maximum 5 new connections per second per source IP.
+- Maximum 50 total peer connections.
+- Maximum 30 inbound (the rest reserved for outbound dialing).
+- Per-peer message rate limits with peer scoring.
+- Evidence-channel ingest rate-limited to prevent FALCON-verify CPU burn from garbage-evidence spam.
+
+A peer that fails repeated message-validation checks is downscored and eventually dropped from the mesh. The score thresholds are intentionally conservative for mainnet and tuned for higher selectivity in post-mainnet hardening.
+
+### 9.5 The synchronization protocol
+
+A new node syncing from cold reaches the chain head through a three-phase protocol:
+
+1. **Trust-bootstrap.** Load the most recent published weak-subjectivity checkpoint (§3.5). Verify the FALCON signatures on the checkpoint against the previous checkpoint's committee. The result is a trusted (slot, state root, committee public keys) tuple.
+
+2. **Backfill.** Request blocks from the trusted checkpoint forward to the current chain head via the `pyde/sync/1` channel. Verify each block's proposer signature, ordering commitment, decryption-share aggregation, FALCON quorum certificate, and state-root continuity.
+
+3. **Live-tail.** Once at the head, switch to live participation on `pyde/blocks/1` and (if validating) `pyde/consensus/1`.
+
+A four-validator devnet bootstrap completes in seconds. A larger network's bootstrap is bounded by the bandwidth from the seed peers; the operator can prefetch a snapshot from a published archive to skip the backfill phase entirely.
+
+---
+
+## 10. Cross-Chain Interactions and the Parachain Architecture
+
+This section describes Pyde's cross-chain story. It is a body chapter — the architecture is settled at genesis even though shipping is staged. The parachain layer ships post-mainnet on a + 6-to-+ 12-month horizon, with detail expanded in §19. What this chapter establishes is the protocol-level structure that makes parachains permissionless, the primitive that mainnet ships to enable them, the unified gas model that hides the parachain layer from the user, and the comparison to the cross-chain models in market today.
+
+### 10.1 The thesis
+
+Cross-chain interaction in production crypto today is dominated by two failure modes. The first is custodial multisigs (Wormhole, Ronin, Nomad, Multichain) — every major bridge exploit on record has been a trusted-relay failure, and the cumulative loss across 2021 – 2023 is on the order of $3 B. The second is complex cross-chain protocols (LayerZero, Axelar, IBC) that bolt onto chains designed without cross-chain in mind, with trust models that depend on small operator sets, oracle-relayer coordination assumptions, or chain-specific light-client implementations.
+
+Pyde takes a different path. Cross-chain — and more broadly, every form of decentralized external interaction (oracle networks, indexers, off-chain compute) — happens through a **parachain layer of decentralized infrastructure providers**. A parachain is not a sovereign app-chain in the Polkadot sense. It is a public, open-source implementation of a Pyde-published specification, run by a permissionless operator set that stakes PYDE, follows the spec's rules, and provides a specific service to Pyde contracts via the `cross_call!` macro. The contract-side surface is uniform: a contract calls `cross_call!`, pays a combined gas fee that covers both Pyde execution and parachain execution, and receives an asynchronous callback when the result is available.
+
+### 10.2 The mainnet primitive: HardFinalityCert
+
+The single piece of cross-chain infrastructure that mainnet ships is the `HardFinalityCert` already defined in §3.3. Restating the structure for completeness:
+
+```rust
+struct HardFinalityCert {
+    slot:         u64,
+    block_hash:   Hash,
+    state_root:   Hash,
+    voter_bitmap: u128,
+    signatures:   Vec<FalconSignature>,
+}
+```
+
+This certificate is the cross-chain-portable proof that "block N was hard-finalized on Pyde at state root R." Any parachain that bridges out of Pyde — or any contract on a counterparty chain that wants to verify a Pyde event — consumes this certificate. The verification cost is 86 FALCON-512 verifications (~86 ms on commodity hardware) plus one Merkle path verification from the state root to the bridged data — feasible on any chain with a reasonable VM. The cert's stability across the chain's lifetime is what makes everything in §10.3 – §10.7 possible without further mainnet protocol work.
+
+### 10.3 Parachains as decentralized functional infrastructure
+
+The Pyde core team publishes a **parachain specification** as part of the protocol. The spec defines:
+
+- The interface a parachain must expose (which operations it serves, what arguments it accepts, what return shape it produces).
+- The attestation format (how parachain operators sign their results so Pyde can verify them).
+- The callback protocol (how attestations make their way back to the originating contract).
+- The gas-metering model (how parachain compute is priced in PYDE compute units, see §10.4).
+- The staking rules (PYDE bond per operator, slashing conditions for invalid attestations or downtime).
+
+The specification is the protocol-level contract. Anyone can implement the spec — in Rust, Go, C++, Python, or any other language — and operate the resulting parachain. Multiple independent implementations of the same parachain category are encouraged; redundancy and operator competition are the reliability story. Pyde may publish reference implementations in major languages as starting points, but the reference implementations are not requirements. **All parachain code is open source by design**; the layer has no proprietary boxes, no privileged operators, no closed implementations.
+
+Operator entry is permissionless. To run a parachain, an operator stakes PYDE according to the category's rules, runs a conforming implementation that meets the published hardware spec, and joins the operator set for that category. There is no application process, no slot auction, no parachain-team gatekeeping. An operator that signs invalid attestations is detectable by the rest of the operator set and slashable on Pyde via on-chain evidence.
+
+Each parachain category chooses its own internal consensus mechanism — a small BFT instance among the operators, threshold-signature aggregation, proof-of-authority among the registered set, or whatever fits the category's latency and security requirements. The choice is documented in the category's spec entry; Pyde verifies the resulting attestation against the registered operator set regardless of how the operators agreed on it. This is the same pluggable-consensus design philosophy that Polkadot's BABE-and-GRANDPA split established as a reasonable shape — applied to a different scope (infrastructure providers, not app-chains).
+
+Looking forward, the parachain attestation model is designed to evolve. As Pyde's ZK roadmap matures (§19.1 Phase 3, ~ + 24-36 months post-mainnet), parachain categories will be able to register a ZK circuit that proves correct execution of the category's operations, and the parachain layer will accept ZK-proof attestations alongside the consensus-signed and threshold-signature attestations described above. The implications fundamentally change the parachain trust model: a parachain category that ships ZK proofs no longer needs M-of-N operator honesty for safety — the proof itself is the trust anchor — and operator validation collapses from re-execution to proof-verification, a roughly two-orders-of-magnitude cost reduction for compute-heavy categories. A bridge parachain producing ZK proofs of Pyde state becomes verifiable on chains whose execution budgets cannot afford native FALCON verification, opening trustless interop with the entire crypto ecosystem rather than only with chains gracious enough to host the FALCON verifier. The parachain spec is sized to absorb this evolution without protocol-level changes; Phase 3 of the ZK roadmap is the integration that turns the parachain layer from "decentralized infrastructure with on-chain rules" into "decentralized infrastructure with cryptographic proofs of correctness."
+
+### 10.4 The unified gas model
+
+The most important UX consequence of the parachain architecture is that **the parachain layer is invisible to the user**.
+
+Parachain function logic is gas-metered, just like Pyde's PVM. The category's spec defines the per-operation compute cost in the same compute units the PVM uses. When a Pyde contract calls `cross_call!`, the gas estimator computes the **combined cost** — the Pyde-side execution plus the parachain-side execution — and the user pays one transaction fee that covers both. The parachain operators earn their share of the fee in proportion to the work they perform, settled on-chain when the callback transaction lands.
+
+There is no separate billing, no separate token, no separate wallet flow, no "buy LINK to pay the oracle" step. The user does not need to know that `cross_call!` routes through a parachain layer; they just see "this transaction costs X gas," sign once, and receive the result via the contract's callback function. The composition is seamless from the user's perspective and trust-minimized at the protocol level.
+
+### 10.5 The cross_call! macro and the async callback pattern
+
+An Otigen contract initiates a cross-call:
+
+```otigen
+cross_call!(
+    target:   "ethereum",
+    method:   "request_price",
+    args:     (pair, address(self)),
+    callback: "on_price_received",
+);
+```
+
+What happens at the protocol level:
+
+1. The Pyde validator runs the contract, hits the `cross_call!`, marks the call as pending in state, and emits an event referencing a unique call ID. The validator computes the combined gas (Pyde + parachain category) and bills the user.
+2. The parachain operators for the target category (in this example, Ethereum-bridge parachains) see the event via gossip on the parachain-coordination channel.
+3. The parachain operators execute the requested operation — in this example, calling the `request_price` function on the Ethereum chain via their Ethereum-side relayer, observing the result via Ethereum block headers, and aggregating the result.
+4. Once the parachain's internal consensus produces an attestation (M-of-N FALCON sigs, a BFT QC, or whatever the category's consensus produces), an operator submits a callback transaction to Pyde. The callback transaction carries the call ID, the attested result, and the operator-set signatures.
+5. The Pyde validator verifies the attestation against the registered parachain's operator set, then invokes the originating contract's callback function (`on_price_received`) with the result. The callback's gas was pre-paid as part of the original transaction.
+
+The pattern is fully asynchronous: the originating transaction completes after marking the call as pending, often many slots before the callback fires (the latency depends on the target chain's finality and the parachain's internal consensus). Contracts that need request-pending semantics implement them as state transitions; the protocol does not constrain how the contract handles the response.
+
+### 10.6 What kinds of parachains people will build
+
+The spec is general enough to accommodate any decentralized service that returns an attested result. Concrete categories the spec is designed to enable:
+
+- **Cross-chain message routers.** Pyde → Solana, Pyde → Ethereum, Pyde → Bitcoin, Pyde → other PoS L1s. Operators run nodes on the target chain and use standard light-client verification or chain-specific proof patterns to attest to Pyde-side observations of the target chain's state.
+- **Oracle networks.** Price feeds (ETH/USD, BTC/USD), weather data, sports results, identity attestations, custom data. Operators aggregate from off-chain sources, apply deviation tolerance, and submit attested results via the same callback pattern.
+- **Indexers.** Subgraph-style data services that materialize derived state (token holders, governance vote tallies, NFT ownership history) for cheap on-chain reads from contracts that would otherwise pay to scan storage.
+- **Off-chain compute.** Zero-knowledge proof generation for compute-heavy operations, ML model inference, custom verifiable computation. The parachain runs the heavy compute and attests to the result; Pyde verifies the attestation cheaply.
+- **Anything else that fits the spec.** The architecture is open. Categories that nobody has thought of yet can be built once the spec ships, without protocol changes.
+
+### 10.7 Comparison to other decentralized-infrastructure and cross-chain models
+
+The closest **functional** comparison is to **Chainlink**. Chainlink is a decentralized oracle network — operators run nodes that aggregate off-chain data and post attested results to a target chain. Pyde's parachain architecture extends the same model to all forms of decentralized external interaction (cross-chain bridges, oracles, indexers, off-chain compute) and integrates it natively into the L1's gas model. A Pyde contract calling `cross_call!` to an oracle parachain pays gas the same way it pays for any other operation: no separate token, no separate billing, no third-party SDK. Chainlink-style decentralized infrastructure as a first-class L1 feature.
+
+The closest **scope** comparison is to **Polkadot**. Polkadot's parachain architecture supports sovereign app-chains via auctioned slots and shared validator security; the auction mechanism exists because Polkadot's relay-chain validator capacity is a finite resource that must be allocated. Pyde's parachain architecture has a different scope: not app-chains, but decentralized infrastructure providers organized by function. Operator entry is permissionless and gated by PYDE staking + spec conformance; there is no slot scarcity, no auction, no parachain-team gatekeeping. The two systems share Polkadot's pluggable-consensus design philosophy — BABE / GRANDPA is a precedent for letting parachain operator sets choose their own internal consensus — applied to different scopes.
+
+**LayerZero, Wormhole, Axelar, and other cross-chain protocols** typically rely on an oracle-and-relayer trust model where the oracle (often a small set of operators) and the relayer collude to prove a message. Pyde's parachain operators are publicly known, stake PYDE on-chain, follow a published spec, and are slashable for misbehavior — a structurally different trust model from "oracle and relayer don't collude."
+
+**Cosmos IBC** is the most rigorous cross-chain protocol shipped to date — light-client verification between sovereign zones. Pyde's parachain layer can interface with IBC by running an IBC-light-client parachain that bridges Pyde to Cosmos zones, but the protocol-level surface is different: IBC's primitive is zone-to-zone, Pyde's primitive is "contract-to-anywhere via a parachain layer."
+
+**Ethereum's L2 ecosystem** fragments the user surface across L2s, each with its own sequencer (centralized in production, decentralization on roadmap), its own bridge (custodial trust assumption), and its own decentralization story. Pyde's parachain layer is one open spec, one staking token, one gas model, one set of trust assumptions — applied uniformly across every category.
+
+### 10.8 What ships at mainnet versus post-mainnet
+
+| Capability | Mainnet | Post-mainnet plan |
+| --- | --- | --- |
+| Sovereign L1 with hard finality | Yes | — |
+| `HardFinalityCert` as cross-chain primitive | Yes | Used by every parachain that bridges out of Pyde |
+| `cross_call!` Otigen macro | Stub (no-op at runtime) | Wired to the parachain layer when spec ships |
+| Parachain specification published | No | ~ + 6 months |
+| First reference parachain (likely Ethereum-bridge with FALCON-in-EVM verifier) | No | ~ + 6 to + 9 months |
+| Multi-category ecosystem (bridges, oracles, indexers, off-chain compute) | No | ~ + 12 months |
+| Multiple competing operators per category | No | ~ + 18 to + 24 months |
+| Slot auctions for parachain inclusion | Not applicable | Not applicable — PYDE staking + spec conformance is the entry rule |
+
+Pyde at launch is a sovereign L1 with a published parachain specification but no live parachain implementations. The parachain ecosystem is the post-mainnet surface; the architecture, the gas model, and the contract-side macro are settled at genesis. The implementations follow.
+
+---
+
+## 11. Account Model
+
+### 11.1 Three account types
+
+Every entity on Pyde is one of three account types:
+
+| Type | Address derivation | Authorization |
+| --- | --- | --- |
+| Externally-owned account (EOA) | `Poseidon2(falcon_pubkey)` | FALCON-512 signature(s) under `AuthKeys::Single` or `AuthKeys::Multisig` |
+| Contract — nonce-derived | `Poseidon2(deployer_addr || deployer_nonce)` | None at the address; calls are authorized by the call-context sender |
+| Contract — salt-derived (CREATE2-style) | `Poseidon2(0xFF || deployer_addr || salt || code_hash)` | Same as nonce-derived |
+
+Addresses are 32 bytes regardless of type. There is no distinction at the type level between an EOA and a contract from the perspective of a transaction recipient — a transaction sending value to an address that turns out to be a contract triggers the contract's payable-fallback path; sending to an EOA simply credits the balance.
+
+### 11.2 Account record layout
+
+The on-chain account record is 141 bytes fixed plus a variable-length `auth_keys` field:
+
+```
+nonce_bitmap:    [u8; 16]   // 16-slot rolling nonce window (no head-of-line blocking)
+balance:         u64
+storage_root:    [u8; 32]   // JMT root for this account's storage (contracts AND programmable EOAs)
+code_hash:       [u8; 32]   // Poseidon2 of attached bytecode (contracts AND programmable EOAs; zero for simple EOAs)
+acct_status:     u8         // Active | Exited | Slashed | Vesting | Frozen
+auth_keys:       AuthKeys   // Variable: Single(pubkey) | Multisig(M, [pubkey; N]) | Programmable (post-mainnet)
+```
+
+The `code_hash` and `storage_root` fields are populated for any account with attached executable code — contracts at mainnet, and programmable EOAs once the post-mainnet feature ships (§11.6). Simple EOAs leave both fields zero. This unification — one set of fields for any account that carries code, regardless of whether it also carries signing keys — is what lets programmable accounts reuse the entire contract-execution machinery (PVM, AOT compiler, gas accounting, parity tests) instead of introducing a separate execution path for authorization policies.
+
+The 16-slot nonce bitmap is the next design choice that needs explanation. A traditional sequential-nonce model (Ethereum) creates head-of-line blocking: if a wallet submits transaction N at high gas and then transaction N+1 at low gas, the chain must process N before N+1, even if N+1 is independent. Under a busy mempool, a stuck transaction freezes the entire account. Pyde's bitmap allows up to 16 in-flight transactions per account in any order within a sliding window; the wallet can submit nonces 50, 51, 52, 60 concurrently, and the chain commits each as gas allows. The window slides forward as the lowest-numbered open nonce commits.
+
+### 11.3 Native multisig
+
+Multisig is not a contract on Pyde; it is a first-class authorization mode. An account whose `auth_keys` is `AuthKeys::Multisig(M, [pubkey_1, ..., pubkey_N])` requires M valid FALCON signatures over the transaction hash, drawn from the listed public keys. The maximum is `MAX_SIGNERS = 16`. Signature verification at execution time produces M FALCON checks; gas cost scales with the signer count.
+
+The motivation is twofold. First, the application surface for multisig (treasury, DAO, exchange custody) is large enough that contract-based multisig (Gnosis Safe and analogues on Ethereum) ends up reimplementing the same logic across many projects with subtle bugs. Second, the protocol-level treasury controls in §14 (`MultisigTx`, `RotateMultisig`) need an M-of-N primitive in the protocol regardless; exposing it to user accounts is incremental work for substantial application benefit.
+
+### 11.4 Vesting and locked balances
+
+Genesis and post-launch token allocations support vesting schedules. An account's record includes an optional vesting field carrying:
+
+- `start_slot` — when vesting begins
+- `cliff_slot` — when the first tranche unlocks
+- `end_slot` — when full vesting completes
+- `total_locked` — the original locked amount
+
+The transaction validator checks every spending transaction against the vested-vs-locked split: only the vested portion at the current slot is spendable. This is enforced at the validation layer (before execution), so a contract-based bypass is structurally impossible — the protocol itself does not permit a transfer that would draw from locked balance. Misconfigured vesting (cliff > end) is rejected at genesis; the runtime prioritizes end-of-vesting over cliff if a contradiction occurs in legacy state.
+
+### 11.5 Airdrop claim
+
+The protocol supports Merkle-tree airdrop claims as a first-class transaction type. A genesis or governance event publishes an airdrop Merkle root and pre-mints the total claimable supply into a dedicated pool address. Each eligible recipient holds `(address, amount, Merkle proof)`; submitting a `ClaimAirdrop` transaction with the proof transfers the amount from the pool to the recipient and records the claim. After a configured deadline, an unclaimed remainder can be swept by the operator to a designated address (treasury or burn).
+
+The on-chain `build_tree()` is public so any off-chain CLI tool can share the leaf and node formulation. The CLI tool itself is post-mainnet (see §19) — the on-chain primitive ships at launch.
+
+### 11.6 Programmable accounts (post-mainnet)
+
+Native multisig is the first step toward a fuller account-abstraction model, with the same opt-in design philosophy: simple EOAs pay nothing extra, while users who want programmable behavior get protocol-native primitives without a separate contract layer.
+
+The post-mainnet roadmap extends `AuthKeys` with a third mode:
+
+```
+enum AuthKeys {
+    Single(FalconPubkey),
+    Multisig(M, Vec<FalconPubkey>),
+    Programmable,                    // post-mainnet — bytecode at code_hash, state at storage_root
+}
+```
+
+The design point: a programmable account is structurally an EOA — it has a signing key (carried by the policy or by an embedded key the policy verifies), a nonce, a balance — that *also* has attached executable code. The policy's bytecode lives at the account's `code_hash` field (the same field a contract uses to reference its bytecode); the policy's runtime state lives at the account's `storage_root` field (the same field a contract uses for its storage); the `AuthKeys::Programmable` marker distinguishes the account from a simple EOA or a regular contract. The unification means the protocol does not need a separate "policy execution" path: the same PVM that runs contract code runs policy code, with a flag indicating policy mode (which restricts state access to the account's own storage during the validation pre-check). The same gas accounting, the same parity tests between interpreter and AOT, and the same upgrade pathways apply. From the protocol's perspective, a programmable EOA is a contract that has signing keys, and a regular contract is a programmable account that has no signing keys.
+
+A programmable account's policy runs on every transaction the account would authorize. The policy receives the candidate transaction (recipient, value, calldata, gas, presented signature set) plus access to its own state slots; it returns Allow or Deny. Concrete patterns people will want to write:
+
+| Policy | What it expresses |
+| --- | --- |
+| Daily spend limit | At most 1,000 PYDE per 24 hours regardless of which signature is presented |
+| Allow-listed recipients | Tx denied unless `tx.to ∈ {set of trusted contracts}` |
+| Time lock | Tx denied until `slot > unlock_slot` |
+| Tiered authorization | Small txs need 1 signature; medium need 2-of-3; large need 3-of-3 |
+| Recovery flow | 2-of-3 sigs OR 1-of-3 after 30-day inactivity window |
+| Tagged session caps | Cumulative spend for a tagged session is bounded |
+
+The policy contract is sandboxed by the PVM, gas-metered, and read-restricted to its own account state (it cannot arbitrarily query other accounts during the validation pre-check). Policy execution adds a small per-transaction overhead — one extra PVM call — paid only by accounts that opted into the mode. Simple `Single`-keyed EOAs are unaffected.
+
+The motivation is twofold. First, the user's threat model expands beyond "someone steals my private key." A programmable account with a daily spend limit and an allow-listed recipient set is meaningfully harder to drain even with full key compromise; the worst-case loss is bounded by the policy rather than by the balance. Second, the operator's cognitive load shrinks: the account is the rule book, not just a signing key. A treasury that requires "spend > $100,000 needs 3-of-5 signatures and a 24-hour delay" is one account configuration, not a separate Gnosis-Safe-style contract that has to be deployed, audited, and re-learned by every new signer.
+
+This is account abstraction as a protocol-native mode rather than a contract layer every project re-implements. The native multisig that ships at mainnet is the proof that the architectural direction works; the full programmable mode ships post-mainnet (Section 19).
+
+### 11.7 Session keys (post-mainnet)
+
+A session key is a delegated authorization that lets an application sign a bounded set of transactions on behalf of an account without prompting the master wallet for each one. The use case is dApps where the wallet popup is itself the friction blocking adoption — gaming with hundreds of small actions per minute, AI agents executing strategies on a schedule, social and consumer apps where "sign every action" is unworkable.
+
+The protocol-level shape:
+
+```rust
+struct AuthorizedSession {
+    session_pubkey:    FalconPubkey,
+    valid_until:       u64,                // slot deadline
+    scope: SessionScope {
+        allowed_contracts: Vec<Address>,    // narrow by default
+        allowed_methods:   Vec<u32>,        // 4-byte selectors, allow-listed
+        max_per_tx:        u64,             // PYDE cap per session-key tx
+        max_total:         u64,             // cumulative session cap
+    },
+    nonce:             u64,                 // master's nonce when issued
+    master_signature:  FalconSignature,     // master signs the above
+}
+```
+
+The master account issues a session by submitting a `RegisterSession` transaction once. From then on, transactions can be signed by the session key and validated against the master's authorization plus the session's running spend. A session-key-signed transaction carries the session's public key and a signature over the transaction hash; the on-chain `AuthorizedSession` record is referenced by ID.
+
+Validators check, in order: the session's `valid_until` has not passed, the operation falls within the session's allow-listed contracts and methods, the cumulative spend stays under the session caps, and the session key's signature on the transaction hash verifies. The master account's authorization signature is verified once when the session is registered and cached in account state thereafter; it does not need to be re-verified per transaction.
+
+Revocation is instant. The master submits a `RevokeSession` transaction; the session record is marked invalid; subsequent session-key transactions fail validation at the validator's auth layer.
+
+Two design choices keep session keys from becoming a slow-MEV channel. First, defaults are narrow: a session created via the SDK defaults to a single contract, a small allow-list of methods, a 24-hour duration, and a low per-tx cap. A wallet has to make explicit, larger grants explicit to the user; a wallet that quietly auto-creates broad sessions without consent is breaking the social contract that the protocol primitives are designed to surface. Second, every session-key transaction emits an observable event keyed to the master account, so the master (or a watcher process the master configures) can monitor session activity in real time.
+
+Session keys ship post-mainnet (Section 19), as a complement to programmable accounts. The two features together give Pyde dApps the UX surface that has been a hand-rolled retrofit on every major chain to date.
+
+---
+
+## 12. Gas and Fee Model
+
+### 12.1 EIP-1559 inheritance, no priority tips
+
+Pyde's fee model is EIP-1559 with one substantive simplification: there are no priority fees. Every transaction at a given block's `base_fee` pays exactly the same per-gas price; there is no priority lane, no MEV-Boost-style bid, no proposer tip.
+
+The reasoning is structural. EIP-1559 priority fees exist to give wallets a way to signal "this transaction is more time-sensitive than others." On Ethereum, the proposer can see the mempool and prioritize accordingly; the priority fee is the price signal. On Pyde, the proposer cannot see the mempool (encrypted-mempool path, §5), so there is no information channel through which a priority signal could be acted on. Adding a priority field would price an asymmetry that does not exist. The mempool's per-sender rate limits, global cap, and TTL eviction (§5.4) handle congestion; the base fee handles long-run pricing.
+
+### 12.2 Block gas, base fee adjustment
+
+```
+GAS_TARGET       = 400_000_000      // 400 M gas per block at equilibrium
+GAS_CEILING      = 1_600_000_000    // 1.6 B gas per block at the elastic ceiling (4×)
+GENESIS_BASE_FEE = 50_000_000_000   // 50 gwei equivalent (50 × 10⁹ quanta per gas unit)
+ADJUSTMENT_DIV   = 8                 // Max ±12.5% base-fee change per block
+```
+
+The base fee adjusts each block based on the previous block's gas usage:
+
+```
+if used > target:  base_fee_next = base_fee × (1 + (used - target) / target / 8)
+if used < target:  base_fee_next = base_fee × (1 - (target - used) / target / 8)
+```
+
+The maximum adjustment per block is 12.5 %; the elastic block ceiling is 4 × the target, so under sustained pressure the base fee climbs quickly until equilibrium is restored. This is the same dynamic Ethereum uses; the parameters are tuned for Pyde's 400 ms slot rate (twice as many adjustment opportunities per minute as Ethereum's 12-second slot).
+
+### 12.3 Fee distribution
+
+Every base-fee payment splits 70 / 20 / 10:
+
+- **70 % burn** — permanently removed from supply, contributing to deflationary pressure under sustained activity.
+- **20 % validator** — credited to the proposer's reward stream for the block, plus a treasury-defined floor for under-load periods.
+- **10 % treasury** — accrues to the treasury account, controlled by the multisig described in §14.
+
+The split is locked in code at the validation layer with constants `FEE_BURN_PCT = 70`, `FEE_VALIDATOR_PCT = 20`, `FEE_TREASURY_PCT = 10`. The constants are referenced from the `tx` and `consensus` crates and from the README; future changes require a coordinated PIP and validator upgrade. There is no per-block governance lever to adjust the split.
+
+### 12.4 Per-opcode gas costs
+
+Sample gas costs for representative opcodes (the full schedule lives in `crates/pvm/src/gas.rs`):
+
+| Operation | Gas cost |
+| --- | --- |
+| `Add`, `Sub`, `And`, `Or`, `Xor`, comparison | 3 |
+| `Mul` | 5 |
+| `Div`, `Mod` | 8 |
+| `Sload` (warm) | 100 |
+| `SloadCold` (first touch) | 2 100 |
+| `Sstore` (warm, no change) | 100 |
+| `Sstore` (warm, set) | 5 000 |
+| `SstoreCold` (first touch, set) | 22 100 |
+| `Poseidon2` (1 block) | 36 |
+| `MerkleVerify` (per level) | 36 |
+| `VerifySig` (FALCON-512 verify) | 30 000 |
+| `CallExt` (base) | 700 |
+| `Memcpy` (per byte) | 3 |
+| Page-touch surcharge | 200 (one-time per 4 KB page) |
+
+The `VerifySig` cost reflects the FALCON-512 verify time; cryptographic primitives are explicit gas line items rather than implicit costs in interpreted code. This is what keeps Pyde's gas accounting honest in the face of post-quantum signature overhead.
+
+### 12.5 Gas tank and paymaster
+
+Two account-abstraction-style features are implemented but production-restricted:
+
+- **Gas tank.** A per-account spending cap that lets a wallet pre-fund a "gas budget" separately from the spending balance. Useful for offboarding gas decisions from the per-tx UX.
+- **Paymaster.** A pattern where a third party (typically a dApp) sponsors gas for a user's transaction.
+
+Both features are implemented in the transaction layer. Both are currently rejected on production chain IDs by the validation layer (caught during internal audit). The reason is integration risk: combinations of multisig + paymaster + gas-tank create authorization-flow paths that have not been audited end-to-end. Mainnet ships with these features gated; the gates lift after an additional audit pass in the post-mainnet hardening track.
+
+### 12.6 The effective cost of a transaction
+
+The headline gas price is one input to what a user actually pays. The other inputs — priority tips, MEV extraction, separate-token holdings for oracle and bridge calls — are absent from Pyde by design, and their absence pushes the effective per-transaction cost meaningfully below what comparable chains charge for the same logical operation. Four compounding mechanisms drive this:
+
+**EIP-1559 base fee floats with utilization.** At demand below the 400 M block-gas target, the base fee drops by up to 12.5 % per block, all the way to the genesis base-fee floor (50 gwei equivalent). A chain operating below saturation runs at the floor; users see headline gas prices that look like Ethereum during its quietest hours. Pyde's high design-target throughput (12,500 sustained TPS, ~ 19 K theoretical at the gas ceiling) means that for every realistic demand level except sustained saturation, the chain operates with substantial headroom and the base fee stays low.
+
+**No priority tips means no fee-bump war.** Every transaction in a block pays the same per-gas price. There is no tip-escalation race during congestion, no wallet UI that quietly raises a "recommended tip" by 5 × in a busy moment, no "I tipped $200 in a panic" failure mode. The user pays base — predictably, transparently, equally.
+
+**No MEV tax on the all-in cost.** Sandwich attacks, frontrunning, and JIT liquidity each impose a hidden cost on every public swap on every visible-mempool chain, measurable in basis points per trade and aggregating to multi-billion-dollar annual extraction industry-wide. Pyde's encrypted mempool removes this entire category. The all-in cost of a Pyde DEX swap is the gas, not the gas plus the MEV. For a retail trader doing $1 000 of swap volume per month on a chain with a typical 20-bps MEV tax, this is a $24-per-year saving that no headline gas-price comparison captures.
+
+**No separate token for oracle or cross-chain calls.** When a contract uses `cross_call!` to query an oracle, route a cross-chain message, or request off-chain compute, the user pays one combined gas fee in PYDE — no LINK to hold for oracle access, no separate billing for the bridge layer, no token-conversion friction. The "I need to hold five tokens to use this dApp" failure mode is structurally absent (§10.4).
+
+**The 9-decimal precision keeps low-value transactions sensible.** With 10⁻⁹ PYDE precision (Solana-equivalent), micro-payments, gaming actions, AI-agent ticks, and consumer-app interactions stay economically meaningful at any plausible PYDE valuation. The chain does not price out high-frequency low-stake interactions at the precision floor.
+
+**The honest caveat.** Cheap fees are not a feature; they are an emergent property of supply versus demand. EIP-1559 will move the base fee up exactly the way it does on Ethereum if demand exceeds supply, and there are workloads (genuinely-saturated mainnet, viral consumer apps) where Pyde's fees will rise. Pyde's claim is structural fee economics, not a guarantee of perpetually-low headline numbers — but the structure pushes hard in the user's favor at every level of utilization, and the four mechanisms above are protocol-level rather than market-level. The user does not pay tips, does not pay MEV tax, does not pay a separate oracle token. Whatever the chain is at any moment, it is at least these things cheaper than the chain that does not have these properties.
+
+---
+
+## 13. Tokenomics
+
+### 13.1 The PYDE token
+
+PYDE is the native token of the Pyde chain. It is the only token recognized by the protocol for staking, fee payment, and governance multisig operations. Application tokens (ERC-20-style fungibles, NFTs, etc.) are smart contracts and are first-class citizens, but they are not interchangeable with PYDE for protocol-level functions.
+
+```
+GENESIS_SUPPLY        = 1 000 000 000  PYDE  (10¹⁸ quanta)
+DECIMALS              = 9                    (1 PYDE = 10⁹ quanta)
+VALIDATOR_STAKE       = 10 000  PYDE         (10¹³ quanta)
+UNBONDING_PERIOD      = 3 024 000 slots      (~14 days)
+```
+
+The 9-decimal precision (rather than the 18-decimal precision common on Ethereum) reflects a practical assumption: per-tx fee precision below 10⁻⁹ PYDE is irrelevant at any plausible PYDE valuation. Storage is correspondingly more compact.
+
+### 13.2 Inflation schedule
+
+Per-block protocol inflation follows a step-down schedule:
+
+| Year | Inflation rate (per epoch, basis points) |
+| --- | --- |
+| 1 | 5.00 % (500 bps) |
+| 2 | 3.00 % (300 bps) |
+| 3 | 2.00 % (200 bps) |
+| 4+ | 1.00 % (100 bps) |
+
+Inflation is computed per block as a fraction of the prior block's circulating supply, rounded to whole quanta. The minted PYDE is distributed across active validators in proportion to their participation in the previous epoch, plus a treasury share. The 1 % terminal rate is fixed indefinitely; any change requires a PIP-driven validator upgrade.
+
+### 13.3 Validator rewards
+
+A validator earns from two streams, tracked separately:
+
+- **Inflation reward.** The validator's share of the per-block protocol inflation, accumulated per epoch and claimed via `ClaimReward` transactions. The active validator count divisor is monotonic per-epoch (only counts validators present for the full epoch), preventing reward dilution by transient validators.
+
+- **Fee reward.** 20 % of every base-fee payment in blocks the validator successfully proposes or attests to, distributed in proportion to attestation share.
+
+A validator who is `Exited` or `Slashed` cannot claim accrued rewards from prior epochs; the accrued amount is forfeited to the treasury and burn pool. This is the gate that prevents an exited validator from withdrawing stake and then claiming rewards earned during the time they were active — an early implementation had this gap, which the internal audit caught and fixed before testnet.
+
+### 13.4 Genesis allocation
+
+The 1 B PYDE genesis supply is distributed across allocation buckets, with per-bucket caps enforced at genesis validation:
+
+| Bucket | Allocation | Notes |
+| --- | --- | --- |
+| Foundation reserve | TBD | Long-horizon protocol stewardship; multisig-controlled |
+| Validator subsidy | TBD | Pre-mints distributed via the validator subsidy stream over the first N epochs |
+| Airdrop pool | TBD | Pre-minted into the airdrop pool address; claimable via Merkle proof |
+| Vesting buckets (team, advisors, early backers) | TBD | Per-account vesting schedules: cliff, end, monthly unlock |
+| Public sale / ecosystem | TBD | Liquid at genesis |
+| Treasury seed | TBD | Initial treasury balance, multisig-controlled, governed via PIP-attached MultisigTx spends |
+
+Specific allocation percentages are governance-set in the genesis TOML and subject to community input before the genesis ceremony. The protocol enforces only the structural constraints: the per-bucket cap arithmetic must equal the genesis supply, the vesting schedules must not be self-contradictory, and the airdrop Merkle root + pool pre-mint must reconcile to the same total. Each of these constraints is enforced at genesis-validation time and was hardened during the internal audit cycle.
+
+### 13.5 Burn dynamics
+
+The 70 % fee-burn rate is the largest deflationary force on the supply. Under sustained activity at the 12,500 TPS design target, with a representative average gas-per-transaction of ~52 K and a base fee of 50 gwei equivalent, the per-second burn is on the order of:
+
+```
+12 500 tx/s × 52 000 gas × 50 × 10⁹ quanta / 10⁹ (decimals) × 0.7 (burn share)
+= ~22.75 PYDE per second burned
+≈ 718 M PYDE per year burned at full saturation
+```
+
+This is a design ceiling, not a forecast. Actual burn depends on actual throughput, which depends on actual usage. The point is that the deflationary pressure is calibrated such that, at full network saturation, burn outpaces the 1 % terminal inflation rate by roughly two orders of magnitude. Pyde becomes a deflationary asset under high utilization and a mildly inflationary asset under low utilization. The crossover point is when annual burn equals annual mint, at roughly 0.6 % of the design throughput; beyond that, supply contracts.
+
+A `total_burned` state variable maintains a running audit trail for any party verifying the supply curve.
+
+### 13.6 Design rationale
+
+Pyde's tokenomics is not arbitrary. Each parameter is informed by what the field has tried, what has worked at scale, and where Pyde deliberately diverges. The honest summary, parameter by parameter:
+
+**EIP-1559 base fee + elastic blocks (inherited from Ethereum).** The base-fee + elastic-ceiling mechanism is one of the field's clearest engineering wins. It self-stabilizes under demand spikes without operator intervention, replaces the wasteful first-price auction that preceded it, and gives wallets a predictable price curve to estimate against. Pyde adopts the mechanism wholesale and tunes the parameters (12.5 % adjustment cap per block, 4 × elastic ceiling) for the 400 ms slot rate. The Ethereum research community produced this design; Pyde's contribution is the integration, not the invention.
+
+**70 / 20 / 10 fee distribution (Pyde-specific blend, informed by Ethereum and Bitcoin).** The two endpoints in the design space are well-known: Ethereum burns 100 % of the base fee post-Merge and routes priority tips to validators; Bitcoin pays validators the full transaction fee with no burn. Pyde sits between them — 70 % burned (capturing most of Ethereum's deflationary discipline), 20 % to the validator (income, since there are no priority tips), 10 % to a treasury (protocol-development funding without taxing validators). The split is calibrated to keep validators economically motivated under low-throughput conditions while retaining strong deflationary pressure under high throughput.
+
+**No priority tips (Pyde-novel, justified by encrypted mempool).** Every other major chain charges priority fees because the proposer can read the mempool and prioritize accordingly. Pyde's encrypted mempool eliminates that information asymmetry, so a priority tip would price an asymmetry that does not exist (§12.1). Removing tips also removes a tax that retail users disproportionately pay — sophisticated users tip strategically against measured base-fee curves, retail users tip blindly to "make sure it goes through." The information-asymmetry removal solves the technical problem; the no-tips choice solves the user-cost problem.
+
+**Decreasing inflation schedule, terminal at 1 % (informed by Bitcoin halvings, smoothed).** Bitcoin's halving model established the precedent that monetary policy on a chain can get tighter over time on a known schedule — and that predictability over decades is itself a feature. Bitcoin halves abruptly every four years; Pyde steps down more smoothly (5 → 3 → 2 → 1 % across four years) and then locks at 1 % indefinitely. The terminal 1 % is permanent without a coordinated PIP and validator upgrade — deliberately friction-heavy. This gives long-term holders a predictable monetary policy without Bitcoin's discontinuous halvings or Ethereum's variable-by-staked-ETH post-Merge issuance.
+
+**Fixed 10,000 PYDE validator bond, equal voting (Ethereum's fixed-stake combined with one-validator-one-vote).** Fixed validator stake (in contrast to Cosmos / Solana variable-stake delegation) is Ethereum's choice, and a defensible one — it caps the per-validator capital requirement and makes the validator-set economics legible. Pyde adopts the fixed bond at 10,000 PYDE and combines it with one-validator-one-vote (§1.2 Axiom 4), pushing one step further than Ethereum: stake doesn't influence voting at all. The bond is anti-sybil, not power-multiplier. To gain a second vote, a holder must stand up a second independent validator. This is Pyde's strongest divergence from the rest of the PoS field.
+
+**9-decimal precision (from Solana).** Solana uses 9 decimals (lamports = 10⁻⁹ SOL); Pyde uses 9 decimals (quanta = 10⁻⁹ PYDE). Finer than typical asset-pricing requires, coarser than Ethereum's 18-decimal precision; the balance is between storage compactness and per-tx fee precision. Solana proved 9 decimals is sufficient at production scale, and Pyde inherits the choice.
+
+**14-day unbonding period (informed by Cosmos's 21 days, calibrated to Pyde's checkpoint cadence).** Cosmos chains typically use 21-day unbonding periods to defend against long-range attacks while bounding the cost of validator exit. Pyde uses 14 days — slightly shorter, because Pyde's weak-subjectivity-checkpoint defense (§3.5, every 64 epochs ≈ 7 hours) shrinks the long-range-attack window that the unbonding period needs to cover. The unbonding window is still long enough to expose double-sign evidence on the chain before stake is released.
+
+**Off-chain governance + multisig treasury (from Bitcoin / Ethereum, against Cosmos / Polkadot).** The two precedents are clear and divergent. Bitcoin and Ethereum evolve their protocols through public off-chain proposal processes (BIPs, EIPs) and voluntary client upgrade; the legitimacy is anchored in social consensus. Cosmos and Polkadot use on-chain stake-weighted voting for protocol changes and treasury spends; the legitimacy is anchored in token concentration. Both have track records. Pyde chooses the Bitcoin / Ethereum model — off-chain PIPs for protocol changes (§14.1), multisig treasury with PIP-attached spends for funding (§14.3) — because the Cosmos / Polkadot model has shown coalition dynamics that the off-chain model avoids. This is one of the editorial calls in the design that the user should be able to disagree with cleanly; the §14.2 reasoning argues the case at length.
+
+**Where Pyde deliberately doesn't innovate.** Vesting schedules (cliff + linear unlock), airdrop Merkle claims, the genesis allocation bucket structure, and the reward-claim pattern are all standard. These are well-understood patterns where reinvention adds risk without adding value; Pyde inherits the field's playbook on all of them.
+
+The thesis: tokenomics is one of the easiest places for an L1 to invent unnecessarily. Pyde adopts the field's defensible mechanisms (EIP-1559, fixed bond, 9 decimals, vesting / airdrop / unbonding patterns), diverges where there is a specific reason to (no priority tips because of encrypted mempool, equal voting because stake-weighted voting concentrates power, off-chain governance because on-chain has track-record problems), and stays out of the parts where reinvention adds risk. The result is monetary policy that is honest about its inheritances and specific about its choices.
+
+---
+
+## 14. Governance
+
+### 14.1 The PIP process
+
+Pyde governance is deliberately off-chain. Protocol changes are proposed, debated, and ratified through Pyde Improvement Proposals (PIPs) — a public, versioned process modeled on Bitcoin's BIPs and Ethereum's EIPs, hosted at the `zarah-s/pips` repository, and ratified by PIP-0001 (which establishes the PIP process itself).
+
+PIPs come in three categories:
+
+- **Standards Track** — consensus-breaking changes. A new opcode, a new transaction type, a change to fee distribution, a change to the consensus protocol.
+- **Meta** — process changes. Updating the PIP workflow itself, changing the dispute-resolution model.
+- **Informational** — design notes, best practices, non-binding analyses.
+
+Standards Track PIPs follow a lifecycle: Draft → Review → Last Call → Accepted → Final (or Rejected, or Withdrawn). A PIP that reaches Accepted status enters a 6.5 M slot (~ 30 day) activation window before validator clients are expected to enable it.
+
+Validator upgrade is voluntary. A validator that disagrees with an Accepted PIP is free to refuse the upgrade; if enough stake (> 33 %) refuses, the PIP fails to activate and the chain continues on the prior protocol. This is the same model as Bitcoin and Ethereum hard forks: rough consensus by social process, executed by individual operator choice.
+
+### 14.2 What governance is *not*
+
+Pyde does not have on-chain stake-weighted voting on protocol changes. There is no PYDE-token-vote referendum that activates a fork, no two-chamber governance system, no on-chain lever that lets a 51 %-of-stake coalition unilaterally change protocol parameters. This is a deliberate choice; the alternative was considered and rejected (rationale catalogued in §19.9).
+
+The reasoning: on-chain stake-weighted governance on consensus-breaking changes makes the chain's evolution a function of token concentration. In every historical instance — Cosmos governance proposals on parameter changes, Polkadot referenda, MakerDAO emergency votes — the median voter ended up being a small coalition of large holders, validators, or delegated voting pools. The political legitimacy of "the chain voted" is not what it appears. Pyde leans the other way: protocol changes go through public technical debate (the PIP process), and validator operators decide individually whether to ship them. Token holders influence the process by being part of the community discussion; they do not have a direct voting right.
+
+The cost is slower decision-making for parameter changes that a stake-weighted vote could ratify in days. The benefit is that controversial changes either earn broad rough consensus or do not happen at all; the chain's evolution is not held by whoever owns the most tokens.
+
+### 14.3 What governance *is* on-chain
+
+On-chain governance is restricted to four operations, all gated by an M-of-N FALCON multisig with the multisig keys held by community-recognized signers:
+
+| Tx type | Operation | Notes |
+| --- | --- | --- |
+| `MultisigTx` (type 9) | Treasury spending | M-of-N signature; spend transactions reference a `data_digest = hash(pip_file_contents)` for auditable PIP → on-chain linkage |
+| `RotateMultisig` (type 10) | Signer rotation | Adds, removes, or replaces signers; same M-of-N gating |
+| `EmergencyPause` (type 11) | Halt non-Resume tx classes for a bounded duration | Maximum 30-day window, baked into the signed preimage |
+| `EmergencyResume` (type 12) | Lift an emergency pause early | Same M-of-N gating |
+
+The suggested defaults are 7 signers with a threshold of 4. The actual signer set and threshold are governance-set at genesis and rotatable via `RotateMultisig`. The hard maximum is `MAX_MULTISIG_SIGNERS = 16`.
+
+The `data_digest = hash(pip_file_contents)` field on `MultisigTx` is the audit-trail mechanism that links treasury spends back to the PIPs that authorized them. A spend without a corresponding accepted PIP is detectable in the on-chain history; the social process holds the multisig signers accountable for the linkage.
+
+### 14.4 Emergency pause semantics
+
+The `EmergencyPause` primitive exists for the genuinely-rare case where a critical bug requires halting non-essential transactions while a fix ships. The duration is bounded into the signed preimage with a hard 30-day maximum; the pause auto-expires on the deadline regardless of further action. `EmergencyResume` allows early lift if the issue resolves sooner. The pause does not prevent block production, finality, or staking operations — only the affected transaction classes are gated. This is the safety valve, not a governance tool.
+
+The state-writeback clobber protections in the multisig handlers prevent a `MultisigTx` whose target equals the sender from executing; this closes a class of treasury-drain attacks where a malicious signer set could direct a spend to themselves and have the post-execution writeback overwrite the credit.
+
+---
+
+## 15. Security
+
+### 15.1 The attack surface
+
+A blockchain's attack surface is the union of every protocol layer's failure modes. Pyde's surface, with the defense for each entry, fits in one table:
+
+| Attack class | Vector | Defense | Status |
+| --- | --- | --- | --- |
+| BFT safety violation | > 42 validators double-sign | Hard finality is a 86-of-128 FALCON QC; double-signers are slashable for 100 % of stake (§3.4) | Live |
+| Long-range attack | Old validator keys sign alternate history | Weak-subjectivity checkpoints (§3.5); new nodes start from a trusted recent checkpoint | Live |
+| Sybil | Many cheap validator identities | 10 000 PYDE bond per validator + equal voting (§3.4, §1.2 Axiom 4) | Live |
+| Eclipse | Adversary surrounds a node's peer set | Diverse peer selection via Kademlia DHT; bootstrap-peer fallback; FALCON peer authentication (§9.3) | Live |
+| DDoS — connection flood | Mass new-connection spam | 5 conns/s per IP, 50 max peers, 30 inbound (§9.4) | Live |
+| DDoS — gossip flood | Mass message spam on a topic | Per-peer rate limits, peer scoring, evidence-channel throttling | Live |
+| DDoS — mempool flood | Mass tx submission | Per-sender rate limit (10/s, 100 concurrent), per-sender mempool cap (128), global cap (100 000), TTL eviction (240 s) (§5.4) | Live |
+| Frontrunning / MEV | Proposer reads pending txs and inserts trades | Threshold-encrypted mempool + ordering commitment + mandatory inclusion (§5) | Live |
+| Censorship | Proposer drops a tx | Mandatory inclusion + local-view enforcement; signed mempool commitments + slashing | Live (local-view); cryptographic upgrade post-mainnet (§19) |
+| State manipulation | Adversary forges Merkle proof | Poseidon2-rooted JMT; light-client verification against published state root (§8.2) | Live |
+| Quantum cryptanalysis | Adversary breaks ECC consensus or account keys | Post-quantum from genesis: FALCON-512, Kyber-768, Poseidon2 (§4) | Live |
+| VM exploit | Crafted bytecode escapes the VM | Checked arithmetic, bounds-checked memory, trap on malformed inputs, parity tests interpreter ↔ AOT (§6) | Live |
+| Key compromise (offline) | Operator's keystore stolen | AES-GCM + Argon2id KDF (m = 64 MiB, t = 3) (§4.7) | Live |
+| Replay | Old signed tx submitted on a new chain | `chain_id` field bound into signature; nonce window prevents intra-chain replay (§11.2) | Live |
+| Treasury drain | Malicious multisig spend | M-of-N FALCON signature + state-writeback clobber protection + 30-day-bounded `EmergencyPause` (§14) | Live |
+| Vesting / airdrop drain | Underpaid claim, double-claim, locked-balance bypass | Gas-limit guard on claim/sweep, claim-once enforcement, vesting check at validation layer | Live |
+| Decryption withhold | Validator refuses to release threshold share | 2 % per-offense slashing + observable in gossip (§3.4) | Live |
+| Resharing manipulation | Corrupt committee member contributes a polynomial whose constant term ≠ their share | Detection via decryption failure at next epoch (mitigation); cryptographic upgrade via Pedersen / KZG commitments | Live (detection); cryptographic upgrade post-mainnet (§19) |
+
+The "Live" status indicates the defense is implemented and tested in the current branch. The two entries with post-mainnet upgrades — censorship slashing and resharing VSS — have working mainnet defenses (local-view enforcement, decryption-failure detection) and tracked future upgrades that strengthen the cryptographic guarantees without re-architecting the protocol.
+
+### 15.2 The audit programme
+
+Pyde's pre-mainnet external audit programme runs across five tracks, each engaging a separate specialist firm. The motivation for splitting is that no single firm covers the full surface — the cryptography track requires lattice-cryptography specialists, the consensus track requires distributed-systems specialists, the PVM track requires VM and JIT specialists, the networking track requires libp2p and gossip specialists, the otic track requires compiler specialists. A single firm purporting to cover all five is a quality-of-engagement red flag.
+
+| Track | Scope | Estimated spend |
+| --- | --- | --- |
+| Consensus | HotStuff variant, VRF, finality, slashing, weak-subjectivity, PSS | $500 K – $1 M |
+| PVM and execution | ISA, interpreter, AOT, gas accounting, parallel scheduler, parity tests | $500 K – $1 M |
+| Cryptography | FALCON, Kyber, Poseidon2, threshold encryption, VRF, Argon2id keystore | $500 K – $1 M+ |
+| Networking | libp2p, gossipsub, peer auth, DDoS resistance, sync protocol | $300 K – $700 K |
+| Otic compiler | Lex/parse/typecheck/codegen, security attributes, cross-contract dispatch | $300 K – $700 K |
+
+The audit programme is the single largest pre-mainnet line item, and the dominant gating concern for a credible launch. Penetration testing (P2P flooding, RPC DoS, eclipse attacks) runs in parallel with the static-analysis tracks. All critical and high findings must be remediated and re-audited before genesis (Phase 8 of the launch plan, §18).
+
+### 15.3 Pre-audit hardening
+
+The current codebase has been through an internal audit cycle producing 308 + tracked findings, of which the substantial majority are remediated in the current branch. Highlights include:
+
+- Wire-format hardening: bounds-checked decoders for `EncryptedTx::from_bytes` and related serialization paths (audit 301).
+- RPC ingress validation: `chainId` resolved against node, mismatches rejected (audit 302).
+- Faucet `chain_id` pinned at boot, fail-loud on RPC error (audit 303).
+- Production rejection of `MultiSig + Paymaster + GasTank` combinations on production chain IDs (audits 304 + 305).
+- Argon2id KDF for keystore encryption across all wallets / SDK / dev tools (audit 306).
+
+These are pre-audit hardening rather than substitutes for external audit; they are the work that lets the external audit focus on novel attack surfaces rather than catching trivial issues.
+
+### 15.4 Property tests and fuzzing
+
+Pyde ships 31 property tests across the audit-surfaced state-management code (multisig, emergency pause/resume, airdrop claim, vesting), covering wire formats, logic invariants, and decoder panic-freedom. Running with `PROPTEST_CASES = 256` (the default) executed in CI, these have surfaced and fixed issues that traditional unit tests missed. Extended runs (`PROPTEST_CASES = 10,000`+ as periodic CI workloads) are tracked as post-mainnet hardening.
+
+`cargo-fuzz` scaffolding exists for several entry points:
+
+- `pvm_interpreter` — arbitrary bytecode → `Vm::load + Vm::execute` must not panic.
+- `tx_decoder` — arbitrary bytes → `Transaction::from_bytes` must return `Option`, not panic.
+- `wire_transaction` — arbitrary bytes → `pyde_node::wire::decode_transaction`.
+- `wire_block`, `wire_consensus_message` — same shape, different decoders.
+- `otic_parser` and the post-quantum crypto deserializers are queued.
+
+Each target needs to run for 72 + hours pre-mainnet to provide the corpus coverage that justifies launch.
+
+### 15.5 Bug bounty
+
+The bug bounty programme ships in two tiers:
+
+- **Testnet tier.** Smaller payouts, broader scope, runs alongside the incentivized testnet (Phase 9 of the launch plan). Encourages the community to find and report issues against a live network at zero risk.
+- **Mainnet tier.** Substantially larger payouts (audit-scale numbers for critical findings), narrower scope, runs continuously after launch.
+
+The two-tier structure is borrowed from Ethereum's and Solana's bounty histories, adjusted for Pyde's scope. Both tiers run on a public coordinated-disclosure timeline.
+
+---
+
+## 16. Performance
+
+### 16.1 Methodology
+
+Pyde's published performance numbers are reproducible against a documented harness rather than a synthetic best-case. The methodology:
+
+- **Topology.** A four-validator local devnet via `pyde testnet --validators 4 --dev` running on a single laptop. All four validators share the host's CPU, RAM, disk, and loopback network.
+- **Slot rate.** 400 ms slot time, mainnet target.
+- **Signatures.** Real FALCON-512 signatures throughout — consensus votes, transaction authorization. No `chain_id = 31337` dev-mode bypass.
+- **Workload.** Configurable mix; the published numbers run a 50 % ERC-20 transfer / 25 % AMM swap / 15 % NFT mint / 10 % plain-PYDE-transfer mix from the bench-contracts spec, encrypted-mempool path for 90 % of the load.
+- **Inclusion.** A run is reported only if 100 % of submitted transactions commit within 30 seconds of submission. A drop rate above 5 % is a fail; we do not paper over partial inclusions.
+
+This is a deliberately stricter standard than several published L1 throughput numbers, which often report submitted-tx / second without an inclusion gate.
+
+### 16.2 Measured ceiling
+
+| Test | Target | Result |
+| --- | --- | --- |
+| Sustained × 10 min, plaintext path | 4 K TPS | **PASS** at 100 % inclusion |
+| Burst × 30 s, plaintext path | 7 K TPS | **PASS** at 100 % inclusion |
+| 4.5 K TPS sustained × 10 min | — | Thermal cliff: 48 % efficiency (laptop CPU throttle) |
+| 8 K TPS burst × 30 s | — | 18 % inclusion (under-provisioned) |
+| Encrypted-path sustained | TBD | Lifecycle test passes 5/5; loadgen toggle queued |
+
+The 4.5 K thermal cliff is the operative bound. Beyond ~ 4 K, the laptop's four cores running four validator processes plus the load generator hit thermal throttling and drop efficiency. The cliff is a hardware artifact, not a protocol limit; cloud-class hardware (dedicated cores, no thermal throttle) is required to validate the 12.5 K sustained / 50 K peak design targets.
+
+The encrypted-path measurements are in progress. The end-to-end multi-node lifecycle test (`multi_node_encrypted_lifecycle`) passes 5/5 across the four-validator devnet with state-root convergence; the same `loadgen_sustained` harness is being extended with an encrypted-path toggle to characterize the Kyber-encapsulation + threshold-decrypt overhead under sustained load.
+
+### 16.3 The path to 12,500 TPS
+
+The arithmetic that justifies the 12,500 sustained TPS / 50,000 peak design target:
+
+```
+GAS_TARGET                    = 400 000 000 gas/block
+SLOT_RATE                     = 2.5 blocks/s     (400 ms slot)
+GAS_PER_SECOND_AT_TARGET      = 1 G gas/s
+
+Workload mix average gas/tx   = ~52 K gas/tx
+THEORETICAL_TPS_AT_TARGET     = 1 G / 52 K ≈ 19 K TPS
+
+Design target (12.5 K / 19 K) = ~ 65 % of theoretical ceiling
+```
+
+The design target leaves ~ 35 % headroom above the gas-derived theoretical ceiling — sufficient buffer for consensus overhead, network propagation, and per-block constant costs. The cloud-validated test will measure the actual achievable fraction; the gap between the laptop measurement and the design target is principally a hardware story, not a protocol story.
+
+### 16.4 Latency profile
+
+Per-stage latency for an encrypted transaction, on the laptop devnet:
+
+| Stage | Latency |
+| --- | --- |
+| `submit → RPC ack` | < 5 ms (FALCON verify + mempool admit) |
+| `submit → first observed in proposed block` | 200 – 400 ms (one slot) |
+| `submit → soft-finalized (one QC)` | 400 – 600 ms |
+| `submit → hard-finalized (committee QC, all phases)` | 600 – 1 000 ms |
+| Encrypted-path overhead vs plaintext | + 150 – 300 ms (Kyber + threshold decrypt) |
+
+Hard-finality latency under one second is the headline UX number. A wallet UI that displays "confirmed" on hard finality can do so within a single network round trip from the user's perspective.
+
+### 16.5 Open performance work
+
+The remaining performance items before mainnet:
+
+- Cloud-validated 12.5 K sustained × 10 min (server-class hardware).
+- Cloud-validated 50 K peak × 30 s (same).
+- Encrypted-path sustained measurement.
+- 128-validator scale test (the laptop devnet is bounded to ~ 8 validators by core count; consensus-message fanout, decryption-share gossip, and view-change msg counts scale ≥ linearly with N).
+- Long-running stability (> 3-minute soak) under mixed workload.
+
+These items are the throughput-validation gates between testnet alpha and incentivized testnet (Phases 7 → 9 of the launch plan). They are infrastructure-bound (cloud capacity), not protocol-bound.
+
+---
+
+## 17. Comparison to Other L1s
+
+### 17.1 Comparison matrix
+
+The major L1s, scored on the eight axes that matter for Pyde's positioning. *Roadmap* indicates a published direction without a shipped, default-on protocol; *partial* indicates active mitigations that don't structurally remove the issue; *no* indicates no shipped work in the area. Every assessment is current as of mid-2026 and is subject to the standard disclaimer that other chains' roadmaps move quickly.
+
+| Axis | Pyde | Ethereum (L1) | Solana | Aptos | Sui | Polkadot | Cosmos | Avalanche |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Post-quantum signatures (default) | **Yes** (FALCON-512) | Roadmap | Roadmap | Roadmap | Roadmap | Roadmap | Roadmap | Roadmap |
+| Encrypted mempool (default) | **Yes** (Kyber-768 threshold) | No (PBS / MEV-Boost is auction, not encryption) | No (Jito is auction) | No | No | No | Threshold-encryption proposals in IBC track | No |
+| Sandwich-attack prevention | **Structural** | Partial (PBS) | Partial (Jito) | Partial | Partial | N/A (relay-chain blockspace) | Partial | Partial |
+| Sustained throughput | 12.5 K TPS design / 4 K measured | ~ 15 TPS | High (peak); outage history | Lab high; production lower | Lab high; production lower | Variable (per-parachain) | Variable (per-zone) | High (per-subnet) |
+| Hard-finality time | < 1 s (committee QC) | ~ 12 min | Probabilistic (32 slots ~ 13 s) | < 1 s | < 1 s | ~ 12 – 60 s | ~ 6 s | ~ 1 s |
+| Validator hardware | 8 cores / 16 GB / 500 GB / 100 Mbps | Modest | 12 + cores / 256 + GB | Modest | Modest | Modest (validator tier) | Modest (per zone) | Modest |
+| Equal validator voting | **Yes** (1 = 1) | Stake-weighted | Stake-weighted | Stake-weighted | Stake-weighted | Stake-weighted | Stake-weighted | Stake-weighted |
+| Permissionless decentralized infrastructure layer (parachains as oracles, bridges, indexers, off-chain compute) | Roadmap (~ + 6-to-12 mo, spec + open implementations, PYDE-staked, unified gas) | L2 ecosystem (per-L2 sequencer); third-party oracle networks (Chainlink) | Third-party (Pyth, Switchboard) | No | No | App-chains via auctioned slots | IBC zone-to-zone (no integrated infra layer) | Subnet model (sovereign chains, not infra layer) |
+
+Each chain in the table is competently engineered by serious teams. The differences are choices, not capability gaps. The matrix exists to make those choices visible, not to imply a ranking.
+
+### 17.2 Ethereum
+
+Ethereum is the dominant smart-contract platform and the chain whose research output most directly shapes the field. Pyde converges with Ethereum on the EIP-1559 fee model, the account-abstraction direction, and the general posture that a proposer should not extract value from users. Pyde diverges on three fronts:
+
+**Post-quantum.** Ethereum's PQ migration is real research (Vitalik's writing on lattice signatures, account-abstraction primitives that pre-position for key migration, beacon-chain BLS being a planned upgrade target) but no PQ signature is the default for any consensus or execution path on mainnet today. The migration is constrained by the size of the deployed surface — every wallet, every signing library, every contract that hard-codes a key format. Pyde absorbs the cost up front; Ethereum amortizes it over a longer horizon. Both are reasonable engineering choices for their respective starting positions.
+
+**MEV.** Ethereum's response is proposer-builder separation: a structured market in which builders compete to sell bundles of transactions to proposers. The mechanism makes the market more efficient and (debatably) shares the surplus more equitably. Pyde's response is to remove the underlying information asymmetry at the protocol level — the proposer cannot see the mempool, so there is no surplus to extract, share, or auction. The two designs answer different questions: PBS asks "how should MEV be priced and distributed?" Pyde asks "is there a protocol that doesn't have this problem?"
+
+**Throughput at L1.** Ethereum's L1 throughput is intentionally modest (~ 15 TPS) because the strategy is to push throughput to L2 rollups. Pyde's strategy is to scale at L1; the parachain layer provides decentralized infrastructure (cross-chain routing, oracles, indexers, off-chain compute) rooted in light-client verification rather than custodial bridges (§10). The L2 ecosystem has succeeded as a scaling story; it has done so at the cost of fragmenting the user surface across L2s with their own sequencers and trust assumptions. Pyde's bet is that a unified L1 with a permissionless parachain layer is a cleaner end state than L1 + N rollups + N bridges.
+
+### 17.3 Solana
+
+Solana is the high-throughput benchmark. Pyde converges with Solana on the monolithic-binary architecture — consensus and execution share one process — and on the parallel-execution-via-access-lists strategy. Pyde diverges on hardware and MEV.
+
+**Hardware.** Solana's documented validator spec has crept upward across releases, settling at a real-world-effective 12 + cores and 256 + GB of RAM. The result is that running a Solana validator is a data-center operation, and a small number of professional operators run a disproportionate share of stake. Pyde's mainnet validator spec is 8 cores, 16 GB RAM, 500 GB NVMe — a developer workstation. The protocol design is calibrated against this budget rather than the hardware being calibrated against the protocol. The cost is throughput headroom (Pyde's 12.5 K design target is below Solana's claimed peak); the benefit is that validation is genuinely accessible to non-professional operators.
+
+**MEV.** Solana's Jito client is a builder market analogous to MEV-Boost on Ethereum — an auction over reorder rights, with revenue shared back to validators. Pyde's encrypted-mempool design removes the underlying surface. The frame is the same as the Ethereum comparison: distribute MEV efficiently versus prevent it from arising.
+
+**Outage history.** Solana has had seven major outages between 2021 and 2024, several attributed to mempool overload, resource exhaustion, or consensus liveness under specific traffic patterns. The chain's stability work has been substantial and the recent track record is improved. Pyde's testnet bringup explicitly stress-tests the same surfaces (mempool overload via `loadgen_sustained`, resource exhaustion via 1 K parallel transfers, consensus liveness under partition-and-heal). The stability-versus-throughput trade is something Pyde takes very seriously precisely because Solana has demonstrated where the failure modes live.
+
+### 17.4 Aptos and Sui
+
+Aptos and Sui are the two leading Move-based chains, with sub-second finality, parallel execution, and modern language ergonomics. They are the closest peers to Pyde in design philosophy if not in cryptographic posture. Pyde converges with both on parallel execution and sub-second finality. Pyde diverges on MEV protection, post-quantum cryptography, and the specifics of parallel scheduling.
+
+**Parallel execution.** Aptos's Block-STM is optimistic concurrency — execute speculatively, detect conflicts, retry. Sui's object-centric model encodes ownership in the transaction structure, so non-owned objects can run in parallel by construction. Pyde's declared-access-list model is closer to Solana's: the transaction commits up front to the storage cells it will touch, and the scheduler builds a conflict DAG from those declarations. Each design has merits — Block-STM hides complexity from the developer, Sui's model rewards careful object design, Pyde's model gives the scheduler the most up-front information at the cost of requiring access-list authoring (which the otic compiler can infer for many cases).
+
+**MEV.** Neither Aptos nor Sui ships an encrypted mempool as the default. Both have research and proposals; neither is the default protocol path today.
+
+**Post-quantum.** Same picture as the Ethereum and Solana comparisons — both chains have PQ research, neither has PQ signatures as the default for consensus or accounts.
+
+### 17.5 Polkadot, Cosmos, Avalanche, and the decentralized-infrastructure layer
+
+Polkadot, Cosmos, and Avalanche are multi-chain ecosystems rather than monolithic L1s. Pyde positions itself as a different shape of system at launch — monolithic L1 with a permissionless parachain layer of decentralized infrastructure providers ( + 6-to- + 12-month roadmap item) — so the comparison is structural rather than feature-by-feature.
+
+**Polkadot's** parachain architecture is the most direct point of name comparison to Pyde's parachain layer, but the scope is different. Polkadot's parachains are sovereign app-chains backed by relay-chain validator capacity, allocated via slot auctions because validator capacity is finite. Pyde's parachains are decentralized infrastructure providers (cross-chain message routers, oracle networks, indexers, off-chain compute) organized by function rather than by application. Operator entry is permissionless and gated by PYDE staking + spec conformance — there is no slot scarcity, no auction, no parachain-team gatekeeping. The two systems share the pluggable-consensus design philosophy that Polkadot's BABE / GRANDPA split established: each parachain operator set chooses its own internal consensus mechanism, and the host chain verifies the resulting attestation regardless of how it was produced.
+
+**Cosmos** zones connect via IBC, which is genuinely excellent cross-chain protocol design. Each Cosmos zone is its own trust island — its validator set, its security, its governance, unrelated to the validator sets of the zones it talks to. Pyde's parachains are structurally different: they are infrastructure providers within Pyde's economic security (operators stake PYDE, are slashable under Pyde rules), not sovereign zones with independent trust models. A parachain can interface with IBC by running an IBC-light-client parachain that bridges Pyde to Cosmos zones, but Pyde's primitive is "contract-to-anywhere via a parachain layer," whereas IBC's primitive is "zone-to-zone."
+
+**Avalanche's** subnet model lets anyone launch a subnet with custom rules — closer in spirit to Polkadot's app-chain model than to Pyde's infrastructure-provider model. Avalanche subnets do not natively share security with the primary Avalanche network; each subnet's validator set is its own. Pyde's parachain operators stake PYDE and are slashable under Pyde rules, unifying the economic security across the chain and the parachain layer.
+
+The most useful **functional** comparison is to the decentralized-infrastructure ecosystem that exists alongside the L1 ecosystem. **Chainlink** is the closest reference: a decentralized oracle network where operators run nodes that aggregate off-chain data and post attested results on-chain. Pyde's parachain architecture extends the same model to all forms of decentralized external interaction (oracles, cross-chain bridges, indexers, off-chain compute) and integrates it natively into the L1's gas model — a Pyde contract calling `cross_call!` to an oracle parachain pays gas the same way it pays for any other operation, with no separate token to hold. **LayerZero, Wormhole, Axelar** typically rely on an oracle-and-relayer trust model where small operator sets coordinate to prove a message; Pyde's parachain operators are publicly known, on-chain-staked, slashable, and bound by a published specification — a structurally different trust model.
+
+None of the multi-chain ecosystems and none of the cross-chain protocols ships an encrypted mempool or post-quantum signatures as the default. Pyde's positioning against this group is on the four-axiom claim collectively rather than on parachain architecture alone.
+
+### 17.6 What Pyde owes the field
+
+Pyde does not invent every wheel. Each of the chains in this comparison contributed innovations that Pyde adopts, adapts, or builds on. The honest version of Pyde's positioning is that the chain stands on a foundation the rest of the industry built — and the strategic claim is not that other chains are wrong, but that the time has come to integrate the field's best ideas into a single greenfield design.
+
+**Bitcoin** invented the field. Digital scarcity, proof-of-work consensus, the principle of an immutable distributed ledger, and the social model of a permissionless monetary base layer all begin with Satoshi's paper. Bitcoin established that a public chain with hard rules and minimal trust assumptions is a thing that can exist; everything in this whitepaper presupposes that demonstration. Pyde inherits the philosophy of public, rule-bound, trust-minimized infrastructure that Bitcoin made the default expectation.
+
+**Ethereum** invented the programmable blockchain and shaped most of the design vocabulary the field still uses. Smart contracts, EVM execution semantics, the EIP process, the EIP-1559 fee market, the Verkle-tree research, the entire MEV literature, the proposer-builder-separation direction, the account-abstraction roadmap, and the L2 ecosystem are all Ethereum-originated work that the field has absorbed. Pyde adopts the EIP-1559 base-fee + elastic-block design (with the priority-tip removal that the encrypted mempool makes possible), the EIP-process structure for off-chain governance, and the spirit of formal protocol-improvement workflow. Vitalik Buterin's published thinking on lattice signatures and post-quantum-friendly account abstraction is part of the intellectual backdrop against which Pyde's PQ-default design is intelligible.
+
+**Solana** proved at scale that a monolithic-binary L1 with parallel execution can deliver retail-scale throughput, and that consensus and execution sharing one process is operationally viable. Pyde's monolithic architecture, its access-list-driven parallel scheduler, and its commitment to sub-second finality are the same family of design choices that Solana legitimized in production. Solana's stability work — the mempool-overload mitigations, the consensus liveness fixes, the gossipsub tuning — is the production reference for what hardening a high-throughput chain looks like, and Pyde's testnet bringup explicitly stresses the same surfaces because Solana's outage history made the failure modes visible.
+
+**Aptos** and the broader Move ecosystem produced the Jellyfish Merkle Tree (JMT) that Pyde adopts as its state structure — the swap from a previous SMT implementation to JMT during testnet bringup was the proximate enabler of the 4 K TPS sustained measurement on the laptop devnet. Aptos's parallel-execution work via Block-STM is one of the field's two leading approaches to the parallelism problem; Pyde's choice favors declared access lists, but the Aptos team's exploration of the optimistic-concurrency design space is what made every other chain's parallelism choice better-informed.
+
+**Sui's** object-centric model is one of the cleanest expressions of "ownership encoded in the transaction structure" the field has produced. Pyde's parallel scheduler operates against declared access lists rather than encoded ownership, but the Sui team's design work helped establish that parallelism is a function of how the transaction format is shaped, not just of how the scheduler is implemented.
+
+**Polkadot** pioneered pluggable consensus (the BABE / GRANDPA split) and the parachain architecture as a first-class concept. Pyde's parachain layer applies the pluggable-consensus philosophy to a different scope — decentralized infrastructure providers, not app-chains — and the architectural precedent for "let each parachain category choose its own internal consensus mechanism, the host chain just verifies the resulting attestation" is Polkadot's contribution. The parachain-architecture-as-a-first-class-protocol-feature framing came from Polkadot before Pyde.
+
+**Cosmos** built the most rigorous cross-chain protocol shipped to date in IBC, and proved that sovereign-zone interconnection can work at scale via light-client verification rather than custodial bridges. Pyde's parachain layer can interface with IBC where the use case calls for it; the IBC team's work on light-client verification is the intellectual ancestor of Pyde's `HardFinalityCert`-based bridge primitive. The principle that cross-chain interaction should be cryptographically verifiable rather than custodially trusted is a Cosmos-originated commitment that Pyde inherits.
+
+**Avalanche** demonstrated that subnet-style horizontal scaling is operationally tractable and that Snowman / Avalanche consensus can deliver sub-second finality at scale. Pyde's design goals on finality and parachain composition share a vocabulary with Avalanche's subnet work; the proof that the multi-chain architecture is viable at production scale was made before Pyde shipped a line of code.
+
+**Cardano** has shipped hash-based signature primitives as building blocks toward post-quantum readiness, and the chain's commitment to formal-methods research (alongside Tezos and others) is part of the field's broader maturation toward verified protocol implementations. Pyde's pre-audit hardening process — property tests, parity tests between interpreter and AOT, fuzz scaffolding — is in the same lineage as the formal-methods culture that Cardano helped normalize.
+
+**Chainlink** built the production reference for decentralized oracle networks — the operator-set staking model, the deviation-tolerance attestation pattern, the off-chain-data-on-chain bridge, the per-feed reputation system. Pyde's parachain layer extends the same model to all forms of decentralized external interaction (cross-chain bridges, oracles, indexers, off-chain compute), but the proof that decentralized infrastructure with permissionless operator entry is a viable production category is Chainlink's contribution. Pyde's parachain spec is the integration of Chainlink-style decentralization into an L1's gas model; the original demonstration is older than Pyde.
+
+**Filecoin** and the broader libp2p / IPFS ecosystem produced the modular networking stack that Pyde uses as transport. The years of work that went into making libp2p production-grade — connection lifecycle, gossipsub mesh maintenance, peer scoring, transport multiplexing, the noise handshake — are what makes Pyde's networking layer credible as a launch component rather than a multi-year engineering project. Pyde's net-layer crate is integration work over a stack the field built.
+
+The list is not exhaustive. Tezos, Near, Algorand, Mina, Aleo, Tendermint, Diem, the Move language design team, the entire ZK-rollup research community, the Flashbots team, the libp2p maintainers, the Rust language and async-runtime ecosystems, the cryptographic standards bodies (NIST, IETF), and many others all shaped how Pyde was designed. The field that built this much in a decade and a half is not a field that has been wrong. It is a field that has been doing the work that lets the next chain be possible.
+
+Where Pyde diverges — post-quantum-from-genesis, encrypted-mempool-by-default, equal voting, commodity hardware, the permissionless parachain layer with unified gas — is where the bet sits. Every chain in the comparison matrix is well-engineered, by serious teams, against the constraints of the moment they were built in. Every one of them has at least one structural property that would require a multi-year coordinated migration to add. **Pyde is the only chain in the table that needs no migration to ship all four.**
+
+The pitch is not that Pyde is better than Ethereum. Ethereum was built for the era it was built for; the chain has earned the position it holds, and the engineering that took it there is among the field's finest work. The same is true of Solana, Aptos, Sui, Polkadot, Cosmos, Avalanche, Cardano, Chainlink, and every other chain in this comparison. The pitch is that the next default Layer 1 — the chain that the next decade of crypto runs on — needs all four of these properties at the protocol layer; that the only honest path to a chain with all four is greenfield; that the strategic window for a greenfield chain to ship the answer first is open and closing; and that Pyde is the chain built to ship it, on a foundation the rest of the industry built.
+
+---
+
+## 18. Launch Roadmap
+
+### 18.1 Status as of this paper
+
+Pyde's mainnet readiness work runs against a 143-task plan derived from a 2026-04 internal audit. Of the 143 tasks, 86 are complete, 6 are partial, and 51 are open. The breakdown by phase:
+
+| Phase | Done | Partial | Open | Total | Status |
+| --- | --- | --- | --- | --- | --- |
+| 1 — Critical safety fixes | 20 | 0 | 1 | 21 | Substantially complete |
+| 2 — Documentation reconciliation | 0 | 0 | 9 | 9 | Deferred (documentation rewrite at end of mainnet work) |
+| 3 — MEV end-to-end integration | 11 | 0 | 0 | 11 | Complete |
+| 4 — Governance + tokenomics | 18 | 0 | 0 | 18 | Complete |
+| 5 — Hardening + CI | 9 | 4 | 2 | 15 | Substantially complete |
+| 6 — Devnet + multi-node tests | 13 | 0 | 0 | 13 | Complete |
+| 7a — Mempool bug batch | 7 | 0 | 1 | 8 | Substantially complete |
+| 7b — Mempool production hardening | 6 | 0 | 0 | 6 | Complete |
+| 7 — Testnet alpha | 2 | 2 | 11 | 15 | In progress (cloud-bound stress tests) |
+| 8 — External audits | 0 | 0 | 9 | 9 | Pre-funded; engaged firms TBD |
+| 9 — Incentivized testnet | 0 | 0 | 8 | 8 | Sequenced after Phase 8 |
+| 10 — Mainnet genesis | 0 | 0 | 10 | 10 | Sequenced after Phase 9 |
+| **Total** | **86** | **6** | **51** | **143** | — |
+
+The critical path runs through Phase 7 → Phase 8 → Phase 9 → Phase 10. Phases 2 (documentation) and the later subset of Phase 5 (extended fuzz runs) can land in parallel with the critical path; they do not gate launch.
+
+### 18.2 The path to mainnet
+
+The remaining work, in execution order:
+
+1. **Cloud-validated throughput.** Move the laptop-bound 4 K TPS sustained / 7 K burst measurements to server-class hardware. Validate the 12.5 K sustained / 50 K peak design targets. Characterize the encrypted-path loadgen overhead. (~ 4 – 8 weeks once cloud capacity is in place.)
+2. **External audit programme.** Engage five specialist firms across consensus, PVM, cryptography, networking, and otic compiler. Remediate all critical and high findings; re-audit remediation. (~ 16 – 24 weeks.)
+3. **Incentivized testnet.** Deploy reference dApps (DEX, lending, NFT marketplace), fund the bug bounty at mainnet-tier scale, run for 3 + months, document community-found issues. Critical and high severity must be fixed before launch. (~ 12 – 16 weeks of soak; required by the launch-strategy criterion.)
+4. **128-validator genesis.** Recruit and validate genesis operators with documented hardware benchmarks and Phase 9 participation proof. Geo-distribute across 3 + regions. Coordinate validator DKG for the threshold pubkey. Sign the genesis block. Publish the chain hash. (~ 4 – 8 weeks of coordinated execution.)
+
+Adding integration buffer, the execution distance from this paper to mainnet is approximately 9 – 12 months of focused work, gated principally on (1) cloud capacity for stress validation and (2) audit-firm calendar and capacity.
+
+### 18.3 Funding sequence
+
+Pyde's roadmap is structured around a testnet-MVP → fundraise → audit → mainnet sequence rather than a fundraise-first model. The reasoning is straightforward: the technical surface this paper describes is more credible to investors when most of it is shipped. The current branch's 86-of-143 task completion, 4 K TPS measurement, and end-to-end MEV pipeline tests are the substance the fundraise rests on; the capital deployment then funds the audit programme, the cloud-validated stress runs, and the incentivized-testnet operations.
+
+This whitepaper is the technical credibility document for that sequence. It is not a prospectus; specific token-allocation figures and capital-raise structure are out of scope here and live in separate fundraise material.
+
+---
+
+## 19. Post-Mainnet Appendix
+
+This section catalogues capabilities that are tracked on Pyde's roadmap but explicitly do not ship at mainnet. Each entry describes the capability, the reason for deferral, and the cost or work estimate. The list is the honest counterpart to the comparison matrix in §17 — these are the items where Pyde's mainnet does not match an incumbent's published feature set, and the deferral is intentional rather than oversight.
+
+### 19.1 ZK execution proofs and the verifiable computation network
+
+Pyde's longest-horizon roadmap item is the introduction of zero-knowledge execution proofs across the chain and the parachain layer. This is not a footnote; it is the direction that turns Pyde from a fast post-quantum L1 into a verifiable computation network at scale. The story splits into three phases.
+
+**Phase 1 (mainnet, shipping).** Validators execute every block they vote on. Hard finality is a FALCON quorum certificate signed by 86 of 128 committee members. Light-client verification of any chain event costs 86 FALCON verifications (~ 86 ms on commodity hardware) plus a Merkle-path verification. This is the model described throughout this paper. The original Pyde architecture proposal included STARK proofs from genesis; mainnet ships committee-only finality instead, because the engineering investment for production-grade circuits, audited prover-network economics, and coordinated launch is large enough to dominate the mainnet timeline on its own. The ZK work is sequenced after mainnet stability.
+
+**Phase 2 (post-mainnet, ~ + 18-30 months): STARK execution proofs as a parallel finality path.** A separate prover network — operators who are not committee members but who stake PYDE under a parachain-style spec — produces STARK proofs of block execution. A block accompanied by a valid STARK proof reaches an additional finality flag in addition to the FALCON QC. Light clients and cross-chain bridges can then verify the proof for ~ 1-5 ms per block instead of ~ 86 ms — a roughly 50-100 × reduction in cross-chain verification cost.
+
+The Phase 2 design is deliberately additive. The existing FALCON-based finality remains valid; STARKs are a parallel option, not a replacement. A wallet, a contract on another chain, or a parachain-side bridge verifier can choose which finality path to consume based on its constraints — a chain with cheap pairing operations might prefer FALCON-on-chain verification; a gas-constrained chain might prefer STARK-on-chain verification. Pyde provides both surfaces; the consumer picks.
+
+The work in Phase 2 splits into three engagements: circuit design and implementation for Pyde's PVM and consensus path (the largest piece, requiring a cryptographic specialist firm), prover-network economic and governance design (parallel to circuit work, requires its own audit), and the on-chain verifier for the produced proofs (a smaller engagement that lives in Pyde's execution layer). Combined audit budget is comparable in scale to the mainnet five-track audit programme.
+
+**Phase 3 (post-mainnet, ~ + 24-36 months): ZK proofs as a parachain attestation mode.** This is the interesting integration, and the place where Pyde's ZK direction diverges from the typical "L1 with execution proofs" story. Parachains in Pyde's architecture (§10) currently attest results via internal consensus among operators — M-of-N FALCON signatures or a small BFT QC, depending on the category. ZK proofs become an alternative attestation mode: a parachain category can register a ZK circuit that proves correct execution of its operations, and Pyde's parachain layer accepts ZK-proof attestations alongside consensus-signed attestations. The implications are substantial.
+
+*Lighter parachain operators.* A parachain operator who can verify a ZK proof can validate operations without re-executing them. For off-chain-compute parachains (the canonical example: ZK-proof generation as a service for Pyde contracts), this becomes a recursive structure where the parachain produces proofs of its own work and other operators verify those proofs at a tiny fraction of the cost of re-execution. Parachain validators stop being executors and start being verifiers; the parachain layer scales horizontally on proof-verification cost rather than on re-execution cost.
+
+*Smaller operator sets become acceptable.* The current parachain trust model relies on M-of-N operator honesty plus on-chain slashing for misbehavior. Once a ZK proof verifies, the trust model collapses to "the proof is mathematically valid" — operator-set size becomes a liveness concern, not a safety concern. A category that ships a ZK circuit can run with a single well-funded operator producing valid proofs, with the proof itself supplying the trust anchor that an M-of-N committee previously supplied.
+
+*Trustless bridges to gas-constrained chains.* A bridge parachain that produces ZK proofs of Pyde state can be verified on chains whose execution budget cannot afford 86 FALCON verifications — most EVM chains today, Bitcoin's restricted scripting, other PoS L1s with limited per-tx gas. This is the long-term path to truly trustless interop with the entire crypto ecosystem, as opposed to interop gated on the counterparty chain having a generous-enough VM for native FALCON.
+
+*Composable verifiable compute.* A Pyde contract that needs verifiable off-chain computation — private financial logic, ML model inference, complex simulations, custom proof-of-honesty assertions — can request it from an off-chain-compute parachain via `cross_call!`. The parachain runs the computation, produces a ZK proof of correct execution, and posts the result + proof back via the standard callback path. The contract verifies the proof on-chain and acts on the result. Pyde becomes a composability surface for verifiable computation, not just for state.
+
+**The unified vision.** Across the three phases, the architecture converges on a single principle: every operation on or adjacent to Pyde — every block, every cross-chain message, every oracle attestation, every off-chain compute result — can be cryptographically proved when the cost-benefit ratio justifies it. Mainnet ships the FALCON-anchored substrate that makes this evolution possible without protocol-breaking changes. Phase 2 adds STARK execution proofs as a parallel verification mode for the chain itself. Phase 3 extends the same proof-based verification mode to the parachain layer, unifying the trust model across the entire Pyde + parachain ecosystem under one cryptographic primitive: the proof.
+
+The end state is a chain whose verification cost scales with the computational complexity of producing proofs, not with the number of operators replicating execution. That is a different shape of system from any L1 in production today, and it is the shape Pyde is building toward.
+
+### 19.2 Parachain specification and reference implementations
+
+Detailed in §10. The Pyde core team publishes a parachain specification on a ~ + 6-month post-mainnet horizon, defining the interface, attestation format, callback protocol, gas-metering rules, and PYDE staking rules that any parachain implementation must follow. Reference implementations in Rust, Go, and C++ ship alongside the spec, starting with an Ethereum-bridge parachain as the first reference (which audits the FALCON-in-EVM verifier as part of the same engagement). Anyone can implement the spec in any language; the reference implementations are starting points, not requirements. Subsequent reference parachains target oracle networks, indexers, off-chain compute, and additional bridge directions (Solana, Bitcoin, other PoS L1s) on a ~ + 12-to- + 18-month horizon, gated on independent audits of the relevant cryptographic-verifier code. The architecture and the contract-side `cross_call!` macro are settled at mainnet; the spec and the implementations follow.
+
+### 19.3 Native bridges
+
+Per-chain bridges to Ethereum, Bitcoin, and other PoS L1s. The Ethereum bridge (FALCON-in-EVM verifier + permissionless relay) is the most concrete near-term target on a + 6-month post-mainnet horizon. The Bitcoin bridge (SPV-style proofs) is harder because Bitcoin's PoW finality is probabilistic; a Pyde-side Bitcoin light client requires choices about how many confirmations equal "final."
+
+### 19.4 Signed mempool commitments and cryptographic censorship slashing
+
+Mainnet ships censorship defense via local-view enforcement (a committee member rejects a block whose ordering omits a tx the member has seen). Post-mainnet adds signed mempool commitments — each validator periodically signs a hash-set of encrypted_txs they have seen, gossiped to the committee — plus committee-aggregated views and slashing evidence for proposers who exclude txs present in ≥ f + 1 signed commitments.
+
+The deferral is scope: mainnet ships safe under HotStuff (false positives cost liveness, not safety). The cryptographic upgrade is a 2 – 3 slice project that does not need to block launch on a 128-validator network.
+
+### 19.5 Pedersen / KZG commitments on PSS resharing
+
+Adds verifiable secret sharing to the committee resharing protocol (§3.6 / §4.6). Defends against a corrupt committee member contributing a polynomial whose constant term ≠ their actual share (currently mitigated by detection — a corrupt resharing causes ciphertexts to stop decrypting at the new epoch, observable within one slot). The cryptographic upgrade is long-horizon hardening, sequenced into the same wave as ZK execution proofs (§19.1 Phase 2).
+
+### 19.6 Programmable accounts
+
+Extends `AuthKeys` with a `Programmable` mode that marks an account as carrying an attached policy contract — the policy bytecode lives at the account's `code_hash` field, the policy state at `storage_root`, reusing the same fields a regular contract uses (the unification is detailed in §11.2 and §11.6). The policy runs on every transaction the account would authorize and returns Allow or Deny. Patterns expressible via policy: per-window spend limits, time locks, allow-listed recipient sets, tiered authorization (small txs need fewer signatures than large ones), inactivity-triggered recovery flows, tagged session caps. Account abstraction as a protocol-native mode rather than a contract layer every project re-implements. Section 11.6 specifies the design. Simple `Single`-keyed EOAs are unaffected; programmable accounts pay one extra PVM call per transaction.
+
+### 19.7 Session keys
+
+Native protocol support for delegated authorization. Lets dApps execute transactions on a user's behalf within a registered scope (specific contracts, specific methods, capped per-tx spend, capped cumulative spend, slot-bounded duration) without prompting the master wallet for each transaction. The use case is dApps where wallet-popup-per-action is the adoption block: gaming with high-frequency interactions, AI agents executing strategies on a schedule, consumer apps. Section 11.7 specifies the design. Master account can revoke any session instantly via a `RevokeSession` transaction; every session-key transaction emits an observable event keyed to the master.
+
+### 19.8 Expanded TypeScript SDK coverage
+
+The TypeScript SDK (`pyde-ts-sdk`) ships at mainnet at ethers-equivalent maturity: provider with batch calls / fee data / gas estimation, wallet with FALCON-512 keypair handling and Poseidon2 address derivation and AES-256-GCM keystore (Argon2id-shared with the Rust SDK and dev tools), contract with ABI-aware calldata encoding / auto-decoding / event queries, WASM-compiled crypto via `pyde-crypto-wasm`, ergonomic utilities (address validation, unit formatting, hex handling). Post-mainnet expands coverage: full parity with the Rust SDK's `EncryptedTx` builder, advanced WebSocket subscription patterns, dedicated bindings for `cross_call!`-style parachain interactions once the parachain spec and reference implementations ship, and first-class TypeScript bindings for the programmable-account and session-key APIs once those ship.
+
+### 19.9 On-chain stake-weighted voting
+
+Explicitly evaluated and rejected for mainnet. The reasoning is in §14.2 — on-chain stake-weighted voting on consensus changes makes protocol evolution a function of token concentration. Pyde's chosen model is off-chain PIPs plus voluntary validator upgrade. Future PIPs may reopen this design space; the current mainnet shipment makes the choice without removing the option to revisit.
+
+### 19.10 Mempool-level pause filter
+
+A cleaner emergency-pause path that propagates the pause signal back to mempool admission rather than gating only at execution time. Currently every non-Resume tx during a pause pays decode + gate-check CPU at the validator; the cleaner path drops them at mempool ingress. Not a DoS (gate-check is cheap) and not a correctness issue (gate rejects before state writes), but post-mainnet polish.
+
+### 19.11 Extended proptest CI and 72-hour fuzz runs
+
+Default proptest is 256 cases; periodic CI runs at `PROPTEST_CASES = 10,000` find more bugs. `cargo-fuzz` targets need 72 + hour soak runs with corpus accumulation pre-mainnet. Both are post-launch hardening that strengthens confidence over time without changing the protocol.
+
+### 19.12 Off-chain Merkle builder CLI for airdrops
+
+The on-chain `build_tree()` for airdrop Merkle proofs is public; an operator-facing CLI tool that takes a CSV of `(address, amount)` pairs and emits the root + per-address proofs is post-mainnet tooling (~ 150 LOC, no consensus impact).
+
+### 19.13 Two-dimensional gas model
+
+The original tokenomics chapter sketched a `(exec_cost, prove_cost)` two-dimensional gas model intended to price ZK proving separately from execution. Without the prover network, this collapses to single-dimensional gas at mainnet. If ZK proofs ship post-mainnet, the second dimension can be reintroduced to price prover-network resource consumption.
+
+---
+
+## 20. Constants Reference
+
+A consolidated reference for every protocol constant referenced in this paper. The authoritative source is the corresponding crate in the Pyde codebase; values in this table are current as of this paper's version stamp.
+
+### 20.1 Consensus
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `BLOCK_TIME_MS` | 400 | Slot duration |
+| `COMMITTEE_SIZE` | 128 | Active validators per epoch |
+| `QUORUM_THRESHOLD` | 86 | 2f + 1 with f = 42 |
+| `RANDOMNESS_THRESHOLD` | 85 | Min sigs to seed next epoch's randomness |
+| `EPOCH_LENGTH` | 1 000 slots | ≈ 6.6 minutes per epoch |
+| `PROPOSAL_TIMEOUT_MS` | 200 | Primary-proposer timeout before fallback fires |
+| `PROGRESS_TIMEOUT_MS` | 2 000 | Max delay before view change |
+| `RESHARE_AGGREGATION_DELAY_SLOTS` | 5 | PSS deterministic-aggregation window |
+| `UNBONDING_PERIOD` | 3 024 000 slots | ≈ 14 days |
+| Weak-subjectivity checkpoint interval | 64 epochs | ≈ 7 hours |
+
+### 20.2 Slashing
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `VALIDATOR_STAKE` | 10 000 PYDE | Bond per validator |
+| `FINDER_FEE_PERCENT` | 10 % | On slashed stake to evidence submitter |
+| `EVIDENCE_VERSION` | 1 | Wire format version |
+| Double-sign slash | 100 % | Of stake; immediate ejection |
+| Invalid-proposal slash | 50 % | Of stake |
+| Liveness-major slash | 5 % | Absent > 50 % of an epoch |
+| Liveness-minor slash | 1 % | Absent > 10 % of an epoch |
+| Decryption-withhold slash | 2 % | Per offense |
+
+### 20.3 Gas and fee
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `GAS_TARGET` | 400 M | Equilibrium block gas |
+| `GAS_CEILING` | 1.6 B | Elastic ceiling (4 × target) |
+| `GENESIS_BASE_FEE` | 50 × 10⁹ quanta/gas | 50 gwei equivalent |
+| `ADJUSTMENT_DIVISOR` | 8 | Max ± 12.5 % base-fee change per block |
+| `FEE_BURN_PCT` | 70 | Fee distribution |
+| `FEE_VALIDATOR_PCT` | 20 | Fee distribution |
+| `FEE_TREASURY_PCT` | 10 | Fee distribution |
+
+### 20.4 Tokenomics
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `GENESIS_SUPPLY` | 1 B PYDE (10¹⁸ quanta) | Initial supply |
+| `DECIMALS` | 9 | 1 PYDE = 10⁹ quanta |
+| Inflation Y1 | 5.00 % | Per-epoch issuance rate |
+| Inflation Y2 | 3.00 % | |
+| Inflation Y3 | 2.00 % | |
+| Inflation Y4+ | 1.00 % | Terminal rate |
+
+### 20.5 PVM
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `MAX_CODE_SIZE` | 60 KB | Per-contract bytecode |
+| `MAX_CALLDATA` | 64 KB | Per-call calldata |
+| `MAX_TX_SIZE` | 128 KB | Full encoded transaction |
+| `MAX_EXT_CALL_DEPTH` | 64 | Cross-contract recursion |
+| `MAX_WITNESS_SIZE` | 1 MB | Per-block state witness |
+| `PAGE_ALLOC_GAS` | 200 | One-time per touched 4 KB page |
+| GP register count | 16 | Each 64-bit, r0 hardwired zero |
+| Wide register count | 8 | Each 256-bit |
+| Total address space | 4 MB | Null-page guarded, code/heap/stack regions |
+| Opcode count | 62 | Of 64 possible (6-bit field) |
+
+### 20.6 Mempool
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| `MEMPOOL_SENDER_CAP` | 128 | Per-sender max pending |
+| `MEMPOOL_GLOBAL_CAP` | 100 000 | Global max pending |
+| `MEMPOOL_TX_TTL` | 240 s (~ 600 slots) | Eviction threshold |
+| Per-sender rate limit | 10 tx/s | Submit-rate cap |
+| Per-sender concurrent | 100 | In-flight cap |
+
+### 20.7 Cryptography
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| FALCON-512 public key | 897 B | NIST FIPS 206 |
+| FALCON-512 signature | 600 – 900 B (1 280 B max) | Variable length |
+| FALCON-512 verify time | ~ 1 ms | Commodity hardware |
+| Kyber-768 public key | 1 184 B | NIST FIPS 203 (ML-KEM) |
+| Kyber-768 ciphertext | 1 088 B | Per encapsulation |
+| Kyber-768 shared secret | 32 B | Output of `encapsulate` |
+| Poseidon2 state width | 8 | Goldilocks field |
+| Poseidon2 internal rounds | 22 | Per Pyde parameter set |
+| Goldilocks field prime | 2⁶⁴ - 2³² + 1 | |
+| Argon2id memory | 64 MiB | Keystore KDF |
+| Argon2id iterations | 3 | t parameter |
+| Argon2id lanes | 1 | p parameter |
+| Argon2id derivation cost | ~ 250 ms | Per guess on single core |
+
+### 20.8 Hardware spec
+
+| Constant | Value | Notes |
+| --- | --- | --- |
+| Validator CPU | 8 + cores | x86_64 or ARM64 |
+| Validator RAM | 16 GB | |
+| Validator disk | 500 GB NVMe SSD | |
+| Validator network | 100 Mbps symmetric | Low jitter |
+| Full node | Same minus per-vote fsync | |
+
+---
+
+## 21. Glossary
+
+**AOT (Ahead-of-Time compiler).** Pyde's Cranelift-based JIT that compiles PVM bytecode to native machine code at contract deploy time. Ensures interpreter / native parity via property-based parity tests.
+
+**BFT (Byzantine Fault Tolerance).** A consensus protocol property where the chain remains safe and live as long as fewer than f = ⌊(n - 1) / 3⌋ validators are Byzantine. Pyde's BFT bound is f ≤ 42 across 128 validators; the safety quorum is 86.
+
+**Committee.** The 128 active validators in a given epoch, eligible to propose blocks, sign votes, and participate in threshold decryption. Rotates at every epoch boundary.
+
+**Commodity hardware.** Pyde's validator hardware spec (8 cores, 16 GB RAM, 500 GB NVMe SSD, 100 Mbps network) — a developer workstation, not a data-center server. Deliberately accessible to non-professional operators.
+
+**Cross-chain.** Pyde's term for interactions between Pyde and other chains (the parachain layer, native bridges, light-client deployments). Mainnet ships the `HardFinalityCert` primitive; parachain specification, reference implementations, and native bridges ship post-mainnet.
+
+**`cross_call!` (macro).** The Otigen macro that initiates an asynchronous interaction with the parachain layer — cross-chain calls (Pyde → Solana / Ethereum / Bitcoin / etc.), oracle queries, off-chain compute requests. Combined gas (Pyde-side + parachain-side) is computed at call time and billed in one transaction; the result arrives via a callback function on the originating contract. At mainnet the macro lowers to "not yet supported" pending the parachain layer (§10).
+
+**Encrypted mempool.** Pyde's MEV protection mechanism: transactions enter the mempool encrypted under a 86-of-128 threshold Kyber-768 public key. The proposer cannot read pending transactions before committing to an ordering.
+
+**Epoch.** A 1 000-slot (~ 6.6-minute) period during which the committee is fixed. Committee rotation, randomness seeding, and PSS resharing all happen at epoch boundaries.
+
+**FALCON-512.** Lattice-based signature scheme standardized as NIST FIPS 206. Pyde's signature primitive for consensus votes, transaction authorization, and validator key registration.
+
+**Finality, hard.** A block is hard-finalized when 86 of 128 committee members have signed a FALCON commit vote, aggregated into a `HardFinalityCert`. Irreversible under the BFT assumption.
+
+**Finality, soft.** A block is soft-finalized when included in a chain backed by at least one quorum certificate. Lands within the same slot as proposal under normal conditions.
+
+**Gossipsub.** The libp2p topic-based publish-subscribe protocol Pyde uses for block, consensus, and transaction propagation across five distinct channels.
+
+**`HardFinalityCert`.** The cross-chain-portable proof of finality on Pyde — a signed certificate carrying slot, block hash, state root, voter bitmap, and 86 + FALCON signatures from the active committee. The mainnet primitive that future bridges, parachains, and external verifiers consume to prove "block N was hard-finalized on Pyde at state root R" (§3.3, §10.2).
+
+**HotStuff.** The pipelined BFT consensus protocol family Pyde modifies. Provides O(n) message complexity per slot and clean view-change.
+
+**JMT (Jellyfish Merkle Tree).** A sparse Merkle variant optimized for incremental updates. Pyde's authenticated state structure, hashed with Poseidon2.
+
+**Kyber-768 / ML-KEM.** Lattice-based key encapsulation mechanism standardized as NIST FIPS 203. Pyde's threshold-encryption primitive.
+
+**MEV (Miner / Maximal Extractable Value).** The profit a block proposer can extract by reordering, censoring, or front-running unconfirmed transactions. Removed at the protocol level by Pyde's encrypted mempool.
+
+**Otigen.** Pyde's purpose-built smart-contract language. Compiles to PVM bytecode plus an ABI JSON via the otic compiler.
+
+**Parachain.** An open-source implementation of the Pyde-published parachain specification, run by a permissionless operator set that stakes PYDE. Categories include cross-chain message routers (Pyde ↔ other chains), oracle networks, indexers, and off-chain compute. Pyde contracts compose with parachains via the `cross_call!` macro; combined gas (Pyde-side + parachain-side) is billed in one transaction. Each category chooses its own internal consensus mechanism. No slot auctions, no parachain-team gatekeeping. Ships post-mainnet on a + 6-to-+ 12-month horizon. Detailed in §10.
+
+**Programmable account (post-mainnet).** An account whose `AuthKeys` is `Programmable`, marking it as carrying an attached PVM bytecode policy at the same `code_hash` field a regular contract uses. The policy runs on every transaction the account would authorize and returns Allow or Deny — expressing patterns like spend limits, time locks, allow-listed recipients, tiered authorization, and recovery flows. Account abstraction as a protocol-native mode rather than a contract layer every project re-implements. Opt-in: simple EOAs are unaffected (§11.6, §19.6).
+
+**PIP (Pyde Improvement Proposal).** The off-chain governance process for protocol changes. Categories are Standards Track, Meta, and Informational. Activation is voluntary validator upgrade after a 6.5 M slot (~ 30 day) window.
+
+**Poseidon2.** Algebraic hash function over the Goldilocks field. Pyde's hash primitive for blocks, transactions, addresses, JMT nodes, VRF input, and threshold-MAC binding.
+
+**PSS (Proactive Secret Sharing).** The protocol that rotates the threshold-encryption secret across committee changes at epoch boundaries. Uses deterministic aggregation to prevent async-arrival convergence failure.
+
+**PVM (Pyde Virtual Machine).** Pyde's register-based VM. 32-bit fixed-width ISA, 16 general-purpose 64-bit registers, 8 wide 256-bit registers, 4 MB address space, 62 opcodes.
+
+**PYDE.** The native token of the Pyde chain. 1 B genesis supply, 9 decimals, used for staking, fee payment, and treasury operations.
+
+**Quorum.** A subset of the committee whose collective signature satisfies a protocol threshold. Pyde's safety quorum is 86 of 128.
+
+**Session key (post-mainnet).** A delegated authorization that lets an application sign a bounded set of transactions on behalf of an account without prompting the master wallet for each one. The master issues an `AuthorizedSession` once specifying scope (allowed contracts, allowed methods, per-tx and cumulative spend caps, slot deadline); subsequent transactions can be signed by the session key. Use cases: gaming, AI agents, consumer apps where wallet-popup-per-action is the adoption block. Master can revoke any session instantly (§11.7, §19.7).
+
+**Slashing.** The on-chain penalty applied to validators who violate consensus rules. Penalties range from 1 % (liveness-minor) to 100 % (double-sign) of the validator's stake; a 10 % finder's fee goes to the evidence submitter.
+
+**Slot.** A 400 ms time interval during which the protocol expects exactly one new block. Slot index is monotonically increasing.
+
+**Threshold encryption.** A cryptographic scheme where a secret key is distributed across N parties such that any K can decrypt cooperatively but fewer than K cannot. Pyde's mempool uses 86-of-128 over Kyber-768.
+
+**Verifiable computation network (post-mainnet).** Pyde's long-horizon ZK direction: across three phases, the chain plus its parachain layer evolves into a system where every operation — every block, every cross-chain message, every oracle attestation, every off-chain compute result — can be cryptographically proved when the cost-benefit ratio justifies it. Phase 2 adds STARK execution proofs as a parallel finality path; Phase 3 adds ZK proofs as a parachain attestation mode (§19.1).
+
+**VRF (Verifiable Random Function).** A function that produces a pseudorandom output and a proof that the output is correctly computed under a given key. Pyde's VRF is lattice-based, used for proposer selection and epoch randomness seeding.
+
+**Weak subjectivity.** A property of long-lived proof-of-stake chains that requires a new node to start syncing from a recent trusted checkpoint rather than from genesis. Pyde publishes weak-subjectivity checkpoints every 64 epochs.

--- a/crates/account/src/auth.rs
+++ b/crates/account/src/auth.rs
@@ -254,8 +254,7 @@ mod tests {
 
         // Same sig pasted into positions 0 AND 1 (both bound to pk1).
         // Should be rejected because pk1 only counts once.
-        let result =
-            validate_signature(&account, message, &[sig1.clone(), sig1, vec![]]);
+        let result = validate_signature(&account, message, &[sig1.clone(), sig1, vec![]]);
         assert_eq!(
             result,
             AuthResult::Invalid,

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -479,7 +479,7 @@ mod tests {
                 pub fn get_count() -> u64 { return self.count; }
             }
         "#;
-        let results = otic::compile_all(src);
+        let results = otic::compile_all_unchecked(src);
         assert_eq!(results.len(), 1);
         let (_, compiled) = &results[0];
         let runtime = &compiled.runtime_bytecode;
@@ -659,7 +659,7 @@ mod tests {
                 }
             }
         "#;
-        let results = otic::compile_all(src);
+        let results = otic::compile_all_unchecked(src);
         assert_eq!(results.len(), 1);
         let (_, compiled) = &results[0];
         let runtime = &compiled.runtime_bytecode;
@@ -853,7 +853,7 @@ mod tests {
                 }
             }
         "#;
-        let all = otic::compile_all(src);
+        let all = otic::compile_all_unchecked(src);
         assert_eq!(all.len(), 2, "Should compile Token and Factory");
         let (_, factory_compiled) = &all[1];
         let runtime = &factory_compiled.runtime_bytecode;

--- a/crates/consensus/src/epoch_randomness.rs
+++ b/crates/consensus/src/epoch_randomness.rs
@@ -153,7 +153,8 @@ fn combine_shares_with_threshold(
     // Sort by VRF output bytes for last-revealer protection within
     // the canonical subset (the input set is already deterministic;
     // this just removes any in-set ordering signal).
-    let mut sorted_outputs: Vec<Hash256> = canonical.iter().map(|s| s.vrf_output.to_hash()).collect();
+    let mut sorted_outputs: Vec<Hash256> =
+        canonical.iter().map(|s| s.vrf_output.to_hash()).collect();
     sorted_outputs.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
 
     let combined = poseidon2_many(&sorted_outputs);

--- a/crates/consensus/tests/prop_hotstuff_safety.proptest-regressions
+++ b/crates/consensus/tests/prop_hotstuff_safety.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5f2bab405ec358c562e3570004bbc7cd8e92619cbf0d6d71cfb3b6a4c171bed2 # shrinks to slots = [87, 1]

--- a/crates/crypto/src/threshold.rs
+++ b/crates/crypto/src/threshold.rs
@@ -947,6 +947,27 @@ pub fn apply_refresh(key_share: &KeyShare, contributions: &[RefreshContribution]
     }
 }
 
+/// Audit 406: same as `apply_refresh` but operates on the slice of
+/// references returned by `canonical_refresh_subset`, so callers
+/// don't need to clone the contributions just to satisfy the
+/// `&[RefreshContribution]` signature.
+pub fn apply_refresh_canonical(
+    key_share: &KeyShare,
+    canonical: &[&RefreshContribution],
+) -> KeyShare {
+    let validator_idx = key_share.index - 1;
+    let mut new_shares = key_share.shares.clone();
+    for contrib in canonical {
+        for elem_idx in 0..SEED_ELEMENTS {
+            new_shares[elem_idx] += contrib.deltas[validator_idx][elem_idx];
+        }
+    }
+    KeyShare {
+        index: key_share.index,
+        shares: new_shares,
+    }
+}
+
 /// Verify a refresh contribution by checking that each zero-secret polynomial
 /// evaluates correctly (the shares from this contribution alone reconstruct to zero).
 pub fn verify_refresh_contribution(contribution: &RefreshContribution, threshold: usize) -> bool {
@@ -1240,6 +1261,30 @@ pub fn canonical_resharing_subset(
     let mut refs: Vec<&ResharingContribution> = pool.iter().collect();
     refs.sort_by_key(|c| c.from_old_index);
     refs.truncate(old_threshold);
+    Some(refs)
+}
+
+/// Audit 406: same idea as `canonical_resharing_subset` but for PSS
+/// same-committee refresh contributions. Picks the `threshold`
+/// contributions with the LOWEST `from_index` so every validator
+/// applies the same delta polynomial sum to its share. Pre-fix the
+/// runtime applied whichever `threshold` contributions arrived
+/// first via gossip, which produced different `(first-N)` subsets
+/// across nodes under async delivery — exactly the failure mode
+/// audit 403 fixed for epoch randomness — and the resulting shares
+/// no longer interpolated to the same secret. Decryption then
+/// failed every time because the threshold-Kyber Lagrange
+/// reconstruction collapsed onto a wrong-secret seed.
+pub fn canonical_refresh_subset(
+    pool: &[RefreshContribution],
+    threshold: usize,
+) -> Option<Vec<&RefreshContribution>> {
+    if pool.len() < threshold {
+        return None;
+    }
+    let mut refs: Vec<&RefreshContribution> = pool.iter().collect();
+    refs.sort_by_key(|c| c.from_index);
+    refs.truncate(threshold);
     Some(refs)
 }
 
@@ -1697,6 +1742,417 @@ mod tests {
         // so they should also work. PSS only protects against partial compromise.
         let plaintext_old = combine_shares(&dec_shares_old, 3, &ct).unwrap();
         assert_eq!(plaintext_old, msg);
+    }
+
+    /// AUDIT 406 REGRESSION GUARD — reshare canonical-subset
+    /// divergence when each node's local pool is missing its own
+    /// contribution.
+    ///
+    /// The runtime symptom: every node fired `committee handoff
+    /// complete` cleanly, but each node's `canonical_resharing_subset`
+    /// returned a DIFFERENT 3-of-4 subset (each missing the
+    /// contribution from its own old position, because
+    /// `start_committee_reshare` never seeded the local pool with
+    /// the local contribution). The new shares then evaluated
+    /// different polynomials, post-reshare on-disk shares didn't
+    /// combine to recover the secret, and 100% of encrypted txs
+    /// failed to decrypt despite all four nodes having "valid-
+    /// looking" shares. This test reproduces that divergence.
+    #[test]
+    fn audit_406_reshare_local_pool_must_include_own_contribution() {
+        let (tpk, genesis_shares) = threshold_keygen(4, 3).unwrap();
+        let msg = b"reshare-own-in-pool bug repro";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+        // Generate one resharing contribution per old member.
+        let pool_full: Vec<ResharingContribution> = genesis_shares
+            .iter()
+            .map(|s| generate_resharing_contribution(s, 4, 3, 1, b"reshare-fix"))
+            .collect();
+
+        // BUG CASE: each node's local pool is missing the
+        // contribution from its OWN old index (mirrors what
+        // `start_committee_reshare` left behind pre-fix). canonical
+        // ends up different on every node.
+        let perm: [usize; 4] = [3, 4, 1, 2]; // genesis_idx → new_index
+        let mut buggy_new_shares: Vec<KeyShare> = Vec::with_capacity(4);
+        for missing_old_idx in 1..=4usize {
+            let local_pool: Vec<ResharingContribution> = pool_full
+                .iter()
+                .filter(|c| c.from_old_index != missing_old_idx)
+                .cloned()
+                .collect();
+            assert_eq!(local_pool.len(), 3);
+            let canonical = canonical_resharing_subset(&local_pool, 3).unwrap();
+            // canonical here is whatever 3-of-3 the local pool
+            // contains — one will be {2,3,4}, next {1,3,4}, etc.
+            let new_idx = perm[missing_old_idx - 1];
+            let new_share = aggregate_new_share(new_idx, &canonical).unwrap();
+            buggy_new_shares.push(new_share);
+        }
+
+        // Buggy: every 3-of-4 subset MUST fail to combine, because
+        // the four shares lie on four different polynomials.
+        let mut any_buggy_ok = false;
+        for skip in 0..4 {
+            let dec: Vec<DecryptionShare> = (0..4)
+                .filter(|&i| i != skip)
+                .map(|i| generate_decryption_share(&buggy_new_shares[i], &ct))
+                .collect();
+            if let Ok(plain) = combine_shares(&dec, 3, &ct) {
+                if plain == msg {
+                    any_buggy_ok = true;
+                }
+            }
+        }
+        assert!(
+            !any_buggy_ok,
+            "buggy local-pool reshare unexpectedly recovered secret — \
+             repro is wrong, the runtime divergence is something else"
+        );
+
+        // FIX CASE: every node's local pool includes its OWN
+        // contribution. canonical = lowest-3 by from_old_index =
+        // {1,2,3} on every node. New shares all interpolate to the
+        // same polynomial.
+        let canonical_fix = canonical_resharing_subset(&pool_full, 3).unwrap();
+        let fixed_new_shares: Vec<KeyShare> = (1..=4usize)
+            .map(|new_idx| aggregate_new_share(new_idx, &canonical_fix).unwrap())
+            .collect();
+
+        for skip in 0..4 {
+            let dec: Vec<DecryptionShare> = (0..4)
+                .filter(|&i| i != skip)
+                .map(|i| generate_decryption_share(&fixed_new_shares[i], &ct))
+                .collect();
+            let plain = combine_shares(&dec, 3, &ct)
+                .unwrap_or_else(|e| panic!("fixed skip {} failed: {}", skip, e));
+            assert_eq!(plain, msg, "fixed skip {} wrong plaintext", skip);
+        }
+    }
+
+    /// AUDIT 406 — `DecryptionShare` wire round-trip must preserve
+    /// every byte, otherwise the runtime — which gossips shares
+    /// across the committee — will combine round-tripped shares
+    /// that no longer interpolate to the same secret. This was the
+    /// last remaining drift hypothesis when in-process decrypt
+    /// passed the diag but every block of encrypted txs failed.
+    #[test]
+    fn audit_406_decryption_share_wire_roundtrip_decrypts() {
+        let (tpk, key_shares) = threshold_keygen(4, 3).unwrap();
+        let msg = b"share wire roundtrip";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+        // Generate 4 fresh decryption shares locally.
+        let local_shares: Vec<DecryptionShare> = key_shares
+            .iter()
+            .map(|ks| generate_decryption_share(ks, &ct))
+            .collect();
+
+        // Wire-roundtrip every share via `to_bytes` / `from_bytes`,
+        // mirror of what gossip does between sender and receiver.
+        let roundtripped: Vec<DecryptionShare> = local_shares
+            .iter()
+            .map(|s| {
+                let bytes = s.to_bytes();
+                DecryptionShare::from_bytes(&bytes).expect("share roundtrip")
+            })
+            .collect();
+
+        // Bytes must be identical.
+        for (orig, rt) in local_shares.iter().zip(&roundtripped) {
+            assert_eq!(orig.to_bytes(), rt.to_bytes(), "share bytes drifted");
+            assert_eq!(orig.index, rt.index, "share index drifted");
+        }
+
+        // Every threshold-sized subset of round-tripped shares must
+        // still combine to recover the secret.
+        for skip in 0..4 {
+            let subset: Vec<DecryptionShare> = roundtripped
+                .iter()
+                .enumerate()
+                .filter_map(|(i, s)| if i == skip { None } else { Some(s.clone()) })
+                .collect();
+            let plain = combine_shares(&subset, 3, &ct).unwrap_or_else(|e| {
+                panic!(
+                    "skip {} round-tripped shares failed combine: {} — \
+                     wire round-trip corrupts DecryptionShare",
+                    skip, e
+                )
+            });
+            assert_eq!(plain, msg);
+        }
+    }
+
+    /// AUDIT 406 RUNTIME-PIPELINE INTEGRATION TEST.
+    ///
+    /// Simulates the exact sequence the runtime runs at every
+    /// epoch boundary: genesis keygen → cross-committee reshare
+    /// (canonical-subset aggregate) → PSS canonical-subset apply.
+    /// At the end, every 3-of-4 subset of post-pipeline shares must
+    /// still combine to the original secret behind the (unchanged)
+    /// public key. This is the property the on-disk-shares
+    /// diagnostic test (`crates/crypto/tests/encrypted_pipeline_diag.rs`)
+    /// failed to satisfy before the fix.
+    #[test]
+    fn audit_406_runtime_pipeline_preserves_secret() {
+        let (tpk, genesis_shares) = threshold_keygen(4, 3).unwrap();
+        let msg = b"runtime pipeline preserves secret";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+
+        // ---- Cross-committee resharing pass ----
+        // Each genesis-share holder generates a resharing contribution
+        // for the new committee. We use a permuted "new committee"
+        // where each validator's new_index differs from its old.
+        let new_n = 4usize;
+        let new_t = 3usize;
+        let entropy_reshare = b"runtime-test-reshare";
+        let reshare_pool: Vec<ResharingContribution> = genesis_shares
+            .iter()
+            .map(|s| generate_resharing_contribution(s, new_n, new_t, 1, entropy_reshare))
+            .collect();
+        let canonical = canonical_resharing_subset(&reshare_pool, /* old_threshold */ 3)
+            .expect("resharing canonical subset");
+
+        // Permute new positions: validator i (genesis) maps to new
+        // index P[i]. This mimics the runtime where the new committee
+        // shuffles positions per VRF.
+        let perm: [usize; 4] = [3, 4, 1, 2]; // genesis_idx → new_index (1-based)
+        let post_reshare_shares: Vec<KeyShare> = (0..4)
+            .map(|i| aggregate_new_share(perm[i], &canonical).expect("aggregate"))
+            .collect();
+
+        // Sanity: post-reshare alone must decrypt.
+        let dec_after_reshare: Vec<DecryptionShare> = post_reshare_shares[..3]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let plain_reshare =
+            combine_shares(&dec_after_reshare, 3, &ct).expect("post-reshare alone must decrypt");
+        assert_eq!(plain_reshare, msg);
+
+        // ---- PSS canonical apply pass ----
+        // Each validator broadcasts a PSS contribution. from_index is
+        // the validator's OLD (genesis) index in the runtime — that's
+        // what start_pss_refresh uses since it runs BEFORE reshare
+        // overwrites identity.key_share.
+        let entropy_pss = b"runtime-test-pss-entropy";
+        let pss_pool: Vec<RefreshContribution> = (1..=4usize)
+            .map(|old_idx| generate_refresh_contribution(old_idx, new_n, new_t, 2, entropy_pss))
+            .collect();
+        let pss_canonical = canonical_refresh_subset(&pss_pool, 3).expect("PSS canonical subset");
+
+        // Validators apply PSS canonical to their post-reshare share.
+        // post_reshare_share.index is the NEW position (perm[i]).
+        let post_pss_shares: Vec<KeyShare> = post_reshare_shares
+            .iter()
+            .map(|s| apply_refresh_canonical(s, &pss_canonical))
+            .collect();
+
+        // The post-pipeline shares MUST still decrypt the original
+        // ciphertext via every 3-of-4 subset.
+        for skip in 0..4usize {
+            let subset_shares: Vec<KeyShare> = (0..4)
+                .filter(|&i| i != skip)
+                .map(|i| post_pss_shares[i].clone())
+                .collect();
+            let dec: Vec<DecryptionShare> = subset_shares
+                .iter()
+                .map(|s| generate_decryption_share(s, &ct))
+                .collect();
+            let plain = combine_shares(&dec, 3, &ct).unwrap_or_else(|e| {
+                panic!(
+                    "subset (skip {}) failed to decrypt: {} \
+                     — runtime pipeline did NOT preserve secret",
+                    skip, e
+                )
+            });
+            assert_eq!(plain, msg, "subset (skip {}) wrong plaintext", skip);
+        }
+    }
+
+    /// AUDIT 406 RUNTIME-PIPELINE INTEGRATION TEST — TWO CYCLES.
+    /// The single-cycle test passes; the on-disk diagnostic against
+    /// a real testnet that ran multiple cycles fails. So either two
+    /// cycles compound an error, or the PSS contribution generation
+    /// in cycle 2 reads stale state. This test runs the full
+    /// pipeline twice and asserts the original ciphertext still
+    /// decrypts at every 3-of-4 subset of the post-cycle-2 shares.
+    #[test]
+    fn audit_406_runtime_pipeline_two_cycles_preserve_secret() {
+        let (tpk, genesis_shares) = threshold_keygen(4, 3).unwrap();
+        let msg = b"two-cycle pipeline preserves secret";
+        let ct = threshold_encrypt(&tpk, msg).unwrap();
+        let new_n = 4usize;
+        let new_t = 3usize;
+
+        // ---- Cycle 1 ----
+        let cycle1_reshare_pool: Vec<ResharingContribution> = genesis_shares
+            .iter()
+            .map(|s| generate_resharing_contribution(s, new_n, new_t, 1, b"reshare-1"))
+            .collect();
+        let c1_canonical_reshare = canonical_resharing_subset(&cycle1_reshare_pool, 3).unwrap();
+        let perm1: [usize; 4] = [3, 4, 1, 2];
+        let after_c1_reshare: Vec<KeyShare> = (0..4)
+            .map(|i| aggregate_new_share(perm1[i], &c1_canonical_reshare).unwrap())
+            .collect();
+
+        // PSS contributions for cycle 1: from_index = OLD index = genesis index.
+        let cycle1_pss_pool: Vec<RefreshContribution> = (1..=4usize)
+            .map(|old_idx| generate_refresh_contribution(old_idx, new_n, new_t, 2, b"pss-1"))
+            .collect();
+        let c1_canonical_pss = canonical_refresh_subset(&cycle1_pss_pool, 3).unwrap();
+        let after_c1_pss: Vec<KeyShare> = after_c1_reshare
+            .iter()
+            .map(|s| apply_refresh_canonical(s, &c1_canonical_pss))
+            .collect();
+
+        // Sanity: post-cycle-1 must decrypt.
+        for skip in 0..4usize {
+            let dec: Vec<DecryptionShare> = (0..4)
+                .filter(|&i| i != skip)
+                .map(|i| generate_decryption_share(&after_c1_pss[i], &ct))
+                .collect();
+            let plain = combine_shares(&dec, 3, &ct)
+                .unwrap_or_else(|e| panic!("c1 skip {} fail: {}", skip, e));
+            assert_eq!(plain, msg, "c1 skip {} wrong plaintext", skip);
+        }
+
+        // ---- Cycle 2 ----
+        // Inputs: post-cycle-1 shares. Each validator's "OLD index"
+        // for cycle 2 is its CURRENT key_share.index = perm1[i].
+        let cycle2_reshare_pool: Vec<ResharingContribution> = after_c1_pss
+            .iter()
+            .map(|s| generate_resharing_contribution(s, new_n, new_t, 2, b"reshare-2"))
+            .collect();
+        let c2_canonical_reshare = canonical_resharing_subset(&cycle2_reshare_pool, 3).unwrap();
+        let perm2: [usize; 4] = [4, 2, 3, 1]; // a different permutation
+        let after_c2_reshare: Vec<KeyShare> = (0..4)
+            .map(|i| aggregate_new_share(perm2[i], &c2_canonical_reshare).unwrap())
+            .collect();
+
+        // PSS for cycle 2: from_index = current key_share.index BEFORE
+        // reshare runs. Since start_pss_refresh runs BEFORE
+        // start_committee_reshare in the runtime, key_share at
+        // generation time is still post-cycle-1 = perm1[i].
+        let cycle2_pss_pool: Vec<RefreshContribution> = (0..4)
+            .map(|i| generate_refresh_contribution(perm1[i], new_n, new_t, 3, b"pss-2"))
+            .collect();
+        let c2_canonical_pss = canonical_refresh_subset(&cycle2_pss_pool, 3).unwrap();
+        let after_c2_pss: Vec<KeyShare> = after_c2_reshare
+            .iter()
+            .map(|s| apply_refresh_canonical(s, &c2_canonical_pss))
+            .collect();
+
+        // The post-cycle-2 shares MUST still decrypt.
+        for skip in 0..4usize {
+            let dec: Vec<DecryptionShare> = (0..4)
+                .filter(|&i| i != skip)
+                .map(|i| generate_decryption_share(&after_c2_pss[i], &ct))
+                .collect();
+            let plain = combine_shares(&dec, 3, &ct).unwrap_or_else(|e| {
+                panic!(
+                    "post-cycle-2 skip {} failed: {} — \
+                     two-cycle pipeline did NOT preserve secret",
+                    skip, e
+                )
+            });
+            assert_eq!(plain, msg, "c2 skip {} wrong plaintext", skip);
+        }
+    }
+
+    /// AUDIT 406 REGRESSION GUARD.
+    ///
+    /// Pre-fix the runtime applied refresh contributions eagerly on
+    /// first-`threshold` arrival. Under async gossip every validator
+    /// saw a different "first 3 of N" arrival order, so each one
+    /// applied a different DELTA SET to its share — the shares
+    /// stopped interpolating to the same secret and every block of
+    /// encrypted txs failed to decrypt.
+    ///
+    /// This test simulates that bug directly: each validator's
+    /// share is mutated by `apply_refresh` over a DIFFERENT pool
+    /// subset. We then check that
+    ///   (a) decryption with the mutated shares fails (the bug
+    ///       manifests), AND
+    ///   (b) decryption with the canonical-subset apply succeeds
+    ///       (the fix works).
+    #[test]
+    fn pss_eager_apply_breaks_decryption_canonical_apply_fixes_it() {
+        let (epoch_mat, shares) = setup_epoch(4, 3);
+        let msg = b"audit-406 regression";
+        let ct = threshold_encrypt(&epoch_mat.tpk, msg).unwrap();
+
+        // Generate 4 contributions, one per validator.
+        let entropy = b"audit-406-test-entropy";
+        let pool: Vec<RefreshContribution> = (1..=4usize)
+            .map(|idx| generate_refresh_contribution(idx, 4, 3, 1, entropy))
+            .collect();
+
+        // Simulate buggy runtime: each validator picks a DIFFERENT
+        // first-3-of-4 subset (whatever arrived fastest in their
+        // gossip order). Validator 1 saw {own, 2, 3} first;
+        // validator 2 saw {own, 3, 4}; validator 3 saw {own, 1, 4};
+        // validator 4 saw {own, 1, 2}. Same membership but each
+        // skips a different peer's contribution.
+        let buggy_subsets: [[usize; 3]; 4] = [
+            [1, 2, 3], // validator 1 misses 4
+            [2, 3, 4], // validator 2 misses 1
+            [3, 1, 4], // validator 3 misses 2
+            [4, 1, 2], // validator 4 misses 3
+        ];
+        let buggy_shares: Vec<KeyShare> = (0..4)
+            .map(|i| {
+                let owned: Vec<RefreshContribution> = buggy_subsets[i]
+                    .iter()
+                    .map(|&j| pool[j - 1].clone())
+                    .collect();
+                apply_refresh(&shares[i], &owned)
+            })
+            .collect();
+
+        // (a) Decryption with the buggy mixed shares should NOT
+        // recover the plaintext — the shares are on different
+        // polynomials.
+        let buggy_dec: Vec<DecryptionShare> = buggy_shares[..3]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let buggy_result = combine_shares(&buggy_dec, 3, &ct);
+        assert!(
+            buggy_result.is_err() || buggy_result.as_ref().unwrap() != msg,
+            "buggy first-N-wins apply should NOT decrypt — \
+             this is the audit 406 failure mode"
+        );
+
+        // (b) Same starting shares + same pool, but apply the
+        // canonical subset on every validator. They must all
+        // converge on the same polynomial.
+        let canonical = canonical_refresh_subset(&pool, 3).expect("canonical subset");
+        let fixed_shares: Vec<KeyShare> = (0..4)
+            .map(|i| apply_refresh_canonical(&shares[i], &canonical))
+            .collect();
+
+        let fixed_dec: Vec<DecryptionShare> = fixed_shares[..3]
+            .iter()
+            .map(|s| generate_decryption_share(s, &ct))
+            .collect();
+        let fixed_plaintext = combine_shares(&fixed_dec, 3, &ct)
+            .expect("canonical apply must decrypt the same ciphertext");
+        assert_eq!(
+            fixed_plaintext, msg,
+            "canonical-subset apply must preserve the secret",
+        );
+
+        // Defensive: also verify the canonical subset is the
+        // lowest-from_index `threshold`-sized subset, regardless of
+        // pool ordering.
+        let mut shuffled = pool.clone();
+        shuffled.reverse();
+        let canon_shuffled =
+            canonical_refresh_subset(&shuffled, 3).expect("canonical from shuffled");
+        let canon_indices: Vec<usize> = canon_shuffled.iter().map(|c| c.from_index).collect();
+        assert_eq!(canon_indices, vec![1, 2, 3]);
     }
 
     #[test]

--- a/crates/crypto/tests/encrypted_pipeline_diag.rs
+++ b/crates/crypto/tests/encrypted_pipeline_diag.rs
@@ -1,0 +1,152 @@
+//! Diagnostic: load real `threshold.pk` + every node's
+//! `threshold.share` from a live testnet datadir, run the full
+//! encrypt → share-gen → combine cycle against the loaded keys.
+//!
+//! Skipped unless `PYDE_DIAG_DATADIR` points at a testnet root.
+//!
+//! ```bash
+//! PYDE_DIAG_DATADIR=/tmp/diag-net cargo test -p pyde-crypto \
+//!   --test encrypted_pipeline_diag -- --nocapture
+//! ```
+//!
+//! `quorum_for_committee` is duplicated from
+//! `pyde-consensus::block` so we don't pull the entire workspace
+//! into this fast diagnostic.
+
+fn quorum_for_committee(n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    (2 * n).div_ceil(3)
+}
+
+#[test]
+fn loaded_keys_round_trip() {
+    let Ok(root) = std::env::var("PYDE_DIAG_DATADIR") else {
+        eprintln!("skip: PYDE_DIAG_DATADIR not set");
+        return;
+    };
+    let root = std::path::PathBuf::from(root);
+    assert!(root.is_dir(), "{} must be a directory", root.display());
+
+    let mut node_dirs: Vec<std::path::PathBuf> = std::fs::read_dir(&root)
+        .expect("read datadir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("node-"))
+                && p.join("threshold.pk").exists()
+                && p.join("threshold.share").exists()
+        })
+        .collect();
+    node_dirs.sort();
+    assert!(
+        !node_dirs.is_empty(),
+        "no node-* dirs with threshold.{{pk,share}} under {}",
+        root.display()
+    );
+    eprintln!("found {} node dirs", node_dirs.len());
+
+    // 1. All threshold.pk files must be byte-identical.
+    let pk_bytes_first = std::fs::read(node_dirs[0].join("threshold.pk")).unwrap();
+    for d in &node_dirs[1..] {
+        let pk_bytes = std::fs::read(d.join("threshold.pk")).unwrap();
+        assert_eq!(
+            pk_bytes_first,
+            pk_bytes,
+            "threshold.pk diverges at {}",
+            d.display()
+        );
+    }
+
+    let tpk = pyde_crypto::threshold::ThresholdPublicKey::from_bytes(&pk_bytes_first)
+        .expect("parse threshold.pk");
+
+    // 2. Load every share.
+    let shares: Vec<pyde_crypto::threshold::KeyShare> = node_dirs
+        .iter()
+        .map(|d| {
+            let bytes = std::fs::read(d.join("threshold.share")).unwrap();
+            pyde_crypto::threshold::KeyShare::from_bytes(&bytes).expect("parse threshold.share")
+        })
+        .collect();
+
+    for (i, ks) in shares.iter().enumerate() {
+        eprintln!("  node-{}: share index = {} (1-based)", i, ks.index);
+    }
+
+    // Distinct indices?
+    let mut idx: Vec<_> = shares.iter().map(|s| s.index).collect();
+    idx.sort();
+    let pre = idx.clone();
+    idx.dedup();
+    assert_eq!(idx, pre, "duplicate share indices: {:?}", pre);
+
+    // 3. Encrypt with the on-disk public key.
+    let payload = b"diag payload v1";
+    let ct = pyde_crypto::threshold::threshold_encrypt(&tpk, payload).expect("encrypt");
+
+    // 4. Wire round-trip.
+    let ct_wire = ct.to_wire_bytes();
+    let ct_rt = pyde_crypto::threshold::ThresholdCiphertext::from_wire_bytes(&ct_wire)
+        .expect("wire round-trip");
+
+    // 5. Decryption shares from each loaded share.
+    let dec_shares: Vec<pyde_crypto::threshold::DecryptionShare> = shares
+        .iter()
+        .map(|ks| pyde_crypto::threshold::generate_decryption_share(ks, &ct_rt))
+        .collect();
+
+    let threshold = quorum_for_committee(node_dirs.len());
+    eprintln!(
+        "expected threshold for committee of {} = {}",
+        node_dirs.len(),
+        threshold
+    );
+
+    // 6. Try every threshold-sized subset.
+    let n = dec_shares.len();
+    let mut any_ok = false;
+    let mut tried = 0usize;
+    if threshold == 3 && n >= 3 {
+        for i in 0..n {
+            for j in (i + 1)..n {
+                for k in (j + 1)..n {
+                    tried += 1;
+                    let subset = vec![
+                        dec_shares[i].clone(),
+                        dec_shares[j].clone(),
+                        dec_shares[k].clone(),
+                    ];
+                    match pyde_crypto::threshold::combine_shares(&subset, threshold, &ct_rt) {
+                        Ok(plain) => {
+                            assert_eq!(plain, payload, "wrong plaintext");
+                            eprintln!(
+                                "  subset (idx {},{},{}) [shares {},{},{}] OK",
+                                i, j, k, shares[i].index, shares[j].index, shares[k].index
+                            );
+                            any_ok = true;
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "  subset (idx {},{},{}) [shares {},{},{}] FAIL: {}",
+                                i, j, k, shares[i].index, shares[j].index, shares[k].index, e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    eprintln!("\ntried {} subsets; any_ok={}", tried, any_ok);
+    assert!(
+        any_ok,
+        "every threshold-sized subset of loaded shares FAILED to combine — \
+         on-disk shares are not consistent with the on-disk public key. \
+         This is the encrypted-tx pipeline bug."
+    );
+}

--- a/crates/mempool/src/decryption.rs
+++ b/crates/mempool/src/decryption.rs
@@ -11,6 +11,7 @@
 use crate::encrypted::{decrypt_payload, EncryptedTx};
 use pyde_crypto::threshold::{generate_decryption_share, DecryptionShare, KeyShare};
 use pyde_tx::types::{FeePayer, Transaction, TransactionType};
+use std::fmt::Write;
 
 /// Decryption state for a single block's worth of encrypted transactions.
 #[derive(Debug)]
@@ -77,6 +78,21 @@ impl BlockDecryptor {
             .map(|tx| generate_decryption_share(key_share, &tx.ciphertext))
             .collect();
 
+        if std::env::var("PYDE_DECRYPT_DIAG").is_ok() && !self.encrypted_txs.is_empty() {
+            let kct_first8 = {
+                let wire = self.encrypted_txs[0].ciphertext.to_wire_bytes();
+                let mut out = [0u8; 8];
+                let n = 8.min(wire.len());
+                out[..n].copy_from_slice(&wire[..n]);
+                out
+            };
+            let share_index_local = shares.first().map(|s| s.index).unwrap_or(0);
+            eprintln!(
+                "[decrypt-diag-add-member] my_key_share.index={} share_local.index={} num_txs={} kct[0..8]={:02x?}",
+                key_share.index, share_index_local, self.encrypted_txs.len(), kct_first8
+            );
+        }
+
         let mut accepted = 0;
         for (i, share) in shares.into_iter().enumerate() {
             if self.add_share(i, share) {
@@ -127,11 +143,51 @@ impl BlockDecryptor {
             ));
         }
 
+        // Audit 406 diag: env-gated cross-node fingerprint so a
+        // failing decryption can be cross-correlated against the
+        // pool composition on every validator. Set
+        // `PYDE_DECRYPT_DIAG=1` on the running node.
+        if std::env::var("PYDE_DECRYPT_DIAG").is_ok() {
+            let indices: Vec<usize> = self.shares[tx_index].iter().map(|s| s.index).collect();
+            let wire = self.encrypted_txs[tx_index].ciphertext.to_wire_bytes();
+            let kct_first8 = &wire[..8.min(wire.len())];
+            let msg_len = wire.len();
+            eprintln!(
+                "[decrypt-diag] tx_index={} share_count={} threshold={} share_indices={:?} kct[0..8]={:02x?} msg_len={}",
+                tx_index, share_count, self.threshold, indices, kct_first8, msg_len
+            );
+        }
+
         let (to, value, calldata) = decrypt_payload(
             &self.encrypted_txs[tx_index].ciphertext,
             &self.shares[tx_index],
             self.threshold,
-        )?;
+        )
+        .inspect_err(|e| {
+            if std::env::var("PYDE_DECRYPT_DIAG").is_ok() {
+                let indices: Vec<usize> = self.shares[tx_index]
+                    .iter()
+                    .map(|s| s.index)
+                    .collect();
+                let to_hex = |b: &[u8]| -> String {
+                    let mut s = String::with_capacity(b.len() * 2);
+                    for x in b {
+                        let _ = write!(s, "{:02x}", x);
+                    }
+                    s
+                };
+                let wire = self.encrypted_txs[tx_index].ciphertext.to_wire_bytes();
+                let ct_hex = to_hex(&wire);
+                let shares_hex: Vec<String> = self.shares[tx_index]
+                    .iter()
+                    .map(|s| to_hex(&s.to_bytes()))
+                    .collect();
+                eprintln!(
+                    "[decrypt-diag-full] FAIL tx_index={} indices={:?} threshold={} ct={} shares={:?} err={}",
+                    tx_index, indices, self.threshold, ct_hex, shares_hex, e
+                );
+            }
+        })?;
 
         let enc_tx = &self.encrypted_txs[tx_index];
         Ok(Transaction {

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -577,6 +577,70 @@ mod tests {
         assert!(EncryptedTx::from_bytes(&bytes).is_none());
     }
 
+    /// AUDIT 406 REGRESSION GUARD — the runtime decrypts an
+    /// EncryptedTx that was wire-roundtripped at least twice (RPC
+    /// in, block-body out → validator block-body in). Each
+    /// roundtrip must preserve the ciphertext byte-for-byte;
+    /// otherwise `ciphertext_binding_hash` differs between encrypt
+    /// and decrypt and `combine_shares` collapses onto the audit-
+    /// 360 oracle-safe error every single time.
+    #[test]
+    fn audit_406_encrypted_tx_double_roundtrip_is_byte_identical_and_decrypts() {
+        let (pk, key_shares) = make_threshold_keys();
+        let sender = derive_eoa_address(b"sender");
+        let to = derive_eoa_address(b"recipient");
+        let original = encrypt_transaction(
+            sender,
+            42,
+            500_000,
+            vec![],
+            Some(1_000_500),
+            7331,
+            vec![0xAA; 64],
+            &to,
+            1_000_000,
+            b"audit 406 double-roundtrip payload",
+            &pk,
+        )
+        .unwrap();
+
+        // First roundtrip: simulates RPC submission decode.
+        let bytes_1 = original.to_bytes();
+        let after_1 = EncryptedTx::from_bytes(&bytes_1).expect("first roundtrip");
+        let bytes_2 = after_1.to_bytes();
+        // Second roundtrip: simulates proposer block re-serialization.
+        let after_2 = EncryptedTx::from_bytes(&bytes_2).expect("second roundtrip");
+        let bytes_3 = after_2.to_bytes();
+
+        assert_eq!(bytes_1, bytes_2, "first roundtrip changed bytes");
+        assert_eq!(bytes_2, bytes_3, "second roundtrip changed bytes");
+        assert_eq!(
+            original.ciphertext.to_wire_bytes(),
+            after_2.ciphertext.to_wire_bytes(),
+            "ciphertext wire bytes drifted across two EncryptedTx roundtrips"
+        );
+
+        // Decrypt the post-double-roundtrip ciphertext via the
+        // committee's shares. This is the exact path the runtime
+        // takes: validators decode wire bytes from a block body,
+        // generate shares, and combine.
+        let dec_shares: Vec<pyde_crypto::threshold::DecryptionShare> = key_shares[..2]
+            .iter()
+            .map(|ks| pyde_crypto::threshold::generate_decryption_share(ks, &after_2.ciphertext))
+            .collect();
+        let plaintext_bytes =
+            pyde_crypto::threshold::combine_shares(&dec_shares, 2, &after_2.ciphertext)
+                .expect("post-roundtrip ciphertext must decrypt");
+        // Plaintext layout: to(32) || value(16 LE) || calldata.
+        assert_eq!(&plaintext_bytes[..32], &to);
+        let value_le: [u8; 16] = plaintext_bytes[32..48].try_into().unwrap();
+        assert_eq!(u128::from_le_bytes(value_le), 1_000_000);
+        assert_eq!(
+            &plaintext_bytes[48..],
+            b"audit 406 double-roundtrip payload"
+        );
+    }
+
     #[test]
     fn from_bytes_roundtrip_with_real_payload() {
         // Sanity: the new decoder still accepts a real, encoded

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -275,8 +275,17 @@ pub mod topics {
     /// from plaintext transactions so the receive dispatcher can
     /// decode the right wire format without probing. Audit item
     /// 227 step 4 / option E.
+    ///
+    /// The literal string MUST match the arm in
+    /// `crate::channels::Channel::from_topic`. Pre-fix this returned
+    /// `pyde/encrypted_tx/1` while `Channel::from_topic` only knew
+    /// `pyde/encrypted_transactions/1`, so every received encrypted-
+    /// tx gossip message fell into the catch-all "unknown topic"
+    /// branch and the encrypted mempool was a no-op over the network.
+    /// `topics_round_trip_through_channel_from_topic` below locks
+    /// the alignment in.
     pub fn encrypted_transactions() -> IdentTopic {
-        IdentTopic::new("pyde/encrypted_tx/1")
+        IdentTopic::new("pyde/encrypted_transactions/1")
     }
 
     /// Proposed blocks and scheduled blocks.
@@ -438,6 +447,47 @@ mod tests {
         // Last bumped when `encrypted_transactions` shipped with the
         // MEV-protected encrypted-tx flow (item 227).
         assert_eq!(topics::all().len(), 5);
+    }
+
+    /// TPL-201: every subscribed topic name must round-trip through
+    /// `Channel::from_topic`. The pre-existing
+    /// `channel_from_topic_roundtrip` in `channels.rs` only checks
+    /// `Channel::topic()` against `Channel::from_topic` — both
+    /// internal to that file — so it can't notice when a `topics::*`
+    /// function in this file drifts away from the dispatcher's
+    /// table. The bug it would have caught: pre-fix
+    /// `topics::encrypted_transactions()` returned
+    /// `pyde/encrypted_tx/1`, the dispatcher only knew
+    /// `pyde/encrypted_transactions/1`, and every received
+    /// encrypted-tx gossip silently fell into the catch-all
+    /// "unknown topic" branch — the encrypted mempool was a no-op
+    /// over the network.
+    #[test]
+    fn topics_round_trip_through_channel_from_topic() {
+        use crate::channels::Channel;
+
+        let pairs = [
+            (topics::consensus(), Channel::Consensus),
+            (topics::transactions(), Channel::Transactions),
+            (
+                topics::encrypted_transactions(),
+                Channel::EncryptedTransactions,
+            ),
+            (topics::blocks(), Channel::Blocks),
+            (topics::sync(), Channel::Sync),
+        ];
+        for (topic, expected) in pairs {
+            let name = topic.hash().to_string();
+            assert_eq!(
+                Channel::from_topic(&name),
+                Some(expected),
+                "subscribed topic {:?} (name {:?}) did not round-trip \
+                 through Channel::from_topic — receive-side dispatch \
+                 will silently drop messages on this topic",
+                expected,
+                name,
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -133,6 +133,26 @@ impl BlockProcessor {
         // 1. Validate header
         Self::validate_header_with_checkpoint(&block.header, chain, ws_checkpoint_slot)?;
 
+        // 1b. Audit 408: verify tx_root against the body BEFORE
+        // executing anything. Without this, a node whose
+        // canonical-apply path supplies a body that doesn't
+        // match `header.tx_root` (e.g. compact-block reconstruct
+        // that pulled a stale-bytes copy of a tx from this
+        // node's mempool, or a synthesize-empty-body fallback
+        // for a block whose header actually committed to a
+        // non-empty payload) silently commits diverging state.
+        // `validate_block_body` is the authoritative
+        // header↔body consistency check; it batch-verifies
+        // signatures + decodes encrypted-tx hashes + computes
+        // the merged tx_root and compares against
+        // `block.header.tx_root`. The on-receive path at
+        // `node.rs:4667` already gates apply on it; gating here
+        // too means *every* apply path gets the same protection
+        // without depending on every caller to remember the
+        // pre-check. The cost is one extra signature batch on
+        // the receive-then-apply path, paid once per block.
+        Self::validate_block_body(block, state, chain.chain_id)?;
+
         // 2. Build block context for tx execution.
         //
         // `dev_skip_signature` follows `chain_id == 31337` (devnet) so the

--- a/crates/node/src/faucet.rs
+++ b/crates/node/src/faucet.rs
@@ -895,10 +895,7 @@ async fn serve_dispense(
                 ip = %ip_key,
                 "faucet queue saturated — returning 503 (audit 382)"
             );
-            return json_response(
-                503,
-                r#"{"error":"faucet queue saturated, retry shortly"}"#,
-            );
+            return json_response(503, r#"{"error":"faucet queue saturated, retry shortly"}"#);
         }
     };
     match send_faucet_tx(rpc, from, address, amount, signer, signing_lock, chain_id).await {

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -1610,7 +1610,18 @@ mod tests {
         // Audit 383: chain_id=1 (mainnet) is now refused by
         // `generate_testnet`. Use the canonical testnet id for
         // tests that exercise the distributed-write surface.
-        generate_testnet(tmp.path(), 4, 0, 30303, 8545, true, pyde_net::discovery::TESTNET_CHAIN_ID, 400, Some(&addrs)).unwrap();
+        generate_testnet(
+            tmp.path(),
+            4,
+            0,
+            30303,
+            8545,
+            true,
+            pyde_net::discovery::TESTNET_CHAIN_ID,
+            400,
+            Some(&addrs),
+        )
+        .unwrap();
 
         // node-0's config must:
         //  - carry its own region/host as a comment header
@@ -1694,7 +1705,10 @@ mod tests {
             err.contains("refusing to generate testnet artifacts"),
             "expected mainnet refusal, got: {err}"
         );
-        assert!(err.contains("audit 383"), "expected audit 383 ref, got: {err}");
+        assert!(
+            err.contains("audit 383"),
+            "expected audit 383 ref, got: {err}"
+        );
     }
 
     /// Audit 400: the generator must stamp a real wall-clock

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -177,10 +177,7 @@ impl PydeNode {
 
         // 1. Load validator identity early (needed for genesis funding)
         let early_validator_identity = if is_validator {
-            Some(load_validator_identity(
-                datadir,
-                self.config.node.chain_id,
-            )?)
+            Some(load_validator_identity(datadir, self.config.node.chain_id)?)
         } else {
             None
         };
@@ -889,6 +886,19 @@ impl PydeNode {
             initial_slot = slot_clock.current_slot(),
             "slot_clock initialized"
         );
+        // Audit 408: hand the validator engine the same wall-clock
+        // anchor the slot clock uses, so its `advance_target_height`
+        // resets the proposal-timeout tracker to the new slot's
+        // actual start (genesis_ts + N * block_time) rather than
+        // wall-clock "now". Without this, the timer for slot N
+        // begins counting at the moment slot N-1's QC formed —
+        // which is typically 50–150 ms into slot N-1, so the 200 ms
+        // PROPOSAL_TIMEOUT fires ~50 ms BEFORE slot N starts and
+        // every other slot view-changes spuriously. See the
+        // `slot_start_ms_for_target` helper in validator.rs.
+        if let Some(engine) = validator_engine.as_mut() {
+            engine.set_slot_anchor(slot_clock_anchor_ms, block_time_ms);
+        }
         let mut last_slot = slot_clock.current_slot();
 
         // Periodic timers
@@ -1114,17 +1124,59 @@ impl PydeNode {
                             // `log_tag` to distinguish call sites in
                             // operator logs.
                             let _ = swarm.behaviour_mut().consensus_rr.send_response(channel, resp);
+                            // Audit 408: mirror the own-vote-QC path's
+                            // synthesize-empty-body fallback so QC
+                            // application is deterministic across all
+                            // nodes regardless of which node's own vote
+                            // closed the QC. The fallback is gated on
+                            // `header.tx_root == EMPTY_TX_ROOT` so it
+                            // only applies for blocks the proposer
+                            // committed to as empty (view-change empty
+                            // blocks, idle slots) — `compute_tx_root`
+                            // returns `[0u8; 32]` exactly when both
+                            // plaintext txs and encrypted-tx hashes are
+                            // empty (`pyde_consensus::block::compute_tx_root`).
+                            // For non-empty bodies we MUST wait on the
+                            // gossip-delivered body: pre-fix the
+                            // synthesize fallback applied an empty body
+                            // for any block the body buffer didn't hold,
+                            // and `process_full_block_…` doesn't verify
+                            // tx_root, so non-empty payloads silently
+                            // committed wrong state on the fallback path.
+                            const EMPTY_TX_ROOT: [u8; 32] = [0u8; 32];
                             let block = {
                                 let pbb = pending_block_bodies.read().await;
-                                match pbb.get(&qc_block_hash).cloned() {
-                                    Some(b) => b,
-                                    None => {
-                                        debug!(
-                                            qc_slot,
-                                            "RR-QC canonical apply: block not in buffer (sync will recover)"
-                                        );
-                                        continue;
-                                    }
+                                pbb.get(&qc_block_hash).cloned()
+                            }
+                            .or_else(|| {
+                                let engine = validator_engine.as_ref()?;
+                                let (header, sig) =
+                                    engine.buffered_proposal_for(qc_slot, &qc_block_hash)?;
+                                if header.tx_root != EMPTY_TX_ROOT {
+                                    return None;
+                                }
+                                Some(pyde_consensus::block::Block {
+                                    header,
+                                    body: pyde_consensus::block::BlockBody {
+                                        transactions: vec![],
+                                        encrypted_txs: vec![],
+                                        execution_schedule:
+                                            pyde_tx::parallel::ExecutionSchedule {
+                                                groups: vec![],
+                                                total_txs: 0,
+                                            },
+                                    },
+                                    proposer_signature: sig,
+                                })
+                            });
+                            let block = match block {
+                                Some(b) => b,
+                                None => {
+                                    debug!(
+                                        qc_slot,
+                                        "RR-QC canonical apply: body unavailable (sync will recover)"
+                                    );
+                                    continue;
                                 }
                             };
                             let mut chain_w = chain.write().await;
@@ -1448,17 +1500,46 @@ impl PydeNode {
                             // it is. Same body runs from the
                             // RR-fallback handler at line ~780 with a
                             // different log_tag.
+                            // Audit 408: same `EMPTY_TX_ROOT`-gated
+                            // synthesize fallback as the RR-QC path
+                            // above. Both paths must apply view-change
+                            // empty blocks identically. Non-empty bodies
+                            // still wait on gossip — see the rationale
+                            // attached to the RR-QC version.
+                            const EMPTY_TX_ROOT: [u8; 32] = [0u8; 32];
                             let block = {
                                 let pbb = pending_block_bodies.read().await;
-                                match pbb.get(&qc_block_hash).cloned() {
-                                    Some(b) => b,
-                                    None => {
-                                        debug!(
-                                            qc_slot,
-                                            "ApplyCanonicalAfterQc: block not in buffer (sync will recover)"
-                                        );
-                                        continue;
-                                    }
+                                pbb.get(&qc_block_hash).cloned()
+                            }
+                            .or_else(|| {
+                                let engine = validator_engine.as_ref()?;
+                                let (header, sig) =
+                                    engine.buffered_proposal_for(qc_slot, &qc_block_hash)?;
+                                if header.tx_root != EMPTY_TX_ROOT {
+                                    return None;
+                                }
+                                Some(pyde_consensus::block::Block {
+                                    header,
+                                    body: pyde_consensus::block::BlockBody {
+                                        transactions: vec![],
+                                        encrypted_txs: vec![],
+                                        execution_schedule:
+                                            pyde_tx::parallel::ExecutionSchedule {
+                                                groups: vec![],
+                                                total_txs: 0,
+                                            },
+                                    },
+                                    proposer_signature: sig,
+                                })
+                            });
+                            let block = match block {
+                                Some(b) => b,
+                                None => {
+                                    debug!(
+                                        qc_slot,
+                                        "ApplyCanonicalAfterQc: body unavailable (sync will recover)"
+                                    );
+                                    continue;
                                 }
                             };
                             let mut chain_w = chain.write().await;
@@ -2087,6 +2168,31 @@ impl PydeNode {
                                 }
                             }
 
+                            // Audit 406: re-broadcast our PSS contribution
+                            // during the same window. Without this a
+                            // dropped gossip message strands a peer's pool
+                            // at n-1 and the all-N apply guard blocks
+                            // PSS for the epoch — the share stays valid
+                            // (resharing already produced it) but the
+                            // genesis-trust-dissolution intent of PSS
+                            // doesn't fire. The rebroadcast loop here
+                            // closes that gap with the same window cross-
+                            // committee resharing already uses.
+                            if let Some((target_epoch, bytes)) = engine.maybe_rebroadcast_pss() {
+                                if is_validator {
+                                    let msg = wire::encode_pss_refresh(target_epoch, &bytes);
+                                    let topic = pyde_net::node::topics::consensus();
+                                    broadcast_consensus_with_rr_fallback(
+                                        &mut swarm,
+                                        topic,
+                                        msg,
+                                        &peer_manager,
+                                        &mut gossip_cache,
+                                    );
+                                    debug!(target_epoch, "re-broadcast PSS contribution");
+                                }
+                            }
+
                             // Task 034: deterministic aggregation trigger. We
                             // deliberately DON'T aggregate on first-threshold
                             // arrival because async gossip can deliver a
@@ -2102,6 +2208,24 @@ impl PydeNode {
                                     last_outgoing_committee_size,
                                     identity,
                                 );
+                            }
+
+                            // Audit 406: deterministic PSS apply trigger.
+                            // Same first-N-wins race that audit 403 fixed for
+                            // randomness and `try_aggregate_reshare_on_slot`
+                            // fixes for cross-committee resharing — eagerly
+                            // applying the first `threshold` PSS contributions
+                            // produced different "first 3-of-4" subsets across
+                            // nodes under async gossip, leaving each
+                            // validator's share on a different polynomial and
+                            // breaking threshold decryption (every block of
+                            // encrypted txs failed to combine, even with all
+                            // 4 shares present). Waiting through the same
+                            // RESHARE_AGGREGATION_DELAY_SLOTS lets gossipsub
+                            // deliver every contribution to every node before
+                            // we run the canonical-subset apply.
+                            if let Some(identity) = validator_identity.as_mut() {
+                                engine.try_apply_pss_on_slot(current_slot, identity);
                             }
 
                             // Audit 403: deterministically finalize the
@@ -2668,26 +2792,50 @@ impl PydeNode {
                                     if let Some((qc_slot, qc_hash)) = qc_slot_hash {
                                         if let Some((header, sig)) = engine.buffered_proposal_for(qc_slot, &qc_hash) {
                                             // Prefer the real body buffered at gossip
-                                            // receipt; fall back to the audit-234
-                                            // synthesized empty body for blocks whose
-                                            // gossip body hasn't arrived yet (RR
-                                            // fallback can deliver the QC vote before
-                                            // the Blocks-topic payload).
-                                            let block = {
+                                            // receipt; fall back to a synthesized
+                                            // empty body ONLY when the header
+                                            // commits to an empty tx_root (audit
+                                            // 408). `process_full_block_…` does NOT
+                                            // verify tx_root, so the prior
+                                            // unconditional synthesize would
+                                            // silently apply an empty body for any
+                                            // non-empty-tx block whose body hadn't
+                                            // arrived yet — diverging state across
+                                            // peers. Gate on
+                                            // `compute_tx_root([], []) == [0u8; 32]`
+                                            // so the fallback only fires for blocks
+                                            // the proposer truly committed to as
+                                            // empty (view-change empties, idle
+                                            // slots).
+                                            const EMPTY_TX_ROOT: [u8; 32] = [0u8; 32];
+                                            let buffered_block = {
                                                 let pbb = pending_block_bodies.read().await;
                                                 pbb.get(&qc_hash).cloned()
-                                            }.unwrap_or_else(|| pyde_consensus::block::Block {
-                                                header: header.clone(),
-                                                body: pyde_consensus::block::BlockBody {
-                                                    transactions: vec![],
-                                                    encrypted_txs: vec![],
-                                                    execution_schedule: pyde_tx::parallel::ExecutionSchedule {
-                                                        groups: vec![],
-                                                        total_txs: 0,
-                                                    },
-                                                },
-                                                proposer_signature: sig,
-                                            });
+                                            };
+                                            let block = match buffered_block {
+                                                Some(b) => b,
+                                                None if header.tx_root == EMPTY_TX_ROOT => {
+                                                    pyde_consensus::block::Block {
+                                                        header: header.clone(),
+                                                        body: pyde_consensus::block::BlockBody {
+                                                            transactions: vec![],
+                                                            encrypted_txs: vec![],
+                                                            execution_schedule: pyde_tx::parallel::ExecutionSchedule {
+                                                                groups: vec![],
+                                                                total_txs: 0,
+                                                            },
+                                                        },
+                                                        proposer_signature: sig,
+                                                    }
+                                                }
+                                                None => {
+                                                    debug!(
+                                                        slot = qc_slot,
+                                                        "own-vote-QC inline apply: body unavailable for non-empty block (sync will recover)"
+                                                    );
+                                                    continue;
+                                                }
+                                            };
                                             let mut chain_w = chain.write().await;
                                             let mut state_w = state.write().await;
 
@@ -4777,6 +4925,26 @@ fn handle_swarm_event(
                         if !message.data.is_empty() && message.data[0] == wire::tag::PSS_REFRESH {
                             match wire::decode_pss_refresh(&message.data) {
                                 Ok((epoch, contrib_bytes)) => {
+                                    // Audit 406: drop stale contributions
+                                    // targeted at epochs other than the
+                                    // currently-active PSS refresh.
+                                    // Without this an old-epoch contribution
+                                    // could pass the polynomial verify
+                                    // (zero-secret check is structural and
+                                    // epoch-agnostic) and pollute the
+                                    // canonical-subset pool, which
+                                    // `try_apply_pss_on_slot` then folds
+                                    // into the new share — silently breaking
+                                    // decryption for every block that
+                                    // follows.
+                                    if epoch != engine.pss_target() {
+                                        debug!(
+                                            epoch,
+                                            active = engine.pss_target(),
+                                            "ignoring stale PSS refresh contribution"
+                                        );
+                                        return PostEventAction::None;
+                                    }
                                     if let Some(contrib) =
                                         pyde_crypto::threshold::RefreshContribution::from_bytes(
                                             &contrib_bytes,
@@ -5772,10 +5940,7 @@ fn handle_swarm_event(
 /// explicitly opt in via `PYDE_INIT_VALIDATOR_KEY=1`. Devnet
 /// (`chain_id == 31337`) keeps the silent-generate ergonomics so
 /// laptop test infra doesn't have to set the env var.
-fn load_validator_identity(
-    datadir: &Path,
-    chain_id: u64,
-) -> Result<ValidatorIdentity, String> {
+fn load_validator_identity(datadir: &Path, chain_id: u64) -> Result<ValidatorIdentity, String> {
     let key_path = datadir.join("validator.key");
     let passphrase = std::env::var("PYDE_VALIDATOR_PASSPHRASE").ok();
 

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -18,7 +18,7 @@ use pyde_consensus::view_change::{
 };
 use pyde_crypto::falcon::{FalconPublicKey, FalconSecretKey};
 use pyde_crypto::threshold::{
-    aggregate_new_share, apply_refresh, canonical_resharing_subset, generate_refresh_contribution,
+    aggregate_new_share, canonical_resharing_subset, generate_refresh_contribution,
     generate_resharing_contribution, verify_refresh_contribution, verify_resharing_contribution,
     RefreshContribution, ResharingContribution,
 };
@@ -224,6 +224,28 @@ pub struct ValidatorEngine {
     pub finality: FinalityTracker,
     /// Timeout tracker for the current slot.
     pub timeout: TimeoutTracker,
+    /// Audit 408: wall-clock anchor for converting slot numbers into
+    /// the moment that slot actually begins. The
+    /// `PROPOSAL_TIMEOUT_MS` window for slot N is measured from
+    /// `genesis_timestamp_ms + N * block_time_ms`, NOT from the
+    /// instant the prior slot's QC happened to form. Pre-fix,
+    /// `advance_target_height` reset the tracker to wall-clock
+    /// `now`, so a slot whose QC formed early (e.g. slot 26 QC at
+    /// 100 ms into the slot) started counting timeout for slot 27
+    /// from that same moment — 200 ms later it would fire a view-
+    /// change for slot 27 even though slot 27's wall-clock window
+    /// hadn't begun yet (slot 27 starts at slot 26 + 400 ms). The
+    /// 3-min soak observed 50 % of slots view-changing under this
+    /// bug. Both fields default to 0 until `set_slot_anchor()` is
+    /// called after the runtime constructs the slot clock; while
+    /// they're 0 the engine falls back to the wall-clock-now
+    /// behavior so unit tests that don't wire a slot clock
+    /// continue to pass.
+    pub genesis_timestamp_ms: u64,
+    /// Block-time interval in milliseconds. Paired with
+    /// `genesis_timestamp_ms` for the timeout-anchor computation
+    /// described above.
+    pub block_time_ms: u64,
     /// Committee public keys for the current epoch (index → key bytes).
     pub committee_keys: Vec<Vec<u8>>,
     /// Epoch randomness seed (for VRF proposer selection).
@@ -330,6 +352,36 @@ pub struct ValidatorEngine {
     pss_contributions: Vec<RefreshContribution>,
     /// Target epoch for PSS refresh.
     pss_target_epoch: u64,
+    /// Audit 406: slot at which `try_apply_pss_on_slot` is allowed to
+    /// combine the buffered PSS contributions. Mirror of
+    /// `reshare_aggregation_trigger_slot` for cross-committee
+    /// resharing and `randomness_aggregation_trigger_slot` for epoch
+    /// randomness — under async gossip every node sees a different
+    /// "first `threshold`-of-N" arrival order, so eagerly applying
+    /// the first `threshold` contributions caused different nodes
+    /// to apply different delta subsets, breaking the PSS invariant
+    /// that all refreshed shares interpolate to the same secret.
+    /// Set to `current_slot + RESHARE_AGGREGATION_DELAY_SLOTS` by
+    /// `start_pss_refresh`; the slot tick fires
+    /// `try_apply_pss_on_slot` once `current_slot` crosses it.
+    pss_aggregation_trigger_slot: u64,
+    /// `true` once `try_apply_pss_on_slot` has fired for the current
+    /// target epoch. Prevents re-applying when additional late
+    /// contributions arrive after the canonical apply.
+    pss_aggregated: bool,
+    /// Audit 406: own PSS contribution bytes stashed for periodic
+    /// re-broadcast, mirror of `pending_reshare_rebroadcast`. Without
+    /// this a single dropped gossip message means the missing-contrib
+    /// validator's pool stays at `n - 1`, the all-N guard in
+    /// `try_apply_pss_on_slot` blocks the apply, and PSS silently
+    /// skips the epoch. With the rebroadcast loop a missed message
+    /// recovers within `PSS_REBROADCAST_INTERVAL_SLOTS` slots.
+    /// Layout: `(target_epoch, contribution_bytes)`.
+    pending_pss_rebroadcast: Option<(u64, Vec<u8>)>,
+    /// Slot at which `start_pss_refresh` published our contribution.
+    /// `maybe_rebroadcast_pss` uses this + `current_slot` to scope
+    /// the rebroadcast window.
+    pss_broadcast_start_slot: u64,
     /// Cross-committee resharing contributions collected at epoch boundary
     /// (task 034). Keyed by target epoch so late contributions from
     /// previous epochs are ignored.
@@ -428,6 +480,13 @@ impl ValidatorEngine {
             consensus,
             finality: FinalityTracker::new(),
             timeout: TimeoutTracker::new(initial_target, now_ms),
+            // Audit 408: anchor stays 0 until the runtime calls
+            // `set_slot_anchor()` post-slot-clock-construction.
+            // While 0, `slot_start_ms_for_target()` falls back to
+            // wall-clock — preserving prior behavior for tests
+            // that exercise the engine without wiring a clock.
+            genesis_timestamp_ms: 0,
+            block_time_ms: 0,
             committee_keys: Vec::new(),
             epoch_randomness,
             // Audit 402: prior-epoch caches start empty; populated
@@ -455,6 +514,10 @@ impl ValidatorEngine {
             randomness_aggregation_trigger_slot: 0,
             pss_contributions: Vec::new(),
             pss_target_epoch: 0,
+            pss_aggregation_trigger_slot: 0,
+            pss_aggregated: false,
+            pending_pss_rebroadcast: None,
+            pss_broadcast_start_slot: 0,
             reshare_contributions: Vec::new(),
             reshare_target_epoch: 0,
             reshare_new_committee: Vec::new(),
@@ -742,17 +805,69 @@ impl ValidatorEngine {
 
         self.pss_contributions = vec![contribution.clone()];
         self.pss_target_epoch = epoch;
+        // Audit 406: arm the canonical-subset apply gate. The slot
+        // tick fires `try_apply_pss_on_slot` once `current_slot`
+        // crosses this trigger; until then, contributions just pool.
+        // Mirrors `RESHARE_AGGREGATION_DELAY_SLOTS` for cross-
+        // committee resharing so PSS, randomness, and reshare all
+        // resolve their first-N-wins races identically.
+        self.pss_aggregation_trigger_slot =
+            self.consensus.current_slot + Self::RESHARE_AGGREGATION_DELAY_SLOTS;
+        self.pss_aggregated = false;
+        // Audit 406: stash bytes + window start for the rebroadcast
+        // loop. Mirror of `pending_reshare_rebroadcast` —
+        // `maybe_rebroadcast_pss` re-publishes every
+        // `RESHARE_REBROADCAST_INTERVAL_SLOTS` slots for
+        // `RESHARE_REBROADCAST_SLOTS` slots after the initial publish
+        // so a single dropped gossip message doesn't strand a
+        // validator's pool at n-1.
+        self.pending_pss_rebroadcast = Some((epoch, contribution.to_bytes()));
+        self.pss_broadcast_start_slot = self.consensus.current_slot;
         info!(epoch, "started PSS key share refresh");
         Some(contribution)
     }
 
-    /// Add a received PSS refresh contribution. Returns the new KeyShare if threshold reached.
+    /// Audit 406: return our own PSS contribution bytes for a
+    /// rebroadcast on this slot tick, or `None` if we're outside the
+    /// rebroadcast window or it isn't a rebroadcast slot. Caller
+    /// publishes the returned bytes on the consensus topic. Mirror
+    /// of `maybe_rebroadcast_reshare`.
+    pub fn maybe_rebroadcast_pss(&mut self) -> Option<(u64, Vec<u8>)> {
+        let (target_epoch, bytes) = self.pending_pss_rebroadcast.as_ref()?;
+        let now = self.consensus.current_slot;
+        let elapsed = now.saturating_sub(self.pss_broadcast_start_slot);
+        if elapsed > Self::RESHARE_REBROADCAST_SLOTS {
+            self.pending_pss_rebroadcast = None;
+            return None;
+        }
+        if elapsed == 0 {
+            return None;
+        }
+        if elapsed % Self::RESHARE_REBROADCAST_INTERVAL_SLOTS != 0 {
+            return None;
+        }
+        Some((*target_epoch, bytes.clone()))
+    }
+
+    /// Add a received PSS refresh contribution. Pools it for the
+    /// canonical-subset apply that fires on slot tick. Returns
+    /// `true` when the contribution was new (not a duplicate index)
+    /// and structurally valid; the boolean is informational only —
+    /// the actual apply lives in `try_apply_pss_on_slot`.
     pub fn on_pss_contribution(
         &mut self,
         contribution: RefreshContribution,
-        identity: &mut ValidatorIdentity,
+        _identity: &mut ValidatorIdentity,
     ) -> bool {
         let threshold = quorum_for_committee(self.committee_keys.len());
+
+        // Audit 406: drop late contributions for an already-applied
+        // refresh. Pre-fix the eager-apply bucket was cleared on
+        // first-threshold and any `from_index` could refill it;
+        // post-fix `pss_aggregated` gates this explicitly.
+        if self.pss_aggregated {
+            return false;
+        }
 
         // Verify the contribution (zero-secret reconstruction check)
         if !verify_refresh_contribution(&contribution, threshold) {
@@ -773,21 +888,81 @@ impl ValidatorEngine {
         }
 
         self.pss_contributions.push(contribution);
+        // Audit 406: NO eager apply here. The canonical-subset
+        // apply runs on slot tick via `try_apply_pss_on_slot`,
+        // after gossip has had time to fan every member's
+        // contribution out to every node, so all validators see
+        // the same pool and converge on the same canonical subset.
+        true
+    }
 
-        // If threshold reached, apply all contributions to our key share
-        if self.pss_contributions.len() >= threshold {
-            if let Some(ref old_share) = identity.key_share {
-                let new_share = apply_refresh(old_share, &self.pss_contributions);
-                identity.key_share = Some(new_share);
-                self.pss_contributions.clear();
-                self.key_share_dirty = true;
-                info!(
-                    epoch = self.pss_target_epoch,
-                    contributions = threshold,
-                    "PSS key share refreshed — genesis trust dissolved"
+    /// Audit 406: canonical-subset PSS apply, fired by the slot tick
+    /// once `current_slot` crosses the aggregation trigger. Mirror of
+    /// `try_aggregate_reshare_on_slot` for cross-committee resharing
+    /// — picks the canonical lowest-`threshold` subset (sorted by
+    /// `from_index`) and adds those zero-secret deltas to our share.
+    ///
+    /// Pre-fix `on_pss_contribution` applied refresh eagerly the
+    /// moment the pool reached `threshold` items, which under async
+    /// gossip gave every node a different "first-3-of-4" arrival set
+    /// and diverged the post-PSS shares onto different polynomials.
+    /// The fix mirrors cross-committee resharing exactly:
+    /// `start_pss_refresh` arms a deadline + seeds the pool with our
+    /// own contribution + stashes bytes for `maybe_rebroadcast_pss`,
+    /// the gossip handler just buffers, and this method commits the
+    /// canonical apply on the slot tick when the deadline has passed
+    /// AND the pool has reached `threshold` (the rebroadcast loop
+    /// fills the pool to `n` for honest committees, so all members
+    /// converge on the SAME `lowest-threshold` subset).
+    ///
+    /// Late contributions arriving after the apply are dropped (the
+    /// `pss_aggregated` gate in `on_pss_contribution`).
+    pub fn try_apply_pss_on_slot(
+        &mut self,
+        current_slot: u64,
+        identity: &mut ValidatorIdentity,
+    ) -> bool {
+        if self.pss_aggregated || self.pss_aggregation_trigger_slot == 0 {
+            return false;
+        }
+        if current_slot < self.pss_aggregation_trigger_slot {
+            return false;
+        }
+        let threshold = quorum_for_committee(self.committee_keys.len());
+        if threshold == 0 {
+            return false;
+        }
+        let canonical = match pyde_crypto::threshold::canonical_refresh_subset(
+            &self.pss_contributions,
+            threshold,
+        ) {
+            Some(c) => c,
+            None => {
+                warn!(
+                    target_epoch = self.pss_target_epoch,
+                    received = self.pss_contributions.len(),
+                    threshold,
+                    "PSS aggregation trigger fired but below threshold — waiting"
                 );
-                return true;
+                return false;
             }
+        };
+        if let Some(ref old_share) = identity.key_share {
+            let pre_idx = old_share.index;
+            let canon_indices: Vec<usize> = canonical.iter().map(|c| c.from_index).collect();
+            let new_share = pyde_crypto::threshold::apply_refresh_canonical(old_share, &canonical);
+            identity.key_share = Some(new_share);
+            self.pss_contributions.clear();
+            self.pss_aggregated = true;
+            self.key_share_dirty = true;
+            info!(
+                target_epoch = self.pss_target_epoch,
+                contributions = threshold,
+                pre_index = pre_idx,
+                canon_indices = ?canon_indices,
+                "PSS key share refreshed (canonical) — genesis trust dissolved"
+            );
+            return true;
         }
         false
     }
@@ -912,6 +1087,27 @@ impl ValidatorEngine {
             target_epoch,
             entropy.as_bytes(),
         );
+        // Audit 406: seed our own reshare pool with our own
+        // contribution. Pre-fix the local pool was filled SOLELY by
+        // gossip arrivals from peers, so each old member's own
+        // contribution never landed in its own pool. With 4-validator
+        // committees and `old_threshold = 3`, that left every node
+        // looking at a 3-of-4 pool — and `canonical_resharing_subset`
+        // (lowest-`old_threshold` `from_old_index`) picked a DIFFERENT
+        // subset on each node (each was missing the contribution from
+        // its own OLD position). The aggregated new shares ended up on
+        // different polynomials and threshold decryption failed every
+        // time. Adding own here mirrors `start_pss_refresh` and lets
+        // every old member's pool converge on the same canonical
+        // {lowest old_threshold from_old_index} once gossip finishes
+        // delivering the n-1 peer contributions.
+        if self
+            .reshare_contributions
+            .iter()
+            .all(|c| c.from_old_index != contribution.from_old_index)
+        {
+            self.reshare_contributions.push(contribution.clone());
+        }
         // Stash bytes + target epoch so `maybe_rebroadcast_reshare` can
         // re-publish during the early target-epoch slot window.
         self.pending_reshare_rebroadcast = Some((target_epoch, contribution.to_bytes()));
@@ -1172,6 +1368,8 @@ impl ValidatorEngine {
             None => return false,
         };
 
+        let post_idx = new_share.index;
+        let canon_old_indices: Vec<usize> = canonical.iter().map(|c| c.from_old_index).collect();
         identity.key_share = Some(new_share);
         self.key_share_dirty = true;
         self.reshare_aggregated = true;
@@ -1181,6 +1379,8 @@ impl ValidatorEngine {
             target_epoch = self.reshare_target_epoch,
             new_index = self.reshare_new_index,
             old_threshold,
+            post_index = post_idx,
+            canon_old_indices = ?canon_old_indices,
             "committee handoff complete — new key share derived from resharing"
         );
         true
@@ -1190,6 +1390,14 @@ impl ValidatorEngine {
     /// stale-message filtering).
     pub fn reshare_target(&self) -> u64 {
         self.reshare_target_epoch
+    }
+
+    /// Audit 406: expose the target epoch of any pending PSS refresh
+    /// for node-layer stale-message filtering. Mirror of
+    /// `reshare_target` — drops gossip from old epochs that would
+    /// otherwise pollute the canonical-subset apply.
+    pub fn pss_target(&self) -> u64 {
+        self.pss_target_epoch
     }
 
     pub fn start_epoch_randomness(
@@ -1286,15 +1494,9 @@ impl ValidatorEngine {
         let n = self.committee_keys.len();
         let threshold = quorum_for_committee(n);
 
-        let ready = if collector.has_full_set() {
-            true
-        } else if current_slot >= self.randomness_aggregation_trigger_slot
-            && collector.share_count() >= threshold
-        {
-            true
-        } else {
-            false
-        };
+        let ready = collector.has_full_set()
+            || (current_slot >= self.randomness_aggregation_trigger_slot
+                && collector.share_count() >= threshold);
         if !ready {
             return None;
         }
@@ -2278,8 +2480,14 @@ impl ValidatorEngine {
                 // and the build-side gate in
                 // `try_build_fallback_proposal` recognize that
                 // recovery is in progress.
-                let now_ms = current_time_ms();
-                let mut new_tracker = TimeoutTracker::new(slot, now_ms);
+                //
+                // Audit 408: anchor the new tracker on the slot's
+                // wall-clock start (same fix as `advance_target_height`).
+                // After a VC-QC the fallback leader gets a fresh
+                // `PROPOSAL_TIMEOUT_MS` window measured from the
+                // slot's actual start, not "now".
+                let slot_start_ms = self.slot_start_ms_for_target(slot);
+                let mut new_tracker = TimeoutTracker::new(slot, slot_start_ms);
                 new_tracker.view_change_qc = Some(vc_qc);
                 self.timeout = new_tracker;
             } else {
@@ -2652,6 +2860,28 @@ impl ValidatorEngine {
         new_slot
     }
 
+    /// Audit 408: set the slot-clock anchor on the engine. Called by
+    /// the runtime after the `SlotClock` is constructed (which
+    /// happens later in node startup than `ValidatorEngine::new`).
+    /// Once set, `advance_target_height` resets the timeout tracker
+    /// to the slot's actual wall-clock start instead of "now".
+    pub fn set_slot_anchor(&mut self, genesis_timestamp_ms: u64, block_time_ms: u64) {
+        self.genesis_timestamp_ms = genesis_timestamp_ms;
+        self.block_time_ms = block_time_ms;
+    }
+
+    /// Wall-clock instant (Unix ms) when slot `target` begins.
+    /// Falls back to `current_time_ms()` if the slot anchor hasn't
+    /// been wired yet (test paths). See `set_slot_anchor`.
+    fn slot_start_ms_for_target(&self, target: u64) -> u64 {
+        if self.block_time_ms == 0 {
+            current_time_ms()
+        } else {
+            self.genesis_timestamp_ms
+                .saturating_add(target.saturating_mul(self.block_time_ms))
+        }
+    }
+
     /// Advance `target_height` to `new_height` and reset the timeout
     /// tracker for the new height. No-op if `new_height` doesn't
     /// advance the target. Persists the consensus state.
@@ -2659,10 +2889,16 @@ impl ValidatorEngine {
     /// audit-234 part 4 (CONSENSUS_INVARIANTS.md O2): called when a
     /// vote-QC for the current target forms — the chain has moved
     /// on, recovery state for the old height is no longer needed.
+    ///
+    /// Audit 408: the new tracker's `slot_start_ms` is the wall-
+    /// clock start of `new_height` per `slot_start_ms_for_target`,
+    /// not `now`. The prior code used `now` and fired view-change
+    /// 200 ms after the *previous* slot's QC — typically before the
+    /// new slot's wall-clock window even started.
     fn advance_target_height(&mut self, new_height: u64) {
         if self.consensus.advance_target_height(new_height) {
-            let now_ms = current_time_ms();
-            self.timeout = TimeoutTracker::new(new_height, now_ms);
+            let slot_start_ms = self.slot_start_ms_for_target(new_height);
+            self.timeout = TimeoutTracker::new(new_height, slot_start_ms);
             self.persist_consensus();
             debug!(target_height = new_height, "advanced target_height");
         }

--- a/crates/node/tests/bench_mempool.rs
+++ b/crates/node/tests/bench_mempool.rs
@@ -109,7 +109,7 @@ fn bench_preloaded_mempool() {
     let num_contracts = 20usize;
     println!("  Deploying {} complex contracts...", num_contracts);
 
-    let compiled = otic::compile_all(
+    let compiled = otic::compile_all_unchecked(
         r#"
         struct Stats { sum: u256, count: u64, min: u64, max: u64 }
         contract HeavyWork {

--- a/crates/node/tests/benchmark.rs
+++ b/crates/node/tests/benchmark.rs
@@ -91,7 +91,7 @@ fn make_transfer(from: [u8; 32], to: [u8; 32], nonce: u64) -> Transaction {
 }
 
 fn compile(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -57,7 +57,7 @@ struct BlockMetrics {
 // ═══════════════════════════════════════════════════════════════════
 
 fn compile_single(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());
@@ -68,7 +68,7 @@ fn compile_single(source: &str) -> Vec<u8> {
 }
 
 fn compile_last(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     let (_, c) = compiled.last().unwrap();
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/integration.rs
+++ b/crates/node/tests/integration.rs
@@ -121,7 +121,7 @@ fn call_tx(
 }
 
 fn compile_contract(source: &str) -> (Vec<u8>, String) {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     assert!(!compiled.is_empty(), "compilation produced no contracts");
     let (name, contract) = &compiled[0];
     let clen = contract.constructor_bytecode.len() as u32;
@@ -739,7 +739,7 @@ fn cross_contract_storage_visibility() {
     // Driver deploys Vault, calls withdraw twice, reads balance back.
     // Tests that Vault.withdraw()'s storage changes are visible to
     // the next Vault.get_balance() call within the same transaction.
-    let compiled = otic::compile_all(
+    let compiled = otic::compile_all_unchecked(
         r#"
         contract Vault {
             storage { balance: u64, }
@@ -814,7 +814,7 @@ fn reentrancy_attack_blocked() {
     // Vault: withdraw calls back to caller via raw_call! (simulates ETH transfer callback).
     // Attacker: on_hook() tries to re-enter Vault.withdraw().
     // Without #[reentrant], the guard should block the re-entry.
-    let compiled = otic::compile_all(
+    let compiled = otic::compile_all_unchecked(
         r#"
         contract Vault {
             storage { balance: u64, }

--- a/crates/node/tests/lifecycle_bench.rs
+++ b/crates/node/tests/lifecycle_bench.rs
@@ -34,7 +34,7 @@ fn sign(tx: &mut Transaction, sk: &pyde_crypto::falcon::FalconSecretKey) {
     tx.signature = falcon_sign(sk, &tx.hash()).unwrap().as_bytes().to_vec();
 }
 fn compile(src: &str) -> Vec<u8> {
-    let c = otic::compile_all(src);
+    let c = otic::compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut d = Vec::new();
     d.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/loadgen.rs
+++ b/crates/node/tests/loadgen.rs
@@ -173,7 +173,7 @@ fn load_test_full_pipeline() {
             }
         }
     "#;
-    let compiled = otic::compile_all(heavy_source);
+    let compiled = otic::compile_all_unchecked(heavy_source);
     let (_, cc) = &compiled[0];
     let mut deploy_data = Vec::new();
     deploy_data.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/loadgen_mixed.rs
+++ b/crates/node/tests/loadgen_mixed.rs
@@ -1,0 +1,937 @@
+//! Mixed-workload sustained loadgen — exercises the full mainnet
+//! transaction shape on a 4-validator network.
+//!
+//! Where the existing `loadgen_sustained` runs plaintext transfers
+//! only, this test fires a weighted mix of the three real production
+//! transaction shapes against the same chain instance:
+//!
+//!   - **plaintext transfer** (default 60%): Alice → Bob, signed
+//!     FALCON, 50 K gas. Same as `loadgen_sustained`.
+//!   - **plaintext contract call** (default 30%):
+//!     `Counter.increment()` — exercises AOT cache (warm after
+//!     first call), parallel-exec scheduler, PVM execution path.
+//!   - **encrypted value tx** (default 10%): Kyber-768 encrypted
+//!     transfer via `pyde_sendRawEncryptedTransaction` —
+//!     exercises threshold encryption + cooperative decrypt-share
+//!     gossip + post-QC seal-then-execute. The MEV-protected path
+//!     real DeFi traffic uses.
+//!
+//! The default 60/30/10 mix matches what most L1 production traffic
+//! looks like in practice (most txs are simple value movement; a
+//! large minority is contract activity; a small slice is the
+//! MEV-target DeFi/swap traffic that self-selects encrypted). Tunable
+//! via `PYDE_LOADGEN_MIX=transfer:60,call:30,encrypted:10`.
+//!
+//! Output: per-type submit/inclusion counts plus aggregate. The
+//! aggregate is the headline number quotable at testnet launch —
+//! "this hardware sustains X TPS of mainnet-shaped traffic".
+//!
+//! # Run
+//!
+//!   cargo test -p pyde-node --test loadgen_mixed --release -- \
+//!     --ignored --nocapture
+//!
+//! # Knobs (env vars)
+//!
+//!   PYDE_LOADGEN_TPS         — target submit rate (default 1000)
+//!   PYDE_LOADGEN_DURATION    — measurement duration in seconds (default 300)
+//!   PYDE_LOADGEN_WARMUP      — warm-up in seconds (default 30)
+//!   PYDE_LOADGEN_SENDERS     — funded sender count (default 200)
+//!   PYDE_LOADGEN_MIX         — weight string (default "transfer:60,call:30,encrypted:10")
+//!   PYDE_LOADGEN_FUND        — per-sender fund override
+//!
+//! # On sender count
+//!
+//! The mempool enforces a per-sender nonce window of 16. With ~400 ms
+//! slots that's ~2.5 successful txs/sender/s before `InvalidNonce`
+//! starts rejecting. So `num_senders ≥ target_TPS / 2.5`. The default
+//! 200 senders gives ~500 TPS of headroom before the loadgen — not
+//! the system — becomes the bottleneck.
+//!
+//! Beyond that, the loadgen makes no assumptions about validator
+//! internals. Proposer selection, scheduler grouping, AOT cache
+//! warm-up, JMT commit cadence — all happen inside the validators.
+//! The loadgen just bombards; whatever throughput falls out is the
+//! real number.
+
+mod common;
+
+use common::TestNetwork;
+use pyde_account::address::derive_eoa_address;
+use pyde_crypto::falcon::{
+    falcon_keygen, falcon_sign, FalconPublicKey, FalconSecretKey, FalconSignature,
+};
+use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const CHAIN_ID: u64 = 1;
+const RECIPIENT: [u8; 32] = [0x42u8; 32];
+const TX_VALUE: u128 = 1;
+// 1 PYDE = 10^9 quanta. Each sender gets enough headroom to cover
+// gas at the genesis base-fee (50 gwei × 100 K gas ≈ 5 K PYDE upper
+// bound per-tx) over a 5-minute run at the per-sender rate. Default
+// fund matches the plaintext loadgen.
+const FUND_PER_SENDER: u128 = 1_000_000_000_000_000_000;
+
+/// Counter contract source — same one used across the multi-node
+/// test suite. Tiny ctor, single u64 storage slot, `increment()`
+/// is one storage read + add + write — minimal compute, but
+/// exercises the full AOT cache + PVM execution path.
+const COUNTER_SRC: &str = r#"
+contract Counter {
+    storage { count: u64, }
+    #[constructor] pub fn init() { self.count = 0; }
+    pub fn increment() { self.count = self.count + 1; }
+    #[view] pub fn get_count() -> u64 { return self.count; }
+}
+"#;
+
+/// Compile the Counter source into the on-chain deploy envelope
+/// shape `pyde_tx::pipeline` expects (4-byte LE constructor length +
+/// 4-byte LE runtime length + constructor bytes + runtime bytes).
+fn compile_deploy_payload(src: &str) -> Vec<u8> {
+    let c = otic::compile_all_unchecked(src);
+    let (_, cc) = &c[0];
+    let mut out = Vec::with_capacity(8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len());
+    out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(cc.runtime_bytecode.len() as u32).to_le_bytes());
+    out.extend_from_slice(&cc.constructor_bytecode);
+    out.extend_from_slice(&cc.runtime_bytecode);
+    out
+}
+
+struct Wallet {
+    address: [u8; 32],
+    pk_bytes: Vec<u8>,
+    sk: FalconSecretKey,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MixWeights {
+    transfer: u32,
+    call: u32,
+    encrypted: u32,
+}
+
+impl MixWeights {
+    fn parse(s: &str) -> Self {
+        // "transfer:60,call:30,encrypted:10" → MixWeights{60,30,10}
+        let mut transfer = 60u32;
+        let mut call = 30u32;
+        let mut encrypted = 10u32;
+        for part in s.split(',') {
+            if let Some((k, v)) = part.split_once(':') {
+                let val = v.trim().parse::<u32>().unwrap_or(0);
+                match k.trim() {
+                    "transfer" => transfer = val,
+                    "call" => call = val,
+                    "encrypted" => encrypted = val,
+                    _ => {}
+                }
+            }
+        }
+        Self {
+            transfer,
+            call,
+            encrypted,
+        }
+    }
+
+    fn total(&self) -> u32 {
+        self.transfer + self.call + self.encrypted
+    }
+
+    /// Pick a tx type for this submit slot via `(slot_idx % total)`
+    /// against cumulative weights. Deterministic + uniform across
+    /// the run; no RNG needed (which would also block easy
+    /// reproduction).
+    fn pick(&self, idx: u64) -> TxKind {
+        let r = (idx % self.total() as u64) as u32;
+        if r < self.transfer {
+            TxKind::Transfer
+        } else if r < self.transfer + self.call {
+            TxKind::Call
+        } else {
+            TxKind::Encrypted
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TxKind {
+    Transfer,
+    Call,
+    Encrypted,
+}
+
+#[test]
+#[ignore = "Mixed-workload load test — spawns 4-node subprocess testnet, run with --ignored"]
+fn mixed_workload_load_test() {
+    let target_tps: u64 = env_var_u64("PYDE_LOADGEN_TPS", 1000);
+    let duration_s: u64 = env_var_u64("PYDE_LOADGEN_DURATION", 300);
+    let warmup_s: u64 = env_var_u64("PYDE_LOADGEN_WARMUP", 30);
+    let num_senders: usize = env_var_u64("PYDE_LOADGEN_SENDERS", 200) as usize;
+    let fund_per_sender: u128 = env_var_u64("PYDE_LOADGEN_FUND", FUND_PER_SENDER as u64) as u128;
+    let mix = MixWeights::parse(
+        &std::env::var("PYDE_LOADGEN_MIX")
+            .unwrap_or_else(|_| "transfer:60,call:30,encrypted:10".into()),
+    );
+
+    let per_acct_rate = target_tps as f64 / num_senders as f64;
+    let inflight_per_slot = per_acct_rate * 0.4;
+    assert!(
+        inflight_per_slot < 12.0,
+        "num_senders ({}) too low for target {} TPS — per-account rate {:.1}/s, in-flight/slot {:.1} near nonce window 16",
+        num_senders, target_tps, per_acct_rate, inflight_per_slot
+    );
+
+    println!("╔══════════════════════════════════════════════════════╗");
+    println!("║  Pyde Mixed-Workload Load Test                      ║");
+    println!("╠══════════════════════════════════════════════════════╣");
+    println!("  Target TPS:   {}", target_tps);
+    println!(
+        "  Duration:     {} s  (+ {} s warm-up, not measured)",
+        duration_s, warmup_s
+    );
+    println!(
+        "  Senders:      {} (per-account rate: {:.1} tx/s)",
+        num_senders, per_acct_rate
+    );
+    println!(
+        "  Mix:          transfer:{}, call:{}, encrypted:{} (sum {})",
+        mix.transfer,
+        mix.call,
+        mix.encrypted,
+        mix.total()
+    );
+    println!("  chain_id:     {} (FALCON sig verification ON)", CHAIN_ID);
+    println!("╚══════════════════════════════════════════════════════╝");
+
+    // ── Phase 0: spawn 4-validator testnet ──────────────────────
+    println!("\n[0/4] Spawning 4-validator native testnet at chain_id = 1…");
+    let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+    net.wait_for_slot(3, Duration::from_secs(30))
+        .unwrap_or_else(|e| panic!("chain warm-up: {}", e));
+
+    let (faucet_pk_bytes, faucet_sk_bytes) = net
+        .load_faucet_key()
+        .unwrap_or_else(|e| panic!("load faucet.key: {}", e));
+    let faucet_sk =
+        FalconSecretKey::from_bytes(&faucet_sk_bytes).expect("invalid FALCON secret key");
+    let faucet_addr = derive_eoa_address(&faucet_pk_bytes);
+    println!("  faucet: 0x{}", hex::encode(faucet_addr));
+
+    let rpc_urls: Vec<String> = net.nodes.iter().map(|n| n.rpc_url()).collect();
+
+    // ── Phase 1: fund + register pubkeys for N senders ──────────
+    println!(
+        "\n[1/4] Funding + registering {} sender wallets…",
+        num_senders
+    );
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let client = reqwest::Client::builder()
+        .tcp_keepalive(Duration::from_secs(60))
+        .pool_idle_timeout(Duration::from_secs(60))
+        .build()
+        .expect("reqwest client");
+
+    let setup_start = Instant::now();
+    let wallets: Vec<Arc<Wallet>> = runtime.block_on(async {
+        let mut wallets = Vec::with_capacity(num_senders);
+        for _ in 0..num_senders {
+            let (pk, sk) = falcon_keygen().expect("keygen");
+            let address = derive_eoa_address(pk.as_bytes());
+            wallets.push(Arc::new(Wallet {
+                address,
+                pk_bytes: pk.as_bytes().to_vec(),
+                sk,
+            }));
+        }
+
+        // 1a. Fund each wallet from faucet.
+        let mut faucet_nonce = fetch_nonce(&client, &rpc_urls[0], &faucet_addr)
+            .await
+            .expect("faucet nonce");
+        let mut signed_hex: Vec<String> = Vec::with_capacity(num_senders);
+        for w in &wallets {
+            let mut tx = Transaction {
+                from: faucet_addr,
+                to: w.address,
+                value: fund_per_sender,
+                data: vec![],
+                gas_limit: 50_000,
+                nonce: faucet_nonce,
+                signature: vec![],
+                fee_payer: FeePayer::Sender,
+                access_list: vec![],
+                deadline: None,
+                chain_id: CHAIN_ID,
+                tx_type: TransactionType::Standard,
+            };
+            tx.signature = falcon_sign(&faucet_sk, &tx.hash())
+                .expect("fund sig")
+                .as_bytes()
+                .to_vec();
+            signed_hex.push(hex::encode(tx.to_bytes()));
+            faucet_nonce += 1;
+        }
+        // Stream funding in nonce-window-friendly chunks.
+        let mut chunk_idx = 0usize;
+        for chunk in signed_hex.chunks(15) {
+            for hex_tx in chunk {
+                let _ = rpc_send_raw(&client, &rpc_urls[0], hex_tx).await;
+            }
+            chunk_idx += 1;
+            tokio::time::sleep(Duration::from_millis(800)).await;
+        }
+        // Wait for all funded.
+        let poll_deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let mut funded = 0usize;
+            for w in &wallets {
+                if fetch_balance(&client, &rpc_urls[0], &w.address)
+                    .await
+                    .unwrap_or(0)
+                    > 0
+                {
+                    funded += 1;
+                }
+            }
+            if funded == wallets.len() {
+                break;
+            }
+            if Instant::now() >= poll_deadline {
+                panic!("funding timed out: {}/{}", funded, wallets.len());
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        let _ = chunk_idx;
+
+        // 1b. RegisterPubkey for each wallet (audit 226 / 229).
+        let mut signed_register: Vec<String> = Vec::with_capacity(wallets.len());
+        for w in &wallets {
+            let tx = Transaction {
+                from: w.address,
+                to: [0u8; 32],
+                value: 0,
+                data: w.pk_bytes.clone(),
+                gas_limit: 0,
+                nonce: 0,
+                signature: vec![],
+                fee_payer: FeePayer::Sender,
+                access_list: vec![],
+                deadline: None,
+                chain_id: CHAIN_ID,
+                tx_type: TransactionType::RegisterPubkey,
+            };
+            signed_register.push(hex::encode(tx.to_bytes()));
+        }
+        use futures_util::stream::{iter, StreamExt};
+        let mut futs = Vec::new();
+        for (i, hex_tx) in signed_register.iter().enumerate() {
+            let url = rpc_urls[i % rpc_urls.len()].clone();
+            let cli = client.clone();
+            let hex_tx = hex_tx.clone();
+            futs.push(async move {
+                let _ = rpc_send_raw(&cli, &url, &hex_tx).await;
+            });
+        }
+        iter(futs).buffer_unordered(32).collect::<Vec<()>>().await;
+
+        let poll_deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let mut registered = 0usize;
+            for w in &wallets {
+                if fetch_nonce(&client, &rpc_urls[0], &w.address)
+                    .await
+                    .unwrap_or(0)
+                    >= 1
+                {
+                    registered += 1;
+                }
+            }
+            if registered == wallets.len() {
+                break;
+            }
+            if Instant::now() >= poll_deadline {
+                panic!("RegisterPubkey timed out: {}/{}", registered, wallets.len());
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        wallets
+    });
+    println!(
+        "  ✓ {} wallets funded + registered in {:.1} s",
+        wallets.len(),
+        setup_start.elapsed().as_secs_f64()
+    );
+
+    // ── Phase 2: deploy Counter contract from faucet ────────────
+    let mut counter_addr: [u8; 32] = [0u8; 32];
+    if mix.call > 0 {
+        println!("\n[2/4] Deploying Counter contract from faucet…");
+        let deploy_start = Instant::now();
+        let payload = compile_deploy_payload(COUNTER_SRC);
+        let faucet_nonce = runtime
+            .block_on(fetch_nonce(&client, &rpc_urls[0], &faucet_addr))
+            .unwrap_or(0);
+        let mut deploy_tx = Transaction {
+            from: faucet_addr,
+            to: [0u8; 32],
+            value: 0,
+            data: payload,
+            gas_limit: 100_000_000,
+            nonce: faucet_nonce,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: CHAIN_ID,
+            tx_type: TransactionType::Deploy,
+        };
+        deploy_tx.signature = falcon_sign(&faucet_sk, &deploy_tx.hash())
+            .expect("deploy sig")
+            .as_bytes()
+            .to_vec();
+        let deploy_hash = net
+            .submit_raw_tx(0, &deploy_tx.to_bytes())
+            .unwrap_or_else(|e| panic!("submit deploy: {}", e));
+        let receipts = net
+            .wait_for_receipt_on_all(&deploy_hash, Duration::from_secs(60))
+            .unwrap_or_else(|e| panic!("deploy receipt: {}", e));
+        assert!(receipts[0].success, "deploy failed: {}", receipts[0].raw);
+        let return_bytes = TestNetwork::decode_return_data(&receipts[0].raw)
+            .unwrap_or_else(|e| panic!("decode deploy returnData: {}", e));
+        counter_addr.copy_from_slice(&return_bytes);
+        println!(
+            "  ✓ Counter at 0x{} (deploy in {:.1}s)",
+            hex::encode(counter_addr),
+            deploy_start.elapsed().as_secs_f64()
+        );
+    } else {
+        println!("\n[2/4] Skipping Counter deploy (mix.call=0)");
+    }
+
+    // ── Phase 3: fetch threshold pubkey for encrypted-tx path ───
+    let threshold_pk_bytes: Option<Vec<u8>> = if mix.encrypted > 0 {
+        println!("\n[3/4] Fetching threshold pubkey for encrypted-tx path…");
+        let pk = runtime
+            .block_on(fetch_threshold_pubkey(&client, &rpc_urls[0]))
+            .unwrap_or_else(|e| panic!("threshold pubkey: {}", e));
+        println!("  ✓ threshold pk fetched ({} bytes)", pk.len());
+        Some(pk)
+    } else {
+        println!("\n[3/4] Skipping threshold-pk fetch (mix.encrypted=0)");
+        None
+    };
+
+    // ── Phase 4: sustained mixed-rate submission ────────────────
+    let rate_per_acct = target_tps as f64 / num_senders as f64;
+    let per_acct_interval = Duration::from_secs_f64(1.0 / rate_per_acct);
+    let total_run_s = warmup_s + duration_s;
+
+    println!(
+        "\n[4/4] Mixed-load run: {} s total ({} warm-up + {} measured)",
+        total_run_s, warmup_s, duration_s
+    );
+
+    let counts = Arc::new(MixCounts::new());
+    let run_start = Instant::now();
+    let measurement_start_at = run_start + Duration::from_secs(warmup_s);
+    let run_deadline = run_start + Duration::from_secs(total_run_s);
+
+    runtime.block_on(async {
+        let mut tasks = Vec::with_capacity(num_senders);
+        for (i, w) in wallets.iter().enumerate() {
+            let wallet = w.clone();
+            let cli = client.clone();
+            let url = rpc_urls[i % rpc_urls.len()].clone();
+            let counts = counts.clone();
+            let interval = per_acct_interval;
+            let measure_at = measurement_start_at;
+            let deadline = run_deadline;
+            let cnt_addr = counter_addr;
+            let tpk_bytes = threshold_pk_bytes.clone();
+
+            tasks.push(tokio::spawn(async move {
+                let mut nonce = 1u64; // nonce 0 was RegisterPubkey
+                let mut next_submit = Instant::now();
+                let mut submit_idx: u64 = (i as u64) * 7919; // staggered seed so senders don't all pick the same kind in lockstep
+                loop {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        break;
+                    }
+                    if now < next_submit {
+                        tokio::time::sleep(next_submit - now).await;
+                    }
+                    next_submit += interval;
+
+                    let kind = mix.pick(submit_idx);
+                    submit_idx += 1;
+
+                    let result = match kind {
+                        TxKind::Transfer => submit_transfer(&cli, &url, &wallet, nonce).await,
+                        TxKind::Call => {
+                            if cnt_addr == [0u8; 32] {
+                                Ok(()) // skipped; treat as no-op
+                            } else {
+                                submit_counter_call(&cli, &url, &wallet, nonce, &cnt_addr).await
+                            }
+                        }
+                        TxKind::Encrypted => {
+                            if let Some(ref tpk) = tpk_bytes {
+                                submit_encrypted(&cli, &url, &wallet, nonce, tpk).await
+                            } else {
+                                Ok(())
+                            }
+                        }
+                    };
+
+                    let in_measure = Instant::now() >= measure_at;
+                    match result {
+                        Ok(()) => {
+                            counts.record_ok(kind, in_measure);
+                            nonce += 1;
+                        }
+                        Err(_) => {
+                            counts.record_err(kind, in_measure);
+                            tokio::time::sleep(Duration::from_millis(400)).await;
+                            next_submit = Instant::now();
+                        }
+                    }
+                }
+            }));
+        }
+
+        // Progress reporter — per-type.
+        let progress_counts = counts.clone();
+        let progress_end = run_deadline;
+        let progress_measure_at = measurement_start_at;
+        let progress_task = tokio::spawn(async move {
+            let mut last = MixSnapshot::default();
+            while Instant::now() < progress_end {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                let now = Instant::now();
+                let cur = progress_counts.snapshot();
+                let delta = cur.minus(&last);
+                let phase = if now < progress_measure_at {
+                    "warmup"
+                } else {
+                    "measure"
+                };
+                println!(
+                    "  [{:>7}] +T{}/C{}/E{} in 10s ({}+{}+{} ok / {}+{}+{} err total)",
+                    phase,
+                    delta.transfer_ok,
+                    delta.call_ok,
+                    delta.encrypted_ok,
+                    cur.transfer_ok,
+                    cur.call_ok,
+                    cur.encrypted_ok,
+                    cur.transfer_err,
+                    cur.call_err,
+                    cur.encrypted_err,
+                );
+                last = cur;
+            }
+        });
+
+        for t in tasks {
+            let _ = t.await;
+        }
+        let _ = progress_task.await;
+    });
+
+    // ── Settle + report ─────────────────────────────────────────
+    println!("\n  Settling 20 s for final inclusion…");
+    runtime.block_on(async {
+        tokio::time::sleep(Duration::from_secs(20)).await;
+    });
+
+    let snap = counts.snapshot();
+    let total_submitted = snap.transfer_ok + snap.call_ok + snap.encrypted_ok;
+    let measure_submitted =
+        snap.transfer_ok_measure + snap.call_ok_measure + snap.encrypted_ok_measure;
+    let total_errors = snap.transfer_err + snap.call_err + snap.encrypted_err;
+
+    println!("\n╔══════════════════════════════════════════════════════╗");
+    println!("║  RESULTS                                             ║");
+    println!("╠══════════════════════════════════════════════════════╣");
+    println!(
+        "  Target:                 {} TPS for {} s",
+        target_tps, duration_s
+    );
+    println!(
+        "  Mix:                    transfer:{}, call:{}, encrypted:{}",
+        mix.transfer, mix.call, mix.encrypted
+    );
+    println!("  ─ submitted (measured) ─");
+    println!("    transfer:    {}", snap.transfer_ok_measure);
+    println!("    call:        {}", snap.call_ok_measure);
+    println!("    encrypted:   {}", snap.encrypted_ok_measure);
+    println!(
+        "    AGGREGATE:   {} ({} TPS)",
+        measure_submitted,
+        measure_submitted / duration_s.max(1)
+    );
+    println!("  ─ submitted (total over warmup+measure) ─");
+    println!("    transfer:    {}", snap.transfer_ok);
+    println!("    call:        {}", snap.call_ok);
+    println!("    encrypted:   {}", snap.encrypted_ok);
+    println!("    AGGREGATE:   {}", total_submitted);
+    println!("  ─ errors ─");
+    println!("    transfer:    {}", snap.transfer_err);
+    println!("    call:        {}", snap.call_err);
+    println!("    encrypted:   {}", snap.encrypted_err);
+    println!("    AGGREGATE:   {}", total_errors);
+    println!("╚══════════════════════════════════════════════════════╝");
+
+    // We don't fail the test on TPS — this is a measurement
+    // instrument, not a regression gate. Operators inspect the
+    // aggregate number and decide.
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Per-tx-kind submitters
+// ════════════════════════════════════════════════════════════════════
+
+async fn submit_transfer(
+    client: &reqwest::Client,
+    url: &str,
+    wallet: &Wallet,
+    nonce: u64,
+) -> Result<(), ()> {
+    let mut tx = Transaction {
+        from: wallet.address,
+        to: RECIPIENT,
+        value: TX_VALUE,
+        data: vec![],
+        gas_limit: 50_000,
+        nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: CHAIN_ID,
+        tx_type: TransactionType::Standard,
+    };
+    let sig = falcon_sign(&wallet.sk, &tx.hash()).map_err(|_| ())?;
+    tx.signature = sig.as_bytes().to_vec();
+    rpc_send_raw_fast(client, url, &hex::encode(tx.to_bytes())).await
+}
+
+async fn submit_counter_call(
+    client: &reqwest::Client,
+    url: &str,
+    wallet: &Wallet,
+    nonce: u64,
+    counter_addr: &[u8; 32],
+) -> Result<(), ()> {
+    let selector = otic::codegen::compute_selector("increment");
+    let calldata = selector.to_be_bytes().to_vec();
+    let mut tx = Transaction {
+        from: wallet.address,
+        to: *counter_addr,
+        value: 0,
+        data: calldata,
+        gas_limit: 200_000,
+        nonce,
+        signature: vec![],
+        fee_payer: FeePayer::Sender,
+        access_list: vec![],
+        deadline: None,
+        chain_id: CHAIN_ID,
+        tx_type: TransactionType::Standard,
+    };
+    let sig = falcon_sign(&wallet.sk, &tx.hash()).map_err(|_| ())?;
+    tx.signature = sig.as_bytes().to_vec();
+    rpc_send_raw_fast(client, url, &hex::encode(tx.to_bytes())).await
+}
+
+/// Submit an encrypted value tx via `pyde_sendRawEncryptedTransaction`.
+///
+/// Mirrors `TestNetwork::submit_encrypted_transfer_inner` but takes
+/// the threshold pubkey + chain_id as parameters so the caller can
+/// cache the pk (avoids one extra RPC per submit) and use the
+/// production chain_id (the helper hardcodes 31337).
+async fn submit_encrypted(
+    client: &reqwest::Client,
+    url: &str,
+    wallet: &Wallet,
+    nonce: u64,
+    threshold_pk_bytes: &[u8],
+) -> Result<(), ()> {
+    let tpk =
+        pyde_crypto::threshold::ThresholdPublicKey::from_bytes(threshold_pk_bytes).ok_or(())?;
+    // Same structural scaffolding as the
+    // `submit_encrypted_transfer_inner` helper: minimal access list
+    // (mempool requires non-empty), 100K gas, sign AFTER encryption
+    // because the hash covers the ciphertext.
+    let access_list = vec![AccessEntry {
+        address: RECIPIENT,
+        reads: Vec::new(),
+        writes: Vec::new(),
+    }];
+    let mut enc_tx = pyde_mempool::encrypted::encrypt_transaction(
+        wallet.address,
+        nonce,
+        100_000,
+        access_list,
+        None,
+        CHAIN_ID,
+        Vec::new(),
+        &RECIPIENT,
+        TX_VALUE,
+        &[],
+        &tpk,
+    )
+    .map_err(|_| ())?;
+    let tx_hash = enc_tx.hash();
+    let sig = falcon_sign(&wallet.sk, &tx_hash).map_err(|_| ())?;
+    enc_tx.signature = sig.as_bytes().to_vec();
+    let wire = enc_tx.to_bytes();
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"pyde_sendRawEncryptedTransaction","params":["0x{}"]}}"#,
+        hex::encode(wire)
+    );
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .map_err(|_| ())?;
+    if !resp.status().is_success() {
+        return Err(());
+    }
+    let text = resp.text().await.map_err(|_| ())?;
+    if text.contains(r#""error""#) {
+        return Err(());
+    }
+    // Self-verify so a bad sig surfaces here, not as a server-side
+    // rejection that's harder to interpret in the loadgen output.
+    let pk = FalconPublicKey::from_bytes(&wallet.pk_bytes).ok_or(())?;
+    let sig_obj = FalconSignature::from_bytes(&enc_tx.signature).ok_or(())?;
+    if !pyde_crypto::falcon::falcon_verify(&pk, &enc_tx.hash(), &sig_obj) {
+        return Err(());
+    }
+    Ok(())
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Counters
+// ════════════════════════════════════════════════════════════════════
+
+#[derive(Default)]
+struct MixCounts {
+    transfer_ok: AtomicU64,
+    call_ok: AtomicU64,
+    encrypted_ok: AtomicU64,
+    transfer_ok_measure: AtomicU64,
+    call_ok_measure: AtomicU64,
+    encrypted_ok_measure: AtomicU64,
+    transfer_err: AtomicU64,
+    call_err: AtomicU64,
+    encrypted_err: AtomicU64,
+}
+
+impl MixCounts {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn record_ok(&self, kind: TxKind, in_measure: bool) {
+        match kind {
+            TxKind::Transfer => {
+                self.transfer_ok.fetch_add(1, Ordering::Relaxed);
+                if in_measure {
+                    self.transfer_ok_measure.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            TxKind::Call => {
+                self.call_ok.fetch_add(1, Ordering::Relaxed);
+                if in_measure {
+                    self.call_ok_measure.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            TxKind::Encrypted => {
+                self.encrypted_ok.fetch_add(1, Ordering::Relaxed);
+                if in_measure {
+                    self.encrypted_ok_measure.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    fn record_err(&self, kind: TxKind, _in_measure: bool) {
+        match kind {
+            TxKind::Transfer => self.transfer_err.fetch_add(1, Ordering::Relaxed),
+            TxKind::Call => self.call_err.fetch_add(1, Ordering::Relaxed),
+            TxKind::Encrypted => self.encrypted_err.fetch_add(1, Ordering::Relaxed),
+        };
+    }
+
+    fn snapshot(&self) -> MixSnapshot {
+        MixSnapshot {
+            transfer_ok: self.transfer_ok.load(Ordering::Relaxed),
+            call_ok: self.call_ok.load(Ordering::Relaxed),
+            encrypted_ok: self.encrypted_ok.load(Ordering::Relaxed),
+            transfer_ok_measure: self.transfer_ok_measure.load(Ordering::Relaxed),
+            call_ok_measure: self.call_ok_measure.load(Ordering::Relaxed),
+            encrypted_ok_measure: self.encrypted_ok_measure.load(Ordering::Relaxed),
+            transfer_err: self.transfer_err.load(Ordering::Relaxed),
+            call_err: self.call_err.load(Ordering::Relaxed),
+            encrypted_err: self.encrypted_err.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+struct MixSnapshot {
+    transfer_ok: u64,
+    call_ok: u64,
+    encrypted_ok: u64,
+    transfer_ok_measure: u64,
+    call_ok_measure: u64,
+    encrypted_ok_measure: u64,
+    transfer_err: u64,
+    call_err: u64,
+    encrypted_err: u64,
+}
+
+impl MixSnapshot {
+    fn minus(&self, other: &Self) -> Self {
+        Self {
+            transfer_ok: self.transfer_ok - other.transfer_ok,
+            call_ok: self.call_ok - other.call_ok,
+            encrypted_ok: self.encrypted_ok - other.encrypted_ok,
+            transfer_ok_measure: self.transfer_ok_measure - other.transfer_ok_measure,
+            call_ok_measure: self.call_ok_measure - other.call_ok_measure,
+            encrypted_ok_measure: self.encrypted_ok_measure - other.encrypted_ok_measure,
+            transfer_err: self.transfer_err - other.transfer_err,
+            call_err: self.call_err - other.call_err,
+            encrypted_err: self.encrypted_err - other.encrypted_err,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// HTTP helpers
+// ════════════════════════════════════════════════════════════════════
+
+async fn rpc_call(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    params: &str,
+) -> serde_json::Value {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"{}","params":[{}],"id":1}}"#,
+        method, params
+    );
+    match client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+    {
+        Ok(resp) => resp.json().await.unwrap_or_default(),
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+async fn rpc_send_raw(client: &reqwest::Client, url: &str, tx_hex: &str) -> serde_json::Value {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"pyde_sendRawTransaction","params":["0x{}"]}}"#,
+        tx_hex
+    );
+    match client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+    {
+        Ok(resp) => resp.json().await.unwrap_or_default(),
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+async fn rpc_send_raw_fast(client: &reqwest::Client, url: &str, tx_hex: &str) -> Result<(), ()> {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"pyde_sendRawTransaction","params":["0x{}"]}}"#,
+        tx_hex
+    );
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .map_err(|_| ())?;
+    if !resp.status().is_success() {
+        return Err(());
+    }
+    let text = resp.text().await.map_err(|_| ())?;
+    if text.contains(r#""error""#) {
+        return Err(());
+    }
+    Ok(())
+}
+
+async fn fetch_nonce(client: &reqwest::Client, url: &str, addr: &[u8; 32]) -> Option<u64> {
+    let resp = rpc_call(
+        client,
+        url,
+        "pyde_getTransactionCount",
+        &format!("\"0x{}\"", hex::encode(addr)),
+    )
+    .await;
+    let raw = resp.get("result")?.as_str()?;
+    if let Some(stripped) = raw.strip_prefix("0x") {
+        u64::from_str_radix(stripped, 16).ok()
+    } else {
+        raw.parse().ok()
+    }
+}
+
+async fn fetch_balance(client: &reqwest::Client, url: &str, addr: &[u8; 32]) -> Option<u128> {
+    let resp = rpc_call(
+        client,
+        url,
+        "pyde_getBalance",
+        &format!("\"0x{}\"", hex::encode(addr)),
+    )
+    .await;
+    let raw = resp.get("result")?.as_str()?;
+    raw.parse().ok()
+}
+
+async fn fetch_threshold_pubkey(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {
+    let resp = rpc_call(client, url, "pyde_getThresholdPublicKey", "").await;
+    let raw = resp
+        .get("result")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("threshold pk missing in response: {}", resp))?;
+    hex::decode(raw.strip_prefix("0x").unwrap_or(raw))
+        .map_err(|e| format!("decode threshold pk hex: {}", e))
+}
+
+fn env_var_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}

--- a/crates/node/tests/loadgen_soak.rs
+++ b/crates/node/tests/loadgen_soak.rs
@@ -80,7 +80,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const CHAIN_ID: u64 = 1;
+// Audit 383: `pyde testnet` refuses to generate artifacts for
+// chain_id=1 (the canonical mainnet id). The soak runs against a
+// 4-validator dev testnet, so use the canonical public-testnet id
+// instead. Switching to 31337 would also work, but 7331 keeps the
+// soak's signed-tx surface (chain_id != 31337 enforces FALCON
+// signature verification on every tx) which matches what real
+// testnet operators see.
+const CHAIN_ID: u64 = 7331;
 const FUND_PER_SENDER: u128 = 1_000_000_000_000_000_000;
 
 // Method selector — delegate to the otic codegen helper so it stays
@@ -132,16 +139,27 @@ contract Helper {
 
 // MegaContract — most of the feature surface in one place.
 //
-// Storage covers: u64, i64, Map<Address,u256>, Vec<u64>, struct field,
+// Storage covers: u64, Map<Address,u256>, Vec<u64>, struct field,
 // enum-tag field, Address. Methods cover: payable, complex args
 // (UserData struct), complex returns (u256), complex logic
 // (state-mutating math), enum match, events with #[indexed], errors,
 // require!, assert!, view functions, cross-contract calls.
+//
+// Audit 404 / 354: previously this contract had a `signed_val: i64`
+// field + `checked_signed(delta: i64)` method exercising signed
+// integer math. Audit 354 documents that the codegen treats all
+// integers as unsigned — `<`, `>`, `/`, `%`, `>>` on signed types
+// produce wrong results. The strict typechecker rejects i64 to
+// catch this; pre-audit-404 the soak compiled the source via the
+// lax path and ran the broken arithmetic, reporting `ok=735 err=0`
+// for the `checked_signed` bucket while the on-chain math was
+// silently wrong (the assert and adds happened to coincide with
+// correct values for the test inputs). Until the codegen gains
+// real signed-integer ISA opcodes, the bucket is dropped.
 contract MegaContract {
     storage {
         owner: Address,
         counter: u64,
-        signed_val: i64,
         balances: Map<Address, u256>,
         scores: Vec<u64>,
         helper_addr: Address,
@@ -181,7 +199,6 @@ contract MegaContract {
         self.owner = msg.sender;
         self.counter = initial;
         self.helper_addr = helper;
-        self.signed_val = -42;
     }
 
     // Payable + indexed event. Exercises VALUE in calldata and the
@@ -230,12 +247,6 @@ contract MegaContract {
         self.counter = self.counter + 1;
     }
 
-    // Asserts + signed integer math.
-    pub fn checked_signed(delta: i64) {
-        assert!(self.signed_val > -1000);
-        self.signed_val = self.signed_val + delta;
-    }
-
     #[view]
     pub fn get_counter() -> u64 {
         return self.counter;
@@ -256,15 +267,24 @@ contract MegaContract {
 // via the deploy! macro, exercising CREATE + per-caller create
 // counter (audit 379) + per-block tx that does state writes via
 // inner-CREATE.
+//
+// Audit 404: pre-fix `spawn()` returned `Address` and stored the
+// child's address via `address(deploy!(Helper))`. The strict
+// typechecker (now wired into `compile_all`) rejects that cast
+// because `deploy!` returns a contract handle, not an Address.
+// The lax path silently accepted it because contract handles ARE
+// addresses internally — but that's a coincidence, not a contract.
+// We drop the address-tracking machinery and call a method on the
+// freshly-deployed `child` instead, which still exercises the full
+// CREATE → constructor → runtime install path that the test cares
+// about. The chain-side feature (factory-pattern deploys at
+// execution time) is unchanged.
 contract Spawner {
     storage {
-        spawned: Vec<Address>,
         count: u64,
     }
 
     event Spawned {
-        #[indexed]
-        child: Address,
         count: u64,
     }
 
@@ -273,12 +293,15 @@ contract Spawner {
         self.count = 0;
     }
 
-    pub fn spawn() -> Address {
+    pub fn spawn() {
         let child = deploy!(Helper);
-        self.spawned.push(child);
+        // Calling a method on the just-deployed child proves the
+        // runtime is actually installed end-to-end, not just that
+        // the constructor returned. We don't capture the address
+        // because `address(<contract>)` doesn't typecheck.
+        child.ping();
         self.count = self.count + 1;
-        emit Spawned { child: child, count: self.count };
-        return child;
+        emit Spawned { count: self.count };
     }
 
     #[view]
@@ -313,8 +336,6 @@ enum CallKind {
     ChangeStatus,
     /// MegaContract::deposit (payable) — exercises VALUE + LOG.
     Deposit,
-    /// MegaContract::checked_signed — exercises signed integer math.
-    SignedMath,
     /// Spawner::spawn — exercises factory / deploy!.
     Spawn,
     /// Helper::ping (cross-contract) — exercises CallExt.
@@ -332,25 +353,25 @@ impl CallKind {
             CallKind::ComplexLogic => "complex_logic",
             CallKind::ChangeStatus => "change_status",
             CallKind::Deposit => "deposit",
-            CallKind::SignedMath => "checked_signed",
             CallKind::Spawn => "spawn",
             CallKind::Ping => "ping",
             CallKind::EncryptedIncrement => "encrypted_increment",
         }
     }
 
-    /// Default 9-bucket workload weights summing to 100. The mix is
-    /// roughly representative of what testnet traffic should look
-    /// like: a third pure transfers, a third hot-path AOT exercise,
-    /// the rest spread across the feature surface.
-    fn default_weights() -> [(CallKind, u32); 9] {
+    /// Default 8-bucket workload weights summing to 100. Audit 404
+    /// dropped the prior `SignedMath` bucket — the i64 contract it
+    /// targeted ran wrong arithmetic via the lax compile path
+    /// (audit 354), so the bucket was reporting `ok` for code that
+    /// produced wrong results. Reintroduce post-codegen-signed-int
+    /// support.
+    fn default_weights() -> [(CallKind, u32); 8] {
         [
             (CallKind::Transfer, 25),
             (CallKind::Increment, 25),
             (CallKind::ComplexLogic, 10),
             (CallKind::ChangeStatus, 5),
-            (CallKind::Deposit, 5),
-            (CallKind::SignedMath, 5),
+            (CallKind::Deposit, 10),
             (CallKind::Spawn, 3),
             (CallKind::Ping, 7),
             (CallKind::EncryptedIncrement, 15),
@@ -375,9 +396,17 @@ fn compile_deploy_payload(
     contract_name: &str,
     constructor_args: &[u8],
 ) -> Result<Vec<u8>, String> {
-    let compiled =
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| otic::compile_all(src)))
-            .map_err(|_| "otic compiler panicked on suite source".to_string())?;
+    // Audit 404: strict pipeline (resolve + typecheck + safety +
+    // lower + codegen). Pre-fix this called the lax variant, which
+    // silently accepted `i64` arithmetic (audit 354) and
+    // `address(<contract>)` casts in the suite source. The strict
+    // path now catches those at compile time so test fixtures can't
+    // hide broken contracts.
+    let compiled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        otic::compile_all(src)
+    }))
+    .map_err(|_| "otic compiler panicked on suite source".to_string())?
+    .map_err(|diagnostics| format!("suite frontend rejected:\n{}", diagnostics))?;
     let (_, cc) = compiled
         .iter()
         .find(|(name, _)| name == contract_name)
@@ -416,14 +445,14 @@ fn comprehensive_soak() {
     println!("  Encrypted %:  {}", encrypted_pct);
     println!("  Features:     transfer / increment(AOT) / complex_logic /");
     println!("                change_status / deposit(payable) /");
-    println!("                checked_signed / spawn(factory) /");
-    println!("                ping(cross-contract) / enc_increment");
+    println!("                spawn(factory) / ping(cross-contract) /");
+    println!("                enc_increment");
     println!("╚══════════════════════════════════════════════════════════╝");
 
     // ── Phase 0: spawn 4-validator network ────────────────────────
     println!("\n[0/5] Spawning 4-validator native testnet…");
     let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id={}: {}", CHAIN_ID, e));
     net.wait_for_slot(3, Duration::from_secs(30))
         .unwrap_or_else(|e| panic!("chain warm-up: {}", e));
 
@@ -695,8 +724,8 @@ fn comprehensive_soak() {
         }
     }
     println!(
-        "    bucket coverage:    {}/9 exercised  (pass: 9/9)",
-        9 - zero_buckets.len()
+        "    bucket coverage:    {}/8 exercised  (pass: 8/8)",
+        8 - zero_buckets.len()
     );
     if !zero_buckets.is_empty() {
         println!("    UNEXERCISED:        {}", zero_buckets.join(", "));
@@ -718,7 +747,7 @@ fn comprehensive_soak() {
     println!(
         "\n  ✓ PASS — {:.1}-min soak, {} buckets exercised, {:.1}% submit err",
         measure_elapsed.as_secs_f64() / 60.0,
-        9 - zero_buckets.len(),
+        8 - zero_buckets.len(),
         err_rate * 100.0,
     );
 }
@@ -734,7 +763,7 @@ async fn run_workload(
     wallets: &[Arc<Wallet>],
     contracts: &DeployedContracts,
     nonce_counters: &Arc<Vec<AtomicU64>>,
-    weights: &[(CallKind, u32); 9],
+    weights: &[(CallKind, u32); 8],
     target_tps: u64,
     encrypted_pct: u32,
     duration: Duration,
@@ -827,14 +856,6 @@ async fn submit_one(
             let mut d = Vec::with_capacity(4);
             d.extend_from_slice(&selector("deposit"));
             (mega, d, 100u128, Standard) // payable, send 100 quanta
-        }
-        CallKind::SignedMath => {
-            let mut d = Vec::with_capacity(4 + 8);
-            d.extend_from_slice(&selector("checked_signed"));
-            // delta = +1 or -1 alternating
-            let delta: i64 = if nonce % 2 == 0 { 1 } else { -1 };
-            d.extend_from_slice(&delta.to_le_bytes());
-            (mega, d, 0, Standard)
         }
         CallKind::Spawn => {
             let mut d = Vec::with_capacity(4);
@@ -1292,14 +1313,14 @@ async fn fetch_threshold_pubkey(client: &reqwest::Client, url: &str) -> Option<V
 // ────────────────────────────────────────────────────────────────────
 
 struct SoakMetrics {
-    ok: [AtomicU64; 9],
-    err: [AtomicU64; 9],
+    ok: [AtomicU64; 8],
+    err: [AtomicU64; 8],
 }
 
 #[derive(Clone)]
 struct SoakSnapshot {
-    ok: [u64; 9],
-    err: [u64; 9],
+    ok: [u64; 8],
+    err: [u64; 8],
 }
 
 impl SoakMetrics {
@@ -1316,10 +1337,9 @@ impl SoakMetrics {
             CallKind::ComplexLogic => 2,
             CallKind::ChangeStatus => 3,
             CallKind::Deposit => 4,
-            CallKind::SignedMath => 5,
-            CallKind::Spawn => 6,
-            CallKind::Ping => 7,
-            CallKind::EncryptedIncrement => 8,
+            CallKind::Spawn => 5,
+            CallKind::Ping => 6,
+            CallKind::EncryptedIncrement => 7,
         }
     }
     fn record_ok(&self, kind: CallKind, _measured: bool) {

--- a/crates/node/tests/loadgen_soak.rs
+++ b/crates/node/tests/loadgen_soak.rs
@@ -23,25 +23,25 @@
 //!
 //!   - Constructors with args ............ MegaContract::init, Helper::init
 //!   - Events with indexed fields ........ Deposit, StatusChanged,
-//!                                          ComplexResult, Ponged, Spawned
+//!     ComplexResult, Ponged, Spawned
 //!   - Enums with match .................. Status::{Active,Paused,Locked}
 //!   - Payable functions ................. MegaContract::deposit
 //!   - Complex args (struct) ............. UserData → complex_logic
 //!   - Complex returns (u256) ............ complex_logic returns total
 //!   - Complex storage layouts ........... Map<Address, u256>, Vec<u64>,
-//!                                          struct fields, enum tag fields
+//!     struct fields, enum tag fields
 //!   - Complex logic (math + state) ...... complex_logic + change_status
 //!   - Cross-contract calls .............. MegaContract → IHelper.ping
 //!   - Factory pattern (deploy!) ......... Spawner.spawn → deploy!(Helper)
 //!   - Reentrancy probe .................. MegaContract.delegate_ping
-//!                                          calls Helper which writes
-//!                                          state — exercises CallExt +
-//!                                          cross-contract state isolation
+//!     calls Helper which writes
+//!     state — exercises CallExt +
+//!     cross-contract state isolation
 //!   - AOT optimization wiring ........... hot-path repeatedly hits
-//!                                          MegaContract.increment, the
-//!                                          AotCache compiles in
-//!                                          background, subsequent calls
-//!                                          take the JIT path.
+//!     MegaContract.increment, the
+//!     AotCache compiles in
+//!     background, subsequent calls
+//!     take the JIT path.
 //!   - Plaintext + encrypted mix ......... configurable; default 50/50
 //!
 //! # Run
@@ -402,11 +402,10 @@ fn compile_deploy_payload(
     // `address(<contract>)` casts in the suite source. The strict
     // path now catches those at compile time so test fixtures can't
     // hide broken contracts.
-    let compiled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        otic::compile_all(src)
-    }))
-    .map_err(|_| "otic compiler panicked on suite source".to_string())?
-    .map_err(|diagnostics| format!("suite frontend rejected:\n{}", diagnostics))?;
+    let compiled =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| otic::compile_all(src)))
+            .map_err(|_| "otic compiler panicked on suite source".to_string())?
+            .map_err(|diagnostics| format!("suite frontend rejected:\n{}", diagnostics))?;
     let (_, cc) = compiled
         .iter()
         .find(|(name, _)| name == contract_name)
@@ -626,15 +625,10 @@ fn comprehensive_soak() {
 
                 // Every 60s: print head + dump per-node logs to disk.
                 if tick % 60 == 0 {
-                    eprintln!(
-                        "    [watchdog] head={} stall={}s",
-                        last_head, stall_secs,
-                    );
+                    eprintln!("    [watchdog] head={} stall={}s", last_head, stall_secs,);
                     for (i, out) in outputs.iter().enumerate() {
                         if let Ok(buf) = out.lock() {
-                            let path = format!(
-                                "/tmp/pyde-soak-node-{}.log", i
-                            );
+                            let path = format!("/tmp/pyde-soak-node-{}.log", i);
                             let _ = std::fs::write(&path, buf.join("\n"));
                         }
                     }
@@ -842,14 +836,14 @@ async fn submit_one(
             let mut amt = [0u8; 32];
             amt[0..8].copy_from_slice(&1000u64.to_le_bytes());
             d.extend_from_slice(&amt);
-            d.extend_from_slice(&((nonce % 100) as u64).to_le_bytes()); // score
+            d.extend_from_slice(&(nonce % 100).to_le_bytes()); // score
             (mega, d, 0, Standard)
         }
         CallKind::ChangeStatus => {
             // change_status(s: Status) — pass enum tag (0/1/2)
             let mut d = Vec::with_capacity(4 + 8);
             d.extend_from_slice(&selector("change_status"));
-            d.extend_from_slice(&((nonce % 3) as u64).to_le_bytes());
+            d.extend_from_slice(&(nonce % 3).to_le_bytes());
             (mega, d, 0, Standard)
         }
         CallKind::Deposit => {

--- a/crates/node/tests/multi_node_contract_sigs.rs
+++ b/crates/node/tests/multi_node_contract_sigs.rs
@@ -258,7 +258,7 @@ fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
 /// Mirrors `production_sigs.rs::compile` — this is the canonical
 /// on-chain deploy envelope.
 fn compile_deploy_payload(src: &str) -> Vec<u8> {
-    let c = otic::compile_all(src);
+    let c = otic::compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut out = Vec::with_capacity(8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len());
     out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/production_e2e.rs
+++ b/crates/node/tests/production_e2e.rs
@@ -259,7 +259,7 @@ fn production_signed_deploy_and_call() {
     };
 
     // Compile Counter contract
-    let compiled = otic::compile_all(
+    let compiled = otic::compile_all_unchecked(
         r#"
         contract Counter {
             storage { count: u64, }

--- a/crates/node/tests/production_sigs.rs
+++ b/crates/node/tests/production_sigs.rs
@@ -22,7 +22,7 @@ fn sign(tx: &mut Transaction, sk: &pyde_crypto::falcon::FalconSecretKey) {
 }
 
 fn compile(src: &str) -> Vec<u8> {
-    let c = otic::compile_all(src);
+    let c = otic::compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut d = Vec::new();
     d.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/production_sim.rs
+++ b/crates/node/tests/production_sim.rs
@@ -38,7 +38,7 @@ struct FundedAccount {
 }
 
 fn compile_single(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());
@@ -52,7 +52,7 @@ fn compile_single(source: &str) -> Vec<u8> {
 /// (the one that references earlier contracts via deploy!/at()).
 #[allow(dead_code)]
 fn compile_last(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all(source);
+    let compiled = otic::compile_all_unchecked(source);
     let (_, c) = compiled.last().unwrap();
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -8468,7 +8468,9 @@ mod tests {
         "#;
         // Audit 404: codegen-internal determinism check uses the lax
         // path so the test stays focused on lower / codegen output.
-        let runs = (0..5).map(|_| crate::compile_all_unchecked(src)).collect::<Vec<_>>();
+        let runs = (0..5)
+            .map(|_| crate::compile_all_unchecked(src))
+            .collect::<Vec<_>>();
         // All 5 compilations produce one Token contract.
         for r in &runs {
             assert_eq!(r.len(), 1);

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -8403,7 +8403,10 @@ mod tests {
             }
         "#;
 
-        let results = crate::compile_all(src);
+        // Audit 404: codegen tests use the lax `compile_all_unchecked`
+        // because they probe lower / codegen invariants directly,
+        // not the full frontend.
+        let results = crate::compile_all_unchecked(src);
         assert_eq!(results.len(), 2);
 
         let (name, factory) = &results[1];
@@ -8463,7 +8466,9 @@ mod tests {
                 }
             }
         "#;
-        let runs = (0..5).map(|_| crate::compile_all(src)).collect::<Vec<_>>();
+        // Audit 404: codegen-internal determinism check uses the lax
+        // path so the test stays focused on lower / codegen output.
+        let runs = (0..5).map(|_| crate::compile_all_unchecked(src)).collect::<Vec<_>>();
         // All 5 compilations produce one Token contract.
         for r in &runs {
             assert_eq!(r.len(), 1);

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -250,9 +250,7 @@ pub fn compile_all_unchecked(src: &str) -> Vec<(String, codegen::CompiledContrac
 ///     one of the two.
 ///
 /// All those checks now run by default via this function.
-pub fn compile_all(
-    src: &str,
-) -> Result<Vec<(String, codegen::CompiledContract)>, String> {
+pub fn compile_all(src: &str) -> Result<Vec<(String, codegen::CompiledContract)>, String> {
     // Lex.
     let (tokens, lex_errors) = lexer::Lexer::new(src).tokenize();
     if !lex_errors.is_empty() {

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -130,12 +130,29 @@ fn extract_all_contract_signatures(
     (contract_functions, contract_constructors)
 }
 
-/// Compile all contracts in a source file. Returns a map of contract name → CompiledContract.
-/// Contracts are compiled in declaration order. Later contracts can reference earlier ones
-/// via `create!(ContractName, args)` — the compiler embeds the bytecode at compile time.
-/// Cross-contract typed dispatch (Contract::at(addr).method()) works across all contracts
-/// in the file.
-pub fn compile_all(src: &str) -> Vec<(String, codegen::CompiledContract)> {
+/// **Permissive** compile (audit 404): runs ONLY lex + parse + lower
+/// + optimize + codegen. Does **NOT** run resolve, typecheck, or
+/// safety. Production code MUST use [`compile_all`] (the strict
+/// variant), which catches all the audit-354 violations and other
+/// frontend-only checks this function silently lets through.
+///
+/// Provided for two narrow use cases:
+///   1. **Compiler-internal tests** that probe the lower / codegen
+///      pipeline against fixtures with intentionally-invalid frontend
+///      shapes (e.g., `crates/otic/src/codegen.rs` self-tests).
+///   2. **`pyde-dev build` / `otic` CLI** which already run the
+///      frontend explicitly via `run_frontend(...)` BEFORE calling
+///      this function — so a second pass would just duplicate work.
+///
+/// Audit 404 documents the gap that motivated splitting the public
+/// API: `pyde-dev script` and a dozen test fixtures used to call
+/// the lax path directly, which bypassed audit-354 (signed integer
+/// rejection) and audit-356 (selector collision detection) and let
+/// silently-broken contracts compile to bytecode. The fix routes
+/// production callers through the strict `compile_all`; this
+/// function survives only behind an opt-in name so the lax path
+/// can never be picked accidentally.
+pub fn compile_all_unchecked(src: &str) -> Vec<(String, codegen::CompiledContract)> {
     let (tokens, _) = lexer::Lexer::new(src).tokenize();
     let (file, _) = parser::Parser::new(tokens).parse();
 
@@ -197,4 +214,127 @@ pub fn compile_all(src: &str) -> Vec<(String, codegen::CompiledContract)> {
     }
 
     results
+}
+
+/// **Strict** compile (audit 404, production default): runs the full
+/// pipeline — lex, parse, **resolve**, **typecheck**, **safety**,
+/// lower, optimize, codegen. Returns formatted diagnostics on any
+/// frontend failure.
+///
+/// Use this everywhere except where you've already run the frontend
+/// in a wider build context (`pyde-dev build`, `otic` CLI) or in
+/// compiler-internal lower/codegen tests. See
+/// [`compile_all_unchecked`] for those narrow cases.
+///
+/// # Audit 404
+///
+/// Pre-fix the public `compile_all` skipped resolve/typecheck/safety
+/// entirely. That meant `pyde-dev script`, `tests/loadgen_soak.rs`,
+/// `tests/integration.rs`, the AOT cache self-tests, and a dozen
+/// other call sites silently let through:
+///
+///   - **Audit 354 violations**: `i64`/`i128`/`i256` arithmetic that
+///     the typechecker explicitly rejects (codegen treats all ints
+///     as unsigned, so signed `<`, `>`, `/`, `%`, `>>` produce wrong
+///     results). The soak test's `checked_signed` bucket was
+///     reporting `ok=735 err=0` for hours of runtime against
+///     contracts whose comparisons were silently broken.
+///   - **Undefined names**: resolve catches `nonexistent_function()`
+///     calls; without it the lower pass emits garbage bytecode.
+///   - **Visibility / view purity**: safety enforces that `#[view]`
+///     functions can't write state and contracts have at most one
+///     `#[constructor]`.
+///   - **Audit 356 selector collisions**: typecheck rejects two
+///     functions whose FNV-1a-32 selectors collide; the lax path
+///     would emit a contract whose dispatch table can only call
+///     one of the two.
+///
+/// All those checks now run by default via this function.
+pub fn compile_all(
+    src: &str,
+) -> Result<Vec<(String, codegen::CompiledContract)>, String> {
+    // Lex.
+    let (tokens, lex_errors) = lexer::Lexer::new(src).tokenize();
+    if !lex_errors.is_empty() {
+        let diagnostics: Vec<diagnostic::Diagnostic> = lex_errors
+            .iter()
+            .map(|err| diagnostic::Diagnostic {
+                level: diagnostic::Level::Error,
+                message: format!("lex error: {:?}", err),
+                file: "<input>".into(),
+                line: 0,
+                col: 0,
+            })
+            .collect();
+        return Err(diagnostic::format_diagnostics(&diagnostics, src));
+    }
+
+    // Parse.
+    let (file, parse_errors) = parser::Parser::new(tokens).parse();
+    if !parse_errors.is_empty() {
+        let diagnostics: Vec<diagnostic::Diagnostic> = parse_errors
+            .iter()
+            .map(|err| diagnostic::Diagnostic {
+                level: diagnostic::Level::Error,
+                message: format!("parse error: {:?}", err),
+                file: "<input>".into(),
+                line: 0,
+                col: 0,
+            })
+            .collect();
+        return Err(diagnostic::format_diagnostics(&diagnostics, src));
+    }
+
+    // Helper: collect diagnostics from any frontend pass + bail if
+    // non-empty. `errors` is a Vec of types that all expose
+    // `.message: String` and `.span: token::Span` — the three
+    // frontend passes have nearly-identical error shapes, so this
+    // closure absorbs the boilerplate.
+    fn fail_if<E>(
+        errors: &[E],
+        src: &str,
+        get: impl Fn(&E) -> (String, u32, u32),
+    ) -> Result<(), String> {
+        if errors.is_empty() {
+            return Ok(());
+        }
+        let diagnostics: Vec<diagnostic::Diagnostic> = errors
+            .iter()
+            .map(|err| {
+                let (message, line, col) = get(err);
+                diagnostic::Diagnostic {
+                    level: diagnostic::Level::Error,
+                    message,
+                    file: "<input>".into(),
+                    line,
+                    col,
+                }
+            })
+            .collect();
+        Err(diagnostic::format_diagnostics(&diagnostics, src))
+    }
+
+    // Pass 1 — name resolution. Catches undefined identifiers,
+    // duplicate definitions, scope violations.
+    let resolve_result = resolve::Resolver::new().resolve(&file);
+    fail_if(&resolve_result.errors, src, |e| {
+        (e.message.clone(), e.span.line, e.span.col)
+    })?;
+
+    // Pass 2 — type check. Catches type mismatches, audit-354 signed
+    // integers, audit-356 selector collisions, ABI shape errors.
+    let tc_result = typecheck::TypeChecker::new().check(&file);
+    fail_if(&tc_result.errors, src, |e| {
+        (e.message.clone(), e.span.line, e.span.col)
+    })?;
+
+    // Pass 3 — safety. Catches view-purity violations, multiple
+    // constructors, attribute misuse.
+    let safety_result = safety::SafetyChecker::new().check(&file);
+    fail_if(&safety_result.errors, src, |e| {
+        (e.message.clone(), e.span.line, e.span.col)
+    })?;
+
+    // All frontend passes clean — lower + optimize + codegen.
+    Ok(compile_all_unchecked(src))
 }

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1222,9 +1222,47 @@ impl Lowerer {
                     Expr::Ident(ident) if ident.name == "hash" => {
                         self.emit(Inst::Hash(dst, arg_regs));
                     }
-                    // address(self)
+                    // address(...) — three cases the typechecker
+                    // accepts (audit 405):
+                    //   * `address(self)` → emit `AddressOfSelf`.
+                    //   * `address(<contract_or_interface_handle>)` →
+                    //     identity copy. The handle is stored as the
+                    //     32-byte address in its register, so we emit
+                    //     a `Move` from the arg register into `dst`.
+                    //   * `address(<address-typed-expr>)` → identity
+                    //     copy. Same reason.
+                    //
+                    // Pre-audit-405 this branch always emitted
+                    // `AddressOfSelf` regardless of argument, which
+                    // silently produced wrong bytecode whenever the
+                    // typechecker's lax (compile_all_unchecked) path
+                    // let `address(child)` through — the factory got
+                    // its OWN address back instead of the deployed
+                    // child's. The strict path now rejects that
+                    // shape early, but the canonical factory pattern
+                    // (capture the deployed child's address) needs
+                    // this branch to copy the handle's register.
                     Expr::Ident(ident) if ident.name == "address" => {
-                        self.emit(Inst::Builtin(dst, BuiltinOp::AddressOfSelf));
+                        let is_self_arg = args
+                            .first()
+                            .map(|a| matches!(a, Expr::SelfExpr(_)))
+                            .unwrap_or(false);
+                        if is_self_arg {
+                            self.emit(Inst::Builtin(dst, BuiltinOp::AddressOfSelf));
+                        } else if let Some(src_reg) = arg_regs.first() {
+                            // Wide → Wide cast in codegen lowers to a
+                            // `Wmov` (or no-op if dst == src after
+                            // register allocation). Contract /
+                            // Interface handles + Address all share
+                            // the 32-byte wide-register layout, so
+                            // the copy preserves the deployed-child
+                            // address bits exactly.
+                            self.emit(Inst::Cast(dst, *src_reg, Ty::Address));
+                        } else {
+                            // No args — degenerate; let the typechecker
+                            // surface the error and emit a no-op blob.
+                            self.emit(Inst::Builtin(dst, BuiltinOp::AddressOfSelf));
+                        }
                     }
                     // gas_remaining()
                     Expr::Ident(ident) if ident.name == "gas_remaining" => {

--- a/crates/otic/src/main.rs
+++ b/crates/otic/src/main.rs
@@ -152,7 +152,13 @@ fn cmd_build(path: &str) {
 
     // Multi-contract compilation: compile all contracts in the file.
     // Later contracts can reference earlier ones via create!(ContractName, args).
-    let results = otic::compile_all(&src);
+    //
+    // Audit 404: this binary already ran the full frontend (resolve +
+    // typecheck + safety) inside `run_frontend(path)` above, so we
+    // intentionally use the lax `compile_all_unchecked` here to avoid
+    // re-running the same checks. The strict `compile_all` is for
+    // callers that haven't yet run the frontend separately.
+    let results = otic::compile_all_unchecked(&src);
 
     if results.is_empty() {
         eprintln!("error: no contracts found in {}", path);

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -1243,10 +1243,8 @@ impl TypeChecker {
                             } else if let Some(arg) = args.first() {
                                 let is_self = matches!(arg, Expr::SelfExpr(_));
                                 let arg_ty = &arg_types[0];
-                                let is_contract_or_iface = matches!(
-                                    arg_ty,
-                                    Ty::Contract(_) | Ty::Interface(_)
-                                );
+                                let is_contract_or_iface =
+                                    matches!(arg_ty, Ty::Contract(_) | Ty::Interface(_));
                                 if !is_self
                                     && !is_contract_or_iface
                                     && *arg_ty != Ty::Address

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -1219,20 +1219,43 @@ impl TypeChecker {
                             return Ty::Array(Box::new(Ty::U8), 32);
                         }
                         if ident.name == "address" {
-                            // address() only accepts self or Address-typed arguments
+                            // address() accepts:
+                            //   - `self` (returns this contract's address)
+                            //   - an Address-typed expression (no-op, identity)
+                            //   - a Contract/Interface handle (audit 405; the
+                            //     handle stores a 32-byte address internally,
+                            //     so coercing to Address is a register-copy
+                            //     in the lowerer). Without this case, the
+                            //     canonical factory pattern
+                            //     `let child = deploy!(Helper); address(child)`
+                            //     was rejected even though the lower pass
+                            //     already emits a contract handle that IS
+                            //     the deployed child's address. Pre-audit-
+                            //     405 this only worked through the lax
+                            //     `compile_all_unchecked` path which produced
+                            //     INCORRECT bytecode (the lowerer emitted
+                            //     `AddressOfSelf` for any `address(...)`
+                            //     call, regardless of argument — so the
+                            //     factory got its OWN address back rather
+                            //     than the child's). Fixed in lower.rs.
                             if args.len() != 1 {
                                 self.error("address() takes exactly one argument".into(), *span);
                             } else if let Some(arg) = args.first() {
                                 let is_self = matches!(arg, Expr::SelfExpr(_));
                                 let arg_ty = &arg_types[0];
+                                let is_contract_or_iface = matches!(
+                                    arg_ty,
+                                    Ty::Contract(_) | Ty::Interface(_)
+                                );
                                 if !is_self
+                                    && !is_contract_or_iface
                                     && *arg_ty != Ty::Address
                                     && *arg_ty != Ty::Unknown
                                     && *arg_ty != Ty::Error
                                 {
                                     self.error(
                                         format!(
-                                            "address() expects 'self' or an Address, found {}. Use Address::ZERO for zero address",
+                                            "address() expects 'self', an Address, or a Contract/Interface handle, found {}. Use Address::ZERO for zero address",
                                             arg_ty
                                         ),
                                         *span,
@@ -2775,7 +2798,7 @@ mod tests {
             }
         "#,
         );
-        assert!(errors[0].message.contains("expects 'self' or an Address"));
+        assert!(errors[0].message.contains("expects 'self'"));
     }
 
     #[test]
@@ -2789,7 +2812,7 @@ mod tests {
             }
         "#,
         );
-        assert!(errors[0].message.contains("expects 'self' or an Address"));
+        assert!(errors[0].message.contains("expects 'self'"));
     }
 
     #[test]
@@ -2801,6 +2824,39 @@ mod tests {
                 pub fn f() {
                     let sender = msg.sender;
                     let addr = address(sender);
+                }
+            }
+        "#,
+        );
+    }
+
+    /// Audit 405 regression: `address(<contract handle>)` must
+    /// typecheck. Pre-fix the canonical factory pattern
+    /// (`let child = deploy!(Helper); let a = address(child);`)
+    /// was rejected with "expects 'self' or an Address" even though
+    /// the lowerer already produced a 32-byte address handle for
+    /// the deploy!() result. The lax compile path silently let it
+    /// through and generated WRONG bytecode (the factory got its
+    /// own address back instead of the child's).
+    #[test]
+    fn check_address_of_contract_handle_audit_405() {
+        check_ok(
+            r#"
+            contract Child {
+                #[constructor]
+                pub fn init() {}
+            }
+            contract Parent {
+                storage {
+                    children: Vec<Address>,
+                }
+                #[constructor]
+                pub fn init() {}
+                pub fn spawn() -> Address {
+                    let c = deploy!(Child);
+                    let a = address(c);
+                    self.children.push(a);
+                    return a;
                 }
             }
         "#,

--- a/crates/pyde-crypto-wasm/src/lib.rs
+++ b/crates/pyde-crypto-wasm/src/lib.rs
@@ -788,6 +788,55 @@ mod tests {
         assert_eq!(decoded.encrypted_len(), payload.len());
     }
 
+    /// REGRESSION GUARD for the bombard 100% encrypted-tx drop.
+    ///
+    /// The existing `threshold_encrypt_primitive_roundtrips` test
+    /// only verifies that the WASM-produced ciphertext bytes can
+    /// be DECODED by the real wire-format reader. It does NOT
+    /// verify that the ciphertext can actually be DECRYPTED back
+    /// to the original payload using threshold shares — exactly
+    /// the path the validator committee runs at canonical-apply.
+    /// That gap is what let the WASM ship producing ciphertexts
+    /// that decoded fine but failed the MAC check 100% of the
+    /// time.
+    ///
+    /// This test closes that gap: encrypt via WASM, decode via
+    /// the real reader, generate decryption shares from the
+    /// committee shares, combine them, and assert the recovered
+    /// plaintext matches the original.
+    #[test]
+    fn wasm_encrypt_then_real_decrypt_with_shares() {
+        let (tpk, key_shares) = threshold_keygen(4, 3).unwrap();
+        let payload = b"end-to-end encrypt-then-decrypt-with-shares smoke test";
+
+        // WASM-side encryption — same path the TS bombard / SDK
+        // uses through `threshold_encrypt` / `buildRawEncryptedTx`.
+        let ct_hex = threshold_encrypt_wasm(
+            &format!("0x{}", hex::encode(tpk.to_bytes())),
+            &format!("0x{}", hex::encode(payload)),
+        )
+        .unwrap();
+        let ct_bytes = hex::decode(ct_hex.trim_start_matches("0x")).unwrap();
+        let ct = pyde_crypto::threshold::ThresholdCiphertext::from_wire_bytes(&ct_bytes)
+            .expect("real decoder must accept WASM ciphertext");
+
+        // Validator-side: every share-holder produces a decryption
+        // share for this ciphertext, then any THRESHOLD of them
+        // combine to recover plaintext. Mirrors the on-chain
+        // `BlockDecryptor::decrypt_all` flow, minus the FALCON
+        // re-verify and tx-execution scaffolding.
+        let shares: Vec<pyde_crypto::threshold::DecryptionShare> = key_shares[..3]
+            .iter()
+            .map(|ks| pyde_crypto::threshold::generate_decryption_share(ks, &ct))
+            .collect();
+        let plaintext = pyde_crypto::threshold::combine_shares(&shares, 3, &ct)
+            .expect("WASM ciphertext must decrypt with real shares");
+        assert_eq!(
+            plaintext, payload,
+            "WASM-encrypt + real-decrypt-with-shares must round-trip the original payload"
+        );
+    }
+
     // Negative-path testing (invalid threshold pubkey, bad hex, etc.)
     // is not run natively here: the workspace profile uses
     // `panic = "abort"`, and `wasm_bindgen` functions cannot unwind a

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -305,8 +305,14 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
             continue;
         }
 
-        // Compile
-        let contracts = otic::compile_all(source);
+        // Compile.
+        //
+        // Audit 404: `run_frontend` above already ran resolve +
+        // typecheck + safety on this source. Use the lax
+        // `compile_all_unchecked` so we don't repeat the same
+        // checks; if `run_frontend` had any failures we already
+        // continued past this contract via `had_errors = true`.
+        let contracts = otic::compile_all_unchecked(source);
         if contracts.is_empty() {
             println!("  {} — no contracts", rel.display());
             continue;

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -98,9 +98,17 @@ pub fn run(file: &str, network: &str, signer: &crate::signer::Signer) -> Result<
         return Err(format!("script has parse errors: {:?}", parse_errors[0]));
     }
 
-    // Compile script using compile_all (handles multi-contract files + inline deploy!).
-    // Merge build registry so deploy!(ImportedContract) also works.
-    let all_compiled = otic::compile_all(&source);
+    // Compile script using the strict pipeline (audit 404).
+    //
+    // Pre-fix this used `otic::compile_all` (the lax variant) which
+    // skipped resolve / typecheck / safety. Scripts that referenced
+    // undefined symbols, used signed integers (audit 354), or
+    // collided FNV-1a-32 selectors (audit 356) compiled silently to
+    // bytecode that produced wrong results at execution. The strict
+    // variant runs the full frontend; failures bubble up here as a
+    // formatted diagnostic the operator can act on.
+    let all_compiled = otic::compile_all(&source)
+        .map_err(|diagnostics| format!("script compilation failed:\n{}", diagnostics))?;
 
     // Find the target contract
     let target_name = contract_filter

--- a/crates/pyde-dev/src/signer.rs
+++ b/crates/pyde-dev/src/signer.rs
@@ -190,7 +190,10 @@ fn is_localhost(url: &str) -> bool {
         Err(_) => return false,
     };
     match parsed.host_str() {
-        Some(host) => matches!(host, "localhost" | "127.0.0.1" | "0.0.0.0" | "[::1]" | "::1"),
+        Some(host) => matches!(
+            host,
+            "localhost" | "127.0.0.1" | "0.0.0.0" | "[::1]" | "::1"
+        ),
         None => false,
     }
 }

--- a/crates/tx/src/parallel.rs
+++ b/crates/tx/src/parallel.rs
@@ -21,6 +21,41 @@ use crate::types::{AccessEntry, Transaction};
 use pyde_account::address::Address;
 use std::collections::{HashMap, HashSet};
 
+/// An access list is "uninformative" when it declares no concrete
+/// `(address, key)` pairs the scheduler can use for conflict detection.
+/// This covers two equivalent shapes:
+///
+///   1. The Vec is empty (`vec![]`) — the user opted out of declaring
+///      keys altogether.
+///   2. The Vec has `AccessEntry`s, but every entry's `reads` and
+///      `writes` are both empty — the user named addresses they
+///      touch but didn't list any storage keys.
+///
+/// Both shapes mean the same thing semantically: "I touch storage,
+/// but I haven't told you which keys." The scheduler must treat
+/// uninformative txs as conflicting with everything; otherwise a
+/// caller declaring `[{addr, [], []}]` would slip past the
+/// "is_empty" check, contribute zero keys to the union-find, and
+/// land in its own parallel group — which is unsafe (e.g. multiple
+/// same-sender txs would race on `sender.nonce` since the implicit
+/// nonce-write is never declared in any AL).
+///
+/// Audit 407: `loadgen_soak`'s workload txs use shape (2) for every
+/// contract call (`[{contract, [], []}]`), which produced
+/// proposer/non-proposer state-root divergence the moment tx
+/// traffic hit a fresh 4-validator soak. The 4 non-proposers
+/// converged on the sequential single-group answer, the proposer
+/// produced a parallel-execution answer where all but the
+/// nonce-N tx reverted with `InvalidNonce` (each parallel group
+/// reads pre-block sender.nonce=N). After this fix, shape (2) is
+/// treated as shape (1) and unions with all other txs, restoring
+/// the safe sequential default.
+fn access_list_is_uninformative(access_list: &[AccessEntry]) -> bool {
+    access_list
+        .iter()
+        .all(|e| e.reads.is_empty() && e.writes.is_empty())
+}
+
 /// A group of conflicting transactions that must execute sequentially.
 /// Different groups are independent and can be proven in parallel.
 #[derive(Clone, Debug)]
@@ -104,9 +139,12 @@ impl UnionFind {
 ///
 /// Two txs touching the same contract but different keys are NOT conflicting.
 pub fn conflicts(tx_a: &Transaction, tx_b: &Transaction) -> bool {
-    // Transactions with empty access lists are treated as touching EVERYTHING.
-    // They must be sequential with all other txs (can't parallelize safely).
-    if tx_a.access_list.is_empty() || tx_b.access_list.is_empty() {
+    // A tx with no declared keys (empty AL or all-empty entries — see
+    // `access_list_is_uninformative`) is treated as touching EVERYTHING.
+    // It must be sequential with all other txs (can't parallelize safely).
+    if access_list_is_uninformative(&tx_a.access_list)
+        || access_list_is_uninformative(&tx_b.access_list)
+    {
         return true;
     }
 
@@ -182,10 +220,15 @@ pub fn schedule(txs: &[Transaction]) -> ExecutionSchedule {
         };
     }
 
-    // If NO txs have access lists, they're all potentially conflicting
-    // → put everything in one sequential group (safe default).
-    let has_any_access_list = txs.iter().any(|t| !t.access_list.is_empty());
-    if !has_any_access_list {
+    // If NO tx declared concrete (address, key) pairs, the scheduler
+    // has zero conflict information — every tx is "I touch storage,
+    // unspecified". Put everything in one sequential group (safe
+    // default). See `access_list_is_uninformative` for why an AL
+    // shaped `[{addr, [], []}]` counts the same as `vec![]` here.
+    let has_any_keyed_access_list = txs
+        .iter()
+        .any(|t| !access_list_is_uninformative(&t.access_list));
+    if !has_any_keyed_access_list {
         return ExecutionSchedule {
             groups: vec![ExecutionGroup {
                 tx_indices: (0..n).collect(),
@@ -200,14 +243,14 @@ pub fn schedule(txs: &[Transaction]) -> ExecutionSchedule {
     // When a second tx touches this key, we union them.
     let mut write_owners: HashMap<(Address, [u8; 32]), usize> = HashMap::new();
 
-    // Track the first empty-access-list tx to union all such txs together.
+    // Track the first uninformative-AL tx to union all such txs together.
     let mut empty_representative: Option<usize> = None;
 
     for (i, tx) in txs.iter().enumerate() {
-        if tx.access_list.is_empty() {
-            // Empty access list = unknown keys = conflicts with everything.
-            // Union with the representative (and the representative unions with
-            // every keyed tx below).
+        if access_list_is_uninformative(&tx.access_list) {
+            // No declared keys = unknown = conflicts with everything.
+            // Union with the representative (and the representative unions
+            // with every keyed tx below).
             match empty_representative {
                 Some(rep) => uf.union(i, rep),
                 None => empty_representative = Some(i),
@@ -334,7 +377,11 @@ pub fn schedule_from_access_lists(access_lists: &[Vec<AccessEntry>]) -> Executio
     let mut empty_rep: Option<usize> = None;
 
     for (i, al) in access_lists.iter().enumerate() {
-        if al.is_empty() {
+        // Same uninformative-AL handling as `schedule()`. See
+        // `access_list_is_uninformative` for why a list shaped
+        // `[{addr, [], []}]` must be treated as no-info, not as a
+        // declared "I touch addr" hint.
+        if access_list_is_uninformative(al) {
             match empty_rep {
                 Some(rep) => uf.union(i, rep),
                 None => {
@@ -681,6 +728,135 @@ mod tests {
         let schedule = schedule(&txs);
         assert_eq!(schedule.group_count(), 1);
         assert_eq!(schedule.groups[0].tx_indices.len(), 3);
+    }
+
+    /// Audit 407 regression: an `AccessEntry` with empty `reads` and
+    /// empty `writes` is still a non-empty `Vec`, so the pre-fix
+    /// `t.access_list.is_empty()` check missed it. Each tx ended up
+    /// alone in its own component — proposers ran them in parallel,
+    /// non-proposers (whose compact-block reconstruct hard-codes a
+    /// single-group schedule) ran them sequentially, and the two
+    /// paths produced different post-block state under any
+    /// undeclared write (sender nonce being the universal example).
+    /// The fix treats this shape as no-info and unions everything.
+    #[test]
+    fn access_list_with_only_addresses_no_keys_unions_with_all() {
+        let mega_addr = {
+            let mut a = ZERO_ADDRESS;
+            a[0] = 0xAB;
+            a
+        };
+        let only_addr_no_keys = || {
+            vec![AccessEntry {
+                address: mega_addr,
+                reads: vec![],
+                writes: vec![],
+            }]
+        };
+        let txs = vec![
+            make_tx_with_access(only_addr_no_keys()),
+            make_tx_with_access(only_addr_no_keys()),
+            make_tx_with_access(only_addr_no_keys()),
+            make_tx_with_access(only_addr_no_keys()),
+        ];
+        let schedule = schedule(&txs);
+        assert_eq!(
+            schedule.group_count(),
+            1,
+            "AL=[{{addr,[],[]}}] is uninformative — all txs must serialize"
+        );
+        assert_eq!(schedule.groups[0].tx_indices.len(), 4);
+    }
+
+    /// Same as above but mixed: one tx declares a real write key,
+    /// the others use the empty-keys shape. The keyed tx must still
+    /// land in the single group with everyone else, because the
+    /// uninformative txs union with all.
+    #[test]
+    fn uninformative_unions_with_keyed_txs() {
+        let mega_addr = {
+            let mut a = ZERO_ADDRESS;
+            a[0] = 0xAB;
+            a
+        };
+        let txs = vec![
+            // One tx with a real declared write
+            make_tx_with_access(vec![write_access(0xCC, &[[0x42; 32]])]),
+            // Three txs with the soak-loadgen shape
+            make_tx_with_access(vec![AccessEntry {
+                address: mega_addr,
+                reads: vec![],
+                writes: vec![],
+            }]),
+            make_tx_with_access(vec![AccessEntry {
+                address: mega_addr,
+                reads: vec![],
+                writes: vec![],
+            }]),
+            make_tx_with_access(vec![AccessEntry {
+                address: mega_addr,
+                reads: vec![],
+                writes: vec![],
+            }]),
+        ];
+        let schedule = schedule(&txs);
+        assert_eq!(schedule.group_count(), 1);
+        assert_eq!(schedule.groups[0].tx_indices.len(), 4);
+    }
+
+    /// Same regression check via `schedule_from_access_lists` (the
+    /// path the encrypted-tx mempool block builder uses). Both
+    /// entry points must use identical uninformative-AL semantics
+    /// — otherwise the encrypted and plaintext schedules diverge
+    /// on the same workload.
+    #[test]
+    fn schedule_from_access_lists_treats_empty_keys_as_uninformative() {
+        let mega_addr = {
+            let mut a = ZERO_ADDRESS;
+            a[0] = 0xAB;
+            a
+        };
+        let als: Vec<Vec<AccessEntry>> = (0..4)
+            .map(|_| {
+                vec![AccessEntry {
+                    address: mega_addr,
+                    reads: vec![],
+                    writes: vec![],
+                }]
+            })
+            .collect();
+        let schedule = schedule_from_access_lists(&als);
+        assert_eq!(schedule.group_count(), 1);
+        assert_eq!(schedule.groups[0].tx_indices.len(), 4);
+    }
+
+    /// `conflicts(a, b)` must also treat the uninformative shape as
+    /// "conflicts with everything", matching the scheduler's
+    /// behavior. A pre-fix `is_empty()` check missed
+    /// `[{addr,[],[]}]` and reported "no conflict", which would
+    /// break any caller that uses pairwise conflict detection
+    /// instead of the union-find scheduler.
+    #[test]
+    fn conflicts_treats_uninformative_as_conflicting() {
+        let mega_addr = {
+            let mut a = ZERO_ADDRESS;
+            a[0] = 0xAB;
+            a
+        };
+        let tx_uninformative = make_tx_with_access(vec![AccessEntry {
+            address: mega_addr,
+            reads: vec![],
+            writes: vec![],
+        }]);
+        let tx_keyed = make_tx_with_access(vec![write_access(0xCC, &[[0x77; 32]])]);
+        assert!(
+            conflicts(&tx_uninformative, &tx_keyed),
+            "uninformative AL must conflict with any other tx"
+        );
+        assert!(
+            conflicts(&tx_keyed, &tx_uninformative),
+            "uninformative AL must conflict regardless of arg order"
+        );
     }
 
     #[test]

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -3287,7 +3287,7 @@ mod tests {
                 pub fn get_value() -> u64 { return self.value; }
             }
         "#;
-        let compiled = otic::compile_all(src);
+        let compiled = otic::compile_all_unchecked(src);
         assert!(!compiled.is_empty());
         let (_, contract) = &compiled[0];
 
@@ -3382,7 +3382,7 @@ mod tests {
                 pub fn set_value(v: u64) { self.value = v; }
             }
         "#;
-        let compiled = otic::compile_all(src);
+        let compiled = otic::compile_all_unchecked(src);
         let (_, contract) = &compiled[0];
 
         let clen = contract.constructor_bytecode.len() as u32;
@@ -3468,7 +3468,7 @@ mod tests {
                 pub fn increment() { self.count = self.count + 1; }
             }
         "#;
-        let compiled = otic::compile_all(src);
+        let compiled = otic::compile_all_unchecked(src);
         let (_, contract) = &compiled[0];
 
         let clen = contract.constructor_bytecode.len() as u32;


### PR DESCRIPTION
## Summary

Original 404/405 strict-compile work (commit `988be86`) plus five
coupled fixes that piled up while soaking the same branch:

- **404, 405 — strict-compile frontend** (`988be86`, original scope).
  `otic::compile_all` runs the full frontend; `pyde-dev script` migrated;
  `address(<contract handle>)` typechecks and lowers to a register copy.
- **406, 408 — consensus determinism wave** (`37fdadf`). Two coupled
  state-machine bugs the 4-validator soak surfaced.
  - PSS canonical-subset apply (mirror of audit 403): under async gossip
    each node was applying a different "first `threshold`-of-N" subset,
    breaking threshold decryption every refresh. Fixed via
    `try_apply_pss_on_slot` slot-tick canonical apply +
    `start_committee_reshare` own-pool seeding for the cross-committee
    case.
  - Slot-anchored proposal timeouts: timeout for slot N now measures
    from `genesis_ts + N * block_time`, not the prior QC's wall-clock.
    View-change rate dropped from ~50 % to 0.24 % in the 8-min soak.
  - `tx_root`-gated synthesize-empty body fallback in three apply paths
    (own-vote-QC, RR-QC, ApplyCanonicalAfterQc); plus a
    `validate_block_body` gate at `BlockProcessor::process_block` so
    every apply path gets header↔body consistency.
- **407 — uninformative access lists** (`3d9df08`). `[{addr, [], []}]`
  shape was treated as a "declared" AL but contributed zero keys to the
  union-find — proposers parallelised, non-proposers serialised, slot-23+
  state divergence. `access_list_is_uninformative()` unifies empty-Vec
  and all-empty-keys cases.
- **TPL-201 — encrypted-tx gossip topic** (`4bf893f`).
  `topics::encrypted_transactions()` returned `pyde/encrypted_tx/1`
  while the dispatcher only matched `pyde/encrypted_transactions/1`,
  so every received encrypted-tx gossip silently fell into the
  unknown-topic branch. Aligned + cross-module round-trip test.
- **Whitepaper v0.9 draft** (`1f2c9d5`).
- **Cleanup** (`1367bc5`, `b5ecfaf`). Pre-existing rustfmt drift across
  8 production files + clippy fixups in `loadgen_soak.rs`; `.gitignore`
  for the launch tracker. These cleared the rustfmt + clippy gates the
  original PR was red on.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo audit` clean
- `cargo deny check` advisories / bans / licenses / sources ok (one
  stale-ignore warning for `RUSTSEC-2026-0119`, logged as TPL-109)
- `cargo test --lib` on the 6 touched crates: 729/729 pass
- 25-min 4-validator soak (audit 404/405 verification, still valid)
- 8-min soak with 408 anchor in place: 0.24 % view-change rate

## Follow-ups (not in this PR)

- Editorial pass on the whitepaper against shipped code (TPL-801..810)
- Wave 1 ops/docs items (TPL-101..113) and remaining T-0 blockers
  (TPL-202..209) — see `TESTNET_LAUNCH_TRACKER.md`
- Audit-354: typechecker rejects signed integers; codegen support
  (`Sdiv`/`Smod`/`Slt`/`Sgt`/`Sar`) is post-mainnet