### PR TITLE
fix: launch blockers wave 2 — TPL-202..209

### DIFF
--- a/crates/aot/src/codegen.rs
+++ b/crates/aot/src/codegen.rs
@@ -121,11 +121,16 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
     // Declare host function signatures in the module
-    // host_load(ctx, addr, width) -> u64
+    // host_load(ctx, addr, width, trap_out) -> u64
+    // TPL-202: trap_out is an explicit fault channel. Pre-fix
+    // host_load returned u64::MAX on fault, which collided with a
+    // legitimate load64 of 0xFFFF_FFFF_FFFF_FFFF and produced an
+    // AOT-vs-interpreter divergence (consensus fork vector).
     let mut sig_load = module.make_signature();
     sig_load.params.push(AbiParam::new(ptr_type));
     sig_load.params.push(AbiParam::new(I64));
     sig_load.params.push(AbiParam::new(I64));
+    sig_load.params.push(AbiParam::new(ptr_type));
     sig_load.returns.push(AbiParam::new(I64));
     let fn_load = module
         .declare_function("host_load", Linkage::Import, &sig_load)
@@ -215,13 +220,30 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
         .declare_function("host_push", Linkage::Import, &sig_push)
         .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
-    // host_pop(ctx) -> u64
+    // host_pop(ctx, trap_out) -> u64
+    // TPL-202: trap_out is an explicit fault channel — see
+    // host_load above. Without it, an AOT-side `Pop` of a stack
+    // slot containing `0xFFFF_FFFF_FFFF_FFFF` trapped while the
+    // interpreter accepted the value.
+    //
+    // host_pop has its own signature (`sig_pop_with_trap`)
+    // distinct from `sig_pop` (the historical `(ctx) -> u64`
+    // shape still used by the env-query host fns below —
+    // host_block_number, host_timestamp, etc).
+    let mut sig_pop_with_trap = module.make_signature();
+    sig_pop_with_trap.params.push(AbiParam::new(ptr_type));
+    sig_pop_with_trap.params.push(AbiParam::new(ptr_type));
+    sig_pop_with_trap.returns.push(AbiParam::new(I64));
+    let fn_pop = module
+        .declare_function("host_pop", Linkage::Import, &sig_pop_with_trap)
+        .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
+
+    // sig_pop: shared `(ctx) -> u64` shape for env-query host fns
+    // (host_block_number, host_timestamp, host_gas_remaining,
+    // host_tx_nonce, host_tx_gas_limit, host_drain_page_gas).
     let mut sig_pop = module.make_signature();
     sig_pop.params.push(AbiParam::new(ptr_type));
     sig_pop.returns.push(AbiParam::new(I64));
-    let fn_pop = module
-        .declare_function("host_pop", Linkage::Import, &sig_pop)
-        .map_err(|e| CodegenError::CompilationFailed(e.to_string()))?;
 
     // Environment host functions: (ctx) -> u64
     // host_caller(ctx, wd) -> u64, host_address(ctx, wd) -> u64
@@ -755,17 +777,27 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         builder.switch_to_block(cont);
                     }
                     Opcode::Pop => {
+                        // TPL-202: same out-pointer pattern as Load.
+                        // Pre-fix this checked `result == u64::MAX`
+                        // and trapped on that, but a stack slot
+                        // containing `0xFFFF_FFFF_FFFF_FFFF` is a
+                        // legitimate value — the interpreter's
+                        // `Opcode::Pop` accepts it, so AOT-only
+                        // trapping was a fork.
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
-                        let call = builder.ins().call(fn_pop_ref, &[vm_ctx]);
+                        let z = builder.ins().iconst(I64, 0);
+                        builder.ins().stack_store(z, trap_flag_ss, 0);
+                        let trap_ptr = builder.ins().stack_addr(ptr_type, trap_flag_ss, 0);
+                        let call = builder.ins().call(fn_pop_ref, &[vm_ctx, trap_ptr]);
                         let result = builder.inst_results(call)[0];
                         emit_drain_page_gas!(builder);
-                        // Check for fault (u64::MAX)
-                        let is_err = builder.ins().icmp_imm(IntCC::Equal, result, -1i64);
+                        gp_write!(builder, d.rd, result);
+                        let flag = builder.ins().stack_load(I64, trap_flag_ss, 0);
+                        let trapped = builder.ins().icmp_imm(IntCC::NotEqual, flag, 0);
                         let cont = builder.create_block();
-                        builder.ins().brif(is_err, trap_block, &[], cont, &[]);
+                        builder.ins().brif(trapped, trap_block, &[], cont, &[]);
                         builder.seal_block(cont);
                         builder.switch_to_block(cont);
-                        gp_write!(builder, d.rd, result);
                     }
 
                     // --- Wide register ops (host calls) ---
@@ -929,6 +961,15 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
 
                     // --- Memory operations (host calls) ---
                     Opcode::Load => {
+                        // TPL-202: route the fault channel through
+                        // the shared `trap_flag_ss` slot. Pre-fix,
+                        // AOT wrote `host_load`'s return value
+                        // straight into the destination GP register
+                        // with NO trap check, so a memory fault
+                        // (interpreter trap) silently became a
+                        // u64::MAX register write on AOT — chain
+                        // fork on adversarial bytecode that hits an
+                        // OOB load.
                         let base = gp_read!(builder, d.rs1);
                         let offset = pyde_vm::isa::decode_mem_offset(d.rs2_or_imm) as i64;
                         let width = pyde_vm::isa::decode_mem_width(d.rs2_or_imm) as u64;
@@ -936,10 +977,21 @@ pub fn compile(program: &AnalyzedProgram) -> Result<CompiledCode, CodegenError> 
                         let addr = builder.ins().iadd(base, off_val);
                         let w = builder.ins().iconst(I64, width as i64);
                         let vm_ctx = builder.use_var(Variable::from_u32(VAR_VM_CTX));
-                        let call = builder.ins().call(fn_load_ref, &[vm_ctx, addr, w]);
+                        let z = builder.ins().iconst(I64, 0);
+                        builder.ins().stack_store(z, trap_flag_ss, 0);
+                        let trap_ptr = builder.ins().stack_addr(ptr_type, trap_flag_ss, 0);
+                        let call = builder
+                            .ins()
+                            .call(fn_load_ref, &[vm_ctx, addr, w, trap_ptr]);
                         let result = builder.inst_results(call)[0];
                         emit_drain_page_gas!(builder);
                         gp_write!(builder, d.rd, result);
+                        let flag = builder.ins().stack_load(I64, trap_flag_ss, 0);
+                        let trapped = builder.ins().icmp_imm(IntCC::NotEqual, flag, 0);
+                        let cont = builder.create_block();
+                        builder.ins().brif(trapped, trap_block, &[], cont, &[]);
+                        builder.seal_block(cont);
+                        builder.switch_to_block(cont);
                     }
                     Opcode::Store => {
                         let base = gp_read!(builder, d.rs1);

--- a/crates/aot/src/host.rs
+++ b/crates/aot/src/host.rs
@@ -28,9 +28,22 @@ pub type VmCtx = Vm;
 
 // ── Memory operations ──────────────────────────────────────────────────
 
-/// Host: load from memory. Returns the value, or u64::MAX on fault.
-/// Width: 0=8bit, 1=16bit, 2=32bit, 3=64bit
-pub extern "C" fn host_load(ctx: *mut VmCtx, addr: u64, width: u64) -> u64 {
+/// Host: load from memory. Returns the loaded value; writes the
+/// fault flag to `*trap_out` (0 = success, 1 = fault).
+/// Width: 0=8bit, 1=16bit, 2=32bit, 3=64bit.
+///
+/// TPL-202: pre-fix this packed both channels into the return —
+/// `u64::MAX` meant "fault" but was indistinguishable from a
+/// successful load64 of `0xFFFF_FFFF_FFFF_FFFF`. The interpreter's
+/// `Opcode::Load` traps on fault and writes the value on success;
+/// the AOT path took the return value at face value, so a faulted
+/// load and a successful load of `u64::MAX` ran the same code
+/// post-call. Either direction (legitimate u64::MAX silently
+/// dropped to a trap-equivalent on AOT, or a fault silently
+/// becoming a u64::MAX register write) was a consensus fork
+/// vector. Splitting the trap channel into a separate out-pointer
+/// matches the established `host_narrow` pattern.
+pub extern "C" fn host_load(ctx: *mut VmCtx, addr: u64, width: u64, trap_out: *mut u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file). The AOT JIT's callsite emission
     // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
@@ -42,11 +55,25 @@ pub extern "C" fn host_load(ctx: *mut VmCtx, addr: u64, width: u64) -> u64 {
         1 => vm.memory.load16(addr).map(|v| v as u64),
         2 => vm.memory.load32(addr).map(|v| v as u64),
         3 => vm.memory.load64(addr),
-        _ => return u64::MAX,
+        _ => {
+            // SAFETY: `trap_out` is a valid out-pointer provided by
+            // the AOT JIT (emitted alongside the call). See
+            // module-level pointer safety contract.
+            unsafe {
+                *trap_out = 1;
+            }
+            return 0;
+        }
     };
     match result {
         Ok(v) => v,
-        Err(_) => u64::MAX, // signal fault
+        Err(_) => {
+            // SAFETY: see above.
+            unsafe {
+                *trap_out = 1;
+            }
+            0
+        }
     }
 }
 
@@ -134,8 +161,17 @@ pub extern "C" fn host_push(ctx: *mut VmCtx, value: u64) -> u64 {
     }
 }
 
-/// Host: pop a 64-bit value from stack. Returns the value, u64::MAX on fault.
-pub extern "C" fn host_pop(ctx: *mut VmCtx) -> u64 {
+/// Host: pop a 64-bit value from stack. Returns the popped value;
+/// writes the fault flag to `*trap_out` (0 = success, 1 = fault).
+///
+/// TPL-202: same `u64::MAX`-as-sentinel divergence as `host_load`.
+/// Pre-fix, the AOT codegen for `Opcode::Pop` checked
+/// `result == u64::MAX` and trapped on that — but a stack slot
+/// containing `0xFFFF_FFFF_FFFF_FFFF` is a legitimate value, and
+/// the interpreter's `Opcode::Pop` accepts it. Two backends, two
+/// outcomes for the same bytecode → fork. The trap-out pointer
+/// keeps the value channel and the fault channel disjoint.
+pub extern "C" fn host_pop(ctx: *mut VmCtx, trap_out: *mut u64) -> u64 {
     // SAFETY: `ctx` is a valid `&mut Vm` per the module-level pointer
     // safety contract (top of file). The AOT JIT's callsite emission
     // in `aot/src/codegen.rs` loads a live VM pointer into the ABI's
@@ -147,7 +183,15 @@ pub extern "C" fn host_pop(ctx: *mut VmCtx) -> u64 {
             vm.memory.stack_pointer += 8;
             val
         }
-        Err(_) => u64::MAX,
+        Err(_) => {
+            // SAFETY: `trap_out` is a valid out-pointer provided by
+            // the AOT JIT (emitted alongside the call). See
+            // module-level pointer safety contract.
+            unsafe {
+                *trap_out = 1;
+            }
+            0
+        }
     }
 }
 

--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -320,6 +320,68 @@ mod tests {
         assert_gas_parity(&code, 1_000_000, "Push/Pop page-gas parity");
     }
 
+    /// TPL-202: pushing `u64::MAX` and popping it back must succeed
+    /// on both backends with the popped value preserved. Pre-fix,
+    /// AOT's `Opcode::Pop` checked `host_pop`'s return against
+    /// `u64::MAX` and trapped on a match — but `0xFFFF_FFFF_FFFF_FFFF`
+    /// is a perfectly legal stack value. Interpreter accepted it,
+    /// AOT trapped → fork. The trap-out pointer split keeps the
+    /// value channel and the fault channel disjoint.
+    #[test]
+    fn pop_u64_max_stack_value_does_not_trap_aot_tpl_202() {
+        // `Addi r1, r0, -1` materialises u64::MAX in r1 by
+        // sign-extension (i32::MIN .. i32::MAX wraps into the
+        // u64 top half).
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, -1),
+            instr_bytes(Opcode::Push, 1, 0, 0),
+            instr_bytes(Opcode::Pop, 2, 0, 0),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        // Direct AOT run: confirm it succeeds (not RESULT_TRAP) and
+        // r2 == u64::MAX. compare_with_interpreter would also work,
+        // but asserting RESULT_SUCCESS + value here makes the
+        // before/after distinction obvious in test output.
+        let (aot_status, _, regs) = run_aot(&code, 1_000_000);
+        assert_eq!(aot_status, RESULT_SUCCESS);
+        assert_eq!(regs[2], u64::MAX);
+        // Interpreter parity — same value emerges from the same
+        // bytecode under interpretation.
+        compare_with_interpreter(&code, 1_000_000);
+    }
+
+    /// TPL-202: the symmetrical case for `Opcode::Load` — a memory
+    /// fault must trap on AOT (matching the interpreter), even
+    /// though `host_load` no longer encodes the fault into its
+    /// return value. Pre-fix, AOT silently wrote `u64::MAX` to the
+    /// destination register on fault and continued executing while
+    /// the interpreter trapped → fork in the other direction.
+    /// Storing `u64::MAX` into a regular heap slot and loading it
+    /// back is exercised by the existing Load parity tests.
+    #[test]
+    fn load_oob_traps_on_aot_tpl_202() {
+        // r1 = a clearly-OOB address (top of u32 space). Word-wide
+        // load of 8 bytes from there must trap.
+        let code = bytecode(&[
+            instr_ri(Opcode::Addi, 1, 0, -8),
+            // Load r2 = mem[r1 + 0] (W64) — addr = u64::MAX-7,
+            // truncated to u32 = 0xFFFF_FFF8, OOB.
+            // mem-encoding: width=3 (W64) at the right bit position.
+            instr_bytes(
+                Opcode::Load,
+                2,
+                1,
+                pyde_vm::isa::encode_mem_immediate(0, pyde_vm::isa::MemWidth::W64).unwrap(),
+            ),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        let (aot_status, _, _) = run_aot(&code, 1_000_000);
+        assert_eq!(
+            aot_status, RESULT_TRAP,
+            "OOB Load on AOT must trap, not silently write u64::MAX"
+        );
+    }
+
     #[test]
     fn poseidon_aot_charges_page_gas_parity_with_interp() {
         // host_poseidon reads `len` bytes from memory via

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -808,6 +808,20 @@ impl BlockProcessor {
         // every slot regardless of VRF score, multiplying the
         // proposal-buffering surface and (via seen_proposals
         // dedup) the slashing-framing attack window.
+        //
+        // TPL-204 / audit-234 part 4 (CONSENSUS_INVARIANTS.md L2):
+        // pre-fix, the `len() >= 33` gate skipped the entire VRF
+        // block for fallback proofs (24 bytes — 8-byte marker + 16
+        // bytes of slot + view), and nothing else here checked them.
+        // The validator path enforces the
+        // `proposer == fallback_leader_index(slot, view, committee_size)`
+        // invariant in `buffer_fallback_proposal`, but the network
+        // block-apply path used by full nodes flows through
+        // `validate_network_block` and skipped that check entirely
+        // — so two valid Byzantine fallbacks at `(H, V)` both
+        // passed validation at full nodes, breaking the
+        // unique-leader invariant. Mirror the validator's check
+        // here.
         if header.vrf_proof.len() >= 33 {
             let vrf_output_bytes = &header.vrf_proof[..32];
             let vrf_proof_bytes = &header.vrf_proof[32..];
@@ -836,6 +850,54 @@ impl BlockProcessor {
                     committee_keys.len()
                 ));
             }
+        } else if pyde_consensus::view_change::is_fallback_proof(&header.vrf_proof) {
+            // Fallback proposal — the proposer must be the
+            // deterministic leader for `(slot, view-from-proof)`.
+            // The view comes from the proof, not from a local
+            // view counter, because honest full nodes don't track
+            // the proposer's view directly; they trust the proof
+            // because the deterministic leader formula and signed
+            // header together pin the outcome.
+            let (proof_slot, proof_view) =
+                match pyde_consensus::view_change::decode_fallback_proof(&header.vrf_proof) {
+                    Some(decoded) => decoded,
+                    None => {
+                        return Err(format!(
+                            "fallback proof at slot {} is malformed (audit-234 L2)",
+                            slot
+                        ));
+                    }
+                };
+            if proof_slot != slot {
+                return Err(format!(
+                    "fallback proof slot {} does not match header slot {} (audit-234 L2)",
+                    proof_slot, slot
+                ));
+            }
+            let expected_leader = pyde_consensus::view_change::fallback_leader_index(
+                slot,
+                proof_view,
+                committee_keys.len(),
+            );
+            if proposer_idx != expected_leader {
+                return Err(format!(
+                    "fallback proposer at committee index {} is not the deterministic \
+                     leader (expected {}) for (slot {}, view {}) (audit-234 L2)",
+                    proposer_idx, expected_leader, slot, proof_view
+                ));
+            }
+        } else {
+            // Neither a VRF proof (≥ 33 bytes: 32-byte output + ≥ 1
+            // proof byte) nor a fallback proof (8-byte marker + 16
+            // bytes). Every non-genesis block produced by the
+            // pipeline carries one or the other; an unrecognised
+            // shape can only have come from a Byzantine peer.
+            return Err(format!(
+                "block at slot {} has invalid vrf_proof: not a VRF proof and not a fallback \
+                 proof (len={}) (audit-234 L2)",
+                slot,
+                header.vrf_proof.len()
+            ));
         }
 
         // 4. Previous QC should have quorum (skip for early blocks with empty QC)
@@ -2235,6 +2297,168 @@ mod tests {
         assert!(
             !err.contains("audit 325"),
             "None parent_timestamp must skip audit-325 lower bound, got: {err}"
+        );
+    }
+
+    // ── TPL-204 / audit-234 part 4 (CONSENSUS_INVARIANTS.md L2):
+    //    full-node fallback-leader check ────────────────────────────
+
+    /// Build a signed fallback header for a given committee member.
+    /// Used by the TPL-204 tests below to exercise the new branch in
+    /// `validate_network_block`. Returns `(header, proposer_signature,
+    /// committee_keys)`.
+    fn make_signed_fallback_header(
+        chain_id: u64,
+        slot: u64,
+        view: u64,
+        proposer_idx: usize,
+        committee: &[(
+            pyde_crypto::falcon::FalconPublicKey,
+            pyde_crypto::falcon::FalconSecretKey,
+        )],
+    ) -> (BlockHeader, Vec<u8>, Vec<Vec<u8>>) {
+        use pyde_account::address::derive_eoa_address;
+        let committee_keys: Vec<Vec<u8>> = committee
+            .iter()
+            .map(|(pk, _)| pk.as_bytes().to_vec())
+            .collect();
+        let proposer_addr = derive_eoa_address(&committee_keys[proposer_idx]);
+        let mut header = dummy_header(slot);
+        header.proposer = proposer_addr;
+        header.vrf_proof = pyde_consensus::view_change::encode_fallback_proof(slot, view);
+        header.parent_hash = [0xCD; 32];
+        let block_hash = header.hash();
+        let sign_msg = pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &block_hash);
+        let sig = pyde_crypto::falcon::falcon_sign(&committee[proposer_idx].1, &sign_msg)
+            .expect("falcon_sign")
+            .as_bytes()
+            .to_vec();
+        (header, sig, committee_keys)
+    }
+
+    fn make_committee(
+        n: usize,
+    ) -> Vec<(
+        pyde_crypto::falcon::FalconPublicKey,
+        pyde_crypto::falcon::FalconSecretKey,
+    )> {
+        (0..n)
+            .map(|_| pyde_crypto::falcon::falcon_keygen().expect("falcon_keygen"))
+            .collect()
+    }
+
+    /// TPL-204: pre-fix, the `len() >= 33` gate skipped the entire VRF
+    /// block for fallback proofs (24 bytes), so a Byzantine peer could
+    /// stamp `header.vrf_proof = encode_fallback_proof(slot, view)`
+    /// with itself as proposer and pass full-node validation, even
+    /// when it isn't the deterministic leader for `(slot, view)`.
+    /// Two valid Byzantine fallbacks at the same `(H, V)` could both
+    /// apply at full nodes — an L2 violation. Post-fix, this test
+    /// asserts the wrong-leader case is rejected with the L2 marker.
+    #[test]
+    fn validate_network_block_rejects_fallback_from_wrong_leader() {
+        let chain_id = 31337;
+        let committee = make_committee(3);
+        let slot = 5u64;
+        let view = 0u64;
+        // fallback_leader_index(5, 0, 3) = (5+0) % 3 = 2.
+        // Wrong leader: index 1 (or 0).
+        let wrong_idx = 1usize;
+        let (header, sig, committee_keys) =
+            make_signed_fallback_header(chain_id, slot, view, wrong_idx, &committee);
+        let now_ms = header.timestamp.saturating_add(1);
+        let err = BlockProcessor::validate_network_block(
+            chain_id,
+            &header,
+            &sig,
+            &committee_keys,
+            &[0u8; 32],
+            Some(&[0xCD; 32]),
+            None,
+            now_ms,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("audit-234 L2") && err.contains("not the deterministic leader"),
+            "expected fallback-leader audit-234 L2 rejection, got: {err}"
+        );
+    }
+
+    /// TPL-204: positive control — the deterministic leader for
+    /// `(slot, view)` IS allowed to ship the fallback. Without this,
+    /// the rejection test above wouldn't prove the new branch fires
+    /// on the leader bit specifically (vs. some unrelated audit
+    /// further down).
+    #[test]
+    fn validate_network_block_accepts_fallback_from_correct_leader() {
+        let chain_id = 31337;
+        let committee = make_committee(3);
+        let slot = 5u64;
+        let view = 0u64;
+        let correct_idx = 2usize; // (5+0) % 3 == 2
+        let (header, sig, committee_keys) =
+            make_signed_fallback_header(chain_id, slot, view, correct_idx, &committee);
+        let now_ms = header.timestamp.saturating_add(1);
+        let res = BlockProcessor::validate_network_block(
+            chain_id,
+            &header,
+            &sig,
+            &committee_keys,
+            &[0u8; 32],
+            Some(&[0xCD; 32]),
+            None,
+            now_ms,
+        );
+        // The QC-quorum gate (step 4) and the audit-311 sig-verify
+        // gate (step 5) might fail because dummy_header sets
+        // qc_previous.slot = slot - 1 with no signatures. We only
+        // care that the fallback-leader branch passes — assert by
+        // negative.
+        if let Err(e) = res {
+            assert!(
+                !e.contains("audit-234 L2"),
+                "correct leader must NOT trip the fallback-leader check, got: {e}"
+            );
+        }
+    }
+
+    /// TPL-204: a header with neither a VRF proof (≥ 33 bytes) nor a
+    /// fallback proof (8-byte marker) must be rejected. Pre-fix, the
+    /// `if len() >= 33` gate fell through silently for any other
+    /// length and the code accepted the block.
+    #[test]
+    fn validate_network_block_rejects_unrecognised_vrf_proof() {
+        let chain_id = 31337;
+        let committee = make_committee(3);
+        // Build a signed header but stamp a bogus 10-byte vrf_proof
+        // that is neither a real VRF proof nor a fallback marker.
+        let slot = 4u64;
+        let proposer_idx = 0usize;
+        let (mut header, _good_sig, committee_keys) =
+            make_signed_fallback_header(chain_id, slot, 0, proposer_idx, &committee);
+        header.vrf_proof = vec![0xBE; 10];
+        // Re-sign over the mutated header.
+        let block_hash = header.hash();
+        let sign_msg = pyde_consensus::hotstuff::proposer_sign_message(chain_id, slot, &block_hash);
+        let sig = pyde_crypto::falcon::falcon_sign(&committee[proposer_idx].1, &sign_msg)
+            .expect("falcon_sign")
+            .as_bytes()
+            .to_vec();
+        let now_ms = header.timestamp.saturating_add(1);
+        let err = BlockProcessor::validate_network_block(
+            chain_id,
+            &header,
+            &sig,
+            &committee_keys,
+            &[0u8; 32],
+            Some(&[0xCD; 32]),
+            None,
+            now_ms,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("audit-234 L2") && err.contains("invalid vrf_proof"),
+            "expected unrecognised-vrf_proof audit-234 L2 rejection, got: {err}"
         );
     }
 }

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -161,9 +161,19 @@ pub struct FastTxSection {
 
 impl Default for FastTxSection {
     fn default() -> Self {
+        // TPL-207: bind to loopback by default. The fast-tx listener
+        // accepts length-prefixed signed transactions and submits them
+        // straight into `pending_txs` + `tx_gossip_tx` without going
+        // through `ingress_validate` (no `MEMPOOL_*` cap, no per-IP
+        // rate-limit, no signature pre-check). The pre-fix default of
+        // `0.0.0.0` exposed every `--config` deployment that didn't
+        // explicitly override `[fast_tx].listen` to a public ingress
+        // path that drains the validator's memory until peer-banning
+        // cascades. Operators who genuinely want public fast-tx must
+        // opt in via TOML.
         Self {
             enabled: true,
-            listen: "0.0.0.0".into(),
+            listen: "127.0.0.1".into(),
             port: 9545,
         }
     }

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -153,6 +153,31 @@ fn main() {
                 config.node.dev_mode = true;
             }
 
+            // TPL-207: refuse to start with `dev_mode = true` on any
+            // chain_id other than devnet. `dev_mode` short-circuits
+            // signature verification (`validate_transaction` honours
+            // `dev_skip_signature` only when `chain_id == 31337`, but
+            // `pyde_sendTransaction` accepts unsigned txs whenever
+            // `state.dev_mode` is set). A misconfigured operator
+            // running `pyde run --dev --config testnet.toml` opens
+            // unsigned-tx ingress for the duration; this guard
+            // catches the combo at startup. Both `--dev` and a TOML
+            // `dev_mode = true` are funnelled here, so the check
+            // covers either source.
+            if config.node.dev_mode
+                && config.node.chain_id != pyde_net::discovery::DEVNET_CHAIN_ID
+            {
+                eprintln!(
+                    "error: dev_mode is only permitted on devnet \
+                     (chain_id = {}); configured chain_id = {}. Drop \
+                     `--dev` / `[node].dev_mode = false` to run on \
+                     testnet or mainnet.",
+                    pyde_net::discovery::DEVNET_CHAIN_ID,
+                    config.node.chain_id,
+                );
+                std::process::exit(1);
+            }
+
             // Initialize logging first
             logging::init(&config.logging.level, config.logging.json);
 

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -164,8 +164,7 @@ fn main() {
             // catches the combo at startup. Both `--dev` and a TOML
             // `dev_mode = true` are funnelled here, so the check
             // covers either source.
-            if config.node.dev_mode
-                && config.node.chain_id != pyde_net::discovery::DEVNET_CHAIN_ID
+            if config.node.dev_mode && config.node.chain_id != pyde_net::discovery::DEVNET_CHAIN_ID
             {
                 eprintln!(
                     "error: dev_mode is only permitted on devnet \

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -1804,8 +1804,24 @@ impl ValidatorEngine {
     /// Select the best proposal (lowest VRF score) and vote for it.
     /// Called after the proposal collection window (100ms into the slot).
     /// Returns the vote to broadcast, or None if no proposals were buffered.
+    ///
+    /// audit-234 part 4 (CONSENSUS_INVARIANTS.md L1, O3): the slot used
+    /// to look up buffered proposals is `target_height`, NOT
+    /// `current_slot`. Both `try_build_fallback_proposal` and
+    /// `buffer_fallback_proposal` key on the proposer's
+    /// `target_height` (fallback header.slot = target_height), so a
+    /// receiver whose wall-clock advanced past `target_height`
+    /// during recovery (recovery > SLOT_DURATION_MS) would otherwise
+    /// look for proposals at `current_slot` and never find the
+    /// fallback that was buffered at `target_height`. The validator
+    /// then refused to vote on every fallback proposal until the
+    /// chain unstuck itself, prolonging the wedge. The two
+    /// `advance_target_height` callers (vote-QC apply path,
+    /// `advance_target_height_after_sync` from chain-sync) keep
+    /// `target_height` correctly aligned with the height we are
+    /// actively trying to commit.
     pub fn select_and_vote(&mut self, identity: &ValidatorIdentity) -> Option<ConsensusMessage> {
-        let slot = self.consensus.current_slot;
+        let slot = self.consensus.target_height;
 
         // Don't double-vote
         if self.voted_slots.contains(&slot) {
@@ -3244,6 +3260,63 @@ mod tests {
         assert!(!engine.is_inclusion_violated(slot));
         let vote = engine.select_and_vote(&identities[1]);
         assert!(vote.is_some(), "un-flagged slot should produce a vote");
+    }
+
+    /// TPL-203 / audit-234 part 4 (CONSENSUS_INVARIANTS.md L1, O3):
+    /// when recovery for a slot takes longer than `SLOT_DURATION_MS`,
+    /// a validator's wall-clock `current_slot` drifts past
+    /// `target_height`. Fallback proposals are buffered at
+    /// `header.slot = target_height` (the proposer wrote it that
+    /// way). Pre-fix, `select_and_vote` looked up
+    /// `buffered_proposals[current_slot]`, missed the fallback at
+    /// `target_height`, and silently returned None on every tick of
+    /// the recovery window. Post-fix it reads `target_height` and
+    /// finds the buffered proposal.
+    #[test]
+    fn select_and_vote_uses_target_height_not_current_slot() {
+        let (mut engine, identities) = make_engine_with_committee(3);
+        // Drift wall-clock past target_height: target_height stays at
+        // 1 (no QC formed), current_slot walks forward to 5. This is
+        // the exact shape of a recovery > SLOT_DURATION_MS — three
+        // wall-clock ticks fired after the recovery began but no
+        // vote-QC has formed at target_height yet.
+        for _ in 0..5 {
+            engine.advance_slot();
+        }
+        assert_eq!(engine.consensus.current_slot, 5);
+        assert_eq!(engine.consensus.target_height, 1);
+
+        // Buffer a proposal at target_height (where a fallback
+        // proposer would have placed it). vrf_score 0 so it wins
+        // min-by-vrf_score selection.
+        let header = BlockHeader {
+            slot: engine.consensus.target_height,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: identities[0].address,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0u8; 32],
+            state_root: [0u8; 32],
+            timestamp: 0,
+        };
+        engine
+            .buffered_proposals
+            .entry(engine.consensus.target_height)
+            .or_default()
+            .push(BufferedProposal {
+                header,
+                proposer_signature: vec![],
+                vrf_score: 0,
+            });
+
+        // Pre-fix: returned None because lookup was at current_slot=5
+        // but the proposal lives at target_height=1.
+        let vote = engine.select_and_vote(&identities[1]);
+        assert!(
+            vote.is_some(),
+            "select_and_vote must find the proposal at target_height even when current_slot has drifted past"
+        );
     }
 
     // ========== Task 034: cross-committee resharing ==========

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -890,6 +890,14 @@ impl TypeChecker {
         let init_ty = self.infer_expr(&l.initializer);
 
         let declared_ty = if let Some(ref ty) = l.ty {
+            // Audit 354: the upfront `reject_signed_types_in_item`
+            // pass walks fn params, return types, and field
+            // declarations — but `let x: i64 = ...` lives inside a
+            // function body, so a signed annotation here would slip
+            // through and feed an unsigned-only codegen with a
+            // signed `Ty::I*`. Reject signed annotations on let
+            // bindings the same way we reject them on declarations.
+            self.reject_signed_in_type(ty);
             let t = self.resolve_type(ty);
             // Check compatibility — integer literals are polymorphic,
             // and Vec<?>/Unknown types are compatible with concrete types
@@ -1736,6 +1744,13 @@ impl TypeChecker {
 
             Expr::Cast(expr, target_ty, span) => {
                 let source_ty = self.infer_expr(expr);
+                // Audit 354: `expr as i64` is the other body-level
+                // doorway for signed types. The upfront reject pass
+                // doesn't visit expressions, so a contract that
+                // wrote `let x = (a as i64)` (or `(a as i64) + 1`,
+                // with no `let` annotation at all) would route a
+                // signed `Ty` straight through codegen.
+                self.reject_signed_in_type(target_ty);
                 let target = self.resolve_type(target_ty);
 
                 // Validate cast compatibility
@@ -2945,6 +2960,11 @@ mod tests {
 
     #[test]
     fn check_valid_casts() {
+        // TPL-208: `as i64` was a valid-cast positive case here
+        // before audit-354 plugged the body-level signed-type
+        // gap. Casts to signed targets are now rejected (the
+        // signed-cast path has its own `audit_354_rejects_cast_to_signed`
+        // test); this case stays as the unsigned-only happy path.
         check_ok(
             r#"
             contract T {
@@ -2952,7 +2972,7 @@ mod tests {
                     let a: u64 = 42;
                     let b = a as u256;
                     let c = b as u64;
-                    let d = a as i64;
+                    let d = a as u32;
                     let e = true as u256;
                 }
             }
@@ -3310,6 +3330,77 @@ mod tests {
                 pub fn f(x: u32) -> u8 { return 0; }
             }
             "#,
+        );
+    }
+
+    /// Audit 354: TPL-208 — `let x: i64 = 0;` inside a function body
+    /// must be rejected. The original audit-354 pre-pass walks
+    /// declarations only (params, returns, fields, aliases), so a
+    /// signed annotation on a `let` slipped through and minted a
+    /// `Ty::I64` local that downstream codegen then treated as
+    /// unsigned.
+    #[test]
+    fn audit_354_rejects_i64_in_let_binding() {
+        let errs = check_err(
+            r#"
+            contract C {
+                pub fn f() -> u64 {
+                    let x: i64 = 0;
+                    return 0;
+                }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("audit 354")),
+            "expected audit-354 error for `let x: i64`, got: {:?}",
+            errs
+        );
+    }
+
+    /// Audit 354: TPL-208 — `let v: Vec<i32> = ...` is the
+    /// container variant of the let-binding gap; reject it the
+    /// same way fields-of-Vec<i32> are rejected.
+    #[test]
+    fn audit_354_rejects_vec_signed_in_let_binding() {
+        let errs = check_err(
+            r#"
+            contract C {
+                pub fn f() -> u64 {
+                    let v: Vec<i32> = Vec::new();
+                    return 0;
+                }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("audit 354")),
+            "expected audit-354 error for `let v: Vec<i32>`, got: {:?}",
+            errs
+        );
+    }
+
+    /// Audit 354: TPL-208 — `(expr as i32)` is the cast variant of
+    /// the body-level gap. Without a `let` annotation at all, a
+    /// contract that wrote `let x = (a as i32);` would still mint
+    /// a signed `Ty` from the cast target type and route it
+    /// straight into codegen.
+    #[test]
+    fn audit_354_rejects_cast_to_signed() {
+        let errs = check_err(
+            r#"
+            contract C {
+                pub fn f(a: u64) -> u64 {
+                    let x = (a as i32);
+                    return 0;
+                }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("audit 354")),
+            "expected audit-354 error for `as i32` cast, got: {:?}",
+            errs
         );
     }
 

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -280,7 +280,14 @@ impl TypeChecker {
         }
     }
 
-    /// Recurse into a `Type` node looking for signed primitives.
+    /// Recurse into a `Type` node and reject:
+    ///   1. Signed integer primitives anywhere (audit 354).
+    ///   2. Wide elements inside `Vec<…>` or `[…; N]` (TPL-209).
+    ///
+    /// Both walks share the same recursion shape (visit every
+    /// container's payload), so they're folded into one pass.
+    /// Each report carries its own audit/TPL identifier so the
+    /// downstream tests pin the right error.
     fn reject_signed_in_type(&mut self, ty: &Type) {
         match ty {
             Type::Primitive(p, span) => {
@@ -309,8 +316,50 @@ impl TypeChecker {
                 }
             }
             Type::Bytes(_) => {}
-            Type::Array(elem, _, _) => self.reject_signed_in_type(elem),
-            Type::Vec(elem, _) => self.reject_signed_in_type(elem),
+            Type::Array(elem, _, span) => {
+                // TPL-209: arrays use the same 8-byte-stride
+                // codegen as Vec (`MakeArray`/`ArrayRepeat` in
+                // codegen.rs:1922-1946 store at `i * WORD_SIZE`),
+                // so a wide element silently truncates.
+                if let Some(name) = Self::wide_element_name(elem) {
+                    self.error(
+                        format!(
+                            "[{}; N] is not supported (TPL-209): the codegen stores \
+                             elements at an 8-byte stride, so a wider type silently \
+                             truncates to its low 8 bytes. Stride-aware fixed arrays \
+                             land post-mainnet.",
+                            name
+                        ),
+                        *span,
+                    );
+                }
+                self.reject_signed_in_type(elem);
+            }
+            Type::Vec(elem, span) => {
+                // TPL-209: `IndexGet`/`IndexSet` codegen
+                // (`codegen.rs:1869-1889`) reads/writes 8 bytes
+                // at `base + idx*8 + VEC_DATA_OFFSET`, regardless
+                // of the declared element type. A `Vec<Address>`
+                // multisig signer list would lose every byte
+                // past the first 8 of each address; `Vec<u256>`
+                // and `Vec<bytes>` have the same shape. Reject
+                // until per-element-pointer-and-deref (or
+                // stride-aware allocation) lands post-mainnet.
+                if let Some(name) = Self::wide_element_name(elem) {
+                    self.error(
+                        format!(
+                            "Vec<{}> is not supported (TPL-209): the codegen stores Vec \
+                             elements at an 8-byte stride, so a wider type silently \
+                             truncates to its low 8 bytes. Stride-aware Vec lands \
+                             post-mainnet; for now, store wide values via Map<u64, T> or \
+                             a fixed-size struct.",
+                            name
+                        ),
+                        *span,
+                    );
+                }
+                self.reject_signed_in_type(elem);
+            }
             Type::Map(k, v, _) => {
                 self.reject_signed_in_type(k);
                 self.reject_signed_in_type(v);
@@ -321,6 +370,29 @@ impl TypeChecker {
                     self.reject_signed_in_type(t);
                 }
             }
+        }
+    }
+
+    /// TPL-209: name the element type if it is wide (more than
+    /// 8 bytes at runtime). `Type::Bytes` is a length + heap
+    /// pointer, which doesn't fit an 8-byte slot any better than
+    /// `u256`. `Type::Named` could resolve to a struct that's
+    /// also too wide, but per-struct size analysis is post-
+    /// mainnet — for now the reject is scoped to the explicit
+    /// wide primitives + bytes from the tracker.
+    fn wide_element_name(ty: &Type) -> Option<&'static str> {
+        match ty {
+            Type::Primitive(p, _) => match p {
+                PrimitiveType::U128 => Some("u128"),
+                PrimitiveType::U256 => Some("u256"),
+                PrimitiveType::I128 => Some("i128"),
+                PrimitiveType::I256 => Some("i256"),
+                PrimitiveType::Address => Some("Address"),
+                PrimitiveType::StringType => Some("string"),
+                _ => None,
+            },
+            Type::Bytes(_) => Some("bytes"),
+            _ => None,
         }
     }
 
@@ -2853,6 +2925,11 @@ mod tests {
     /// own address back instead of the child's).
     #[test]
     fn check_address_of_contract_handle_audit_405() {
+        // TPL-209 forced the `Vec<Address>` storage out of the
+        // original test (silent stride-truncation for Address).
+        // Audit-405's claim is about `address(c)` returning the
+        // CHILD's address, not the parent's, so a single
+        // `last_child: Address` slot is sufficient.
         check_ok(
             r#"
             contract Child {
@@ -2861,14 +2938,14 @@ mod tests {
             }
             contract Parent {
                 storage {
-                    children: Vec<Address>,
+                    last_child: Address,
                 }
                 #[constructor]
                 pub fn init() {}
                 pub fn spawn() -> Address {
                     let c = deploy!(Child);
                     let a = address(c);
-                    self.children.push(a);
+                    self.last_child = a;
                     return a;
                 }
             }
@@ -3097,11 +3174,13 @@ mod tests {
 
     #[test]
     fn check_return_after_loop() {
-        // Return after loop is fine — loop might not execute
+        // Return after loop is fine — loop might not execute.
+        // TPL-209 prohibits Vec<u256>; the test only cares about
+        // the control-flow shape, so swap to Vec<u64>.
         check_ok(
             r#"
             contract T {
-                pub fn find(items: Vec<u256>, target: u256) -> u256 {
+                pub fn find(items: Vec<u64>, target: u64) -> u64 {
                     for i in 0..10 {
                         if i == target {
                             return i;
@@ -3116,12 +3195,13 @@ mod tests {
 
     #[test]
     fn check_revert_after_loop() {
-        // Revert after loop is a valid exit path
+        // Revert after loop is a valid exit path. TPL-209 forces
+        // u256 → u64 here as in `check_return_after_loop`.
         check_ok(
             r#"
             contract T {
                 error NotFound {}
-                pub fn find(items: Vec<u256>, target: u256) -> u256 {
+                pub fn find(items: Vec<u64>, target: u64) -> u64 {
                     for i in 0..10 {
                         if i == target {
                             return i;
@@ -3229,10 +3309,13 @@ mod tests {
 
     #[test]
     fn check_valid_method_types() {
+        // TPL-209 prohibits Vec<u256>; this test exercises the
+        // method dispatch on Vec/bytes/string and doesn't depend
+        // on the element width, so swap to Vec<u64>.
         check_ok(
             r#"
             contract T {
-                storage { items: Vec<u256>, data: bytes, }
+                storage { items: Vec<u64>, data: bytes, }
                 pub fn f() {
                     let n = self.items.len();
                     let empty = self.items.is_empty();
@@ -3323,10 +3406,15 @@ mod tests {
 
     #[test]
     fn audit_354_unsigned_types_still_accepted() {
+        // TPL-209 forced `Vec<u128>` out of this positive control —
+        // stride-truncating containers are gated until post-mainnet
+        // even when the element is unsigned. The unsigned-type
+        // positive case is now just narrow primitives plus Map
+        // (which uses Sload/Sstore, not the 8-byte-stride codegen).
         check_ok(
             r#"
             contract C {
-                storage { a: u256, b: Vec<u128>, c: Map<Address, u64>, }
+                storage { a: u256, b: Vec<u64>, c: Map<Address, u64>, }
                 pub fn f(x: u32) -> u8 { return 0; }
             }
             "#,
@@ -3401,6 +3489,124 @@ mod tests {
             errs.iter().any(|e| e.message.contains("audit 354")),
             "expected audit-354 error for `as i32` cast, got: {:?}",
             errs
+        );
+    }
+
+    // ========== TPL-209: Vec/Array of wide elements rejected ==========
+
+    /// TPL-209: `Vec<Address>` would silently truncate every
+    /// element to its low 8 bytes — a multisig signer list
+    /// stored this way would lose every byte past the first 8
+    /// of every address. Reject at typecheck.
+    #[test]
+    fn tpl_209_rejects_vec_address() {
+        let errs = check_err(
+            r#"
+            contract C {
+                storage { signers: Vec<Address>, }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("TPL-209")),
+            "expected TPL-209 error for `Vec<Address>`, got: {:?}",
+            errs
+        );
+    }
+
+    /// TPL-209: `Vec<u256>` is the canonical instance — the bug
+    /// description in the tracker calls it out by name.
+    #[test]
+    fn tpl_209_rejects_vec_u256() {
+        let errs = check_err(
+            r#"
+            contract C {
+                storage { values: Vec<u256>, }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("TPL-209")),
+            "expected TPL-209 error for `Vec<u256>`, got: {:?}",
+            errs
+        );
+    }
+
+    /// TPL-209: `Vec<bytes>` packs a length + heap pointer per
+    /// element, which doesn't fit the 8-byte Vec slot any better
+    /// than `u256`. Reject at typecheck.
+    #[test]
+    fn tpl_209_rejects_vec_bytes() {
+        let errs = check_err(
+            r#"
+            contract C {
+                storage { blobs: Vec<bytes>, }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("TPL-209")),
+            "expected TPL-209 error for `Vec<bytes>`, got: {:?}",
+            errs
+        );
+    }
+
+    /// TPL-209: nested-container case. `Map<K, Vec<u256>>`
+    /// recurses into the Vec value, which then trips the
+    /// element-width gate. Confirms the recursion through
+    /// containers fires, not just top-level types.
+    #[test]
+    fn tpl_209_rejects_nested_vec_u256_in_map() {
+        let errs = check_err(
+            r#"
+            contract C {
+                storage { roles: Map<u64, Vec<u256>>, }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("TPL-209")),
+            "expected TPL-209 error for `Map<u64, Vec<u256>>`, got: {:?}",
+            errs
+        );
+    }
+
+    /// TPL-209: `[Address; 4]` (fixed-size array) shares the
+    /// 8-byte-stride codegen with Vec, so the same gate applies.
+    #[test]
+    fn tpl_209_rejects_array_of_address() {
+        let errs = check_err(
+            r#"
+            contract C {
+                storage { signers: [Address; 4], }
+            }
+            "#,
+        );
+        assert!(
+            errs.iter().any(|e| e.message.contains("TPL-209")),
+            "expected TPL-209 error for `[Address; 4]`, got: {:?}",
+            errs
+        );
+    }
+
+    /// TPL-209: positive control — `Vec<u64>` (8-byte element)
+    /// remains accepted, as do `Map<Address, u256>` (the Map
+    /// codegen uses Sload/Sstore with full 32-byte wide
+    /// registers, not the truncating Vec stride) and bare
+    /// `Address` storage.
+    #[test]
+    fn tpl_209_narrow_vec_and_map_still_accepted() {
+        check_ok(
+            r#"
+            contract C {
+                storage {
+                    nums: Vec<u64>,
+                    flags: Vec<bool>,
+                    bal: Map<Address, u256>,
+                    owner: Address,
+                }
+            }
+            "#,
         );
     }
 

--- a/crates/otic/tests/typecheck_integration.rs
+++ b/crates/otic/tests/typecheck_integration.rs
@@ -57,20 +57,28 @@ typecheck_fixture!(
 );
 typecheck_fixture!(typecheck_amm_pool, "fixtures/programs/defi/amm_pool.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_lending_pool,
     "fixtures/programs/defi/lending_pool.oti"
 );
-typecheck_fixture!(typecheck_staking, "fixtures/programs/defi/staking.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_staking,
+    "fixtures/programs/defi/staking.oti"
+);
 typecheck_fixture!(typecheck_vault, "fixtures/programs/defi/vault.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_flash_loan,
     "fixtures/programs/defi/flash_loan.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_order_book,
     "fixtures/programs/defi/order_book.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_yield_farm,
     "fixtures/programs/defi/yield_farm.oti"
 );
@@ -79,23 +87,28 @@ typecheck_fixture!(
     "fixtures/programs/defi/wrapped_token.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_price_oracle,
     "fixtures/programs/defi/price_oracle.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_stable_swap,
     "fixtures/programs/defi/stable_swap.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_fee_distributor,
     "fixtures/programs/defi/fee_distributor.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_liquidity_gauge,
     "fixtures/programs/defi/liquidity_gauge.oti"
 );
 typecheck_fixture!(typecheck_router, "fixtures/programs/defi/router.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_token_vesting,
     "fixtures/programs/defi/token_vesting.oti"
 );
@@ -111,14 +124,17 @@ typecheck_fixture!(
     "fixtures/programs/nft/nft_auction.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_nft_collection,
     "fixtures/programs/nft/nft_collection.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_soulbound_token,
     "fixtures/programs/nft/soulbound_token.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_nft_royalties,
     "fixtures/programs/nft/nft_royalties.oti"
 );
@@ -127,14 +143,17 @@ typecheck_fixture!(typecheck_nft_rental, "fixtures/programs/nft/nft_rental.oti")
 // === Governance ===
 typecheck_fixture!(typecheck_dao, "fixtures/programs/governance/dao.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_governor,
     "fixtures/programs/governance/governor.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_multisig,
     "fixtures/programs/governance/multisig.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_timelock,
     "fixtures/programs/governance/timelock.oti"
 );
@@ -143,20 +162,27 @@ typecheck_fixture!(
     "fixtures/programs/governance/voting_token.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_treasury,
     "fixtures/programs/governance/treasury.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_reputation,
     "fixtures/programs/governance/reputation.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_quadratic_voting,
     "fixtures/programs/governance/quadratic_voting.oti"
 );
 
 // === Games ===
-typecheck_fixture!(typecheck_lottery, "fixtures/programs/games/lottery.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_lottery,
+    "fixtures/programs/games/lottery.oti"
+);
 typecheck_fixture!(
     typecheck_prediction_market,
     "fixtures/programs/games/prediction_market.oti"
@@ -165,7 +191,11 @@ typecheck_fixture!(
     typecheck_rock_paper_scissors,
     "fixtures/programs/games/rock_paper_scissors.oti"
 );
-typecheck_fixture!(typecheck_coin_flip, "fixtures/programs/games/coin_flip.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_coin_flip,
+    "fixtures/programs/games/coin_flip.oti"
+);
 typecheck_fixture!(
     ignore = "audit 354: signed types disabled until post-mainnet ISA opcodes (Elo deltas)",
     typecheck_chess_wager,
@@ -176,11 +206,16 @@ typecheck_fixture!(
     typecheck_nft_battle,
     "fixtures/programs/games/nft_battle.oti"
 );
-typecheck_fixture!(typecheck_raffle, "fixtures/programs/games/raffle.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_raffle,
+    "fixtures/programs/games/raffle.oti"
+);
 
 // === Finance ===
 typecheck_fixture!(typecheck_escrow, "fixtures/programs/finance/escrow.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_payment_splitter,
     "fixtures/programs/finance/payment_splitter.oti"
 );
@@ -191,10 +226,12 @@ typecheck_fixture!(
 typecheck_fixture!(typecheck_invoice, "fixtures/programs/finance/invoice.oti");
 typecheck_fixture!(typecheck_payroll, "fixtures/programs/finance/payroll.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_crowdfund,
     "fixtures/programs/finance/crowdfund.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_insurance,
     "fixtures/programs/finance/insurance.oti"
 );
@@ -203,6 +240,7 @@ typecheck_fixture!(typecheck_bond, "fixtures/programs/finance/bond.oti");
 // === Access Control ===
 typecheck_fixture!(typecheck_ownable, "fixtures/programs/access/ownable.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_role_manager,
     "fixtures/programs/access/role_manager.oti"
 );
@@ -211,6 +249,7 @@ typecheck_fixture!(
     "fixtures/programs/access/two_step_ownership.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_allowlist,
     "fixtures/programs/access/allowlist.oti"
 );
@@ -218,7 +257,11 @@ typecheck_fixture!(
     typecheck_time_lock_admin,
     "fixtures/programs/access/time_lock_admin.oti"
 );
-typecheck_fixture!(typecheck_guardian, "fixtures/programs/access/guardian.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_guardian,
+    "fixtures/programs/access/guardian.oti"
+);
 typecheck_fixture!(
     typecheck_fee_manager,
     "fixtures/programs/access/fee_manager.oti"
@@ -230,12 +273,18 @@ typecheck_fixture!(
     "fixtures/programs/infra/name_registry.oti"
 );
 typecheck_fixture!(typecheck_proxy, "fixtures/programs/infra/proxy.oti");
-typecheck_fixture!(typecheck_factory, "fixtures/programs/infra/factory.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_factory,
+    "fixtures/programs/infra/factory.oti"
+);
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_access_control,
     "fixtures/programs/infra/access_control.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_event_logger,
     "fixtures/programs/infra/event_logger.oti"
 );
@@ -244,10 +293,15 @@ typecheck_fixture!(
     "fixtures/programs/infra/rate_limiter.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_circuit_breaker,
     "fixtures/programs/infra/circuit_breaker.oti"
 );
-typecheck_fixture!(typecheck_whitelist, "fixtures/programs/infra/whitelist.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_whitelist,
+    "fixtures/programs/infra/whitelist.oti"
+);
 
 // === Library ===
 typecheck_fixture!(typecheck_math_lib, "fixtures/programs/library/math_lib.oti");
@@ -256,10 +310,12 @@ typecheck_fixture!(
     "fixtures/programs/library/string_utils.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_array_utils,
     "fixtures/programs/library/array_utils.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_address_utils,
     "fixtures/programs/library/address_utils.oti"
 );
@@ -271,6 +327,7 @@ typecheck_fixture!(
     "fixtures/programs/patterns/token_with_resource.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_multi_contract,
     "fixtures/programs/patterns/multi_contract.oti"
 );
@@ -279,14 +336,17 @@ typecheck_fixture!(
     "fixtures/programs/patterns/state_machine.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_batch_operations,
     "fixtures/programs/patterns/batch_operations.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_diamond_storage,
     "fixtures/programs/patterns/diamond_storage.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_complex_structs,
     "fixtures/programs/patterns/complex_structs.oti"
 );
@@ -295,6 +355,7 @@ typecheck_fixture!(
     "fixtures/programs/patterns/sponsored_functions.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_bytes_and_crypto,
     "fixtures/programs/patterns/bytes_and_crypto.oti"
 );
@@ -311,15 +372,21 @@ typecheck_fixture!(
     "fixtures/programs/social/social_media.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_messaging,
     "fixtures/programs/social/messaging.oti"
 );
-typecheck_fixture!(typecheck_tipping, "fixtures/programs/social/tipping.oti");
+typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
+    typecheck_tipping,
+    "fixtures/programs/social/tipping.oti"
+);
 typecheck_fixture!(
     typecheck_content_platform,
     "fixtures/programs/social/content_platform.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_follow_system,
     "fixtures/programs/social/follow_system.oti"
 );
@@ -346,6 +413,7 @@ typecheck_fixture!(
 
 // === Real Estate ===
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_property_deed,
     "fixtures/programs/realestate/property_deed.oti"
 );
@@ -360,6 +428,7 @@ typecheck_fixture!(
 
 // === Health ===
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_medical_records,
     "fixtures/programs/health/medical_records.oti"
 );
@@ -368,6 +437,7 @@ typecheck_fixture!(
     "fixtures/programs/health/prescription.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_clinical_trial,
     "fixtures/programs/health/clinical_trial.oti"
 );
@@ -378,6 +448,7 @@ typecheck_fixture!(
     "fixtures/programs/education/credential.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_course_marketplace,
     "fixtures/programs/education/course_marketplace.oti"
 );
@@ -389,10 +460,12 @@ typecheck_fixture!(
 // === Legal ===
 typecheck_fixture!(typecheck_will, "fixtures/programs/legal/will.oti");
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_dispute_resolution,
     "fixtures/programs/legal/dispute_resolution.oti"
 );
 typecheck_fixture!(
+    ignore = "TPL-209: Vec<wide> / [wide; N] disabled until post-mainnet stride-aware codegen",
     typecheck_smart_agreement,
     "fixtures/programs/legal/smart_agreement.oti"
 );

--- a/crates/otic/tests/typecheck_integration.rs
+++ b/crates/otic/tests/typecheck_integration.rs
@@ -172,6 +172,7 @@ typecheck_fixture!(
     "fixtures/programs/games/chess_wager.oti"
 );
 typecheck_fixture!(
+    ignore = "audit 354: signed types disabled until post-mainnet ISA opcodes (HP deltas use i32)",
     typecheck_nft_battle,
     "fixtures/programs/games/nft_battle.oti"
 );

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -236,6 +236,19 @@ pub struct Vm {
     /// Keys already journaled (O(1) dedup instead of O(n) scan).
     /// Public for access list extraction after simulation.
     pub storage_journal_keys: std::collections::HashSet<U256>,
+    /// TPL-205: balance write journal for rollback. Mirrors
+    /// `storage_journal` so cross-contract value transfers
+    /// (CallExt, CREATE) can be undone if the outer call or the
+    /// transaction reverts. Pre-fix the child VM's balance changes
+    /// were dropped on the floor — both the explicit value
+    /// transfer and any nested transfer were invisible to the
+    /// parent. Fixing the merge without the journal would have
+    /// flipped the bug from "transfer never happens" to
+    /// "transfer survives a revert" (fund-loss vector).
+    balance_journal: Vec<(Address, Option<U256>)>,
+    /// Addresses already journaled in `balance_journal`. Same
+    /// O(1) dedup pattern as `storage_journal_keys`.
+    balance_journal_keys: std::collections::HashSet<Address>,
     /// Contract registry: address → deployed bytecode.
     pub contracts: HashMap<Address, Vec<u8>>,
     /// Optional code backend for lazy loading contract bytecode (e.g., from SMT).
@@ -310,6 +323,8 @@ impl Vm {
             logs: Vec::new(),
             storage_journal: Vec::new(),
             storage_journal_keys: std::collections::HashSet::new(),
+            balance_journal: Vec::new(),
+            balance_journal_keys: std::collections::HashSet::new(),
             decoded_cache: Vec::new(),
             contracts: HashMap::new(),
             code_backend: None,
@@ -1536,6 +1551,11 @@ impl Vm {
     pub fn execute(&mut self) -> ExecutionOutput {
         self.storage_journal.clear();
         self.storage_journal_keys.clear();
+        // TPL-205: balance journal mirrors storage journal across
+        // execute(). Pair every rollback_storage with rollback_balances
+        // so cross-contract value transfers undo on revert/OOG/trap.
+        self.balance_journal.clear();
+        self.balance_journal_keys.clear();
         let logs_snapshot_len = self.logs.len();
 
         let outcome = loop {
@@ -1543,6 +1563,7 @@ impl Vm {
                 Ok(Some(ExecResult::Halt)) => break Outcome::Success,
                 Ok(Some(ExecResult::Revert)) => {
                     self.rollback_storage();
+                    self.rollback_balances();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
                     break Outcome::Revert;
@@ -1550,12 +1571,14 @@ impl Vm {
                 Ok(None) => {}
                 Err(Trap::OutOfGas) => {
                     self.rollback_storage();
+                    self.rollback_balances();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
                     break Outcome::OutOfGas;
                 }
                 Err(trap) => {
                     self.rollback_storage();
+                    self.rollback_balances();
                     self.logs.truncate(logs_snapshot_len);
                     self.gas_refund = 0;
                     break Outcome::Trap(trap);
@@ -1565,6 +1588,8 @@ impl Vm {
 
         self.storage_journal.clear();
         self.storage_journal_keys.clear();
+        self.balance_journal.clear();
+        self.balance_journal_keys.clear();
 
         ExecutionOutput {
             outcome,
@@ -1857,6 +1882,27 @@ impl Vm {
                     self.storage.insert(*k, v.clone());
                 }
             }
+            // TPL-205: merge child's balance changes into parent.
+            // The local `balances` clone fed to the child held the
+            // post-debit/credit map; the child may have further
+            // modified its `ctx.balances` via nested CallExt /
+            // CREATE. Both kinds of change need to land in
+            // parent's `self.ctx.balances`. Journal each address
+            // BEFORE the write so a later parent revert restores
+            // the pre-call value (same pattern as the storage
+            // merge above). Skipped for `is_delegate` because
+            // delegate-call value semantics use the parent's
+            // address as caller AND callee — there is no value
+            // transfer at the delegate boundary.
+            if !is_delegate {
+                for (addr, child_bal) in &child.ctx.balances {
+                    let parent_bal = self.ctx.balances.get(addr).copied();
+                    if parent_bal != Some(*child_bal) {
+                        self.journal_balance_write(addr);
+                        self.ctx.balances.insert(*addr, *child_bal);
+                    }
+                }
+            }
             // Merge child's logs
             self.logs.extend(output.logs);
             // Accumulate refunds
@@ -2036,8 +2082,13 @@ impl Vm {
             balances,
         };
 
-        // Run constructor if present
-        if let Some(ref constructor_code) = constructor {
+        // Run constructor if present. In either branch we need
+        // the post-deploy balance map (caller -= cv, new_addr += cv,
+        // plus any further changes the constructor made via
+        // nested CallExt / CREATE) so we can journal+apply it to
+        // parent — see the TPL-205 block below.
+        let final_balances: HashMap<Address, U256> = if let Some(ref constructor_code) = constructor
+        {
             let mut child = Vm::with_gas_limit_and_context(max_forward, child_ctx.clone());
             child.contracts = self.contracts.clone();
             child.storage_backend = self.storage_backend.clone();
@@ -2072,6 +2123,28 @@ impl Vm {
             self.warm_storage_keys.extend(child.warm_storage_keys);
             self.accessed_raw_slots.extend(child.accessed_raw_slots);
             self.written_raw_slots.extend(child.written_raw_slots);
+            child.ctx.balances
+        } else {
+            // No constructor — the post-transfer map is already
+            // sitting in `child_ctx`. Pre-fix this branch dropped
+            // `child_ctx` on the floor, so a CREATE without a
+            // constructor block silently lost the deploy value
+            // transfer (caller debited nothing, new contract
+            // received nothing).
+            child_ctx.balances
+        };
+
+        // TPL-205: journal+apply the final balance map to parent.
+        // Skipping a delegate-style "no value transfer" optimisation
+        // intentionally — CREATE always has at least the
+        // (caller, new_addr) pair if `cv > 0`, and the iterator is
+        // a no-op when nothing changed.
+        for (addr, child_bal) in &final_balances {
+            let parent_bal = self.ctx.balances.get(addr).copied();
+            if parent_bal != Some(*child_bal) {
+                self.journal_balance_write(addr);
+                self.ctx.balances.insert(*addr, *child_bal);
+            }
         }
 
         let runtime_code = runtime;
@@ -2101,6 +2174,35 @@ impl Vm {
         if self.storage_journal_keys.insert(*key) {
             let old = self.storage.get(key).cloned();
             self.storage_journal.push((*key, old));
+        }
+    }
+
+    /// TPL-205: record an address's pre-write balance so a later
+    /// revert can restore it. Same first-write-wins semantics as
+    /// `journal_storage_write`.
+    #[inline]
+    pub fn journal_balance_write(&mut self, addr: &Address) {
+        if self.balance_journal_keys.insert(*addr) {
+            let old = self.ctx.balances.get(addr).copied();
+            self.balance_journal.push((*addr, old));
+        }
+    }
+
+    /// TPL-205: rollback balances to the state before journaled
+    /// writes. Drains the journal in reverse so re-runs of the
+    /// same address (which only journaled the first time) restore
+    /// the original pre-call value.
+    fn rollback_balances(&mut self) {
+        self.balance_journal_keys.clear();
+        for (addr, old_value) in self.balance_journal.drain(..).rev() {
+            match old_value {
+                Some(v) => {
+                    self.ctx.balances.insert(addr, v);
+                }
+                None => {
+                    self.ctx.balances.remove(&addr);
+                }
+            }
         }
     }
 
@@ -4196,6 +4298,153 @@ mod tests {
         assert_eq!(output.outcome, Outcome::Success);
         assert_eq!(vm.cpu.read_gp(1), 0); // child failed (OOG)
         assert_eq!(vm.cpu.read_gp(5), 99); // parent continued
+    }
+
+    // ========== TPL-205: balance journal for CallExt + CREATE ==========
+
+    /// TPL-205: a successful `CallExt` with non-zero call value
+    /// must move funds from caller to callee in the parent's
+    /// balance map. Pre-fix the local `balances` clone fed to the
+    /// child carried the debit/credit, but it was never merged
+    /// back — the parent's `ctx.balances` saw the same numbers
+    /// before and after the call. Cross-contract value transfers
+    /// were silent no-ops.
+    #[test]
+    fn call_ext_with_value_persists_to_parent_balances_tpl_205() {
+        let caller_addr = addr(0xAA);
+        let target_addr = addr(0xBB);
+        // Callee: just halts.
+        let callee_code = bytecode(&[instr_bytes(Opcode::Halt, 0, 0, 0)]);
+        // Caller: load r8 = 100 (call value), then CallExt with
+        // imm bit 13 set (has_value flag).
+        // imm = 0x143 | (1 << 13) = 0x2143 (result=r1, gas=r4, len=r3, has_value).
+        let caller_code = bytecode(&[
+            instr_ri(Opcode::Addi, 8, 0, 100),          // r8 = call value
+            instr_ri(Opcode::Addi, 3, 0, 0),            // r3 = calldata len = 0
+            instr_ri(Opcode::Addi, 4, 0, 0),            // r4 = gas = all
+            instr_bytes(Opcode::CallExt, 0, 2, 0x2143), // call_ext w0, r2, has_value
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut balances = HashMap::new();
+        balances.insert(caller_addr, U256::from(1000u64));
+        balances.insert(target_addr, U256::ZERO);
+        let ctx = ExecutionContext {
+            self_address: caller_addr,
+            balances,
+            ..Default::default()
+        };
+        let mut vm = Vm::with_gas_limit_and_context(1_000_000, ctx);
+        vm.cpu.write_wide(0, U256::from_le_bytes(target_addr));
+        vm.contracts.insert(target_addr, callee_code);
+        vm.load(&caller_code).unwrap();
+        let output = vm.execute();
+
+        assert_eq!(output.outcome, Outcome::Success);
+        assert_eq!(
+            vm.ctx.balances.get(&caller_addr).copied(),
+            Some(U256::from(900u64)),
+            "caller must be debited by call value"
+        );
+        assert_eq!(
+            vm.ctx.balances.get(&target_addr).copied(),
+            Some(U256::from(100u64)),
+            "target must be credited by call value"
+        );
+    }
+
+    /// TPL-205: when the parent reverts AFTER a successful child
+    /// call that moved value, the value transfer must be undone.
+    /// Pre-fix this was vacuously true because the transfer was
+    /// already a no-op; with the merge added, the journal+rollback
+    /// keeps the revert atomic.
+    #[test]
+    fn call_ext_value_rollback_on_parent_revert_tpl_205() {
+        let caller_addr = addr(0xAA);
+        let target_addr = addr(0xBB);
+        let callee_code = bytecode(&[instr_bytes(Opcode::Halt, 0, 0, 0)]);
+        let caller_code = bytecode(&[
+            instr_ri(Opcode::Addi, 8, 0, 100),
+            instr_ri(Opcode::Addi, 3, 0, 0),
+            instr_ri(Opcode::Addi, 4, 0, 0),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x2143),
+            // After the (successful) call, parent reverts. The
+            // execute() loop's Revert branch should call
+            // rollback_balances and restore caller=1000 / target=0.
+            instr_bytes(Opcode::Revert, 0, 0, 0),
+        ]);
+
+        let mut balances = HashMap::new();
+        balances.insert(caller_addr, U256::from(1000u64));
+        balances.insert(target_addr, U256::ZERO);
+        let ctx = ExecutionContext {
+            self_address: caller_addr,
+            balances,
+            ..Default::default()
+        };
+        let mut vm = Vm::with_gas_limit_and_context(1_000_000, ctx);
+        vm.cpu.write_wide(0, U256::from_le_bytes(target_addr));
+        vm.contracts.insert(target_addr, callee_code);
+        vm.load(&caller_code).unwrap();
+        let output = vm.execute();
+
+        assert_eq!(output.outcome, Outcome::Revert);
+        assert_eq!(
+            vm.ctx.balances.get(&caller_addr).copied(),
+            Some(U256::from(1000u64)),
+            "caller balance must be restored on revert"
+        );
+        assert_eq!(
+            vm.ctx.balances.get(&target_addr).copied(),
+            Some(U256::ZERO),
+            "target balance must be restored on revert"
+        );
+    }
+
+    /// TPL-205: when the CHILD reverts, the parent's balances
+    /// must remain at their pre-call state (no merge happens at
+    /// all). The pre-call `balances` clone fed to the child is
+    /// dropped, child.ctx.balances is dropped — parent's
+    /// `self.ctx.balances` was never modified.
+    #[test]
+    fn call_ext_value_not_applied_when_child_reverts_tpl_205() {
+        let caller_addr = addr(0xAA);
+        let target_addr = addr(0xBB);
+        // Callee: revert immediately.
+        let callee_code = bytecode(&[instr_bytes(Opcode::Revert, 0, 0, 0)]);
+        let caller_code = bytecode(&[
+            instr_ri(Opcode::Addi, 8, 0, 100),
+            instr_ri(Opcode::Addi, 3, 0, 0),
+            instr_ri(Opcode::Addi, 4, 0, 0),
+            instr_bytes(Opcode::CallExt, 0, 2, 0x2143),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+
+        let mut balances = HashMap::new();
+        balances.insert(caller_addr, U256::from(1000u64));
+        balances.insert(target_addr, U256::ZERO);
+        let ctx = ExecutionContext {
+            self_address: caller_addr,
+            balances,
+            ..Default::default()
+        };
+        let mut vm = Vm::with_gas_limit_and_context(1_000_000, ctx);
+        vm.cpu.write_wide(0, U256::from_le_bytes(target_addr));
+        vm.contracts.insert(target_addr, callee_code);
+        vm.load(&caller_code).unwrap();
+        let output = vm.execute();
+
+        assert_eq!(output.outcome, Outcome::Success);
+        assert_eq!(
+            vm.ctx.balances.get(&caller_addr).copied(),
+            Some(U256::from(1000u64)),
+            "caller balance unchanged when child reverts"
+        );
+        assert_eq!(
+            vm.ctx.balances.get(&target_addr).copied(),
+            Some(U256::ZERO),
+            "target balance unchanged when child reverts"
+        );
     }
 
     // ========== Task 0208: CREATE deploys and returns correct address ==========

--- a/crates/tx/src/execution.rs
+++ b/crates/tx/src/execution.rs
@@ -82,17 +82,34 @@ pub struct ExecutionState {
 
 /// Pre-execution: deduct max gas cost from fee payer.
 /// Returns the amount deducted, or error if insufficient.
+///
+/// TPL-206: `gas_limit * base_fee` and `(gas_cost) + value` are both
+/// checked for `u128` overflow. Pre-fix the bare `*` and `+` on
+/// adversarial `(gas_limit, base_fee, value)` would either panic in
+/// debug or wrap in release (workspace `panic = "abort"` makes the
+/// panic SIGABRT — remote-killable from a single submitted tx in any
+/// base-fee-elevated regime).
 pub fn pre_execution_charge(
     tx: &Transaction,
     sender_balance: &mut u128,
     gas_tank_balance: &mut u128,
     base_fee: u128,
 ) -> Result<u128, String> {
-    let max_gas_cost = tx.gas_limit as u128 * base_fee;
+    let max_gas_cost = (tx.gas_limit as u128).checked_mul(base_fee).ok_or_else(|| {
+        format!(
+            "fee overflow: gas_limit ({}) * base_fee ({}) > u128::MAX",
+            tx.gas_limit, base_fee
+        )
+    })?;
 
     match &tx.fee_payer {
         FeePayer::Sender => {
-            let total = max_gas_cost + tx.value;
+            let total = max_gas_cost.checked_add(tx.value).ok_or_else(|| {
+                format!(
+                    "fee overflow: max_gas_cost ({}) + value ({}) > u128::MAX",
+                    max_gas_cost, tx.value
+                )
+            })?;
             if *sender_balance < total {
                 return Err(format!(
                     "insufficient balance: need {total}, have {}",

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -381,8 +381,22 @@ fn validate_balance(
     sender: &Account,
     ctx: &ValidationContext,
 ) -> Result<(), ValidationError> {
-    let gas_cost = tx.gas_limit as u128 * ctx.base_fee;
-    let total_required = gas_cost + tx.value;
+    // TPL-206: bare `*` and `+` on attacker-controlled
+    // `(gas_limit, base_fee, value)` overflow `u128` and either panic
+    // in debug or wrap in release. With `panic = "abort"` workspace-
+    // wide, the panic is SIGABRT — a remote validator-kill from a
+    // single ingress tx in any base-fee-elevated regime. Reject with
+    // an `InsufficientBalance { required: u128::MAX, available }`
+    // result so operator logs surface "required = 2^128 - 1" as the
+    // overflow tell; no balance can satisfy that demand.
+    let overflow = || ValidationError::InsufficientBalance {
+        required: u128::MAX,
+        available: sender.balance.saturating_sub(ctx.sender_locked),
+    };
+    let gas_cost = (tx.gas_limit as u128)
+        .checked_mul(ctx.base_fee)
+        .ok_or_else(overflow)?;
+    let total_required = gas_cost.checked_add(tx.value).ok_or_else(overflow)?;
 
     // Vested / locked balance (slice 4.4) is subtracted from the raw
     // account balance before any solvency check. `saturating_sub`
@@ -629,6 +643,57 @@ mod tests {
         let ctx = default_ctx(); // base_fee = 1000, so 21000 * 1000 = 21M > 100
         let err = validate_transaction(&tx, &account, &nonce, &ctx).unwrap_err();
         assert!(matches!(err, ValidationError::InsufficientBalance { .. }));
+    }
+
+    /// TPL-206 regression — `gas_cost + value` (and `gas_limit *
+    /// base_fee` upstream) must not overflow `u128`. Pre-fix the
+    /// bare `+` and `*` would either panic in debug or wrap in
+    /// release; with workspace `panic = "abort"` either was a
+    /// remote-killable validator process. Post-fix every overflow
+    /// path returns `InsufficientBalance { required: u128::MAX, ..
+    /// }` so the rejection is clean and the operator log shows
+    /// `required = 2^128 - 1` as the unmistakable overflow tell.
+    #[test]
+    fn fee_overflow_rejected_as_insufficient_balance() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        // Balance is irrelevant — overflow makes `required = u128::MAX`,
+        // which exceeds any possible spendable balance regardless.
+        let account = Account {
+            balance: u128::MAX,
+            ..Account::new_eoa(&pk_bytes)
+        };
+        let nonce = NonceState::new();
+
+        // Adversarial shape: `value = u128::MAX` plus any non-zero
+        // `gas_cost` overflows on the `gas_cost + value` add.
+        let mut tx = Transaction {
+            from: account.address,
+            to: ZERO_ADDRESS,
+            value: u128::MAX,
+            data: vec![],
+            gas_limit: 21_000,
+            nonce: 0,
+            signature: vec![],
+            fee_payer: FeePayer::Sender,
+            access_list: vec![],
+            deadline: None,
+            chain_id: 1,
+            tx_type: TransactionType::Standard,
+        };
+        let tx_hash = tx.hash();
+        tx.signature = falcon_sign(&sk, &tx_hash).unwrap().as_bytes().to_vec();
+
+        let ctx = default_ctx();
+        let err = validate_transaction(&tx, &account, &nonce, &ctx).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ValidationError::InsufficientBalance { required, .. } if required == u128::MAX
+            ),
+            "expected fee-overflow → InsufficientBalance{{required: u128::MAX, ..}}, got {:?}",
+            err
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Eight launch-blocker fixes from `TESTNET_LAUNCH_TRACKER.md`.
Stacked on a single branch per Strategy B; CI billing is still
blocked at the org level so this is admin-merged the same way as
PR #350 / PR #351.

### Consensus correctness

- **TPL-203** (`ed71ea7`) — `select_and_vote` reads
  `consensus.target_height` instead of `current_slot`, matching
  the documented invariant at `node.rs:5278` and the slot-keying
  used by `try_build_fallback_proposal` /
  `buffer_fallback_proposal`. Pre-fix, recovery longer than
  `SLOT_DURATION_MS` drifted `current_slot` past `target_height`
  and the validator silently abstained on every fallback proposal
  for the rest of the recovery window.

- **TPL-204** (`a57eff5`) — `validate_network_block` now mirrors
  the validator-side fallback-leader check (CONSENSUS_INVARIANTS.md
  L2). Pre-fix the `vrf_proof.len() >= 33` gate skipped fallback
  proofs (24 bytes) entirely, so two valid Byzantine fallbacks at
  `(H, V)` both passed full-node validation. Unrecognised proof
  shapes are now also rejected.

### Execution-backend parity

- **TPL-202** (`62caf38`) — `host_load` / `host_pop` take a
  `trap_out: *mut u64` out-parameter; fault no longer collides
  with a legitimate `0xFFFF_FFFF_FFFF_FFFF` value. Both the
  AOT-traps-when-interpreter-doesn't direction (`Pop`) and the
  AOT-doesn't-trap-when-interpreter-does direction (`Load`) are
  closed.

- **TPL-205** (`883d91e`) — `Vm` gains a balance journal mirroring
  `storage_journal`. CallExt and CREATE merge child balance changes
  into parent on success and roll back on revert / OOG / trap.
  Pre-fix every cross-contract value transfer was a silent no-op,
  including the deploy value in `do_create`'s no-constructor path.

### Mempool ingress hardening

- **TPL-206** (`05341f2`) — `pre_execution_charge` and
  `validate_balance` use `checked_mul` + `checked_add` for
  `gas_limit * base_fee` and `gas_cost + value`. Pre-fix overflow
  wrapped to a small number and the tx ran with what looked like
  a sufficient balance but never paid the full fee.

- **TPL-207, TPL-402** (`a387e5a`) — `FastTxSection::default::listen`
  binds to `127.0.0.1` (was `0.0.0.0`); `pyde run --dev` refuses
  to start unless `chain_id == DEVNET_CHAIN_ID`.

### Otigen language

- **TPL-208** (`070982b`) — `reject_signed_in_type` now runs on
  declared types in `let` bindings and on the target type of
  `Expr::Cast`, closing the body-level holes audit 354's
  declaration-only walker missed.

- **TPL-209** (`73210c3`) — Reject `Vec<wide>` and `[wide; N]`
  in typecheck. The 8-byte-stride codegen silently truncates
  every wider element. Stride-aware codegen lands post-mainnet;
  49 stdlib fixtures using these shapes are `#[ignore]`-gated for
  now.

## Notes

- All eight commits include regression tests; where the fix
  affects executable behaviour the tests were verified failing
  on a temporarily-reverted source line and passing post-fix.
- `pyde-vm` 347/347 lib tests pass, `pyde-aot` 51/51 pass,
  `otic` 397/397 lib tests pass plus 47/100 integration tests
  pass with 53 ignored (49 TPL-209 + 4 audit-354).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`
  are both clean for every touched crate.