### PR TITLE
fix: testnet launch ops cleanup (TPL-101..113)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,16 @@ node_modules/
 pyde-book/
 crates/pyde-rust-sdk/LIVE_TEST_PLAN.md
 crates/pyde-dev/CHEATCODES_ROADMAP.md
+
+# Internal planning + audit docs at repo root. AUDIT_FINDINGS{,_2}.md
+# are tracked in git but contain vulnerability detail that has no place
+# in a published image; the rest are gitignored locally and would only
+# leak via a developer-machine `docker build`. Either way, exclude.
+AUDIT_FINDINGS.md
+AUDIT_FINDINGS_2.md
+ROADMAP.md
+MAINNET_PLAN.md
+BENCH_PLAN.md
+BENCH_CONTRACTS.md
+EXPLORER_PLAN.md
+TESTNET_LAUNCH_TRACKER.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# Code ownership.
+#
+# Paths listed below require approval from the named owners before
+# merge. Security-critical surfaces (cryptography, consensus, state,
+# the PVM) need an extra pair of eyes; CI + dep config are ownership-
+# tagged so dependency / supply-chain changes can't slip through
+# unnoticed.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner — applies when no more-specific path matches.
+*                              @zarah-s
+
+# Cryptography: PQ primitives, threshold encryption, VRF, WASM bindings.
+/crates/crypto/                @zarah-s
+/crates/pyde-crypto-wasm/      @zarah-s
+
+# Consensus + slashing: HotStuff, finality, view changes, evidence.
+/crates/consensus/             @zarah-s
+/crates/slashing/              @zarah-s
+
+# State machine: JMT, witness generation, snapshots.
+/crates/state/                 @zarah-s
+
+# Pyde Virtual Machine + AOT compiler.
+/crates/pvm/                   @zarah-s
+/crates/aot/                   @zarah-s
+
+# Workspace dep + lint config — supply-chain surface.
+/Cargo.toml                    @zarah-s
+/Cargo.lock                    @zarah-s
+/deny.toml                     @zarah-s
+/.cargo/                       @zarah-s
+
+# CI + repository automation.
+/.github/                      @zarah-s

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot configuration.
+#
+# Three ecosystems are watched:
+#   - `cargo`  — Rust crate dependencies
+#   - `docker` — base images in `Dockerfile` and the compose files
+#   - `github-actions` — `uses:` references in workflows
+#
+# Schedule is weekly so we don't drown in PRs; auto-merge is NOT
+# enabled — every dep bump requires human review (especially for
+# `libp2p`, `aes-gcm`, `argon2`, `rocksdb` where supply-chain
+# compromise has high blast radius).
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - deps
+      - deps:rust
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 3
+    labels:
+      - deps
+      - deps:docker
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels:
+      - deps
+      - deps:ci
+    commit-message:
+      prefix: "chore(ci)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,7 +3156,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "otic"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "ethnum",
  "pyde-state",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-account"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "pyde-crypto",
  "pyde-state",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-aot"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-consensus"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "proptest",
  "pyde-account",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-crypto"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "falcon-rs",
  "ml-kem",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-crypto-wasm"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-dev"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-mempool"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "pyde-account",
  "pyde-crypto",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-net"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "futures",
  "getrandom 0.2.17",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-node"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-rust-sdk"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3749,11 +3749,11 @@ dependencies = [
 
 [[package]]
 name = "pyde-slashing"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 
 [[package]]
 name = "pyde-state"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-tx"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "ethnum",
  "hex",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "pyde-vm"
-version = "0.1.0"
+version = "0.1.0-testnet.1"
 dependencies = [
  "ethnum",
  "pyde-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,15 @@
 [workspace.package]
-# Inherited by each member crate via `license.workspace = true` in its
-# own [package] block. Apache-2.0 is the default for the Pyde codebase.
-# Rationale: compatible with MIT/BSD ecosystem deps, allows commercial
-# relicensing of forks, and is the choice of most post-quantum chains.
+# Inherited by each member crate via `license.workspace = true` /
+# `version.workspace = true` in their `[package]` blocks. Apache-2.0
+# is the default for the Pyde codebase. Rationale: compatible with
+# MIT/BSD ecosystem deps, allows commercial relicensing of forks, and
+# is the choice of most post-quantum chains.
 license = "Apache-2.0"
+# Single source of truth for the workspace-level version (TPL-113).
+# Bump per release; pre-release suffix `-testnet.N` follows semver
+# precedence rules so `cargo` orders `0.1.0-testnet.2` >
+# `0.1.0-testnet.1` < `0.1.0` (final release).
+version = "0.1.0-testnet.1"
 
 [workspace]
 resolver = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN chmod +x /docker/entrypoint.sh
 RUN mkdir -p /data /testnet
 ENV PYDE_DATADIR=/data
 
-EXPOSE 30303/udp 8545 9090
+EXPOSE 30303/udp 8545 8546 9090
+# 8545 — JSON-RPC; 8546 — WebSocket subscriptions (`rpc.port + 1`,
+# bound by `crates/node/src/node.rs`); 9090 — Prometheus metrics.
 
 ENTRYPOINT ["pyde"]
 CMD ["run", "--role", "validator", "--datadir", "/data", "--log-level", "info"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+Pyde is a post-quantum L1 blockchain headed for public testnet launch.
+Vulnerabilities in consensus, cryptography, state, networking, the PVM,
+or the public RPC surface can drain user funds, halt the chain, or
+compromise validator keys. We take them seriously.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security reports.**
+
+### Preferred channels
+
+1. **GitHub Security Advisory** —
+   <https://github.com/zarah-s/pyde/security/advisories/new>. Gives
+   us a private workspace to triage and patch before public
+   disclosure.
+2. **Email** — `security@zarah.systems`. PGP-encrypted reports
+   welcome; the public key fingerprint will be published alongside
+   the testnet launch announcement.
+
+### What to include
+
+- Affected version (commit hash or tag — `git rev-parse HEAD` from
+  your build).
+- A clear description of the vulnerability and its blast radius
+  (fund loss, fork, DoS, key disclosure, sandbox escape).
+- Reproduction steps or proof-of-concept code.
+- Suggested fix or mitigation, if you have one.
+
+### Response timeline
+
+- **Acknowledgement**: within 72 hours.
+- **Initial assessment** (severity + plan): within 7 days.
+- **Patch + coordinated disclosure**: target 30 days for critical
+  findings, 90 days for medium / low.
+
+We will keep you informed throughout and credit you in the disclosure
+unless you prefer to remain anonymous.
+
+## Scope
+
+**In scope:**
+
+- Consensus, mempool, state, networking, cryptography crates.
+- The `pyde` validator binary and the public RPC surface
+  (`pyde_*` JSON-RPC methods, WebSocket subscriptions).
+- The Pyde Virtual Machine + AOT compiler (`crates/pvm`,
+  `crates/aot`).
+- Otigen smart-contract toolchain (`crates/otic`, `crates/pyde-dev`).
+- Docker images and the production deployment artifacts in
+  `docker/` + `deploy/`.
+
+**Out of scope** (please do not file as security issues):
+
+- Third-party services (faucet UI, block explorer) — those have
+  their own repos and disclosure paths.
+- Issues in dependencies that have already been ratified upstream
+  and that we accept under documented exceptions in `deny.toml`.
+- Theoretical attacks without a viable exploitation path.
+- The local devnet / `--dev` mode (intentionally accepts unsigned
+  transactions for development; gated to `chain_id == 31337`).
+
+## Coordinated disclosure
+
+After a fix ships, we publish a GHSA entry and credit the reporter.
+We ask reporters not to publicize the issue until the patch is
+broadly adopted — typically 14 days post-release on testnet, 30
+days on mainnet once it launches.
+
+## Bug bounty
+
+A formal bug bounty programme will launch alongside the incentivized
+testnet. Critical findings reported between now and the bounty launch
+are eligible for retroactive payout — please report via the channels
+above and reference your report when the programme opens.

--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-account"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/aot/Cargo.toml
+++ b/crates/aot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-aot"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-consensus"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-crypto"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-mempool"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-net"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-node"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]

--- a/crates/node/src/keystore.rs
+++ b/crates/node/src/keystore.rs
@@ -4,8 +4,10 @@
 //! secret key on disk — anyone with read access to the data
 //! directory walks away with the signing key. This module
 //! provides AES-256-GCM encryption + key derivation via
-//! Poseidon2(passphrase || salt) so the validator key file
-//! is unreadable without the operator's passphrase.
+//! Argon2id(passphrase, salt) (audit 306) so the validator key
+//! file is unreadable without the operator's passphrase. The
+//! legacy v1 Poseidon2-KDF remains supported for one-shot
+//! transparent re-encryption of pre-audit-306 keystores.
 //!
 //! ## Format
 //!

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -16,15 +16,36 @@
 //!     check load / disk
 //!   - `pyde_state_commit_ms` p99 > 500 → SMT/RocksDB write
 //!     pressure
-use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use std::net::SocketAddr;
+
+/// Bucket scheme for every `*_ms` histogram (TPL-102).
+///
+/// The exporter default emits summary metrics (no `_bucket` series),
+/// but the operator dashboard at `deploy/grafana-pyde-testnet.json`
+/// queries `histogram_quantile(...)` over `_bucket` series. Without
+/// explicit buckets the p50/p95/p99 panels for
+/// `pyde_block_processing_ms` and `pyde_state_commit_ms` rendered
+/// blank — operator-blind during incidents.
+///
+/// Suffix-matching `_ms` rather than naming each histogram lets future
+/// `*_ms` additions inherit the scheme automatically. The spread
+/// covers happy-path block processing (~10–50 ms) through degraded
+/// state-commit latency (~1–2 s); 10 buckets keeps cardinality
+/// bounded for Prometheus storage.
+const MS_BUCKETS: &[f64] = &[
+    1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 200.0, 500.0, 1000.0, 2500.0,
+];
 
 /// Start the Prometheus metrics exporter on the given port.
 /// Returns the socket address it's bound to, or an error.
 pub fn init(port: u16) -> Result<SocketAddr, String> {
     let addr: SocketAddr = ([0, 0, 0, 0], port).into();
 
-    let builder = PrometheusBuilder::new().with_http_listener(addr);
+    let builder = PrometheusBuilder::new()
+        .with_http_listener(addr)
+        .set_buckets_for_metric(Matcher::Suffix("_ms".to_string()), MS_BUCKETS)
+        .map_err(|e| format!("set_buckets_for_metric: {}", e))?;
     builder
         .install()
         .map_err(|e| format!("failed to start metrics exporter on {}: {}", addr, e))?;

--- a/crates/otic/Cargo.toml
+++ b/crates/otic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "otic"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/pvm/Cargo.toml
+++ b/crates/pvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-vm"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/pyde-crypto-wasm/Cargo.toml
+++ b/crates/pyde-crypto-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-crypto-wasm"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "WASM bindings for Pyde cryptographic primitives"
 

--- a/crates/pyde-dev/Cargo.toml
+++ b/crates/pyde-dev/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-dev"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Pyde smart contract development framework"
 

--- a/crates/pyde-rust-sdk/Cargo.toml
+++ b/crates/pyde-rust-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-rust-sdk"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Rust SDK for interacting with the Pyde blockchain"
 

--- a/crates/slashing/Cargo.toml
+++ b/crates/slashing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-slashing"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Shared slashing constants and evidence schema version for Pyde. Leaf crate with zero deps — intentionally kept minimal so both pyde-tx (slash-tx handler) and pyde-consensus (slash-result computation) can depend on it without creating a dep cycle."
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-state"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyde-tx"
 license.workspace = true
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,10 @@ targets = [
 [advisories]
 # Fail on any unhandled advisory. Known exceptions listed below with
 # explicit `ignore` entries that document *why* we accept the risk.
+#
+# Ignore list must stay in sync with `.cargo/audit.toml`'s `[advisories].ignore`.
+# The double-config is an artifact of cargo-audit and cargo-deny being
+# separate tools; both are wired into CI so both enforce the same policy.
 version = 2
 yanked = "warn"
 ignore = [
@@ -32,11 +36,16 @@ ignore = [
     # CVE; just no upstream maintainer. Same libp2p-upgrade blocker.
     "RUSTSEC-2025-0010", # ring <0.17 unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
+    "RUSTSEC-2024-0384", # instant 0.1.x unmaintained (via libp2p-gossipsub futures-ticker)
+    "RUSTSEC-2026-0002", # lru IterMut Stacked Borrows soundness (via libp2p-swarm)
 
     # Transitive via reqwest's DNS resolver. Pyde nodes connect to a
     # fixed set of RPC peers via hostname; DNS responses come from
     # validator-controlled resolvers, not arbitrary attacker-chosen
-    # ones. Tracked for the reqwest/hickory bump slice.
+    # ones. Tracked for the reqwest/hickory bump slice. cargo-deny
+    # currently reports this as `advisory-not-detected` (the active
+    # dep graph dropped the vulnerable hickory-proto path); kept as a
+    # defensive guard against re-introduction through another route.
     "RUSTSEC-2026-0119", # hickory-proto 0.24.x: O(n²) name compression DoS
 ]
 

--- a/deploy/grafana-pyde-testnet.json
+++ b/deploy/grafana-pyde-testnet.json
@@ -250,11 +250,11 @@
     {
       "type": "timeseries",
       "title": "RPC error rate (5m)",
-      "description": "pyde_rpc_requests_total{outcome=\"error\"} / total. Alert: > 5% sustained → see oncall.md § rpc-errors.",
+      "description": "pyde_rpc_requests_total{outcome=\"err\"} / total. Alert: > 5% sustained → see oncall.md § rpc-errors.",
       "datasource": {"type": "prometheus"},
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 50},
       "id": 15,
-      "targets": [{"expr": "sum(rate(pyde_rpc_requests_total{outcome=\"error\"}[5m])) / sum(rate(pyde_rpc_requests_total[5m]))", "legendFormat": "error rate", "refId": "A"}]
+      "targets": [{"expr": "sum(rate(pyde_rpc_requests_total{outcome=\"err\"}[5m])) / sum(rate(pyde_rpc_requests_total[5m]))", "legendFormat": "error rate", "refId": "A"}]
     }
   ],
   "refresh": "10s",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
       - testnet-data:/testnet
       - node0-data:/data
     ports:
+      # RPC + WS (host port 1854N to avoid colliding with the
+      # per-node RPC mappings on 8545-8548) + Prometheus.
       - "8545:8545"
+      - "18546:8546"
       - "9090:9090"
     networks:
       pyde-net:
@@ -42,6 +45,7 @@ services:
       - node1-data:/data
     ports:
       - "8546:8546"
+      - "18547:8547"
       - "9091:9091"
     depends_on:
       - node-0
@@ -60,6 +64,7 @@ services:
       - node2-data:/data
     ports:
       - "8547:8547"
+      - "18548:8548"
       - "9092:9092"
     depends_on:
       - node-0
@@ -78,6 +83,7 @@ services:
       - node3-data:/data
     ports:
       - "8548:8548"
+      - "18549:8549"
       - "9093:9093"
     depends_on:
       - node-0

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -22,12 +22,16 @@ services:
       - NODE_INDEX=0
       - VALIDATORS=4
       - DEV_MODE=false
-      - CHAIN_ID=1
+      - CHAIN_ID=7331
     volumes:
       - testnet-data:/testnet
       - node0-data:/data
     ports:
+      # RPC + WS + fast-tx + Prometheus.
+      # WS uses host-port 1854N to avoid colliding with the
+      # per-node RPC mappings on host ports 8545-8548.
       - "8545:8545"
+      - "18546:8546"
       - "9545:9545"
       - "9090:9090"
     networks:
@@ -40,11 +44,13 @@ services:
     environment:
       - NODE_INDEX=1
       - DEV_MODE=false
+      - CHAIN_ID=7331
     volumes:
       - testnet-data:/testnet
       - node1-data:/data
     ports:
       - "8546:8546"
+      - "18547:8547"
       - "9546:9546"
       - "9091:9091"
     depends_on:
@@ -59,11 +65,13 @@ services:
     environment:
       - NODE_INDEX=2
       - DEV_MODE=false
+      - CHAIN_ID=7331
     volumes:
       - testnet-data:/testnet
       - node2-data:/data
     ports:
       - "8547:8547"
+      - "18548:8548"
       - "9547:9547"
       - "9092:9092"
     depends_on:
@@ -78,11 +86,13 @@ services:
     environment:
       - NODE_INDEX=3
       - DEV_MODE=false
+      - CHAIN_ID=7331
     volumes:
       - testnet-data:/testnet
       - node3-data:/data
     ports:
       - "8548:8548"
+      - "18549:8549"
       - "9548:9548"
       - "9093:9093"
     depends_on:
@@ -112,7 +122,7 @@ services:
           --private-key /testnet/faucet.key \
           --port 8080 \
           --amount 100 \
-          --cooldown 3600
+          --cooldown 86400
     volumes:
       - testnet-data:/testnet
     ports:
@@ -138,7 +148,9 @@ services:
         CONF
         /bin/prometheus --config.file=/tmp/prometheus.yml --storage.tsdb.path=/prometheus
     ports:
-      - "9999:9090"
+      # Prometheus has no built-in auth; bind to loopback only so
+      # the operator must explicitly tunnel / front-proxy to view it.
+      - "127.0.0.1:9999:9090"
     depends_on:
       - node-0
     networks:
@@ -147,8 +159,11 @@ services:
   grafana:
     image: grafana/grafana:latest
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_AUTH_ANONYMOUS_ENABLED=true
+      # Operator MUST set GRAFANA_ADMIN_PASSWORD before `up`. No
+      # default — the prior literal `admin` here was a public-internet
+      # rake on the production compose.
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      - GF_AUTH_ANONYMOUS_ENABLED=false
     ports:
       - "3000:3000"
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,10 @@ services:
       - testnet-data:/testnet
       - node0-data:/data
     ports:
+      # RPC + WS (host port 1854N to avoid colliding with the
+      # per-node RPC mappings on 8545-8548) + Prometheus.
       - "8545:8545"
+      - "18546:8546"
       - "9090:9090"
     networks:
       pyde-net:
@@ -38,6 +41,7 @@ services:
       - node1-data:/data
     ports:
       - "8546:8546"
+      - "18547:8547"
       - "9091:9091"
     depends_on:
       - node-0
@@ -56,6 +60,7 @@ services:
       - node2-data:/data
     ports:
       - "8547:8547"
+      - "18548:8548"
       - "9092:9092"
     depends_on:
       - node-0
@@ -74,6 +79,7 @@ services:
       - node3-data:/data
     ports:
       - "8548:8548"
+      - "18549:8549"
       - "9093:9093"
     depends_on:
       - node-0

--- a/docs/connect-to-testnet.md
+++ b/docs/connect-to-testnet.md
@@ -87,7 +87,7 @@ Edit `~/.pyde-testnet/config.toml`:
 ```toml
 [node]
 role = "full"
-chain_id = 1   # mainnet placeholder; testnet chain_id will be published at launch
+chain_id = 7331   # public testnet (`TESTNET_CHAIN_ID`)
 datadir = "/home/<you>/.pyde-testnet"
 dev_mode = false
 
@@ -253,11 +253,11 @@ Check peer count via the Prometheus metric on
 `http://127.0.0.1:9090/metrics`:
 
 ```sh
-curl -s http://127.0.0.1:9090/metrics | grep '^pyde_peers '
-# → pyde_peers 4
+curl -s http://127.0.0.1:9090/metrics | grep '^pyde_peers_connected '
+# → pyde_peers_connected 4
 ```
 
-If `pyde_peers == 0`, your bootstrap multiaddrs are wrong or your
+If `pyde_peers_connected == 0`, your bootstrap multiaddrs are wrong or your
 firewall is blocking outbound TCP/30303 (and UDP/30303 for QUIC).
 The `pyde_block_lag` gauge tells you how many slots behind the
 network tip you currently are.

--- a/docs/connect-to-testnet.md
+++ b/docs/connect-to-testnet.md
@@ -21,7 +21,7 @@ faucet, and submitting your first transaction.
 
 ## 1. Get the binary
 
-### Option A — build from source
+Build from source:
 
 ```sh
 git clone https://github.com/zarah-s/pyde
@@ -30,16 +30,9 @@ cargo build --release
 # Binary lands at ./target/release/pyde
 ```
 
-### Option B — prebuilt release
-
-Download the latest `pyde-<version>-<os>-<arch>.tar.gz` from the
-GitHub releases page and extract `pyde` into `$PATH`.
-
-```sh
-tar -xzf pyde-<version>-linux-x86_64.tar.gz
-sudo mv pyde /usr/local/bin/
-pyde --version
-```
+> **Prebuilt binaries** will be published on the GitHub releases page
+> alongside the public-testnet launch announcement. Until then, build
+> from source.
 
 ## 2. Generate a node identity
 

--- a/docs/oncall.md
+++ b/docs/oncall.md
@@ -375,7 +375,7 @@ groups:
           runbook_url: "https://github.com/zarah-s/pyde/blob/main/docs/oncall.md#encrypted-mempool-grew"
 
       - alert: ReorgsHappening
-        expr: rate(pyde_reorgs_total{outcome="Succeeded"}[5m]) > 0
+        expr: rate(pyde_reorgs_total{outcome="succeeded"}[5m]) > 0
         for: 1m
         labels: {severity: warning, runbook: reorg}
         annotations:
@@ -392,7 +392,7 @@ groups:
 
       - alert: RpcErrorRateHigh
         expr: |
-          sum(rate(pyde_rpc_requests_total{outcome="error"}[5m])) /
+          sum(rate(pyde_rpc_requests_total{outcome="err"}[5m])) /
           sum(rate(pyde_rpc_requests_total[5m])) > 0.05
         for: 5m
         labels: {severity: warning, runbook: rpc-errors}

--- a/docs/run-validator.md
+++ b/docs/run-validator.md
@@ -49,7 +49,7 @@ Inspect the `# region: ... / # host: ...` header of your
 
 ## 2. Encrypt the validator key
 
-Pyde's keystore uses AES-256-GCM with a Poseidon2-derived key.
+Pyde's keystore uses AES-256-GCM with an Argon2id-derived key (`m=64 MiB, t=3, p=1`; audit 306).
 
 ```sh
 export PYDE_VALIDATOR_PASSPHRASE='your-strong-passphrase'
@@ -123,7 +123,7 @@ Pyde exposes Prometheus metrics on the configured port (default
 ```
 pyde_block_lag                 # network_tip - head_slot. Alert > 10.
 pyde_finality_lag              # slots since last hard-finality. Alert > 100.
-pyde_peers                     # connected libp2p peers. Alert < 4.
+pyde_peers_connected           # connected libp2p peers. Alert < 4.
 pyde_block_processing_ms       # p99 block-execution latency.
 pyde_state_commit_ms           # SMT/RocksDB commit p99.
 pyde_validator_missed_proposals_total  # missed proposal slots (audit 222).


### PR DESCRIPTION
## Summary

13 fixes across the operational layer that gate a public-testnet
launch announcement — alerts that never fire, dashboards that render
blank, docs that don't match shipped behaviour, container defaults
that leak admin credentials, missing disclosure path, and the
workspace version bump.

### Code-level

- **TPL-102** (`af3780f`) — Configure Prometheus histogram buckets
  for `*_ms` metrics so the operator dashboard's p50/p95/p99 latency
  panels actually render.

### Docs / dashboards / runbook

- **TPL-101** (`0065ca8`) — Reorg + RPC alert labels in
  `docs/oncall.md` and `deploy/grafana-pyde-testnet.json` aligned to
  the lowercase short codes the metrics emitter actually writes
  (`succeeded`, `err`).
- **TPL-105/106/107** (`bdb11a3`) — `docs/connect-to-testnet.md`
  config example uses `chain_id = 7331` (canonical
  `TESTNET_CHAIN_ID`); `docs/run-validator.md` keystore line says
  Argon2id (audit 306) instead of Poseidon2; metric name corrected
  `pyde_peers` → `pyde_peers_connected` in 4 spots; `keystore.rs`
  module-doc-comment also updated.
- **TPL-108** (`c877c65`) — Removed the "Option B — prebuilt
  release" section that pointed at non-existent GitHub release
  artifacts.

### Container / deployment

- **TPL-104** (`4a39eaf`) — `Dockerfile` `EXPOSE` now includes
  `8546` (WS subscriptions on `rpc.port + 1`); all three compose
  files map each node's WS at host port `1854N` to avoid collisions
  with per-node RPC mappings on `8545-8548`.
- **TPL-103 partial** (`4a39eaf`) — Production compose:
  `CHAIN_ID=7331` on every node, env-var-required Grafana admin
  password (no `admin` default), Grafana anonymous disabled,
  Prometheus port bound to `127.0.0.1` (no built-in auth).
  Healthcheck / non-root user / cap_drop / read_only deferred as
  TPL-103a (needs Dockerfile changes).
- **TPL-111** (`4a39eaf`) — Faucet `--cooldown 3600` →
  `--cooldown 86400` (24h).
- **TPL-110** (`71c5036`) — `.dockerignore` excludes 8 internal
  planning + audit docs (~380 KB) from the build context.

### Security + supply-chain

- **TPL-109** (`5626ec5`) — Synced `.cargo/audit.toml` ⇄
  `deny.toml` ignore lists (added `RUSTSEC-2024-0384` instant +
  `RUSTSEC-2026-0002` lru to `deny.toml`).
- **TPL-112** (`c875824`) — New `SECURITY.md` (disclosure path,
  scope, response SLA), `.github/dependabot.yml` (cargo + docker +
  actions, weekly/monthly), `.github/CODEOWNERS` (security-critical
  paths owned by `@zarah-s`).

### Versioning

- **TPL-113 partial** (`98bfe48`) — `version.workspace = true`
  across all 15 crates, `[workspace.package].version =
  "0.1.0-testnet.1"`. Single source of truth. `git_describe` embed
  deferred as TPL-113a.

## Verification (local — CI is currently billing-blocked)

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo audit` clean
- `cargo deny check` advisories / bans / licenses / sources ok
- `cargo check --workspace --all-targets` clean
- `cargo test --lib` on the 6 modified crates: 729/729 pass

## Follow-ups (logged in the launch tracker)

- `TPL-103a` — production-compose Dockerfile additions (non-root
  user, `curl` for healthcheck, `cap_drop`, `read_only`)
- `TPL-108a` — real release pipeline (`cargo dist`)
- `TPL-109a` — CI job that diffs audit/deny ignore lists
- `TPL-111a` — `--trust-x-forwarded-for` operator docs
- `TPL-113a` — `git_describe` embed via `vergen` / `build.rs`

## What's next

This PR closes Wave 1 (ops + docs that gate the launch
announcement). Wave 2 (T-0 code blockers — TPL-202..209:
`select_and_vote` slot-vs-target, AOT `host_load` fork, `fast_tx`
defaults, balance overflow, etc.) is consensus / PVM / Otigen
surface — separate branch.