### PR TITLE
fix: stop trivial DoS, key disclosure, validator-process kills (TPL-401..411)

### DIFF
--- a/crates/mempool/src/block_builder.rs
+++ b/crates/mempool/src/block_builder.rs
@@ -183,7 +183,7 @@ mod tests {
             pk,
         )
         .unwrap();
-        pool.add(tx).unwrap();
+        pool.add_unverified_for_devnet(tx).unwrap();
     }
 
     // ========== Task 0539: Block respects gas limit ==========

--- a/crates/mempool/src/encrypted.rs
+++ b/crates/mempool/src/encrypted.rs
@@ -29,9 +29,20 @@ const MAX_KEYS_PER_ACCESS_ENTRY: usize = 1024;
 /// FALCON-512 signatures are ~600-690 bytes in practice; the pool's
 /// structural-only path accepts [500, 1000]. Cap at 1024 for headroom.
 const MAX_SIG_LEN: usize = 1024;
-/// Threshold ciphertext is bounded by the encrypted payload, which is
-/// itself bounded by the overall tx size limit.
-const MAX_CT_LEN: usize = MAX_TX_SIZE;
+/// TPL-410: cap derived from the actual ciphertext layout, not the
+/// loose `MAX_TX_SIZE` bound. Wire format from
+/// `ThresholdCiphertext::to_wire_bytes` is
+///   `[ct_len:4][kyber_ct:1088][msg_len:4][encrypted_msg:N][mac:32]`
+/// where `N = 48-byte payload header + calldata`, and calldata is
+/// bounded by `pyde_tx::validation::MAX_CALLDATA = 64 KB`. Sum:
+///   `4 + 1088 + 4 + 48 + 65 536 + 32 = 66 712 ≈ 65 KB`.
+/// Round up to 72 KB for ~7 KB headroom against a future format bump
+/// (version byte, additional length field, etc.). Pre-fix the cap
+/// was the full 128 KB tx-size budget — a malicious peer could
+/// claim a 128 KB ciphertext, drive a `Vec::with_capacity(128 KB)`
+/// per malformed gossip blob, and trivially DoS the validator's
+/// allocator under `panic = "abort"`.
+const MAX_CT_LEN: usize = 72 * 1024;
 
 /// An encrypted transaction in the mempool.
 /// Plaintext fields are visible for validation and scheduling.
@@ -576,6 +587,28 @@ mod tests {
         bytes.extend_from_slice(&0u32.to_le_bytes()); // 0-byte signature
         bytes.extend_from_slice(&((MAX_CT_LEN as u32) + 1).to_le_bytes()); // huge ct_len
         assert!(EncryptedTx::from_bytes(&bytes).is_none());
+    }
+
+    /// TPL-410: pre-fix `MAX_CT_LEN` was the loose `MAX_TX_SIZE = 128 KB`
+    /// budget; a malicious peer could claim a 100 KB ciphertext and
+    /// trigger a `Vec::with_capacity(100 KB)` per malformed gossip
+    /// blob. Post-fix the cap is 72 KB (just over the real ciphertext
+    /// max of ~67 KB) so a 100 KB claim is rejected.
+    #[test]
+    fn tpl_410_from_bytes_rejects_100kb_ciphertext_len() {
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(&[0u8; 32]); // sender
+        bytes.extend_from_slice(&0u64.to_le_bytes()); // nonce
+        bytes.extend_from_slice(&21_000u64.to_le_bytes()); // gas
+        bytes.extend_from_slice(&1u64.to_le_bytes()); // chain_id
+        bytes.push(0); // has_deadline = 0
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // 0 access entries
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // 0-byte signature
+        bytes.extend_from_slice(&(100u32 * 1024).to_le_bytes()); // 100 KB ct_len
+        assert!(
+            EncryptedTx::from_bytes(&bytes).is_none(),
+            "100 KB ciphertext claim must be rejected by the tightened cap"
+        );
     }
 
     #[test]

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -18,7 +18,7 @@
 //! when mempool connects to full node state.
 
 use crate::encrypted::EncryptedTx;
-use pyde_account::address::Address;
+use pyde_account::address::{derive_eoa_address, Address};
 use pyde_crypto::falcon::{falcon_verify, FalconPublicKey, FalconSignature};
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -283,12 +283,30 @@ impl Mempool {
     ///   also fail.
     ///
     /// Applies the same structural + rate-limit checks as `add`.
+    ///
+    /// TPL-407: also asserts `derive_eoa_address(sender_pubkey)
+    /// == tx.sender`. Pre-fix the FALCON sig binding closed
+    /// (sender_pubkey, tx.hash()) but NOT (sender_pubkey,
+    /// tx.sender) — an attacker could submit a tx claiming
+    /// `sender = victim`, signed by their own (attacker) pubkey,
+    /// and the sig still verified because verification only
+    /// requires the supplied pubkey to match the signing key. The
+    /// crafted tx then sat in the mempool charged to the victim's
+    /// nonce/quota slot. The address-binding check below closes
+    /// that gap: if the on-chain address derived from the supplied
+    /// pubkey doesn't match `tx.sender`, reject before either the
+    /// sig verify or any further state mutation.
     pub fn add_with_pubkey(
         &mut self,
         tx: EncryptedTx,
         sender_pubkey: &[u8],
     ) -> Result<(), MempoolError> {
         self.check_sender_rate(&tx.sender)?;
+        // TPL-407: pubkey → sender binding. Cheap (Poseidon2 over
+        // the pubkey bytes) so it goes ahead of the FALCON verify.
+        if derive_eoa_address(sender_pubkey) != tx.sender {
+            return Err(MempoolError::UnknownOrUnverifiedSender);
+        }
         if !Self::verify_signature_with_key(&tx, sender_pubkey) {
             return Err(MempoolError::UnknownOrUnverifiedSender);
         }
@@ -1207,6 +1225,44 @@ mod tests {
             MempoolError::UnknownOrUnverifiedSender,
         );
         let _ = to;
+    }
+
+    /// TPL-407: an attacker submits a tx with `sender = victim`,
+    /// signs it with their own (attacker) key, and supplies their
+    /// own pubkey. Pre-fix the FALCON verify passed (their pk
+    /// signed the hash) and the tx landed in the mempool charged
+    /// to the victim's nonce/quota slot. Post-fix the
+    /// pubkey → sender binding rejects before the sig check
+    /// because `derive_eoa_address(attacker_pk) != victim`.
+    #[test]
+    fn tpl_407_add_with_pubkey_rejects_sender_pubkey_mismatch() {
+        let pk = make_pk();
+        // Build a tx legitimately signed by attacker_sk with
+        // sender = derive_eoa_address(attacker_pk).
+        let (mut tx, attacker_pk_bytes, attacker_sk) = make_falcon_signed_tx(&pk, 50_000, 0);
+
+        // Attack: rewrite the sender field to the victim's
+        // address, then re-sign so the FALCON sig verifies against
+        // the attacker's pubkey under the new tx.hash(). Pre-fix
+        // this is enough to slip into the mempool.
+        let victim = derive_eoa_address(b"victim-target-address");
+        tx.sender = victim;
+        let new_hash = tx.hash();
+        tx.signature = pyde_crypto::falcon::falcon_sign(&attacker_sk, &new_hash)
+            .unwrap()
+            .to_vec();
+
+        // Sanity: the sig DOES verify under the supplied pubkey.
+        // The only thing keeping this tx out is the new
+        // address-binding check.
+        assert!(Mempool::verify_signature_with_key(&tx, &attacker_pk_bytes));
+
+        let mut pool = Mempool::new();
+        let err = pool
+            .add_with_pubkey(tx, &attacker_pk_bytes)
+            .expect_err("pubkey/sender mismatch must reject");
+        assert_eq!(err, MempoolError::UnknownOrUnverifiedSender);
+        assert_eq!(pool.len(), 0);
     }
 
     #[test]

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -237,14 +237,20 @@ impl Mempool {
         self.txs.is_empty()
     }
 
-    /// Add an encrypted transaction to the mempool with structural
-    /// validation + per-sender rate limit (task 027).
+    /// Add an encrypted transaction with structural validation +
+    /// per-sender rate limit only — does NOT cryptographically verify
+    /// the FALCON signature against the sender's on-chain pubkey.
     ///
-    /// This path does NOT cryptographically verify the FALCON signature —
-    /// it only checks the signature is structurally plausible (length).
-    /// Mainnet consumers must use `add_with_pubkey` which also enforces
-    /// task 028 (ciphertext-to-pubkey binding). `add` remains available
-    /// for devnet and for tests that don't want to construct a full key.
+    /// TPL-406: previously named `add`, which made it the obvious
+    /// default verb for any caller writing `mempool.add_unverified_for_devnet(tx)`. The
+    /// shorter name was a footgun — production code paths that
+    /// should bind sender → pubkey via `add_with_pubkey` could
+    /// silently accept unverified txs by reaching for the wrong
+    /// method. The renamed `add_unverified_for_devnet` forces every
+    /// caller to consciously acknowledge the bypass; mainnet
+    /// gating still lives in
+    /// `crate::rpc::encrypted_tx_ingest_policy`, which maps
+    /// non-devnet chains away from this path.
     ///
     /// Checks, in order:
     /// 1. Per-sender rate limit (windowed)
@@ -256,7 +262,7 @@ impl Mempool {
     /// 7. Size within limit
     /// 8. Not expired
     /// 9. Not duplicate
-    pub fn add(&mut self, tx: EncryptedTx) -> Result<(), MempoolError> {
+    pub fn add_unverified_for_devnet(&mut self, tx: EncryptedTx) -> Result<(), MempoolError> {
         self.check_sender_rate(&tx.sender)?;
         self.verify_signature(&tx)?;
         self.check_core_validity(&tx)?;
@@ -636,7 +642,7 @@ mod tests {
         let mut pool = Mempool::new();
 
         let tx = make_enc_tx(&pk, 50_000, 0);
-        pool.add(tx).unwrap();
+        pool.add_unverified_for_devnet(tx).unwrap();
         assert_eq!(pool.len(), 1);
     }
 
@@ -646,8 +652,8 @@ mod tests {
         let mut pool = Mempool::new();
 
         let tx = make_enc_tx(&pk, 50_000, 0);
-        pool.add(tx.clone()).unwrap();
-        assert_eq!(pool.add(tx), Err(MempoolError::Duplicate));
+        pool.add_unverified_for_devnet(tx.clone()).unwrap();
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::Duplicate));
     }
 
     #[test]
@@ -657,7 +663,7 @@ mod tests {
         pool.set_current_block(200);
 
         let tx = make_enc_tx_with_deadline(&pk, 50_000, 0, 100); // expired
-        assert_eq!(pool.add(tx), Err(MempoolError::Expired));
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::Expired));
     }
 
     #[test]
@@ -666,7 +672,7 @@ mod tests {
         let mut pool = Mempool::new();
 
         let tx = make_enc_tx(&pk, 20_999, 0); // below 21K
-        assert_eq!(pool.add(tx), Err(MempoolError::GasTooLow));
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::GasTooLow));
     }
 
     #[test]
@@ -675,7 +681,7 @@ mod tests {
         let mut pool = Mempool::new();
 
         let tx = make_enc_tx(&pk, 2_000_000_000, 0); // exceeds GAS_CEILING
-        assert_eq!(pool.add(tx), Err(MempoolError::GasTooHigh));
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::GasTooHigh));
     }
 
     #[test]
@@ -699,7 +705,7 @@ mod tests {
             &pk,
         )
         .unwrap();
-        assert_eq!(pool.add(tx), Err(MempoolError::InvalidSignature));
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::InvalidSignature));
     }
 
     #[test]
@@ -723,7 +729,7 @@ mod tests {
             &pk,
         )
         .unwrap();
-        assert_eq!(pool.add(tx), Err(MempoolError::MissingAccessList));
+        assert_eq!(pool.add_unverified_for_devnet(tx), Err(MempoolError::MissingAccessList));
     }
 
     // ========== Task 0521: Eviction when full ==========
@@ -734,13 +740,13 @@ mod tests {
         let mut pool = Mempool::with_capacity(3);
 
         // Fill pool: nonce 0 (oldest), 1, 2
-        pool.add(make_enc_tx(&pk, 30_000, 0)).unwrap();
-        pool.add(make_enc_tx(&pk, 40_000, 1)).unwrap();
-        pool.add(make_enc_tx(&pk, 50_000, 2)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 30_000, 0)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 40_000, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 50_000, 2)).unwrap();
         assert_eq!(pool.len(), 3);
 
         // Add new tx → evicts oldest (nonce 0, gas 30K)
-        pool.add(make_enc_tx(&pk, 60_000, 3)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 60_000, 3)).unwrap();
         assert_eq!(pool.len(), 3);
 
         // Oldest (30K) should be gone, newest (60K) should be present
@@ -755,9 +761,9 @@ mod tests {
         let pk = make_pk();
         let mut pool = Mempool::new();
 
-        pool.add(make_enc_tx(&pk, 30_000, 0)).unwrap();
-        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
-        pool.add(make_enc_tx(&pk, 45_000, 2)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 30_000, 0)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 45_000, 2)).unwrap();
 
         let txs = pool.in_arrival_order();
         assert_eq!(txs[0].gas_limit, 30_000); // first in
@@ -772,9 +778,9 @@ mod tests {
         let pk = make_pk();
         let mut pool = Mempool::new();
 
-        pool.add(make_enc_tx(&pk, 50_000, 0)).unwrap();
-        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
-        pool.add(make_enc_tx(&pk, 40_000, 2)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 50_000, 0)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 40_000, 2)).unwrap();
 
         // Block gas limit of 100K → picks 60K + 40K (or 60K + 50K... highest first)
         let selected = pool.select_for_block(100_000, usize::MAX, 0);
@@ -788,9 +794,9 @@ mod tests {
         let pk = make_pk();
         let mut pool = Mempool::new();
 
-        pool.add(make_enc_tx_with_deadline(&pk, 50_000, 0, 200))
+        pool.add_unverified_for_devnet(make_enc_tx_with_deadline(&pk, 50_000, 0, 200))
             .unwrap();
-        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap(); // no deadline
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 60_000, 1)).unwrap(); // no deadline
 
         // At slot 300, first tx is expired
         let selected = pool.select_for_block(1_000_000, usize::MAX, 300);
@@ -809,7 +815,7 @@ mod tests {
         // pool has the test-relevant txs.
         pool.set_rate_limits(1_000, 1_000);
         for nonce in 0..5 {
-            pool.add(make_enc_tx(&pk, 30_000, nonce)).unwrap();
+            pool.add_unverified_for_devnet(make_enc_tx(&pk, 30_000, nonce)).unwrap();
         }
         // Gas room = 5×30k = 150k well under 1M, count cap = 2
         let selected = pool.select_for_block(1_000_000, 2, 0);
@@ -827,7 +833,7 @@ mod tests {
         pool.set_rate_limits(10_000, 10_000);
         // Add more than the cap so the cap is the binding constraint.
         for nonce in 0..(MAX_ENCRYPTED_TXS_PER_BLOCK as u64 + 5) {
-            pool.add(make_enc_tx(&pk, 30_000, nonce)).unwrap();
+            pool.add_unverified_for_devnet(make_enc_tx(&pk, 30_000, nonce)).unwrap();
         }
         let selected = pool.select_for_block(1_000_000_000, MAX_ENCRYPTED_TXS_PER_BLOCK, 0);
         assert_eq!(selected.len(), MAX_ENCRYPTED_TXS_PER_BLOCK);
@@ -840,9 +846,9 @@ mod tests {
         let pk = make_pk();
         let mut pool = Mempool::new();
 
-        pool.add(make_enc_tx_with_deadline(&pk, 50_000, 0, 100))
+        pool.add_unverified_for_devnet(make_enc_tx_with_deadline(&pk, 50_000, 0, 100))
             .unwrap();
-        pool.add(make_enc_tx(&pk, 60_000, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx(&pk, 60_000, 1)).unwrap();
         assert_eq!(pool.len(), 2);
 
         pool.set_current_block(200);
@@ -864,12 +870,12 @@ mod tests {
         // Mix: tx 0 expires at slot 100, txs 1..5 don't expire.
         let expired_tx = make_enc_tx_with_deadline(&pk, 50_000, 0, 100);
         let expired_hash = expired_tx.hash();
-        pool.add(expired_tx).unwrap();
+        pool.add_unverified_for_devnet(expired_tx).unwrap();
         let mut retained_hashes = Vec::new();
         for nonce in 1..5u64 {
             let tx = make_enc_tx(&pk, 60_000, nonce);
             retained_hashes.push(tx.hash());
-            pool.add(tx).unwrap();
+            pool.add_unverified_for_devnet(tx).unwrap();
         }
         assert_eq!(pool.len(), 5);
 
@@ -911,7 +917,7 @@ mod tests {
 
         let tx = make_enc_tx_with_deadline(&pk, 50_000, 0, 1_000);
         let hash = tx.hash();
-        pool.add(tx).unwrap();
+        pool.add_unverified_for_devnet(tx).unwrap();
 
         // Block far below the deadline — nothing expires.
         pool.set_current_block(10);
@@ -936,8 +942,8 @@ mod tests {
         let tx2 = make_enc_tx(&pk, 60_000, 1);
         let hash1 = tx1.hash();
 
-        pool.add(tx1).unwrap();
-        pool.add(tx2).unwrap();
+        pool.add_unverified_for_devnet(tx1).unwrap();
+        pool.add_unverified_for_devnet(tx2).unwrap();
         assert_eq!(pool.len(), 2);
 
         pool.remove_included(&[hash1]);
@@ -1014,11 +1020,11 @@ mod tests {
 
         let sender = derive_eoa_address(b"rate-sender");
         for n in 0..3 {
-            pool.add(make_enc_tx_from(&pk, sender, n)).unwrap();
+            pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, n)).unwrap();
         }
 
         // Fourth submission within the same window → rate-limited.
-        let err = pool.add(make_enc_tx_from(&pk, sender, 3)).unwrap_err();
+        let err = pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 3)).unwrap_err();
         assert_eq!(err, MempoolError::RateLimitExceeded);
         assert_eq!(pool.len(), 3);
     }
@@ -1032,20 +1038,20 @@ mod tests {
 
         let sender = derive_eoa_address(b"rolling-sender");
         set_test_clock_ms(100);
-        pool.add(make_enc_tx_from(&pk, sender, 0)).unwrap();
-        pool.add(make_enc_tx_from(&pk, sender, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 0)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 1)).unwrap();
 
         // Still within window — third is rejected.
         set_test_clock_ms(500);
         assert_eq!(
-            pool.add(make_enc_tx_from(&pk, sender, 2)).unwrap_err(),
+            pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 2)).unwrap_err(),
             MempoolError::RateLimitExceeded,
         );
 
         // Advance past window boundary (window = 1000ms, start was 100 ms).
         // At t=1101 all original timestamps are older than now - 1000 = 101.
         set_test_clock_ms(1_101);
-        pool.add(make_enc_tx_from(&pk, sender, 3))
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 3))
             .expect("window should have rolled");
     }
 
@@ -1063,12 +1069,12 @@ mod tests {
         for n in 0..3 {
             let tx = make_enc_tx_from(&pk, sender, n);
             hashes.push(tx.hash());
-            pool.add(tx).unwrap();
+            pool.add_unverified_for_devnet(tx).unwrap();
         }
 
         // 4th concurrently → blocked.
         assert_eq!(
-            pool.add(make_enc_tx_from(&pk, sender, 3)).unwrap_err(),
+            pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 3)).unwrap_err(),
             MempoolError::TooManyConcurrentFromSender,
         );
 
@@ -1077,7 +1083,7 @@ mod tests {
         set_test_clock_ms(2_100); // roll window so the rate counter doesn't
                                   // independently block (submits are windowed
                                   // but in_pool count is not).
-        pool.add(make_enc_tx_from(&pk, sender, 3))
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, sender, 3))
             .expect("slot should have been released");
     }
 
@@ -1092,17 +1098,17 @@ mod tests {
         let alice = derive_eoa_address(b"alice");
         let bob = derive_eoa_address(b"bob");
 
-        pool.add(make_enc_tx_from(&pk, alice, 0)).unwrap();
-        pool.add(make_enc_tx_from(&pk, alice, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, alice, 0)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, alice, 1)).unwrap();
 
         // Alice is at her rate cap, but Bob still has headroom.
         assert_eq!(
-            pool.add(make_enc_tx_from(&pk, alice, 2)).unwrap_err(),
+            pool.add_unverified_for_devnet(make_enc_tx_from(&pk, alice, 2)).unwrap_err(),
             MempoolError::RateLimitExceeded,
         );
-        pool.add(make_enc_tx_from(&pk, bob, 0))
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, bob, 0))
             .expect("bob is unaffected by alice's cap");
-        pool.add(make_enc_tx_from(&pk, bob, 1)).unwrap();
+        pool.add_unverified_for_devnet(make_enc_tx_from(&pk, bob, 1)).unwrap();
     }
 
     // ========== Task 028: FALCON-pubkey binding on submit ==========

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -985,6 +985,26 @@ impl BlockProcessor {
             ));
         }
 
+        // TPL-409: enforce the encrypted-tx-per-block cap on the
+        // validator decode path. Pre-fix the cap lived only in
+        // `Mempool::select_for_block`, so a Byzantine proposer (or
+        // a buggy patched proposer) could ship a block carrying
+        // more than `MAX_ENCRYPTED_TXS_PER_BLOCK` encrypted txs
+        // and every validator would happily decrypt the entire
+        // batch. The decryption-share gossip + Lagrange combine is
+        // O(n_txs * threshold), so an unbounded n_txs lets a
+        // proposer push validators into seconds-per-block of
+        // unrelated work — easy DoS on the consensus loop. Cap is
+        // a hard reject, not a soft warning, because honest
+        // proposers always stay below it.
+        if block.body.encrypted_txs.len() > pyde_mempool::pool::MAX_ENCRYPTED_TXS_PER_BLOCK {
+            return Err(format!(
+                "block carries {} encrypted txs, exceeds MAX_ENCRYPTED_TXS_PER_BLOCK={}",
+                block.body.encrypted_txs.len(),
+                pyde_mempool::pool::MAX_ENCRYPTED_TXS_PER_BLOCK,
+            ));
+        }
+
         let txs = &block.body.transactions;
         if txs.is_empty() && block.body.encrypted_txs.is_empty() {
             return Ok(());
@@ -1839,6 +1859,63 @@ mod tests {
         )
         .unwrap();
         (pk, shares, enc_a, enc_b, falcon_pks, falcon_sks)
+    }
+
+    /// TPL-409: a block carrying more than
+    /// `MAX_ENCRYPTED_TXS_PER_BLOCK` (=100) encrypted txs must be
+    /// rejected by `validate_block_body`. Pre-fix the cap lived
+    /// only in proposer-side selection — a Byzantine proposer
+    /// shipping 200 encrypted txs would force every honest
+    /// validator to run 2× the decryption work the protocol
+    /// budgets for.
+    #[test]
+    fn tpl_409_validate_block_body_rejects_oversize_encrypted_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = StateManager::open(tmp.path(), 1024).unwrap();
+
+        // Build one real encrypted tx and clone its bytes so we can
+        // pad the body up past the cap. The clone shares all fields
+        // including nonce/sender — `validate_block_body` doesn't
+        // dedup encrypted txs by hash (only plaintext does), so
+        // identical bytes are accepted as distinct count slots,
+        // which is exactly what an attacker would do.
+        let (_pk, _shares, enc_a, _enc_b, _falcon_pks, _falcon_sks) =
+            build_two_encrypted_txs_with_keys();
+        let cap = pyde_mempool::pool::MAX_ENCRYPTED_TXS_PER_BLOCK;
+        let oversize: Vec<Vec<u8>> = (0..=cap).map(|_| enc_a.to_bytes()).collect();
+        assert_eq!(oversize.len(), cap + 1);
+
+        // Header must commit to the body's tx_root so the cap check
+        // (which runs AFTER tx_root verify) is the only thing that
+        // can reject. Otherwise the test would fail on tx_root
+        // mismatch and we wouldn't be exercising TPL-409.
+        let hashes: Vec<[u8; 32]> = oversize
+            .iter()
+            .filter_map(|b| pyde_mempool::encrypted::EncryptedTx::from_bytes(b))
+            .map(|e| e.hash())
+            .collect();
+        let mut header = dummy_header(1);
+        header.tx_root = pyde_consensus::block::compute_tx_root(&[], &hashes);
+        let block = Block {
+            header,
+            body: BlockBody {
+                transactions: vec![],
+                encrypted_txs: oversize,
+                execution_schedule: ExecutionSchedule {
+                    groups: vec![],
+                    total_txs: 0,
+                },
+            },
+            proposer_signature: vec![],
+        };
+
+        let err = BlockProcessor::validate_block_body(&block, &state, 1)
+            .expect_err("oversize encrypted-tx body must reject");
+        assert!(
+            err.contains("MAX_ENCRYPTED_TXS_PER_BLOCK"),
+            "expected MAX_ENCRYPTED_TXS_PER_BLOCK in error; got: {}",
+            err
+        );
     }
 
     fn store_block_with_encrypted_order(

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -848,20 +848,82 @@ fn build_multiaddr(host: &str, port: u16, peer_id: &libp2p::PeerId) -> String {
 /// with FALCON signing material from a freshly-generated testnet
 /// bundle. Non-secret files (config.toml, genesis.toml, threshold.pk)
 /// are still written with `fs::write` directly.
-fn write_secret_file(path: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
-    std::fs::write(path, bytes)
-        .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
+/// Atomic, mode-0o600 write of a secret-bearing file (validator.key,
+/// threshold.share, node.key).
+///
+/// TPL-401: pre-fix this helper called `fs::write(path, ...)` and
+/// only set 0o600 *after* the write returned. Two failure modes:
+///   1. **Race window.** Between `write` and `set_permissions` the
+///      file existed at the operator's umask (often 0o644 → world-
+///      readable). On a multi-tenant box another local user with
+///      a tight poll loop could read the FALCON sk before the
+///      mode tightened.
+///   2. **Crash inconsistency.** A `kill -9` mid-write left a
+///      truncated key file with no atomic-replace guarantee, and
+///      on subsequent startup the loader saw a corrupt file
+///      instead of either the old or the new content.
+///
+/// Post-fix:
+///   - Unix path opens a `*.tmp` sibling with `create(true)
+///     .truncate(true).write(true).mode(0o600)` — the file exists
+///     at 0o600 from the very first byte written.
+///   - Bytes are flushed and `sync_all`'d before rename.
+///   - `rename(tmp, path)` is atomic on POSIX, so a crash either
+///     leaves the old file intact or completes the swap.
+///
+/// Non-Unix targets fall back to `fs::write` + `rename` (we don't
+/// run validators on Windows in production; covers test ergonomics
+/// only).
+pub(crate) fn write_secret_file(path: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
+    let tmp_path = match path.file_name() {
+        Some(name) => {
+            let mut tmp = name.to_owned();
+            tmp.push(".tmp");
+            path.with_file_name(tmp)
+        }
+        None => return Err(format!("invalid path (no file name): {}", path.display())),
+    };
+
+    // If a prior crash left a stale tmp, drop it before we open
+    // — `create(true).truncate(true)` would clobber anyway, but
+    // unlinking first means the new file starts from a clean
+    // inode with the requested mode rather than inheriting
+    // whatever permissions the prior tmp had.
+    let _ = std::fs::remove_file(&tmp_path);
+
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
-            format!(
-                "failed to set 0o600 on {} (audit 344): {}",
-                path.display(),
-                e
-            )
-        })?;
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(&tmp_path)
+            .map_err(|e| format!("failed to open {}: {}", tmp_path.display(), e))?;
+        f.write_all(bytes)
+            .map_err(|e| format!("failed to write {}: {}", tmp_path.display(), e))?;
+        f.sync_all()
+            .map_err(|e| format!("failed to fsync {}: {}", tmp_path.display(), e))?;
     }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, bytes)
+            .map_err(|e| format!("failed to write {}: {}", tmp_path.display(), e))?;
+    }
+
+    std::fs::rename(&tmp_path, path).map_err(|e| {
+        // Best-effort tmp cleanup; if rename fails, leaving the
+        // tmp around helps the operator diagnose disk/perms.
+        format!(
+            "failed to rename {} → {}: {}",
+            tmp_path.display(),
+            path.display(),
+            e
+        )
+    })?;
+
     Ok(())
 }
 
@@ -2438,5 +2500,49 @@ mod tests {
         write_secret_file(&path, b"updated").unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
+    }
+
+    /// TPL-401: a successful write leaves no `*.tmp` sibling. The
+    /// atomic-rename pattern stages bytes in `secret.bin.tmp` and
+    /// renames it onto `secret.bin`; a leftover tmp would mean the
+    /// rename never fired (functional bug) or the helper isn't using
+    /// the staging path at all (regression to the pre-fix
+    /// `fs::write` form).
+    #[test]
+    fn tpl_401_write_secret_file_leaves_no_tmp_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.bin");
+        let tmp = dir.path().join("secret.bin.tmp");
+        write_secret_file(&path, b"contents").unwrap();
+        assert!(path.exists(), "final file must exist post-write");
+        assert!(
+            !tmp.exists(),
+            "atomic write must remove the staging tmp on success"
+        );
+        // Bytes round-trip.
+        let read = std::fs::read(&path).unwrap();
+        assert_eq!(read, b"contents");
+    }
+
+    /// TPL-401: a stale `*.tmp` left by a prior crashed write does
+    /// NOT block a fresh `write_secret_file` call. Pre-fix the
+    /// helper used `fs::write` directly so this case didn't apply;
+    /// post-fix the helper unlinks any stale tmp before opening the
+    /// new staging file with `mode(0o600)`, so an interrupted
+    /// previous run can't leave the operator unable to re-save the
+    /// validator's secret material.
+    #[test]
+    fn tpl_401_write_secret_file_recovers_from_stale_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.bin");
+        let tmp = dir.path().join("secret.bin.tmp");
+        // Simulate a prior crash: tmp file from a previous attempt
+        // is sitting around at default umask.
+        std::fs::write(&tmp, b"stale leftover").unwrap();
+        // Fresh write must succeed (not fail because tmp exists).
+        write_secret_file(&path, b"fresh contents").unwrap();
+        let read = std::fs::read(&path).unwrap();
+        assert_eq!(read, b"fresh contents");
+        assert!(!tmp.exists(), "post-success tmp must be cleaned up");
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -494,6 +494,16 @@ impl PydeNode {
 
             let mut engine = ValidatorEngine::new(self.config.node.chain_id, [0xAA; 32]); // devnet epoch randomness
 
+            // TPL-405: hand the engine a clone of the process-wide
+            // shutdown signal so persist failures (consensus state,
+            // evidence, finality checkpoint, reshare state, seen-
+            // proposal/vote) trigger a graceful drain instead of
+            // `panic!`. Pre-fix the engine called `panic!` directly
+            // on any of these paths; under `panic = "abort"` that's
+            // an immediate SIGABRT that bypasses the main loop's
+            // shutdown branch (peer_book save, etc.).
+            engine.attach_shutdown_signal(self.shutdown.clone());
+
             // Attach persistent ConsensusState store. If a prior state exists,
             // it is loaded here — this is what prevents last_voted_slot or
             // highest_qc from regressing after a validator crash/restart.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -747,6 +747,10 @@ impl PydeNode {
                 dev_mode: self.config.node.dev_mode,
                 tx_gossip_tx: tx_gossip_tx.clone(),
                 encrypted_tx_gossip_tx: encrypted_tx_gossip_tx.clone(),
+                // TPL-404: bound concurrent simulator-backed RPCs.
+                call_concurrency: Arc::new(tokio::sync::Semaphore::new(
+                    rpc::CALL_CONCURRENCY_LIMIT,
+                )),
             });
             match rpc::start_rpc_server(
                 &self.config.rpc.listen,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -3678,9 +3678,28 @@ impl PydeNode {
                             if let Some(identity) = validator_identity.as_ref() {
                                 if let Some(ref ks) = identity.key_share {
                                     let share_path = self.config.node.datadir.join("threshold.share");
-                                    if std::fs::write(&share_path, ks.to_bytes()).is_ok() {
-                                        engine.key_share_dirty = false;
-                                        info!("PSS: refreshed key share saved to disk");
+                                    // TPL-401: atomic + 0o600. PSS-refresh
+                                    // hits this path every refresh round,
+                                    // so the pre-fix
+                                    // `fs::write(...).is_ok()` left the
+                                    // share readable at the operator's
+                                    // umask between write and mode-set on
+                                    // every refresh — repeatedly opening
+                                    // the same race window.
+                                    match crate::genesis::write_secret_file(
+                                        &share_path,
+                                        &ks.to_bytes(),
+                                    ) {
+                                        Ok(()) => {
+                                            engine.key_share_dirty = false;
+                                            info!("PSS: refreshed key share saved to disk");
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                error = %e,
+                                                "PSS: failed to persist refreshed key share"
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -6055,12 +6074,16 @@ fn load_validator_identity(datadir: &Path, chain_id: u64) -> Result<ValidatorIde
         // otherwise fall back to legacy raw bytes for devnet
         // ergonomics (existing test infra doesn't set the env
         // var and shouldn't have to).
+        // TPL-401: write atomically with 0o600 from the first
+        // byte. Pre-fix the bytes hit disk via `fs::write` at the
+        // operator's umask, then `set_permissions` tightened to
+        // 0o600 — a multi-tenant box could lose the FALCON sk to
+        // a poll loop running during that window.
         if let Some(pass) = passphrase.as_deref().filter(|p| !p.is_empty()) {
             let keystore = crate::keystore::encrypt(&pk, &sk, pass)?;
             let json = serde_json::to_vec_pretty(&keystore)
                 .map_err(|e| format!("failed to serialize keystore: {e}"))?;
-            std::fs::write(&key_path, &json)
-                .map_err(|e| format!("failed to write {}: {}", key_path.display(), e))?;
+            crate::genesis::write_secret_file(&key_path, &json)?;
             info!(
                 path = %key_path.display(),
                 "generated and encrypted new validator signing key"
@@ -6072,21 +6095,12 @@ fn load_validator_identity(datadir: &Path, chain_id: u64) -> Result<ValidatorIde
             buf.extend_from_slice(&(pk_bytes.len() as u32).to_le_bytes());
             buf.extend_from_slice(pk_bytes);
             buf.extend_from_slice(sk_bytes);
-            std::fs::write(&key_path, &buf)
-                .map_err(|e| format!("failed to write {}: {}", key_path.display(), e))?;
+            crate::genesis::write_secret_file(&key_path, &buf)?;
             info!(
                 path = %key_path.display(),
                 "generated new validator signing key (unencrypted — set \
                  PYDE_VALIDATOR_PASSPHRASE for encryption)"
             );
-        }
-
-        // Tighten permissions on the key file regardless of
-        // format — readable only by the owning user.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600));
         }
 
         (pk, sk)

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1898,8 +1898,34 @@ impl PydeNode {
                             // All txs found — separate into plaintext and encrypted
                             let mut transactions = Vec::new();
                             let mut encrypted_txs = Vec::new();
+                            // TPL-403: don't `unwrap` peer-supplied
+                            // matched slots. `cb.reconstruct` invariant
+                            // says every `None` index also lands in
+                            // `missing`, so the empty-missing check
+                            // above SHOULD imply every entry is `Some`.
+                            // A peer that crafts a compact block which
+                            // breaks that invariant (or any future
+                            // change in `reconstruct` that decouples
+                            // the two vectors) would otherwise crash
+                            // the validator under `panic = "abort"`.
+                            // Treat a stray `None` like a missing-tx
+                            // signal: warn, request the full block via
+                            // sync, and skip this receive.
+                            let mut had_unexpected_none = false;
                             for (i, tx_bytes_opt) in matched.iter().enumerate() {
-                                let tx_bytes = tx_bytes_opt.as_ref().unwrap();
+                                let tx_bytes = match tx_bytes_opt.as_ref() {
+                                    Some(b) => b,
+                                    None => {
+                                        warn!(
+                                            slot,
+                                            tx_idx = i,
+                                            "compact-block reconstructed entry is None despite empty `missing` — \
+                                             refusing this block path and triggering full-block sync"
+                                        );
+                                        had_unexpected_none = true;
+                                        break;
+                                    }
+                                };
                                 // Try plaintext first, then encrypted
                                 if let Ok(tx) = wire::decode_transaction(tx_bytes) {
                                     transactions.push(tx);
@@ -1908,6 +1934,11 @@ impl PydeNode {
                                 } else {
                                     warn!(slot, tx_idx = i, "failed to decode reconstructed tx");
                                 }
+                            }
+                            if had_unexpected_none {
+                                chain_sync.manager.update_network_tip(slot);
+                                chain_sync.request_next_batch(&mut swarm);
+                                continue;
                             }
 
                             let tx_count = transactions.len();

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -88,7 +88,24 @@ pub struct RpcState {
     /// gossipsub topic — otherwise only this node's proposals can
     /// ever include it.
     pub encrypted_tx_gossip_tx: tokio::sync::mpsc::Sender<pyde_mempool::encrypted::EncryptedTx>,
+    /// TPL-404: concurrency cap on simulator-backed RPCs
+    /// (`pyde_call`, `pyde_estimateGas`, `pyde_createAccessList`).
+    /// Each acquires one permit and holds it for the duration of
+    /// the call. Without the cap a single peer could spam the
+    /// public RPC node with concurrent simulator requests; each
+    /// one calls `StateManager::snapshot_reader`, which clones the
+    /// entire write-cache HashMap. Memory usage scales linearly
+    /// with concurrent requests and was unbounded pre-fix.
+    pub call_concurrency: Arc<tokio::sync::Semaphore>,
 }
+
+/// TPL-404: cap on concurrent in-flight `pyde_call` /
+/// `pyde_estimateGas` / `pyde_createAccessList` requests. Each
+/// holds a snapshot of the StateManager cache for its duration; 8
+/// is enough for legitimate dapp UX (RPCs are bursty but
+/// short-lived) and small enough to bound the worst-case memory
+/// footprint at 8 × cache_size during a flood.
+pub const CALL_CONCURRENCY_LIMIT: usize = 8;
 
 /// Define the Pyde JSON-RPC API.
 #[rpc(server)]
@@ -728,6 +745,16 @@ impl PydeApiServer for RpcServer {
     }
 
     async fn call(&self, call_obj: serde_json::Value) -> Result<String, ErrorObjectOwned> {
+        // TPL-404: cap concurrent simulator-backed RPCs. Without
+        // this gate a peer can flood `pyde_call` and force the
+        // public RPC node to clone the StateManager cache once
+        // per request — unbounded memory growth under load.
+        let _permit = self
+            .state
+            .call_concurrency
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| rpc_err(-32000, "server busy: too many concurrent calls".into()))?;
         let from = call_obj
             .get("from")
             .and_then(|v| v.as_str())
@@ -841,6 +868,14 @@ impl PydeApiServer for RpcServer {
     }
 
     async fn estimate_gas(&self, call_obj: serde_json::Value) -> Result<String, ErrorObjectOwned> {
+        // TPL-404: same concurrency cap as `pyde_call`. Both run
+        // through the simulator path with a snapshot-cloned cache.
+        let _permit = self
+            .state
+            .call_concurrency
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| rpc_err(-32000, "server busy: too many concurrent calls".into()))?;
         // Run the same as call but return gas used
         let from = call_obj
             .get("from")
@@ -931,6 +966,14 @@ impl PydeApiServer for RpcServer {
         &self,
         call_obj: serde_json::Value,
     ) -> Result<serde_json::Value, ErrorObjectOwned> {
+        // TPL-404: same concurrency cap as `pyde_call`. Both run
+        // through the simulator path with a snapshot-cloned cache.
+        let _permit = self
+            .state
+            .call_concurrency
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| rpc_err(-32000, "server busy: too many concurrent calls".into()))?;
         let from = call_obj
             .get("from")
             .and_then(|v| v.as_str())

--- a/crates/node/src/tx_relay.rs
+++ b/crates/node/src/tx_relay.rs
@@ -31,8 +31,13 @@ impl TxRelay {
     /// structural + rate-limit checks. Intended for devnet/tests.
     /// Returns true if accepted (new), false if rejected (duplicate, invalid,
     /// rate-limited, etc.).
+    ///
+    /// TPL-406: dispatches to `Mempool::add_unverified_for_devnet`,
+    /// which is the renamed version of the old `Mempool::add`. The
+    /// rename forces any future code reaching for the unverified
+    /// path to acknowledge the bypass at the call site.
     pub fn receive_tx(&mut self, tx: EncryptedTx) -> bool {
-        match self.mempool.add(tx) {
+        match self.mempool.add_unverified_for_devnet(tx) {
             Ok(()) => {
                 debug!("tx accepted into mempool");
                 true

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -461,6 +461,12 @@ pub struct ValidatorEngine {
     /// neither path reaches quorum.
     last_qc_progress_ms: u64,
     last_seen_qc_slot: u64,
+    /// TPL-405: graceful-shutdown handle. When set, fatal-persist
+    /// branches that previously called `panic!` instead trigger
+    /// this signal so the main loop can drain in-flight work and
+    /// exit cleanly. Tests leave this `None`, preserving the
+    /// existing `panic!` behaviour for failure-mode assertions.
+    shutdown_signal: Option<crate::shutdown::ShutdownSignal>,
 }
 
 impl ValidatorEngine {
@@ -528,6 +534,35 @@ impl ValidatorEngine {
             reshare_aggregated: false,
             key_share_dirty: false,
             consensus_store: None,
+            shutdown_signal: None,
+        }
+    }
+
+    /// TPL-405: register a shutdown signal so persist failures can
+    /// trigger drain-then-exit instead of `panic!`. Production
+    /// callers wire this to the same `ShutdownSignal` the SIGTERM
+    /// handler triggers; the main loop then drives the drain.
+    pub fn attach_shutdown_signal(&mut self, signal: crate::shutdown::ShutdownSignal) {
+        self.shutdown_signal = Some(signal);
+    }
+
+    /// TPL-405: log a fatal-persist diagnostic and either trigger
+    /// graceful shutdown (production) or panic (tests / no signal
+    /// configured). Used by the consensus / evidence / reshare
+    /// persist paths whose pre-fix branches called `panic!`
+    /// directly. Continuing after a failed safety-critical write
+    /// would silently degrade BFT guarantees on the next restart;
+    /// the function returns rather than swallowing the error so
+    /// callers stop issuing new actions while the loop drains.
+    fn signal_persist_failure(&self, what: &str, err: &str) {
+        error!(
+            error = %err,
+            what,
+            "FATAL: safety-critical persist failed — halting validator"
+        );
+        match &self.shutdown_signal {
+            Some(sig) => sig.trigger(),
+            None => panic!("{what} persist failed: {err}"),
         }
     }
 
@@ -642,7 +677,8 @@ impl ValidatorEngine {
                 // A corrupt checkpoint is a HARD failure — without it we
                 // can't enforce WS, so refusing to start is safer than
                 // silently running without the guard.
-                panic!("CRITICAL: failed to load finality checkpoint: {}", e);
+                self.signal_persist_failure("finality checkpoint load", &e.to_string());
+                return;
             }
         }
 
@@ -668,11 +704,7 @@ impl ValidatorEngine {
     fn persist_evidence_state(&self) {
         if let Some(store) = &self.consensus_store {
             if let Err(e) = store.save_evidence_state(&self.evidence_snapshot()) {
-                error!(
-                    error = %e,
-                    "FATAL: failed to persist evidence state — halting validator"
-                );
-                panic!("evidence state persist failed: {}", e);
+                self.signal_persist_failure("evidence state", &e.to_string());
             }
         }
     }
@@ -694,11 +726,7 @@ impl ValidatorEngine {
     fn persist_consensus(&self) {
         if let Some(store) = &self.consensus_store {
             if let Err(e) = store.save(&self.consensus) {
-                error!(
-                    error = %e,
-                    "FATAL: failed to persist consensus state — halting validator to preserve BFT safety"
-                );
-                panic!("consensus state persist failed: {}", e);
+                self.signal_persist_failure("consensus state", &e.to_string());
             }
         }
     }
@@ -1231,7 +1259,7 @@ impl ValidatorEngine {
             return;
         };
         if let Err(e) = store.save_finality_checkpoint(cp) {
-            panic!("CRITICAL: finality checkpoint persistence failed — {}", e);
+            self.signal_persist_failure("finality checkpoint", &e.to_string());
         }
     }
 
@@ -1261,7 +1289,7 @@ impl ValidatorEngine {
             return;
         };
         if let Err(e) = store.save_reshare_state(&snap) {
-            panic!("CRITICAL: reshare state persistence failed — {}", e);
+            self.signal_persist_failure("reshare state", &e.to_string());
         }
     }
 
@@ -1797,12 +1825,7 @@ impl ValidatorEngine {
                 if let Err(e) =
                     store.save_seen_proposal(slot, &header.proposer, header, proposer_signature)
                 {
-                    error!(
-                        error = %e,
-                        slot,
-                        "FATAL: failed to persist seen proposal — halting validator"
-                    );
-                    panic!("seen-proposal persist failed: {}", e);
+                    self.signal_persist_failure("seen-proposal", &e.to_string());
                 }
             }
             self.seen_proposals
@@ -2389,13 +2412,7 @@ impl ValidatorEngine {
                 if let Err(e) =
                     store.save_seen_vote(slot, voter_index as u8, &block_hash, &vote_sig)
                 {
-                    error!(
-                        error = %e,
-                        slot,
-                        voter_index,
-                        "FATAL: failed to persist seen vote — halting validator"
-                    );
-                    panic!("seen-vote persist failed: {}", e);
+                    self.signal_persist_failure("seen-vote", &e.to_string());
                 }
             }
             self.seen_votes.insert(vote_key, (block_hash, vote_sig));
@@ -3184,6 +3201,43 @@ mod tests {
         let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
         engine.set_committee(keys);
         (engine, identities)
+    }
+
+    /// TPL-405: when a `ShutdownSignal` is attached, a fatal-
+    /// persist branch triggers the signal (no panic). Subscribers
+    /// observe the trigger so the main loop can begin draining.
+    #[tokio::test]
+    async fn tpl_405_persist_failure_triggers_shutdown_when_signal_attached() {
+        let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
+        let signal = crate::shutdown::ShutdownSignal::new();
+        let mut rx = signal.subscribe();
+        engine.attach_shutdown_signal(signal);
+
+        // Direct invocation of the dispatch helper. Production
+        // call sites (persist_consensus, persist_evidence_state,
+        // persist_finality_checkpoint_direct, persist_reshare_state,
+        // seen-proposal save, seen-vote save) all funnel through it.
+        engine.signal_persist_failure("test", "synthetic-io-error");
+
+        // Subscribers must receive within a tight bound — the
+        // broadcast send is in-process and non-blocking.
+        let recv = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+        assert!(
+            matches!(recv, Ok(Ok(()))),
+            "shutdown signal must fire on attached-signal persist failure; got {:?}",
+            recv
+        );
+    }
+
+    /// TPL-405: with no signal attached, the engine still panics
+    /// — preserves the existing failure-mode contract for the unit
+    /// tests that assert it. Production paths always attach a
+    /// signal via `attach_shutdown_signal`.
+    #[test]
+    #[should_panic(expected = "test persist failed: synthetic-io-error")]
+    fn tpl_405_persist_failure_panics_when_no_signal_attached() {
+        let engine = ValidatorEngine::new(TEST_CHAIN_ID, [0u8; 32]);
+        engine.signal_persist_failure("test", "synthetic-io-error");
     }
 
     #[test]

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -269,7 +269,14 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
     let mut compiled_registry: HashMap<String, Vec<u8>> = HashMap::new();
     let mut contract_functions: HashMap<String, Vec<FnSig>> = HashMap::new();
     let mut contract_constructors: HashMap<String, Vec<(String, otic::types::Ty)>> = HashMap::new();
-    let module_exports: HashMap<String, ModuleExports> = HashMap::new();
+    // TPL-411: do NOT shadow `module_exports` here. The outer
+    // map (declared at the top of `build_project`) is populated
+    // from every source's exports during the dependency-graph
+    // pass; that's the table `run_frontend` needs so the resolver
+    // can validate `use foo::Bar` against real export sets. Pre-
+    // fix an empty `let module_exports = HashMap::new();` shadowed
+    // the populated outer map, neutering the cross-file import
+    // check — bogus imports compiled without diagnostics.
     let mut result = BuildResult {
         contracts: Vec::new(),
         total_bytecode: 0,

--- a/crates/pyde-dev/tests/integration.rs
+++ b/crates/pyde-dev/tests/integration.rs
@@ -182,6 +182,82 @@ fn e2e_init_build() {
     assert!(artifact.get("constructorBytecode").is_some());
 }
 
+/// TPL-411: cross-file imports are checked against the populated
+/// module-export table. Pre-fix, `build_project` shadowed the
+/// populated `module_exports` with an empty `HashMap::new()`
+/// before invoking `run_frontend`, so the resolver's
+/// `is_known_module` always returned false and bogus imports
+/// silently compiled. This test would have passed on broken code
+/// (build succeeds despite a bad import) — post-fix it correctly
+/// fails the build.
+#[test]
+fn tpl_411_strict_frontend_rejects_undeclared_cross_file_import() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("test")).unwrap();
+    fs::create_dir_all(root.join("out")).unwrap();
+    fs::write(
+        root.join("pyde.toml"),
+        r#"
+[project]
+name = "tpl-411-test"
+version = "0.1.0"
+
+[compiler]
+optimize = false
+src = "src"
+test = "test"
+out = "out"
+"#,
+    )
+    .unwrap();
+
+    // Module that exports exactly one contract.
+    fs::write(
+        root.join("src/exporter.oti"),
+        r#"contract Exported {
+    storage { x: u64, }
+
+    #[constructor]
+    pub fn init() {
+        self.x = 0;
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    // Module that imports a name the exporter does NOT export.
+    // Pre-fix the resolver's `is_known_module(exporter)` returned
+    // false (empty map) so the cross-export check was skipped and
+    // build_project returned Ok. Post-fix the populated map flags
+    // `DoesNotExist` as unexported and surfaces a build error.
+    fs::write(
+        root.join("src/importer.oti"),
+        r#"use exporter::DoesNotExist;
+
+contract Importer {
+    storage { x: u64, }
+
+    #[constructor]
+    pub fn init() {
+        self.x = 0;
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let config = load_config(root);
+    let result = pyde_dev::build::build_project(&config, root);
+    assert!(
+        result.is_err(),
+        "build_project must reject the bogus cross-file import; got {:?}",
+        result.as_ref().map(|_| "Ok")
+    );
+}
+
 #[test]
 fn e2e_build_produces_registry() {
     let tmp = TempDir::new().unwrap();

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -5400,7 +5400,12 @@ mod tests {
         // Regression guard: tx.to is unconditionally loaded + written
         // back by the pipeline. If tx.to matches spend.target, the
         // recipient writeback clobbers the handler's target credit.
-        // Enforce tx.to = ZERO_ADDRESS for MultisigTx.
+        // Pre-TPL-408 the multisig handler caught this at execute
+        // time and returned a failed receipt. TPL-408 now rejects
+        // the same shape at validation, so `execute_transaction`
+        // returns `Err(Validation(UnexpectedTo { ... }))` instead
+        // of producing a non-success receipt — strict improvement
+        // (the malformed tx never even reaches the handler).
         let mut smt = PydeSMT::new();
         let ctx = make_block_ctx();
         let sks = multisig_fixture(&mut smt, 3, 2, 10_000_000);
@@ -5413,13 +5418,19 @@ mod tests {
         let sigs = sign_spend(&spend, &[&sks[0], &sks[1]], &[0, 1], 0, 1);
         let payload = crate::multisig::MultisigPayload::Spend { spend, sigs };
         let mut tx = build_multisig_spend_tx(submitter, &sub_sk, payload);
-        tx.to = target; // non-zero tx.to — would clobber target credit
+        tx.to = target; // non-zero tx.to — TPL-408 must reject
         sign_tx(&mut tx, &sub_sk);
 
         let treasury_before =
             load_account(&smt, &pyde_account::address::treasury_address()).balance;
-        let receipt = execute_transaction(&tx, &mut smt, &ctx).unwrap();
-        assert!(!receipt.success, "non-zero tx.to must reject");
+        let err = execute_transaction(&tx, &mut smt, &ctx)
+            .expect_err("non-zero tx.to must reject at validation (TPL-408)");
+        match err {
+            PipelineError::Validation(crate::validation::ValidationError::UnexpectedTo {
+                tx_type,
+            }) => assert_eq!(tx_type, TransactionType::MultisigTx as u8),
+            other => panic!("expected UnexpectedTo, got {other:?}"),
+        }
 
         let treasury_after = load_account(&smt, &pyde_account::address::treasury_address()).balance;
         assert!(treasury_after >= treasury_before);

--- a/crates/tx/src/validation.rs
+++ b/crates/tx/src/validation.rs
@@ -96,6 +96,20 @@ pub enum ValidationError {
     /// declared tx type implies nothing about. Now rejected at
     /// validation so the malformed tx never reaches the pipeline.
     UnexpectedValue { tx_type: u8, value: u128 },
+    /// `tx.tx_type` is non-`Standard`/non-`Deploy` but `tx.to` is
+    /// not `ZERO_ADDRESS` (TPL-408). Pre-fix the pipeline always
+    /// called `apply_account_delta(smt, &tx.to, ...)` regardless of
+    /// tx_type. For variants that don't carry a destination
+    /// (`Slash`, `ClaimReward`, multisig types, etc.), `tx.to` was
+    /// effectively unconstrained — a malicious proposer could set
+    /// it to any unused address, run the tx, and have the SMT
+    /// permanently store an empty `Account` record at that address.
+    /// Repeated at scale this fills the trie with junk entries at
+    /// only the cost of the per-tx gas (no per-write storage gas
+    /// because `apply_account_delta` writes a zero-balance shell).
+    /// Now rejected at validation so the malformed tx can't enter
+    /// the mempool or land in a block.
+    UnexpectedTo { tx_type: u8 },
     /// `tx.tx_type` is currently disabled at the protocol level
     /// (audit 351). `StakeWithdraw` flips a validator entry to
     /// `Unbonding` but there is no `CompleteUnbonding` tx type —
@@ -210,6 +224,34 @@ pub fn validate_transaction(
                 return Err(ValidationError::UnexpectedValue {
                     tx_type: tx.tx_type as u8,
                     value: tx.value,
+                });
+            }
+        }
+    }
+
+    // TPL-408: same shape as the value gate above for `tx.to`.
+    // `Standard` and `Deploy` are the only types whose pipeline
+    // semantics actually consume `tx.to`. For every other variant
+    // the pipeline still calls `apply_account_delta(smt, &tx.to,
+    // ...)` at write-back, which always ends in
+    // `store_account` — even when initial == final the SMT gets a
+    // fresh `Account` shell at the target address. A malicious
+    // proposer (or a loose RPC client) setting `tx.to` to an
+    // unused address per non-Standard tx writes one empty record
+    // per tx into the trie at no storage-gas cost, growing the
+    // SMT and the witness without bound.
+    //
+    // Reject at validation so the malformed input can't enter
+    // the mempool or land in a block. `RegisterPubkey` already
+    // routed away above; honest tooling for the gated variants
+    // (Slash, ClaimReward, multisig types, …) sets
+    // `tx.to = ZERO_ADDRESS`.
+    match tx.tx_type {
+        crate::types::TransactionType::Standard | crate::types::TransactionType::Deploy => {}
+        _ => {
+            if tx.to != pyde_account::address::ZERO_ADDRESS {
+                return Err(ValidationError::UnexpectedTo {
+                    tx_type: tx.tx_type as u8,
                 });
             }
         }
@@ -1249,6 +1291,74 @@ mod tests {
         }
     }
 
+    /// TPL-408: every non-Standard / non-Deploy variant with
+    /// `tx.to != ZERO_ADDRESS` must be rejected. Pre-fix the
+    /// pipeline's blanket `apply_account_delta(smt, &tx.to, ...)`
+    /// wrote an empty Account record at the supplied address
+    /// regardless of tx_type, growing the SMT for free.
+    #[test]
+    fn tpl_408_non_to_types_with_nonzero_to_rejected() {
+        let stranger = derive_eoa_address(b"tpl-408-junk-bloat");
+        // Skip RegisterPubkey (routed earlier) and StakeWithdraw
+        // (audit-351 disables it) so the new gate is what we're
+        // exercising rather than an earlier reject path.
+        let non_to_types = [
+            TransactionType::StakeDeposit,
+            TransactionType::Slash,
+            TransactionType::ClaimReward,
+            TransactionType::ClaimAirdrop,
+            TransactionType::SweepAirdrop,
+            TransactionType::MultisigTx,
+            TransactionType::RotateMultisig,
+            TransactionType::EmergencyPause,
+            TransactionType::EmergencyResume,
+        ];
+        for ty in non_to_types {
+            let (mut tx, account, nonce_state) = make_valid_tx_and_account();
+            tx.tx_type = ty;
+            tx.value = 0; // 352 gate must not trip
+            tx.to = stranger;
+            let ctx = default_ctx();
+            let err = validate_transaction(&tx, &account, &nonce_state, &ctx)
+                .expect_err(&format!("{ty:?} with non-zero tx.to must reject"));
+            match err {
+                ValidationError::UnexpectedTo { tx_type } => assert_eq!(tx_type, ty as u8),
+                other => panic!("{ty:?}: expected UnexpectedTo, got {other:?}"),
+            }
+        }
+    }
+
+    /// TPL-408 positive control: every non-`Standard`/`Deploy` variant
+    /// with `tx.to == ZERO_ADDRESS` reaches at least past the new
+    /// gate (later validation checks may still reject it for
+    /// other reasons — we only verify the gate doesn't trip here).
+    #[test]
+    fn tpl_408_non_to_types_with_zero_to_pass_gate() {
+        let non_to_types = [
+            TransactionType::StakeDeposit,
+            TransactionType::Slash,
+            TransactionType::ClaimReward,
+            TransactionType::ClaimAirdrop,
+            TransactionType::SweepAirdrop,
+            TransactionType::MultisigTx,
+            TransactionType::RotateMultisig,
+            TransactionType::EmergencyPause,
+            TransactionType::EmergencyResume,
+        ];
+        for ty in non_to_types {
+            let (mut tx, account, nonce_state) = make_valid_tx_and_account();
+            tx.tx_type = ty;
+            tx.value = 0;
+            tx.to = ZERO_ADDRESS;
+            let ctx = default_ctx();
+            let res = validate_transaction(&tx, &account, &nonce_state, &ctx);
+            // Either Ok or any error other than UnexpectedTo.
+            if let Err(ValidationError::UnexpectedTo { .. }) = res {
+                panic!("{ty:?}: ZERO_ADDRESS must clear the new gate");
+            }
+        }
+    }
+
     // ========== Audit 351: StakeWithdraw disabled at validation ==========
 
     /// `StakeWithdraw` flips a validator entry to `Unbonding` but
@@ -1262,6 +1372,7 @@ mod tests {
         let (mut tx, account, nonce_state) = make_valid_tx_and_account();
         tx.tx_type = TransactionType::StakeWithdraw;
         tx.value = 0; // 352 gate must not trip
+        tx.to = ZERO_ADDRESS; // TPL-408 gate must not trip
 
         for chain_id in [1u64, 7331, 31337] {
             tx.chain_id = chain_id;


### PR DESCRIPTION
## Summary

Hardening pass against trivial DoS, key disclosure, and process
kills surfaced during the launch-blocker audit.

### Key disclosure

- **TPL-401**: `validator.key` and `threshold.share` writes are
  now atomic temp+rename with `OpenOptions::mode(0o600)` from the
  first byte. Pre-fix the file existed at the operator's umask
  between `fs::write` and `set_permissions`, exposing FALCON sk
  material on multi-tenant boxes; a `kill -9` mid-write also
  left a truncated key file. Stale tmps from prior crashed
  writes are unlinked before each new attempt.

### Process kills / persist failures

- **TPL-403**: compact-block reconstruction `unwrap()` on peer-
  supplied data → `match { Some => ..., None => warn + sync-bail }`.
  A Byzantine peer (or a future change in `cb.reconstruct`'s
  invariant) can no longer take the validator down with a
  crafted compact block.

- **TPL-405**: 6 `panic!` sites in `ValidatorEngine` (consensus
  state, evidence state, finality checkpoint, reshare state,
  seen-proposal, seen-vote) replaced with a single
  `signal_persist_failure(what, err)` helper that triggers the
  process-wide `ShutdownSignal` when one is wired. The main loop
  drains in-flight work (peer_book save, gossip-cache prune,
  flush-pending writes) before exit. Falls back to `panic!` when
  no signal is attached so unit tests retain the existing
  failure-mode contract.

### DoS surface

- **TPL-404**: `pyde_call` / `pyde_estimateGas` /
  `pyde_createAccessList` are now bounded by a tokio
  `Semaphore(8)`. Each handler `try_acquire_owned`s a permit;
  over the cap returns `-32000 server busy: too many concurrent
  calls`. Pre-fix each call cloned the StateManager cache for
  read-consistency, so unbounded concurrent callers drove
  N × cache_size memory growth on the public RPC node.

- **TPL-406**: `Mempool::add` (no-pubkey path) renamed to
  `add_unverified_for_devnet`. The short name was a footgun for
  any code reaching for the unverified path; the renamed
  variant forces every caller to acknowledge the bypass.

- **TPL-407**: `add_with_pubkey` now asserts
  `derive_eoa_address(sender_pubkey) == tx.sender` before the
  FALCON verify. Pre-fix an attacker could submit a tx with
  `sender = victim`, signed by their own key, supply their own
  pubkey, pass sig-verify, and lock the victim out of their
  own nonce window / per-sender quota.

- **TPL-408**: validation rejects `tx.to != ZERO_ADDRESS` for
  non-`Standard`/non-`Deploy` tx_types. Pre-fix the pipeline's
  blanket `apply_account_delta(smt, &tx.to, ...)` always wrote
  an empty `Account` shell at the supplied address regardless
  of tx_type — a malicious proposer could grow the SMT trie
  without bound at only the per-tx gas cost.

- **TPL-409**: validator-side block decode enforces
  `block.body.encrypted_txs.len() <= MAX_ENCRYPTED_TXS_PER_BLOCK`
  (=100). Pre-fix the cap lived only in proposer-side
  selection; a Byzantine proposer shipping 200+ encrypted txs
  forced O(n_txs * threshold) decryption-share work on every
  honest validator.

- **TPL-410**: `MAX_CT_LEN` tightened from 128 KB → 72 KB.
  Real threshold ciphertext is bounded by ~67 KB
  (`4 + 1088 + 4 + 48 + 65 536 + 32`); the loose 128 KB cap
  let a peer claim 100 KB ciphertexts and drive matching
  `Vec::with_capacity` per gossip blob.

### Toolchain

- **TPL-411**: `pyde-dev build` no longer shadows the populated
  `module_exports` map. Pre-fix an empty inner `let
  module_exports = HashMap::new();` neutered the resolver's
  cross-file import check — bogus imports compiled silently.