### PR TITLE
consensus, networking, and PVM hardening for testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,7 @@ dependencies = [
  "pyde-crypto",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/consensus/src/slashing.rs
+++ b/crates/consensus/src/slashing.rs
@@ -95,6 +95,45 @@ pub struct DoubleSignEvidence {
     pub submitter: Address,
 }
 
+/// TPL-502: view-change equivocation evidence — two FALCON sigs
+/// from the same validator at the same slot covering different
+/// `highest_qc.hash()` values. The double-VC slashable pattern
+/// is symmetric to `DoubleSignEvidence` (proposer/vote
+/// double-sign) but the sign-message preimage uses the
+/// `view_change` prefix instead of the proposer prefix, so the
+/// verifier rebuilds the preimage with
+/// `view_change::view_change_sign_message_from_hash`.
+///
+/// Like `DoubleSignEvidence`, the struct carries `qc_hash` rather
+/// than the full `QuorumCert`: the verifier needs nothing more
+/// than the local chain's `chain_id`, the two hashes, the two
+/// FALCON sigs, and the signer's pubkey. The `chain_id` is NOT
+/// in the struct — the verifier rebuilds the preimage with the
+/// LOCAL chain's id, mirroring the audit-240 cross-chain replay
+/// guard.
+#[derive(Clone, Debug)]
+pub struct DoubleViewChangeEvidence {
+    /// `target_height` the two VCs both targeted.
+    pub slot: u64,
+    /// `highest_qc.hash()` covered by the first VC.
+    pub qc_hash_1: [u8; 32],
+    /// FALCON signature over `view_change_sign_message_from_hash(
+    /// chain_id, slot, qc_hash_1)`.
+    pub signature_1: Vec<u8>,
+    /// `highest_qc.hash()` covered by the second VC — must
+    /// differ from `qc_hash_1`.
+    pub qc_hash_2: [u8; 32],
+    /// FALCON signature over `view_change_sign_message_from_hash(
+    /// chain_id, slot, qc_hash_2)`.
+    pub signature_2: Vec<u8>,
+    /// Address of the signer being accused.
+    pub signer: Address,
+    /// Address of the evidence submitter (receives the finder's
+    /// fee). Set by whichever validator broadcasts the on-chain
+    /// Slash tx — typically the next block proposer.
+    pub submitter: Address,
+}
+
 /// Liveness report for a validator over an epoch.
 #[derive(Clone, Debug)]
 pub struct LivenessReport {
@@ -162,6 +201,46 @@ pub fn verify_double_sign(chain_id: u64, evidence: &DoubleSignEvidence, public_k
     falcon_verify(&pk, &msg_1, &sig_1) && falcon_verify(&pk, &msg_2, &sig_2)
 }
 
+/// TPL-502: verify view-change equivocation evidence against the
+/// local chain's `chain_id`. Mirrors `verify_double_sign` but
+/// uses the VC sign-message preimage (`view_change` prefix +
+/// chain_id + slot + qc_hash) so a double-VC on chain A is not
+/// valid evidence on chain B even when FALCON keys match. Two
+/// distinct `qc_hash`es are required — equal hashes are not
+/// equivocation.
+pub fn verify_double_view_change(
+    chain_id: u64,
+    evidence: &DoubleViewChangeEvidence,
+    public_key: &[u8],
+) -> bool {
+    if evidence.qc_hash_1 == evidence.qc_hash_2 {
+        return false;
+    }
+    let pk = match FalconPublicKey::from_bytes(public_key) {
+        Some(pk) => pk,
+        None => return false,
+    };
+    let sig_1 = match FalconSignature::from_bytes(&evidence.signature_1) {
+        Some(s) => s,
+        None => return false,
+    };
+    let sig_2 = match FalconSignature::from_bytes(&evidence.signature_2) {
+        Some(s) => s,
+        None => return false,
+    };
+    let msg_1 = crate::view_change::view_change_sign_message_from_hash(
+        chain_id,
+        evidence.slot,
+        &evidence.qc_hash_1,
+    );
+    let msg_2 = crate::view_change::view_change_sign_message_from_hash(
+        chain_id,
+        evidence.slot,
+        &evidence.qc_hash_2,
+    );
+    falcon_verify(&pk, &msg_1, &sig_1) && falcon_verify(&pk, &msg_2, &sig_2)
+}
+
 // ========== Slash Computation ==========
 
 /// Compute the slash amount and finder's fee for a given offense.
@@ -216,6 +295,35 @@ pub fn slash_double_sign(
         ejected: true,
         forced_unbonding: true,
         offense: SlashingOffense::DoubleSigning,
+    })
+}
+
+/// TPL-502: process a double-VC slashing event. Mirrors
+/// `slash_double_sign` for the proposer/vote case — same 100%
+/// slash via `Equivocation`, same eject + forced-unbonding flags
+/// — so a validator caught equivocating in either layer pays
+/// the same price.
+///
+/// `current_stake` is the live stake (audit 328) so a repeat
+/// offender pays a percentage against what's actually on the
+/// books, not against the constant `VALIDATOR_STAKE`.
+pub fn slash_double_view_change(
+    chain_id: u64,
+    evidence: &DoubleViewChangeEvidence,
+    public_key: &[u8],
+    current_stake: u128,
+) -> Option<SlashResult> {
+    if !verify_double_view_change(chain_id, evidence, public_key) {
+        return None;
+    }
+    let (burned, finder_fee) = compute_slash(current_stake, &SlashingOffense::Equivocation);
+    Some(SlashResult {
+        offender: evidence.signer,
+        amount_burned: burned,
+        finder_fee,
+        ejected: true,
+        forced_unbonding: true,
+        offense: SlashingOffense::Equivocation,
     })
 }
 
@@ -790,5 +898,140 @@ mod tests {
             total_promised,
             "pre→post stake delta must equal promised slash exactly",
         );
+    }
+
+    // ========== TPL-502: VC equivocation evidence ==========
+
+    /// Helper: produce a VC sig over the canonical
+    /// `view_change_sign_message_from_hash` preimage.
+    fn sign_vc(
+        sk: &pyde_crypto::falcon::FalconSecretKey,
+        chain_id: u64,
+        slot: u64,
+        qc_hash: &[u8; 32],
+    ) -> Vec<u8> {
+        let msg = crate::view_change::view_change_sign_message_from_hash(chain_id, slot, qc_hash);
+        falcon_sign(sk, &msg).unwrap().as_bytes().to_vec()
+    }
+
+    /// `verify_double_view_change` accepts well-formed evidence:
+    /// two distinct `qc_hash`es with matching FALCON sigs.
+    #[test]
+    fn tpl_502_verify_double_vc_accepts_well_formed_evidence() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let qc_hash_1 = [0xAA; 32];
+        let qc_hash_2 = [0xBB; 32];
+
+        let evidence = DoubleViewChangeEvidence {
+            slot: 100,
+            qc_hash_1,
+            signature_1: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_1),
+            qc_hash_2,
+            signature_2: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_2),
+            signer: addr,
+            submitter: derive_eoa_address(b"submitter"),
+        };
+
+        assert!(verify_double_view_change(
+            TEST_CHAIN_ID,
+            &evidence,
+            &pk_bytes
+        ));
+    }
+
+    /// Two equal `qc_hash`es is not equivocation — same VC,
+    /// reject as evidence.
+    #[test]
+    fn tpl_502_verify_double_vc_rejects_equal_qc_hashes() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let qc_hash = [0xAA; 32];
+        let sig = sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash);
+
+        let evidence = DoubleViewChangeEvidence {
+            slot: 100,
+            qc_hash_1: qc_hash,
+            signature_1: sig.clone(),
+            qc_hash_2: qc_hash,
+            signature_2: sig,
+            signer: addr,
+            submitter: addr,
+        };
+
+        assert!(!verify_double_view_change(
+            TEST_CHAIN_ID,
+            &evidence,
+            &pk_bytes
+        ));
+    }
+
+    /// Cross-chain replay guard: evidence valid under chain A
+    /// must NOT verify under chain B.
+    #[test]
+    fn tpl_502_verify_double_vc_rejects_cross_chain_replay() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let qc_hash_1 = [0xAA; 32];
+        let qc_hash_2 = [0xBB; 32];
+        let evidence = DoubleViewChangeEvidence {
+            slot: 100,
+            qc_hash_1,
+            signature_1: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_1),
+            qc_hash_2,
+            signature_2: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_2),
+            signer: addr,
+            submitter: addr,
+        };
+
+        // Sigs are bound to TEST_CHAIN_ID; verifier under a
+        // different chain_id rebuilds a different preimage.
+        const OTHER_CHAIN_ID: u64 = TEST_CHAIN_ID + 1;
+        assert!(!verify_double_view_change(
+            OTHER_CHAIN_ID,
+            &evidence,
+            &pk_bytes
+        ));
+    }
+
+    /// The slash result for double-VC mirrors double-sign:
+    /// 100% via `Equivocation`, ejected, forced unbonding.
+    #[test]
+    fn tpl_502_slash_double_vc_uses_current_stake_and_equivocation_offense() {
+        let (pk, sk) = falcon_keygen().unwrap();
+        let pk_bytes = pk.as_bytes().to_vec();
+        let addr = derive_eoa_address(&pk_bytes);
+
+        let qc_hash_1 = [0xAA; 32];
+        let qc_hash_2 = [0xBB; 32];
+        let evidence = DoubleViewChangeEvidence {
+            slot: 100,
+            qc_hash_1,
+            signature_1: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_1),
+            qc_hash_2,
+            signature_2: sign_vc(&sk, TEST_CHAIN_ID, 100, &qc_hash_2),
+            signer: addr,
+            submitter: addr,
+        };
+
+        // Audit-328: slash against the live stake, not VALIDATOR_STAKE.
+        let live_stake = 4_000u128;
+        let result =
+            slash_double_view_change(TEST_CHAIN_ID, &evidence, &pk_bytes, live_stake).unwrap();
+        assert_eq!(result.offense, SlashingOffense::Equivocation);
+        assert!(result.ejected);
+        assert!(result.forced_unbonding);
+        assert_eq!(
+            result.amount_burned + result.finder_fee,
+            live_stake,
+            "100% slash against live stake"
+        );
+        let _ = VALIDATOR_STAKE; // keep the use; was useful for double-sign test
     }
 }

--- a/crates/consensus/src/view_change.rs
+++ b/crates/consensus/src/view_change.rs
@@ -143,12 +143,24 @@ impl TimeoutTracker {
 ///   a payload whose `highest_qc.hash()` differs from the signed
 ///   preimage, and `verify_view_change` rejects.
 fn view_change_sign_message(chain_id: u64, slot: u64, highest_qc: &QuorumCert) -> Vec<u8> {
+    view_change_sign_message_from_hash(chain_id, slot, &highest_qc.hash())
+}
+
+/// TPL-502: same VC sign-message bytes as `view_change_sign_message`
+/// but takes the `highest_qc_hash` directly, so a verifier that
+/// only has the hash (e.g. `DoubleViewChangeEvidence` carrying
+/// `qc_hash` instead of the full QC) can rebuild the preimage.
+pub fn view_change_sign_message_from_hash(
+    chain_id: u64,
+    slot: u64,
+    highest_qc_hash: &[u8; 32],
+) -> Vec<u8> {
     // "view_change"(11) + chain_id(8) + slot(8) + qc_hash(32) = 59
     let mut msg = Vec::with_capacity(59);
     msg.extend_from_slice(b"view_change");
     msg.extend_from_slice(&chain_id.to_le_bytes());
     msg.extend_from_slice(&slot.to_le_bytes());
-    msg.extend_from_slice(&highest_qc.hash());
+    msg.extend_from_slice(highest_qc_hash);
     msg
 }
 

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -133,7 +133,16 @@ type SenderTxIndex = HashMap<Address, HashSet<[u8; 32]>>;
 #[derive(Debug)]
 pub struct Mempool {
     /// All transactions in arrival order.
-    txs: Vec<EncryptedTx>,
+    ///
+    /// TPL-509: switched from `Vec<EncryptedTx>` to `VecDeque<…>`
+    /// so `evict_oldest` runs in O(1) (`pop_front`) instead of
+    /// O(n) (`Vec::remove(0)` shifts every remaining element).
+    /// Under sustained near-cap load — N adds while at the size
+    /// limit — pre-fix eviction was O(n) per add → O(n²) total
+    /// for the burst, which dominated the mempool's hot path
+    /// during stress testing. `VecDeque` keeps the same arrival-
+    /// order semantics.
+    txs: VecDeque<EncryptedTx>,
     /// Set of tx hashes for deduplication.
     seen_hashes: HashSet<[u8; 32]>,
     /// Per-sender nonce tracking (sender → highest nonce seen).
@@ -168,7 +177,7 @@ pub struct Mempool {
 impl Mempool {
     pub fn new() -> Self {
         Self {
-            txs: Vec::new(),
+            txs: VecDeque::new(),
             seen_hashes: HashSet::new(),
             sender_nonces: HashMap::new(),
             first_seen_slot: HashMap::new(),
@@ -185,7 +194,7 @@ impl Mempool {
 
     pub fn with_capacity(max_size: usize) -> Self {
         Self {
-            txs: Vec::with_capacity(max_size),
+            txs: VecDeque::with_capacity(max_size),
             seen_hashes: HashSet::with_capacity(max_size),
             sender_nonces: HashMap::new(),
             first_seen_slot: HashMap::with_capacity(max_size),
@@ -387,7 +396,7 @@ impl Mempool {
         self.sender_tx_index.entry(sender).or_default().insert(hash);
         self.seen_hashes.insert(hash);
         self.first_seen_slot.insert(hash, self.current_block);
-        self.txs.push(tx);
+        self.txs.push_back(tx);
     }
 
     /// Decrement a sender's concurrent count when a tx leaves the pool.
@@ -409,11 +418,13 @@ impl Mempool {
     }
 
     /// Evict the oldest transaction (first in the list).
+    /// TPL-509: O(1) `pop_front` on a `VecDeque`. Pre-fix this was
+    /// `Vec::remove(0)`, which shifts every remaining element.
     fn evict_oldest(&mut self) {
-        if self.txs.is_empty() {
-            return;
-        }
-        let evicted = self.txs.remove(0);
+        let evicted = match self.txs.pop_front() {
+            Some(tx) => tx,
+            None => return,
+        };
         let h = evicted.hash();
         let sender = evicted.sender;
         self.seen_hashes.remove(&h);
@@ -486,8 +497,14 @@ impl Mempool {
 
     /// Get transactions in arrival order (FCFS).
     /// No fee-based priority — Pyde has no tips, everyone pays the same base fee.
-    pub fn in_arrival_order(&self) -> &[EncryptedTx] {
-        &self.txs
+    ///
+    /// TPL-509: post-VecDeque-switch, the underlying storage is no
+    /// longer a contiguous slice, so this returns `Vec<&EncryptedTx>`
+    /// (cheap — only borrowing references, not cloning the txs).
+    /// Existing call sites that iterate (`for tx in mempool.in_arrival_order()`)
+    /// or index (`txs[0]`) keep working unchanged.
+    pub fn in_arrival_order(&self) -> Vec<&EncryptedTx> {
+        self.txs.iter().collect()
     }
 
     /// Select transactions for a block in arrival order, respecting

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -9,13 +9,14 @@ pyde-crypto = { path = "../crypto" }
 pyde-account = { path = "../account" }
 libp2p = { version = "0.54", features = ["tcp", "quic", "gossipsub", "kad", "noise", "yamux", "tokio", "macros", "identify", "request-response", "cbor", "serde"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 getrandom = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
-serde_json = "1"
+tempfile = "3"
 futures = "0.3"
 
 [lints]

--- a/crates/net/src/auth.rs
+++ b/crates/net/src/auth.rs
@@ -129,6 +129,15 @@ pub enum AuthOutcome {
     /// Peer previously attested a DIFFERENT pubkey on the same connection.
     /// Treated as a protocol violation; the caller should disconnect.
     RebindRejected,
+    /// TPL-510: the peer's PeerId has an operator-pinned FALCON
+    /// pubkey in `Discovery::pinned_falcon_pubkey`, but the
+    /// attested pubkey doesn't match. Either the pin is wrong,
+    /// the pinned peer rotated keys without operator coordination,
+    /// or the peer at this `(IP, port, libp2p-noise-id)` tuple is
+    /// an impostor that doesn't hold the expected FALCON sk.
+    /// Caller should hard-disconnect — the safety property of
+    /// pinning is "no acceptance under wrong identity."
+    PinnedPubkeyMismatch,
     /// Pubkey recorded in the peer manager and matched an entry in
     /// `committee_keys` — peer was promoted to `PeerRole::Validator`.
     StoredAsValidator,
@@ -148,12 +157,22 @@ pub enum AuthOutcome {
 /// Committee membership is resolved by byte-level equality with
 /// `committee_keys`, matching the rule used by
 /// `PeerManager::is_consensus_authorized`.
+///
+/// TPL-510: `pinned_falcon_pubkey` is the operator-supplied
+/// FALCON pubkey pin for this peer (resolved via
+/// `Discovery::pinned_falcon_pubkey` at the call site). When
+/// supplied, the attested pubkey MUST byte-match — a mismatch
+/// returns `AuthOutcome::PinnedPubkeyMismatch` and the caller
+/// hard-disconnects. `None` preserves the prior "trust whatever
+/// the peer attests" behavior for peers without a configured
+/// pin.
 pub fn apply_auth_response(
     peer: PeerId,
     response: &PydeAuthResp,
     pending_auth_nonces: &mut HashMap<PeerId, [u8; 32]>,
     peer_manager: &mut PeerManager,
     committee_keys: &[Vec<u8>],
+    pinned_falcon_pubkey: Option<&[u8]>,
 ) -> AuthOutcome {
     let nonce = match pending_auth_nonces.remove(&peer) {
         Some(n) => n,
@@ -170,6 +189,17 @@ pub fn apply_auth_response(
         Some(pk) => pk,
         None => return AuthOutcome::VerifyFailed,
     };
+
+    // TPL-510: bootstrap pubkey pinning. Check BEFORE
+    // recording the pubkey on `peer_manager` so a mismatch
+    // doesn't pollute the manager's state with a key that the
+    // caller will then have to disconnect. Byte-equality match
+    // mirrors `is_consensus_authorized`'s comparison rule.
+    if let Some(expected_pk) = pinned_falcon_pubkey {
+        if expected_pk != pk_bytes.as_slice() {
+            return AuthOutcome::PinnedPubkeyMismatch;
+        }
+    }
 
     if !peer_manager.set_falcon_pubkey(&peer, pk_bytes.clone()) {
         return AuthOutcome::RebindRejected;
@@ -323,7 +353,7 @@ mod tests {
         let (resp, pk_bytes, _sk) = build_real_attestation(nonce);
         let committee = vec![pk_bytes.clone()];
 
-        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee);
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee, None);
         assert_eq!(outcome, AuthOutcome::StoredAsValidator);
         assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
         assert_eq!(
@@ -346,7 +376,7 @@ mod tests {
         // Empty committee — peer is attested but not in consensus.
         let committee: Vec<Vec<u8>> = vec![];
 
-        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee);
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &committee, None);
         assert_eq!(outcome, AuthOutcome::StoredAsNonValidator);
         assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
         assert_eq!(
@@ -364,7 +394,7 @@ mod tests {
         let mut nonces = HashMap::new(); // nothing for this peer
 
         let (resp, _, _) = build_real_attestation([0x01; 32]);
-        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &[]);
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &[], None);
         assert_eq!(outcome, AuthOutcome::NoPendingNonce);
         assert!(mgr.peer_falcon_pubkey(&peer).is_none());
     }
@@ -380,7 +410,7 @@ mod tests {
         nonces.insert(peer, nonce_we_sent);
 
         let (resp_other_nonce, _, _) = build_real_attestation([0x22; 32]);
-        let outcome = apply_auth_response(peer, &resp_other_nonce, &mut nonces, &mut mgr, &[]);
+        let outcome = apply_auth_response(peer, &resp_other_nonce, &mut nonces, &mut mgr, &[], None);
         assert_eq!(outcome, AuthOutcome::VerifyFailed);
         assert!(mgr.peer_falcon_pubkey(&peer).is_none());
         // Nonce still consumed so the peer can't keep retrying the same slot.
@@ -398,7 +428,7 @@ mod tests {
         nonces.insert(peer, nonce_a);
         let (resp_a, _pk_a, _) = build_real_attestation(nonce_a);
         assert_eq!(
-            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[]),
+            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[], None),
             AuthOutcome::StoredAsNonValidator
         );
 
@@ -406,7 +436,7 @@ mod tests {
         let nonce_b = generate_nonce();
         nonces.insert(peer, nonce_b);
         let (resp_b, _pk_b, _) = build_real_attestation(nonce_b);
-        let outcome = apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[]);
+        let outcome = apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[], None);
         assert_eq!(outcome, AuthOutcome::RebindRejected);
     }
 
@@ -426,7 +456,7 @@ mod tests {
         let eoa = pyde_account::address::derive_eoa_address(&pk_bytes);
         let resp_a = build_auth_resp(&PydeAuthReq { nonce: nonce_a }, &eoa, &sk, &pk).unwrap();
         assert_eq!(
-            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[]),
+            apply_auth_response(peer, &resp_a, &mut nonces, &mut mgr, &[], None),
             AuthOutcome::StoredAsNonValidator
         );
 
@@ -435,8 +465,86 @@ mod tests {
         nonces.insert(peer, nonce_b);
         let resp_b = build_auth_resp(&PydeAuthReq { nonce: nonce_b }, &eoa, &sk, &pk).unwrap();
         assert_eq!(
-            apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[]),
+            apply_auth_response(peer, &resp_b, &mut nonces, &mut mgr, &[], None),
             AuthOutcome::StoredAsNonValidator
         );
+    }
+
+    // ========== TPL-510: bootstrap FALCON pubkey pinning ==========
+
+    /// `apply_auth_response` accepts an attested pubkey when
+    /// the operator's pin matches it byte-for-byte.
+    #[test]
+    fn tpl_510_apply_auth_response_accepts_matching_pin() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce = generate_nonce();
+        nonces.insert(peer, nonce);
+
+        let (resp, pk_bytes, _sk) = build_real_attestation(nonce);
+
+        // Pin is exactly the pubkey the peer is about to attest.
+        let outcome =
+            apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &[], Some(&pk_bytes));
+        assert_eq!(outcome, AuthOutcome::StoredAsNonValidator);
+        assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
+    }
+
+    /// `apply_auth_response` rejects an attested pubkey when
+    /// the operator's pin DOES NOT match. The peer manager is
+    /// NOT mutated — pre-fix the pubkey check happened before
+    /// the pin check, leaving a polluted manager state on a
+    /// mismatch.
+    #[test]
+    fn tpl_510_apply_auth_response_rejects_mismatched_pin() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce = generate_nonce();
+        nonces.insert(peer, nonce);
+
+        let (resp, _pk_bytes, _sk) = build_real_attestation(nonce);
+
+        // Pin a DIFFERENT pubkey than what the peer will attest.
+        let (other_pk, _) = falcon_keygen().unwrap();
+        let other_pk_bytes = other_pk.as_bytes().to_vec();
+        let outcome = apply_auth_response(
+            peer,
+            &resp,
+            &mut nonces,
+            &mut mgr,
+            &[],
+            Some(&other_pk_bytes),
+        );
+        assert_eq!(outcome, AuthOutcome::PinnedPubkeyMismatch);
+        assert!(
+            mgr.peer_falcon_pubkey(&peer).is_none(),
+            "pin mismatch must NOT leave the rejected pubkey on peer_manager"
+        );
+        // Nonce IS still consumed — the response was a valid
+        // FALCON sig, just not for the pinned identity. No
+        // replay-via-stuck-nonce attack.
+        assert!(!nonces.contains_key(&peer));
+    }
+
+    /// `apply_auth_response` with `None` pin preserves the
+    /// pre-TPL-510 behavior — accept any valid attestation.
+    /// This is the path for unpinned peers and for operators
+    /// who haven't configured pinning at all.
+    #[test]
+    fn tpl_510_apply_auth_response_no_pin_preserves_prior_behavior() {
+        let peer = PeerId::random();
+        let mut mgr = fresh_manager_with_peer(peer);
+        let mut nonces = HashMap::new();
+        let nonce = generate_nonce();
+        nonces.insert(peer, nonce);
+
+        let (resp, pk_bytes, _sk) = build_real_attestation(nonce);
+
+        // No pin — accept whatever the peer attests.
+        let outcome = apply_auth_response(peer, &resp, &mut nonces, &mut mgr, &[], None);
+        assert_eq!(outcome, AuthOutcome::StoredAsNonValidator);
+        assert_eq!(mgr.peer_falcon_pubkey(&peer), Some(pk_bytes.as_slice()));
     }
 }

--- a/crates/net/src/discovery.rs
+++ b/crates/net/src/discovery.rs
@@ -99,6 +99,18 @@ pub struct Discovery {
     banned: HashMap<PeerId, BanEntry>,
     /// Ban duration in seconds.
     ban_duration: u64,
+    /// TPL-510: operator-supplied FALCON pubkey pins for
+    /// specific peer ids (typically bootstrap peers and
+    /// other known infrastructure). When the auth handshake
+    /// completes, the attested FALCON pubkey is compared to
+    /// the pinned value; a mismatch is a hard-disconnect
+    /// signal. Pre-fix bootstrap entries were trusted by
+    /// multiaddr alone — anyone able to reach the operator's
+    /// claimed (IP, port, libp2p-noise-PeerId) tuple was
+    /// accepted as the bootstrap, with no ability for the
+    /// operator to additionally pin the FALCON identity that
+    /// signs blocks/votes.
+    pinned_falcon_pubkeys: HashMap<PeerId, Vec<u8>>,
 }
 
 impl Discovery {
@@ -108,6 +120,7 @@ impl Discovery {
             known_peers: HashMap::new(),
             banned: HashMap::new(),
             ban_duration: DEFAULT_BAN_DURATION_SECS,
+            pinned_falcon_pubkeys: HashMap::new(),
         }
     }
 
@@ -126,6 +139,35 @@ impl Discovery {
     /// Get bootstrap peers for initial connection.
     pub fn bootstrap_peers(&self) -> &[(PeerId, Multiaddr)] {
         &self.bootstrap_peers
+    }
+
+    /// TPL-510: register an operator-supplied FALCON pubkey
+    /// pin for a specific peer id. The auth handshake's
+    /// `apply_auth_response` rejects any attested pubkey that
+    /// doesn't byte-match the pin. Idempotent on repeat
+    /// registration of the same `(peer, pubkey)`; later calls
+    /// with a different pubkey OVERWRITE the prior pin (the
+    /// operator changed their mind in config and we trust the
+    /// most recent value).
+    pub fn add_falcon_pubkey_pin(&mut self, peer_id: PeerId, falcon_pubkey: Vec<u8>) {
+        self.pinned_falcon_pubkeys.insert(peer_id, falcon_pubkey);
+    }
+
+    /// TPL-510: look up the operator's FALCON pubkey pin for a
+    /// peer. Returns `None` if no pin is registered for that
+    /// peer id (the handshake then accepts whatever pubkey the
+    /// peer attests, same pre-fix behavior). Returns
+    /// `Some(&[u8])` to enforce a byte-equality match against
+    /// the attested pubkey.
+    pub fn pinned_falcon_pubkey(&self, peer_id: &PeerId) -> Option<&[u8]> {
+        self.pinned_falcon_pubkeys
+            .get(peer_id)
+            .map(|v| v.as_slice())
+    }
+
+    /// TPL-510: count of registered pins (for telemetry / startup logs).
+    pub fn pinned_pubkey_count(&self) -> usize {
+        self.pinned_falcon_pubkeys.len()
     }
 
     /// Record a discovered peer from DHT or gossip.
@@ -392,5 +434,36 @@ mod tests {
         let mut disco = Discovery::new();
         disco.add_bootstrap_peers(&["not_a_valid_addr".to_string()]);
         assert_eq!(disco.bootstrap_peers().len(), 0);
+    }
+
+    // ========== TPL-510: bootstrap FALCON pubkey pinning ==========
+
+    #[test]
+    fn tpl_510_pinned_falcon_pubkey_round_trips() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+        let pk = vec![0xAB; 897];
+        disco.add_falcon_pubkey_pin(peer, pk.clone());
+
+        assert_eq!(disco.pinned_falcon_pubkey(&peer), Some(pk.as_slice()));
+        assert_eq!(disco.pinned_pubkey_count(), 1);
+    }
+
+    #[test]
+    fn tpl_510_pinned_falcon_pubkey_returns_none_for_unpinned() {
+        let disco = Discovery::new();
+        let peer = random_peer();
+        assert_eq!(disco.pinned_falcon_pubkey(&peer), None);
+        assert_eq!(disco.pinned_pubkey_count(), 0);
+    }
+
+    #[test]
+    fn tpl_510_repeated_pin_overwrites_prior_value() {
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+        disco.add_falcon_pubkey_pin(peer, vec![0xAA; 897]);
+        disco.add_falcon_pubkey_pin(peer, vec![0xBB; 897]);
+        assert_eq!(disco.pinned_falcon_pubkey(&peer), Some(vec![0xBB; 897].as_slice()));
+        assert_eq!(disco.pinned_pubkey_count(), 1);
     }
 }

--- a/crates/net/src/discovery.rs
+++ b/crates/net/src/discovery.rs
@@ -7,8 +7,11 @@
 //! 4. Maintains a set of known peers for reconnection
 
 use libp2p::{Multiaddr, PeerId};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::time::Instant;
+use std::path::Path;
+use std::str::FromStr;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// Pyde mainnet chain ID. Bound into every consensus signing
 /// preimage (proposer headers, votes, view-change votes, slashing
@@ -45,11 +48,42 @@ pub const MAINNET_BOOTSTRAP: &[&str] = &[];
 /// error instead of a silent fork-of-one.
 pub const TESTNET_BOOTSTRAP: &[&str] = &[];
 
-/// Ban duration in seconds.
+/// Default ban duration in seconds when a `BanReason` doesn't
+/// have a more specific tier (currently only used by the
+/// fallback path in `ban_peer_for(_, _, 0)`-style overrides).
 pub const DEFAULT_BAN_DURATION_SECS: u64 = 3600; // 1 hour
 
+/// TPL-511: per-reason ban duration tiers, in seconds. Each
+/// `BanReason::default_duration_secs()` returns its tier. The
+/// scaling is roughly:
+///
+/// - `RATE_LIMIT_ABUSE` (10 min): low-cost offense, often
+///   triggered by ordinary back-pressure or buggy clients —
+///   short ban encourages reconnect once back-pressure
+///   subsides.
+/// - `INVALID_TRANSACTION` (1 hour): a peer relaying garbage
+///   txs, but that's catchable at the mempool gate without
+///   permanent damage. 1h covers the typical mis-config
+///   window.
+/// - `PROTOCOL_VIOLATION` (1 day): wrong wire format, missing
+///   tags, malformed framing. Indicates a buggy or hostile
+///   client; longer ban gives the operator time to notice.
+/// - `INVALID_CONSENSUS_MESSAGE` (7 days): the most expensive
+///   class — every received consensus msg burns FALCON-verify
+///   cycles, and a peer reliably emitting invalid ones is
+///   either Byzantine or seriously broken. 7d effectively
+///   blacklists the peer for the testnet's incentivized window.
+/// - `MANUAL` (1 day default): operator override — the duration
+///   parameter on `ban_peer_for` lets the operator pick a
+///   different value when needed.
+pub const BAN_TIER_RATE_LIMIT_ABUSE_SECS: u64 = 600; // 10 minutes
+pub const BAN_TIER_INVALID_TRANSACTION_SECS: u64 = 3600; // 1 hour
+pub const BAN_TIER_PROTOCOL_VIOLATION_SECS: u64 = 86_400; // 1 day
+pub const BAN_TIER_INVALID_CONSENSUS_SECS: u64 = 604_800; // 7 days
+pub const BAN_TIER_MANUAL_SECS: u64 = 86_400; // 1 day
+
 /// Ban reason.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BanReason {
     /// Sent invalid consensus messages.
     InvalidConsensusMessage,
@@ -61,6 +95,21 @@ pub enum BanReason {
     ProtocolViolation,
     /// Manual ban by operator.
     Manual(String),
+}
+
+impl BanReason {
+    /// TPL-511: default per-reason ban duration in seconds.
+    /// Used by `ban_peer` (the default path); `ban_peer_for`
+    /// keeps the explicit-duration override.
+    pub fn default_duration_secs(&self) -> u64 {
+        match self {
+            BanReason::RateLimitAbuse => BAN_TIER_RATE_LIMIT_ABUSE_SECS,
+            BanReason::InvalidTransaction => BAN_TIER_INVALID_TRANSACTION_SECS,
+            BanReason::ProtocolViolation => BAN_TIER_PROTOCOL_VIOLATION_SECS,
+            BanReason::InvalidConsensusMessage => BAN_TIER_INVALID_CONSENSUS_SECS,
+            BanReason::Manual(_) => BAN_TIER_MANUAL_SECS,
+        }
+    }
 }
 
 /// A banned peer entry.
@@ -97,8 +146,6 @@ pub struct Discovery {
     known_peers: HashMap<PeerId, KnownPeer>,
     /// Banned peers.
     banned: HashMap<PeerId, BanEntry>,
-    /// Ban duration in seconds.
-    ban_duration: u64,
     /// TPL-510: operator-supplied FALCON pubkey pins for
     /// specific peer ids (typically bootstrap peers and
     /// other known infrastructure). When the auth handshake
@@ -119,7 +166,6 @@ impl Discovery {
             bootstrap_peers: Vec::new(),
             known_peers: HashMap::new(),
             banned: HashMap::new(),
-            ban_duration: DEFAULT_BAN_DURATION_SECS,
             pinned_falcon_pubkeys: HashMap::new(),
         }
     }
@@ -224,15 +270,23 @@ impl Discovery {
 
     // ========== Banning ==========
 
-    /// Ban a peer.
+    /// Ban a peer with the per-reason default duration tier
+    /// (TPL-511: `BanReason::default_duration_secs`). Pre-fix
+    /// every ban used the constant `self.ban_duration` (1 hour),
+    /// so a sustained-spam `InvalidConsensusMessage` peer was
+    /// re-eligible to reconnect after the same window as a
+    /// transient `RateLimitAbuse` — the rate-limit tripper
+    /// stayed banned an order of magnitude longer than was
+    /// proportional, the consensus spammer an order shorter.
     pub fn ban_peer(&mut self, peer_id: PeerId, reason: BanReason) {
+        let duration_secs = reason.default_duration_secs();
         self.banned.insert(
             peer_id,
             BanEntry {
                 peer_id,
                 reason,
                 banned_at: Instant::now(),
-                duration_secs: self.ban_duration,
+                duration_secs,
             },
         );
         // Remove from known peers
@@ -285,6 +339,123 @@ impl Discovery {
             .map(|(id, _)| *id)
             .collect()
     }
+
+    // ========== TPL-511: ban persistence ==========
+
+    /// Persist the active (non-expired) bans to
+    /// `<datadir>/bans.json`. Each entry stores the absolute
+    /// Unix-ms expiration time so a restart correctly recovers
+    /// the remaining duration even though `Instant`s don't
+    /// survive across processes.
+    ///
+    /// Atomic write via temp + rename — same crash-safety
+    /// pattern as `PeerBook::save`. Already-expired bans are
+    /// dropped at save time; load_bans drops anything still
+    /// expired by the time it runs.
+    pub fn save_bans(&self, datadir: &Path) -> Result<(), String> {
+        let now_ms = current_unix_ms();
+        let entries: Vec<BanFileEntry> = self
+            .banned
+            .iter()
+            .filter(|(_, e)| !e.is_expired())
+            .map(|(peer_id, entry)| {
+                let remaining_secs =
+                    entry.duration_secs.saturating_sub(entry.banned_at.elapsed().as_secs());
+                let expires_at_unix_ms = now_ms.saturating_add(remaining_secs.saturating_mul(1000));
+                BanFileEntry {
+                    peer_id: peer_id.to_string(),
+                    reason: entry.reason.clone(),
+                    expires_at_unix_ms,
+                }
+            })
+            .collect();
+        let file = BanFile { entries };
+        let bytes = serde_json::to_vec_pretty(&file).map_err(|e| e.to_string())?;
+        let final_path = datadir.join(BAN_FILENAME);
+        let tmp_path = datadir.join(format!("{}.tmp", BAN_FILENAME));
+        std::fs::write(&tmp_path, bytes).map_err(|e| e.to_string())?;
+        std::fs::rename(&tmp_path, &final_path).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// Load persisted bans from `<datadir>/bans.json`. Missing
+    /// file, parse errors, and unparseable entries all fall
+    /// through to an empty ban set — corruption isn't fatal.
+    /// Already-expired entries (`expires_at_unix_ms <= now_ms`)
+    /// are skipped: a restart that crossed past the original
+    /// expiry shouldn't re-impose a ban.
+    pub fn load_bans(&mut self, datadir: &Path) {
+        let path = datadir.join(BAN_FILENAME);
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => return, // missing or unreadable — start clean
+        };
+        let parsed: BanFile = match serde_json::from_slice(&bytes) {
+            Ok(p) => p,
+            Err(_) => {
+                // Corrupt / future format — skip silently to avoid
+                // refusing startup on a bad ban-file.
+                return;
+            }
+        };
+        let now_ms = current_unix_ms();
+        let restore_instant = Instant::now();
+        let mut count = 0usize;
+        for entry in parsed.entries {
+            let peer_id = match PeerId::from_str(&entry.peer_id) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if entry.expires_at_unix_ms <= now_ms {
+                continue;
+            }
+            let remaining_secs = (entry.expires_at_unix_ms - now_ms) / 1000;
+            if remaining_secs == 0 {
+                continue;
+            }
+            self.banned.insert(
+                peer_id,
+                BanEntry {
+                    peer_id,
+                    reason: entry.reason,
+                    banned_at: restore_instant,
+                    duration_secs: remaining_secs,
+                },
+            );
+            count += 1;
+        }
+        if count > 0 {
+            // Soft signal — operators can grep for this in logs to
+            // confirm the on-disk ban set survived a restart.
+            tracing::info!(count, "restored ban entries from disk");
+        }
+    }
+}
+
+const BAN_FILENAME: &str = "bans.json";
+
+/// On-disk representation of a single ban. Stored separately
+/// from `BanEntry` to avoid coupling the in-memory `Instant`
+/// (monotonic, non-serializable) with the persisted layout.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct BanFileEntry {
+    peer_id: String,
+    reason: BanReason,
+    /// Absolute Unix-ms time at which the ban expires. Computed
+    /// at save time from `banned_at + duration_secs`.
+    expires_at_unix_ms: u64,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct BanFile {
+    entries: Vec<BanFileEntry>,
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 impl Default for Discovery {
@@ -465,5 +636,164 @@ mod tests {
         disco.add_falcon_pubkey_pin(peer, vec![0xBB; 897]);
         assert_eq!(disco.pinned_falcon_pubkey(&peer), Some(vec![0xBB; 897].as_slice()));
         assert_eq!(disco.pinned_pubkey_count(), 1);
+    }
+
+    // ========== TPL-511: ban tier durations + on-disk persistence ==========
+
+    /// Each `BanReason` returns its tier'd default duration —
+    /// rate-limit < tx-invalid < protocol-violation <
+    /// invalid-consensus, with `Manual` near the top of the
+    /// scale (operator override is the explicit-duration form).
+    #[test]
+    fn tpl_511_ban_reason_tier_durations() {
+        assert_eq!(
+            BanReason::RateLimitAbuse.default_duration_secs(),
+            BAN_TIER_RATE_LIMIT_ABUSE_SECS
+        );
+        assert_eq!(
+            BanReason::InvalidTransaction.default_duration_secs(),
+            BAN_TIER_INVALID_TRANSACTION_SECS
+        );
+        assert_eq!(
+            BanReason::ProtocolViolation.default_duration_secs(),
+            BAN_TIER_PROTOCOL_VIOLATION_SECS
+        );
+        assert_eq!(
+            BanReason::InvalidConsensusMessage.default_duration_secs(),
+            BAN_TIER_INVALID_CONSENSUS_SECS
+        );
+        assert_eq!(
+            BanReason::Manual("op".into()).default_duration_secs(),
+            BAN_TIER_MANUAL_SECS
+        );
+        // Invariant: tier ordering preserves the "more
+        // expensive offense → longer ban" property.
+        assert!(BAN_TIER_RATE_LIMIT_ABUSE_SECS < BAN_TIER_INVALID_TRANSACTION_SECS);
+        assert!(BAN_TIER_INVALID_TRANSACTION_SECS < BAN_TIER_PROTOCOL_VIOLATION_SECS);
+        assert!(BAN_TIER_PROTOCOL_VIOLATION_SECS < BAN_TIER_INVALID_CONSENSUS_SECS);
+    }
+
+    /// `ban_peer` (the default path) now uses the per-reason
+    /// tier instead of a single constant. A consensus spammer
+    /// gets the long tier; a rate-limit tripper gets the
+    /// short one.
+    #[test]
+    fn tpl_511_ban_peer_uses_per_reason_tier() {
+        let mut disco = Discovery::new();
+        let consensus_spammer = random_peer();
+        let rate_limit_tripper = random_peer();
+        disco.ban_peer(consensus_spammer, BanReason::InvalidConsensusMessage);
+        disco.ban_peer(rate_limit_tripper, BanReason::RateLimitAbuse);
+
+        let consensus_entry = disco.banned.get(&consensus_spammer).unwrap();
+        let rate_entry = disco.banned.get(&rate_limit_tripper).unwrap();
+        assert_eq!(
+            consensus_entry.duration_secs,
+            BAN_TIER_INVALID_CONSENSUS_SECS
+        );
+        assert_eq!(rate_entry.duration_secs, BAN_TIER_RATE_LIMIT_ABUSE_SECS);
+    }
+
+    /// Bans persist across save/load with their remaining
+    /// duration intact. A ban saved with N seconds remaining
+    /// reloads as ban with ≈N seconds remaining.
+    #[test]
+    fn tpl_511_ban_persistence_roundtrips_remaining_duration() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut disco = Discovery::new();
+        let peer = random_peer();
+        // Custom 60-second ban so the test isn't sensitive to
+        // tier values (and finishes quickly even if the test
+        // host is slow).
+        disco.ban_peer_for(peer, BanReason::Manual("test".into()), 60);
+        assert!(disco.is_banned(&peer));
+
+        disco.save_bans(dir.path()).unwrap();
+
+        // Fresh Discovery — load from disk.
+        let mut disco2 = Discovery::new();
+        disco2.load_bans(dir.path());
+        assert!(
+            disco2.is_banned(&peer),
+            "ban must survive save/load roundtrip"
+        );
+        let restored = disco2.banned.get(&peer).unwrap();
+        assert_eq!(restored.reason, BanReason::Manual("test".into()));
+        // Remaining ≤ 60 (some time elapsed during save+load).
+        assert!(
+            restored.duration_secs <= 60,
+            "remaining duration must reflect time elapsed"
+        );
+    }
+
+    /// Already-expired entries on disk are dropped at load
+    /// time — a node that crashed and came back hours later
+    /// shouldn't re-impose a ban that was supposed to have
+    /// already expired. We exercise this by writing a bans
+    /// file directly with an `expires_at_unix_ms` in the
+    /// past.
+    #[test]
+    fn tpl_511_load_drops_already_expired_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = random_peer();
+        let file = BanFile {
+            entries: vec![BanFileEntry {
+                peer_id: peer.to_string(),
+                reason: BanReason::ProtocolViolation,
+                // 1 sec past the Unix epoch — definitely expired.
+                expires_at_unix_ms: 1000,
+            }],
+        };
+        let bytes = serde_json::to_vec_pretty(&file).unwrap();
+        std::fs::write(dir.path().join("bans.json"), bytes).unwrap();
+
+        let mut disco = Discovery::new();
+        disco.load_bans(dir.path());
+        assert!(
+            !disco.is_banned(&peer),
+            "expired ban entry must be dropped on load"
+        );
+    }
+
+    /// Missing or corrupt bans file falls through to an empty
+    /// ban set — corruption isn't fatal, mirroring `PeerBook::load`.
+    #[test]
+    fn tpl_511_missing_bans_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut disco = Discovery::new();
+        disco.load_bans(dir.path());
+        assert_eq!(disco.banned_count(), 0);
+    }
+
+    #[test]
+    fn tpl_511_corrupt_bans_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bans.json"), b"not-json").unwrap();
+        let mut disco = Discovery::new();
+        disco.load_bans(dir.path());
+        assert_eq!(disco.banned_count(), 0);
+    }
+
+    /// `save_bans` only persists non-expired entries — a
+    /// dirty in-memory ban that's already expired doesn't
+    /// land on disk.
+    #[test]
+    fn tpl_511_save_skips_already_expired_in_memory_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut disco = Discovery::new();
+        let live = random_peer();
+        let expired = random_peer();
+        disco.ban_peer_for(live, BanReason::ProtocolViolation, 60);
+        disco.ban_peer_for(expired, BanReason::ProtocolViolation, 0);
+        // `expired` ban is immediately past — `is_banned` is
+        // already false.
+        assert!(disco.is_banned(&live));
+        assert!(!disco.is_banned(&expired));
+
+        disco.save_bans(dir.path()).unwrap();
+        let mut disco2 = Discovery::new();
+        disco2.load_bans(dir.path());
+        assert!(disco2.is_banned(&live));
+        assert!(!disco2.is_banned(&expired));
     }
 }

--- a/crates/net/src/peer.rs
+++ b/crates/net/src/peer.rs
@@ -110,6 +110,34 @@ impl PeerInfo {
 /// letting any single peer monopolize buffer space.
 pub const MAX_RR_INFLIGHT_PER_PEER: usize = 8;
 
+/// Maximum number of consensus-topic gossip messages we'll
+/// accept (and therefore decode + FALCON-verify) per second
+/// from an UNATTESTED `propagation_source` (TPL-505).
+///
+/// An unattested peer hasn't completed our FALCON auth
+/// handshake yet — it might be a legitimately-pending
+/// committee member during a reconnect race, or a new full
+/// node, or an attacker that opened a connection just to
+/// pump expensive messages through the mesh's forwarding
+/// path. Without a budget every consensus-topic message from
+/// such a peer costs us a FALCON verify (~100K cycles) at
+/// the app layer; an attacker holding a few inbound TCP
+/// substreams can stall the consensus loop with verify work
+/// alone. Attested + authorized committee peers bypass this
+/// budget entirely (they're trusted on the channel by
+/// definition), and attested + non-committee peers were
+/// already hard-dropped pre-fix at the `is_consensus_authorized`
+/// gate. The cap targets the "unattested forwarder" middle
+/// case, which is the only one whose CPU cost was unbounded.
+///
+/// 32 is roughly an order of magnitude above the steady-state
+/// per-peer rate honest validators produce on the consensus
+/// topic (vote + occasional FV/randomness/PSS gossip), so
+/// honest unattested peers during their handshake window stay
+/// well under it; sustained spam at 33+/s from one source
+/// gets shed.
+pub const MAX_UNATTESTED_CONSENSUS_PER_SEC: u32 = 32;
+
 /// Manages connected peers and enforces limits.
 #[derive(Debug)]
 pub struct PeerManager {
@@ -129,6 +157,11 @@ pub struct PeerManager {
     /// yet seen acked / failed. Gates new sends to bound queued
     /// outbound buffers under quadratic-fanout consensus rounds.
     outbound_rr_inflight: HashMap<PeerId, usize>,
+    /// TPL-505: per-`propagation_source` budget for consensus-
+    /// topic gossip when the peer hasn't attested a FALCON pubkey
+    /// yet. Stored as `(count, window_start)`; the count resets
+    /// every wall-clock second.
+    unattested_consensus_budget: HashMap<PeerId, (u32, Instant)>,
 }
 
 impl PeerManager {
@@ -146,6 +179,7 @@ impl PeerManager {
             rate_limits: HashMap::new(),
             rate_limit_per_ip,
             outbound_rr_inflight: HashMap::new(),
+            unattested_consensus_budget: HashMap::new(),
         }
     }
 
@@ -245,7 +279,47 @@ impl PeerManager {
         // from the prior connection — the libp2p substream is
         // gone, so there's nothing to ack the existing slots.
         self.outbound_rr_inflight.remove(peer_id);
+        // TPL-505: drop any unattested-consensus budget so a
+        // re-connecting peer starts with a clean window.
+        self.unattested_consensus_budget.remove(peer_id);
         self.peers.remove(peer_id)
+    }
+
+    /// TPL-505: try to consume one unit of the per-second
+    /// consensus-topic budget for an UNATTESTED peer. Returns
+    /// `true` if the message is admitted (budget available),
+    /// `false` if the per-second cap has been reached. Resets
+    /// the window when the prior window is older than 1 second
+    /// so honest peers post-handshake re-handshake races aren't
+    /// permanently saddled with prior-window state. Should NOT
+    /// be called for attested + authorized committee peers —
+    /// they bypass this gate entirely. Saturating-add on the
+    /// counter so a sustained-overflow attacker can't trigger
+    /// integer wrap.
+    pub fn try_consume_unattested_consensus_budget(&mut self, peer: &PeerId) -> bool {
+        let now = Instant::now();
+        let entry = self
+            .unattested_consensus_budget
+            .entry(*peer)
+            .or_insert((0, now));
+        if entry.1.elapsed().as_secs() >= 1 {
+            *entry = (1, now);
+            return true;
+        }
+        if entry.0 >= MAX_UNATTESTED_CONSENSUS_PER_SEC {
+            return false;
+        }
+        entry.0 = entry.0.saturating_add(1);
+        true
+    }
+
+    /// TPL-505: prune unattested-consensus budget entries whose
+    /// window is more than 60 s stale. Mirrors `prune_rate_limits`
+    /// for the IP rate-limiter; bounds HashMap growth from
+    /// short-lived inbound peers we'll never see again.
+    pub fn prune_unattested_consensus_budget(&mut self) {
+        self.unattested_consensus_budget
+            .retain(|_, (_, window_start)| window_start.elapsed().as_secs() < 60);
     }
 
     /// TPL-504: try to acquire an RR-send slot for a peer. Returns
@@ -739,5 +813,71 @@ mod tests {
             0,
             "remove_peer must drop in-flight counter"
         );
+    }
+
+    // ── TPL-505: unattested consensus-topic budget ─────────────────
+
+    /// `try_consume_unattested_consensus_budget` admits up to
+    /// `MAX_UNATTESTED_CONSENSUS_PER_SEC` messages per peer per
+    /// second, then refuses further admissions in the same
+    /// window without disturbing the budget state.
+    #[test]
+    fn tpl_505_unattested_consensus_budget_caps_per_second() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = PeerId::random();
+
+        for i in 0..MAX_UNATTESTED_CONSENSUS_PER_SEC {
+            assert!(
+                mgr.try_consume_unattested_consensus_budget(&peer),
+                "admission #{i} below per-second cap should succeed"
+            );
+        }
+
+        // Cap reached — further calls in the same window refuse.
+        assert!(!mgr.try_consume_unattested_consensus_budget(&peer));
+        assert!(!mgr.try_consume_unattested_consensus_budget(&peer));
+    }
+
+    /// `remove_peer` clears the budget entry so a reconnecting
+    /// peer starts with a fresh window — without this the
+    /// adversary path "open new TCP connection per second to
+    /// reset state" would already work, but a stuck stale
+    /// entry could lock out a legitimate reconnect.
+    #[test]
+    fn tpl_505_remove_peer_clears_unattested_budget() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer_info = dummy_peer(Direction::Inbound);
+        let id = peer_info.peer_id;
+        assert!(mgr.add_peer(peer_info));
+
+        for _ in 0..MAX_UNATTESTED_CONSENSUS_PER_SEC {
+            assert!(mgr.try_consume_unattested_consensus_budget(&id));
+        }
+        assert!(!mgr.try_consume_unattested_consensus_budget(&id));
+
+        mgr.remove_peer(&id);
+        // Post-disconnect: budget entry gone; a fresh
+        // re-add gets a fresh window.
+        assert!(mgr.try_consume_unattested_consensus_budget(&id));
+    }
+
+    /// `prune_unattested_consensus_budget` only drops entries
+    /// older than 60 s. A fresh entry must survive a prune.
+    #[test]
+    fn tpl_505_prune_unattested_budget_keeps_fresh_entries() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = PeerId::random();
+
+        assert!(mgr.try_consume_unattested_consensus_budget(&peer));
+        // Window is fresh (< 60 s) — must survive the prune.
+        mgr.prune_unattested_consensus_budget();
+        // Asserting via behavior: the next admission counts
+        // against the existing window, so we can still
+        // exhaust it `MAX - 1` more times without creating
+        // a new entry.
+        for _ in 1..MAX_UNATTESTED_CONSENSUS_PER_SEC {
+            assert!(mgr.try_consume_unattested_consensus_budget(&peer));
+        }
+        assert!(!mgr.try_consume_unattested_consensus_budget(&peer));
     }
 }

--- a/crates/net/src/peer.rs
+++ b/crates/net/src/peer.rs
@@ -96,6 +96,20 @@ impl PeerInfo {
     }
 }
 
+/// Maximum number of in-flight RR requests per peer (TPL-504).
+///
+/// Per-peer cap on the consensus-RR + blocks-RR fan-out queue.
+/// Without this, a 128-validator committee broadcasting a VC
+/// round produces N*(N-1) ≈ 16K outbound requests in flight at
+/// FALCON-sig payload sizes (~1KB), peaking around 16 MB of
+/// queued outbound buffers per round. The cap drops *new* sends
+/// to a peer once it already has K in flight; the gossip mesh
+/// covers the happy path, so dropping the redundant RR is safe.
+/// K = 8 leaves headroom for legitimate parallel rounds (vote
+/// + finality vote + view-change in the same window) without
+/// letting any single peer monopolize buffer space.
+pub const MAX_RR_INFLIGHT_PER_PEER: usize = 8;
+
 /// Manages connected peers and enforces limits.
 #[derive(Debug)]
 pub struct PeerManager {
@@ -111,6 +125,10 @@ pub struct PeerManager {
     rate_limits: HashMap<IpAddr, (u32, Instant)>,
     /// Max connections per IP per second.
     rate_limit_per_ip: u32,
+    /// TPL-504: per-peer count of RR requests we've sent and not
+    /// yet seen acked / failed. Gates new sends to bound queued
+    /// outbound buffers under quadratic-fanout consensus rounds.
+    outbound_rr_inflight: HashMap<PeerId, usize>,
 }
 
 impl PeerManager {
@@ -127,6 +145,7 @@ impl PeerManager {
             max_outbound,
             rate_limits: HashMap::new(),
             rate_limit_per_ip,
+            outbound_rr_inflight: HashMap::new(),
         }
     }
 
@@ -221,7 +240,48 @@ impl PeerManager {
 
     /// Remove a disconnected peer.
     pub fn remove_peer(&mut self, peer_id: &PeerId) -> Option<PeerInfo> {
+        // TPL-504: drop the in-flight counter so a re-connect
+        // doesn't inherit a stale (and now-unrecoverable) count
+        // from the prior connection — the libp2p substream is
+        // gone, so there's nothing to ack the existing slots.
+        self.outbound_rr_inflight.remove(peer_id);
         self.peers.remove(peer_id)
+    }
+
+    /// TPL-504: try to acquire an RR-send slot for a peer. Returns
+    /// `true` and increments the per-peer in-flight counter when
+    /// the peer is below `MAX_RR_INFLIGHT_PER_PEER`, otherwise
+    /// returns `false` and leaves the counter unchanged. The
+    /// caller must invoke `release_rr_slot` on RR
+    /// `Message::Response`, `OutboundFailure`, AND `InboundFailure`
+    /// for the matching peer so the counter eventually drains.
+    pub fn try_acquire_rr_slot(&mut self, peer: &PeerId) -> bool {
+        let entry = self.outbound_rr_inflight.entry(*peer).or_insert(0);
+        if *entry >= MAX_RR_INFLIGHT_PER_PEER {
+            return false;
+        }
+        *entry += 1;
+        true
+    }
+
+    /// TPL-504: release a previously-acquired RR-send slot.
+    /// Saturating-decrement so a stray release (e.g. an event the
+    /// caller can't pre-correlate to a `try_acquire_rr_slot`) is
+    /// a no-op rather than a crash. If the counter hits zero the
+    /// entry is removed to bound HashMap growth as peers churn.
+    pub fn release_rr_slot(&mut self, peer: &PeerId) {
+        if let Some(slot) = self.outbound_rr_inflight.get_mut(peer) {
+            *slot = slot.saturating_sub(1);
+            if *slot == 0 {
+                self.outbound_rr_inflight.remove(peer);
+            }
+        }
+    }
+
+    /// TPL-504: introspection for tests + metrics. Returns 0 for
+    /// peers we've never sent to.
+    pub fn rr_inflight_count(&self, peer: &PeerId) -> usize {
+        self.outbound_rr_inflight.get(peer).copied().unwrap_or(0)
     }
 
     /// Get peer info.
@@ -594,5 +654,90 @@ mod tests {
         assert_eq!(mgr.get_peer(&id).unwrap().role, PeerRole::Unknown);
         assert!(mgr.mark_validator(&id));
         assert_eq!(mgr.get_peer(&id).unwrap().role, PeerRole::Validator);
+    }
+
+    // ── TPL-504: per-peer in-flight RR cap ─────────────────────────
+
+    /// `try_acquire_rr_slot` admits up to `MAX_RR_INFLIGHT_PER_PEER`
+    /// concurrent sends per peer, then refuses further admissions
+    /// until `release_rr_slot` drains the count.
+    #[test]
+    fn tpl_504_try_acquire_rr_slot_caps_at_max() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = PeerId::random();
+
+        // First MAX_RR_INFLIGHT_PER_PEER admissions succeed.
+        for i in 0..MAX_RR_INFLIGHT_PER_PEER {
+            assert!(
+                mgr.try_acquire_rr_slot(&peer),
+                "admission #{i} below cap should succeed"
+            );
+            assert_eq!(mgr.rr_inflight_count(&peer), i + 1);
+        }
+
+        // Cap reached: further admissions are refused without
+        // mutating the counter.
+        assert!(!mgr.try_acquire_rr_slot(&peer));
+        assert_eq!(mgr.rr_inflight_count(&peer), MAX_RR_INFLIGHT_PER_PEER);
+        assert!(!mgr.try_acquire_rr_slot(&peer));
+        assert_eq!(mgr.rr_inflight_count(&peer), MAX_RR_INFLIGHT_PER_PEER);
+
+        // After a release, a new admission slots in.
+        mgr.release_rr_slot(&peer);
+        assert_eq!(mgr.rr_inflight_count(&peer), MAX_RR_INFLIGHT_PER_PEER - 1);
+        assert!(mgr.try_acquire_rr_slot(&peer));
+        assert_eq!(mgr.rr_inflight_count(&peer), MAX_RR_INFLIGHT_PER_PEER);
+    }
+
+    /// `release_rr_slot` is saturating: an unmatched release
+    /// (e.g. an event the caller couldn't pre-correlate) is a
+    /// no-op rather than a crash. And once the counter hits
+    /// zero the entry is dropped to bound HashMap growth.
+    #[test]
+    fn tpl_504_release_rr_slot_is_saturating_and_drops_zero_entries() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = PeerId::random();
+
+        // Release on a never-acquired peer is a no-op.
+        mgr.release_rr_slot(&peer);
+        assert_eq!(mgr.rr_inflight_count(&peer), 0);
+
+        // Acquire 2, release 2 → entry should be removed (count
+        // zero ⇒ no map entry, so re-acquire goes through the
+        // entry-insert path).
+        assert!(mgr.try_acquire_rr_slot(&peer));
+        assert!(mgr.try_acquire_rr_slot(&peer));
+        assert_eq!(mgr.rr_inflight_count(&peer), 2);
+        mgr.release_rr_slot(&peer);
+        mgr.release_rr_slot(&peer);
+        assert_eq!(mgr.rr_inflight_count(&peer), 0);
+
+        // Extra release after the entry is gone — still a no-op.
+        mgr.release_rr_slot(&peer);
+        assert_eq!(mgr.rr_inflight_count(&peer), 0);
+    }
+
+    /// `remove_peer` clears any in-flight slots so a re-connect
+    /// doesn't inherit an unrecoverable count from the prior
+    /// connection — the libp2p substream is gone, no events will
+    /// arrive to drain it.
+    #[test]
+    fn tpl_504_remove_peer_clears_inflight_slots() {
+        let mut mgr = PeerManager::new(10, 10, 10, 100);
+        let peer = dummy_peer(Direction::Outbound);
+        let id = peer.peer_id;
+        assert!(mgr.add_peer(peer));
+
+        for _ in 0..3 {
+            assert!(mgr.try_acquire_rr_slot(&id));
+        }
+        assert_eq!(mgr.rr_inflight_count(&id), 3);
+
+        mgr.remove_peer(&id);
+        assert_eq!(
+            mgr.rr_inflight_count(&id),
+            0,
+            "remove_peer must drop in-flight counter"
+        );
     }
 }

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -702,11 +702,24 @@ impl BlockProcessor {
     /// `Some(_)`. `now_ms` is the receiver's wall-clock at validation
     /// time; the header is rejected if its timestamp exceeds
     /// `now_ms + MAX_TIMESTAMP_DRIFT_MS`.
+    ///
+    /// TPL-503 / audit-402: `qc_previous_committee_keys` is the
+    /// committee whose FALCON keys verify the signatures inside
+    /// `header.qc_previous`. At an epoch boundary the proposer at
+    /// the first slot of epoch E ships a `qc_previous` covering
+    /// slot `E*EPOCH_LENGTH - 1`, signed by the OUTGOING committee
+    /// (epoch E-1). Using the current committee for that QC
+    /// verification rejects every legitimate boundary block on
+    /// sync/replay paths. When `Some(prior)` is supplied it is
+    /// used for the `has_quorum_for` and `verify_qc` checks; when
+    /// `None` (the common non-boundary case AND the full-node
+    /// fallback) the function falls back to `committee_keys`.
     pub fn validate_network_block(
         chain_id: u64,
         header: &BlockHeader,
         proposer_signature: &[u8],
         committee_keys: &[Vec<u8>],
+        qc_previous_committee_keys: Option<&[Vec<u8>]>,
         epoch_randomness: &[u8; 32],
         expected_parent_hash: Option<&[u8; 32]>,
         parent_timestamp: Option<u64>,
@@ -906,14 +919,21 @@ impl BlockProcessor {
             ));
         }
 
-        // 4. Previous QC should have quorum (skip for early blocks with empty QC)
-        let committee_size = committee_keys.len();
-        if header.qc_previous.slot > 0 && !header.qc_previous.has_quorum_for(committee_size) {
+        // 4. Previous QC should have quorum (skip for early blocks with empty QC).
+        //
+        // TPL-503: at an epoch boundary the QC was formed by the
+        // OUTGOING committee, whose size may differ from the
+        // current committee. Use `qc_previous_committee_keys` when
+        // supplied so the quorum threshold matches the committee
+        // that actually signed.
+        let qc_keys: &[Vec<u8>] = qc_previous_committee_keys.unwrap_or(committee_keys);
+        let qc_committee_size = qc_keys.len();
+        if header.qc_previous.slot > 0 && !header.qc_previous.has_quorum_for(qc_committee_size) {
             return Err(format!(
                 "previous QC at slot {} has insufficient votes ({}/{})",
                 header.qc_previous.slot,
                 header.qc_previous.vote_count(),
-                pyde_consensus::block::quorum_for_committee(committee_size),
+                pyde_consensus::block::quorum_for_committee(qc_committee_size),
             ));
         }
 
@@ -926,7 +946,10 @@ impl BlockProcessor {
         //    full FALCON verification, the lie propagated into
         //    `state.highest_qc` (via `create_vote`) and downstream
         //    finality records.
-        if !pyde_consensus::hotstuff::verify_qc(&header.qc_previous, committee_keys, chain_id) {
+        //
+        // TPL-503: verify against `qc_keys` (the OUTGOING committee
+        // at an epoch boundary, the current committee otherwise).
+        if !pyde_consensus::hotstuff::verify_qc(&header.qc_previous, qc_keys, chain_id) {
             return Err(format!(
                 "previous QC at slot {} has invalid signatures (audit 311)",
                 header.qc_previous.slot
@@ -2184,6 +2207,7 @@ mod tests {
             &header,
             &[],        // proposer_signature — irrelevant, parent_hash check fires first
             &[],        // committee_keys — same
+            None,       // qc_previous_committee_keys — same
             &[0u8; 32], // epoch_randomness
             Some(&expected),
             None, // parent_timestamp — irrelevant, parent_hash fires first
@@ -2210,6 +2234,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             None,
             None,
@@ -2236,6 +2261,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected),
             None,
@@ -2259,6 +2285,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&[0xFF; 32]),
             None,
@@ -2286,6 +2313,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected_parent_hash),
             Some(parent_ts),
@@ -2304,6 +2332,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected_parent_hash),
             Some(parent_ts_higher),
@@ -2337,6 +2366,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected_parent_hash),
             None, // parent_ts — skip lower bound, isolate drift check
@@ -2363,6 +2393,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected_parent_hash),
             Some(header.timestamp.saturating_sub(1)),
@@ -2391,6 +2422,7 @@ mod tests {
             &header,
             &[],
             &[],
+            None,
             &[0u8; 32],
             Some(&expected_parent_hash),
             None,
@@ -2475,6 +2507,7 @@ mod tests {
             &header,
             &sig,
             &committee_keys,
+            None,
             &[0u8; 32],
             Some(&[0xCD; 32]),
             None,
@@ -2507,6 +2540,7 @@ mod tests {
             &header,
             &sig,
             &committee_keys,
+            None,
             &[0u8; 32],
             Some(&[0xCD; 32]),
             None,
@@ -2553,6 +2587,7 @@ mod tests {
             &header,
             &sig,
             &committee_keys,
+            None,
             &[0u8; 32],
             Some(&[0xCD; 32]),
             None,
@@ -2562,6 +2597,130 @@ mod tests {
         assert!(
             err.contains("audit-234 L2") && err.contains("invalid vrf_proof"),
             "expected unrecognised-vrf_proof audit-234 L2 rejection, got: {err}"
+        );
+    }
+
+    /// TPL-503 / audit-402: at the first block of a new epoch
+    /// `header.qc_previous` covers the LAST slot of the OUTGOING
+    /// epoch and was therefore signed by the OUTGOING committee.
+    /// Pre-fix, `validate_network_block` fed the CURRENT
+    /// `committee_keys` slice into `verify_qc`; FALCON
+    /// verification then failed against the wrong key set and
+    /// every legitimate epoch-boundary block was rejected on the
+    /// sync/replay path. The validator hot path was already
+    /// correct (it threaded `committee_keys_for_slot` into
+    /// `create_vote`), so the bug only surfaced for full nodes
+    /// catching up across an epoch boundary.
+    ///
+    /// Post-fix: callers thread an optional
+    /// `qc_previous_committee_keys` for QC verification. Test
+    /// asserts the SAME boundary block fails when the param is
+    /// `None` (using the new committee, the wrong keys) and
+    /// passes when `Some(prev_committee)` is supplied — the two
+    /// directions of the binding the fix introduces.
+    #[test]
+    fn tpl_503_validate_network_block_uses_qc_previous_committee_for_boundary_qc() {
+        use pyde_consensus::block::EPOCH_LENGTH;
+        use pyde_consensus::hotstuff::proposer_sign_message;
+
+        let chain_id = 31337;
+        let prev_committee = make_committee(3);
+        let new_committee = make_committee(3);
+
+        let prev_committee_keys: Vec<Vec<u8>> = prev_committee
+            .iter()
+            .map(|(pk, _)| pk.as_bytes().to_vec())
+            .collect();
+        let new_committee_keys: Vec<Vec<u8>> = new_committee
+            .iter()
+            .map(|(pk, _)| pk.as_bytes().to_vec())
+            .collect();
+
+        // First slot of a new epoch.
+        let slot = EPOCH_LENGTH;
+        let prev_slot = slot - 1;
+
+        // Build a real qc_previous covering prev_slot, signed by 2
+        // of 3 members of the OUTGOING committee — exactly quorum
+        // for a 3-member committee `(2*3).div_ceil(3) == 2`.
+        let prev_block_hash = [0xAB; 32];
+        let qc_preimage = proposer_sign_message(chain_id, prev_slot, &prev_block_hash);
+        let mut qc_signatures = Vec::new();
+        for (_, sk) in prev_committee.iter().take(2) {
+            let sig = pyde_crypto::falcon::falcon_sign(sk, &qc_preimage)
+                .expect("falcon_sign")
+                .as_bytes()
+                .to_vec();
+            qc_signatures.push(sig);
+        }
+        let qc_previous = QuorumCert {
+            slot: prev_slot,
+            block_hash: prev_block_hash,
+            voter_bitmap: 0b011, // members 0 and 1
+            signatures: qc_signatures,
+        };
+
+        // Build the boundary block. Use a fallback proof so we
+        // can isolate the QC step without spinning up VRF; the
+        // proposer must be the deterministic fallback leader for
+        // (slot, view, n).
+        let view = 0u64;
+        let leader_idx = pyde_consensus::view_change::fallback_leader_index(slot, view, 3);
+        let proposer_addr =
+            pyde_account::address::derive_eoa_address(&new_committee_keys[leader_idx]);
+        let mut header = dummy_header(slot);
+        header.proposer = proposer_addr;
+        header.vrf_proof = pyde_consensus::view_change::encode_fallback_proof(slot, view);
+        header.parent_hash = [0xCD; 32];
+        header.qc_previous = qc_previous;
+        let block_hash = header.hash();
+        let sign_msg = proposer_sign_message(chain_id, slot, &block_hash);
+        let sig = pyde_crypto::falcon::falcon_sign(&new_committee[leader_idx].1, &sign_msg)
+            .expect("falcon_sign")
+            .as_bytes()
+            .to_vec();
+        let now_ms = header.timestamp.saturating_add(1);
+
+        // Pre-fix behavior: passing only the new committee made
+        // verify_qc check sigs against the wrong keys, so the
+        // call surfaces the audit-311 invalid-signatures error.
+        let pre_fix = BlockProcessor::validate_network_block(
+            chain_id,
+            &header,
+            &sig,
+            &new_committee_keys,
+            None,
+            &[0u8; 32],
+            Some(&[0xCD; 32]),
+            None,
+            now_ms,
+        );
+        let err = pre_fix.expect_err(
+            "without prior committee keys the boundary block must fail audit-311 verify_qc",
+        );
+        assert!(
+            err.contains("audit 311") && err.contains("invalid signatures"),
+            "expected audit-311 invalid-signatures rejection, got: {err}"
+        );
+
+        // Post-fix behavior: routing the OUTGOING committee
+        // through `qc_previous_committee_keys` lets verify_qc
+        // succeed and the boundary block validates.
+        let post_fix = BlockProcessor::validate_network_block(
+            chain_id,
+            &header,
+            &sig,
+            &new_committee_keys,
+            Some(&prev_committee_keys),
+            &[0u8; 32],
+            Some(&[0xCD; 32]),
+            None,
+            now_ms,
+        );
+        assert!(
+            post_fix.is_ok(),
+            "with the outgoing committee supplied the boundary block must validate, got: {:?}",
+            post_fix.err()
         );
     }
 }

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -61,6 +61,22 @@ pub struct NetworkSection {
     pub rate_limit_per_ip: u32,
     /// Bootstrap peer multiaddrs.
     pub bootstrap_peers: Vec<String>,
+    /// TPL-510: operator-supplied FALCON pubkey pins for
+    /// specific peer ids. Map of `peer_id_base58` →
+    /// `falcon_pubkey_hex`. When the auth handshake completes
+    /// for a peer in this map, the attested FALCON pubkey
+    /// MUST byte-match the configured value or the connection
+    /// is dropped — pre-fix bootstrap entries were trusted by
+    /// multiaddr alone, so anyone reaching the configured
+    /// `(IP, port, libp2p-noise-id)` tuple was accepted as
+    /// the bootstrap with no operator-visible binding to the
+    /// validator FALCON identity that signs blocks/votes.
+    /// Empty for devnet and for testnets where pinning isn't
+    /// configured; non-empty entries are loaded into a
+    /// `HashMap<PeerId, Vec<u8>>` at startup and passed
+    /// through `handle_swarm_event` to `apply_auth_response`.
+    #[serde(default)]
+    pub bootstrap_pubkey_pins: std::collections::HashMap<String, String>,
 }
 
 impl Default for NetworkSection {
@@ -72,6 +88,7 @@ impl Default for NetworkSection {
             max_outbound: 20,
             rate_limit_per_ip: 5,
             bootstrap_peers: Vec::new(),
+            bootstrap_pubkey_pins: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -15,6 +15,12 @@
 //!                                     broadcast queues + seen dedup set)
 //!   b"p:" || slot_be8 || addr[32]   → (encoded BlockHeader, signature)
 //!   b"v:" || slot_be8 || voter_idx  → (block_hash[32], signature)
+//!   b"vcs:" || slot_be8             → (highest_qc_hash[32], signature)
+//!     [TPL-501: self-VC equivocation guard. Persisted before
+//!      `on_timeout` returns the signed VC, restored on restart.
+//!      Re-attempting a VC at the same slot reuses the persisted
+//!      signature when the highest_qc still matches; refuses to
+//!      sign a different VC at that slot otherwise.]
 
 use crate::wire;
 use pyde_account::address::Address;
@@ -30,12 +36,23 @@ const RESHARE_STATE_KEY: &[u8] = b"reshare:state";
 const FINALITY_CHECKPOINT_KEY: &[u8] = b"finality:checkpoint";
 const PROPOSAL_PREFIX: &[u8] = b"p:";
 const VOTE_PREFIX: &[u8] = b"v:";
+/// TPL-501: self-VC equivocation guard. Stored once per (slot)
+/// since voter_index is always this validator's own committee
+/// index — encoding it would add nothing.
+const VC_SELF_PREFIX: &[u8] = b"vcs:";
 
 /// A proposal seen from a proposer at a given slot (for double-propose detection).
 pub type SeenProposal = ((u64, Address), (BlockHeader, Vec<u8>));
 
 /// A vote seen from a voter at a given slot (for double-vote detection).
 pub type SeenVote = ((u64, u8), ([u8; 32], Vec<u8>));
+
+/// A view-change message we ourselves signed at a given slot.
+/// `(highest_qc_hash, signature)` is enough to (a) reject a
+/// different-content VC at the same slot post-restart and
+/// (b) idempotently re-broadcast the original signature when the
+/// current `highest_qc` still hashes to the same value.
+pub type SeenViewChangeSelf = (u64, ([u8; 32], Vec<u8>));
 
 /// RocksDB-backed store for a validator's `ConsensusState`.
 ///
@@ -271,6 +288,31 @@ impl ConsensusStateStore {
             .map_err(|e| format!("failed to save seen vote: {}", e))
     }
 
+    /// TPL-501: persist the view-change message THIS validator
+    /// signed at `slot` together with the `highest_qc_hash` it
+    /// was signed over. Called BEFORE `on_timeout` returns the
+    /// signed message — without that ordering a crash between
+    /// signing and persisting could let the validator sign a
+    /// different VC at the same slot post-restart, equivocating
+    /// itself for a slashable offense.
+    /// fsync'd before return (see struct docstring).
+    pub fn save_seen_view_change_self(
+        &self,
+        slot: u64,
+        highest_qc_hash: &[u8; 32],
+        signature: &[u8],
+    ) -> Result<(), String> {
+        let mut key = Vec::with_capacity(VC_SELF_PREFIX.len() + 8);
+        key.extend_from_slice(VC_SELF_PREFIX);
+        key.extend_from_slice(&slot.to_be_bytes());
+        let mut value = Vec::with_capacity(32 + signature.len());
+        value.extend_from_slice(highest_qc_hash);
+        value.extend_from_slice(signature);
+        self.db
+            .put_opt(&key, &value, &self.sync_opts)
+            .map_err(|e| format!("failed to save seen view-change: {}", e))
+    }
+
     /// Load all persisted seen proposals. Corrupt entries are skipped + logged.
     pub fn load_all_seen_proposals(&self) -> Vec<SeenProposal> {
         let mut out = Vec::new();
@@ -296,6 +338,46 @@ impl ConsensusStateStore {
                 Ok((header, sig)) => out.push(((slot, addr), (header, sig))),
                 Err(e) => warn!(slot, error = e, "skipping corrupt proposal value"),
             }
+        }
+        out
+    }
+
+    /// TPL-501: load all persisted self-VC records. Corrupt
+    /// entries (wrong key length, value too short to fit the
+    /// 32-byte qc_hash prefix) are skipped + logged. Called
+    /// from `attach_consensus_store` to seed the in-memory
+    /// `seen_view_changes_self` map post-restart.
+    pub fn load_all_seen_view_changes_self(&self) -> Vec<SeenViewChangeSelf> {
+        let mut out = Vec::new();
+        for item in self.db.prefix_iterator(VC_SELF_PREFIX) {
+            let (k, v) = match item {
+                Ok(kv) => kv,
+                Err(e) => {
+                    warn!(error = %e, "iterator error on self-VC records");
+                    continue;
+                }
+            };
+            if !k.starts_with(VC_SELF_PREFIX) {
+                break;
+            }
+            let slot_bytes = match k.get(VC_SELF_PREFIX.len()..VC_SELF_PREFIX.len() + 8) {
+                Some(b) => b,
+                None => {
+                    warn!("skipping self-VC key shorter than VC_SELF_PREFIX + 8");
+                    continue;
+                }
+            };
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(slot_bytes);
+            let slot = u64::from_be_bytes(buf);
+            if v.len() < 32 {
+                warn!(slot, "skipping self-VC value shorter than 32 bytes");
+                continue;
+            }
+            let mut qc_hash = [0u8; 32];
+            qc_hash.copy_from_slice(&v[..32]);
+            let signature = v[32..].to_vec();
+            out.push((slot, (qc_hash, signature)));
         }
         out
     }
@@ -329,13 +411,14 @@ impl ConsensusStateStore {
         out
     }
 
-    /// Delete all seen-proposal and seen-vote entries with slot < prune_before.
-    /// Mirrors the in-memory pruning in `ValidatorEngine::advance_slot`.
+    /// Delete all seen-proposal, seen-vote, and self-VC entries
+    /// with slot < prune_before. Mirrors the in-memory pruning
+    /// in `ValidatorEngine::advance_slot`.
     pub fn prune_evidence_before(&self, prune_before: u64) -> Result<usize, String> {
         let mut batch = WriteBatch::default();
         let mut count = 0usize;
 
-        for prefix in [PROPOSAL_PREFIX, VOTE_PREFIX] {
+        for prefix in [PROPOSAL_PREFIX, VOTE_PREFIX, VC_SELF_PREFIX] {
             for item in self
                 .db
                 .iterator(IteratorMode::From(prefix, rocksdb::Direction::Forward))

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4738,13 +4738,46 @@ fn handle_swarm_event(
                             // signature past the chain head, and
                             // the full node would persist + relay
                             // it without checking.
-                            let (committee_keys_ref, epoch_rand_ref): (&[Vec<u8>], &[u8; 32]) =
+                            //
+                            // TPL-503 / audit-402: the QC inside
+                            // `header.qc_previous` was signed by
+                            // the committee at THAT slot's epoch.
+                            // At an epoch boundary the slice
+                            // differs from the current committee,
+                            // so a same-committee verify rejects
+                            // legitimate boundary blocks on the
+                            // sync/replay path. Look up the right
+                            // slice via `committee_keys_for_slot`;
+                            // pass `Some(prior)` only when it
+                            // actually differs from the current
+                            // committee so the validator engine
+                            // and full-node fallback paths stay
+                            // semantically equivalent for non-
+                            // boundary blocks.
+                            let (
+                                committee_keys_ref,
+                                epoch_rand_ref,
+                                qc_prev_keys_owned,
+                            ): (&[Vec<u8>], &[u8; 32], Option<Vec<Vec<u8>>>) =
                                 if let Some(ref engine) = validator_engine {
-                                    (engine.committee_keys.as_slice(), &engine.epoch_randomness)
+                                    let cur = engine.committee_keys.as_slice();
+                                    let qc_prev = engine
+                                        .committee_keys_for_slot(block.header.qc_previous.slot);
+                                    let qc_prev_owned = if !std::ptr::eq(qc_prev.as_ptr(), cur.as_ptr()) {
+                                        Some(qc_prev.to_vec())
+                                    } else {
+                                        None
+                                    };
+                                    (
+                                        cur,
+                                        &engine.epoch_randomness,
+                                        qc_prev_owned,
+                                    )
                                 } else {
                                     (
                                         committee_keys_for_validation,
                                         epoch_randomness_for_validation,
+                                        None,
                                     )
                                 };
                             if !committee_keys_ref.is_empty() {
@@ -4753,6 +4786,7 @@ fn handle_swarm_event(
                                     &block.header,
                                     &block.proposer_signature,
                                     committee_keys_ref,
+                                    qc_prev_keys_owned.as_deref(),
                                     epoch_rand_ref,
                                     expected_parent.as_ref(),
                                     parent_timestamp,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1046,7 +1046,7 @@ impl PydeNode {
                                             &mut swarm,
                                             consensus_topic,
                                             data,
-                                            &peer_manager,
+                                            &mut peer_manager,
                                             &mut gossip_cache,
                                         );
                                     } else if topic == blocks_topic.hash() {
@@ -1054,6 +1054,7 @@ impl PydeNode {
                                             &mut swarm,
                                             blocks_topic,
                                             data,
+                                            &mut peer_manager,
                                             &mut gossip_cache,
                                         );
                                     }
@@ -1120,7 +1121,7 @@ impl PydeNode {
                                 &mut swarm,
                                 topic,
                                 data,
-                                &peer_manager,
+                                &mut peer_manager,
                             &mut gossip_cache,
                             );
                         }
@@ -1258,7 +1259,7 @@ impl PydeNode {
                                         &state,
                                         &block_store,
                                         &mut swarm,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                         &mut gossip_cache,
                                         qc_slot,
                                         qc_block_hash,
@@ -1271,7 +1272,7 @@ impl PydeNode {
                                         &queued_shares,
                                         &pending_decryptors,
                                         &mut swarm,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                         &mut gossip_cache,
                                         &block,
                                         qc_slot,
@@ -1402,7 +1403,7 @@ impl PydeNode {
                                     &queued_shares,
                                     &pending_decryptors,
                                     &mut swarm,
-                                    &peer_manager,
+                                    &mut peer_manager,
                                     &mut gossip_cache,
                                     &block,
                                     qc_slot,
@@ -1440,7 +1441,7 @@ impl PydeNode {
                                     &mut swarm,
                                     topic,
                                     data,
-                                    &peer_manager,
+                                    &mut peer_manager,
                                 &mut gossip_cache,
                                 );
                             }
@@ -1458,7 +1459,7 @@ impl PydeNode {
                                         &mut swarm,
                                         topic.clone(),
                                         data,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                     &mut gossip_cache,
                                     );
                                 }
@@ -1624,7 +1625,7 @@ impl PydeNode {
                                         &state,
                                         &block_store,
                                         &mut swarm,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                         &mut gossip_cache,
                                         qc_slot,
                                         qc_block_hash,
@@ -1637,7 +1638,7 @@ impl PydeNode {
                                         &queued_shares,
                                         &pending_decryptors,
                                         &mut swarm,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                         &mut gossip_cache,
                                         &block,
                                         qc_slot,
@@ -2206,7 +2207,7 @@ impl PydeNode {
                                         &mut swarm,
                                         topic,
                                         msg,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                     &mut gossip_cache,
                                     );
                                     debug!(target_epoch, "re-broadcast resharing contribution");
@@ -2231,7 +2232,7 @@ impl PydeNode {
                                         &mut swarm,
                                         topic,
                                         msg,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                         &mut gossip_cache,
                                     );
                                     debug!(target_epoch, "re-broadcast PSS contribution");
@@ -2386,7 +2387,7 @@ impl PydeNode {
                                                     &mut swarm,
                                                     topic,
                                                     share_bytes,
-                                                    &peer_manager,
+                                                    &mut peer_manager,
                                                 &mut gossip_cache,
                                                 );
                                             }
@@ -2400,7 +2401,7 @@ impl PydeNode {
                                                     &mut swarm,
                                                     topic,
                                                     contrib_bytes,
-                                                    &peer_manager,
+                                                    &mut peer_manager,
                                                 &mut gossip_cache,
                                                 );
                                             }
@@ -2423,7 +2424,7 @@ impl PydeNode {
                                                         &mut swarm,
                                                         topic,
                                                         contrib_bytes,
-                                                        &peer_manager,
+                                                        &mut peer_manager,
                                                     &mut gossip_cache,
                                                     );
                                                 }
@@ -2713,7 +2714,8 @@ impl PydeNode {
                                         &mut swarm,
                                         topic.clone(),
                                         compact_bytes,
-                                    &mut gossip_cache,
+                                        &mut peer_manager,
+                                        &mut gossip_cache,
                                     );
 
                                     // Audit item 207: publish the encrypted_txs
@@ -2736,7 +2738,8 @@ impl PydeNode {
                                             &mut swarm,
                                             topic,
                                             bundle_bytes,
-                                        &mut gossip_cache,
+                                            &mut peer_manager,
+                                            &mut gossip_cache,
                                         );
                                     }
 
@@ -2760,7 +2763,7 @@ impl PydeNode {
                                         &mut swarm,
                                         cons_topic,
                                         proposal_bytes,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                     &mut gossip_cache,
                                     );
 
@@ -2785,7 +2788,7 @@ impl PydeNode {
                                             &mut swarm,
                                             topic,
                                             bytes,
-                                            &peer_manager,
+                                            &mut peer_manager,
                                         &mut gossip_cache,
                                         );
                                     }
@@ -3026,7 +3029,7 @@ impl PydeNode {
                                         &mut swarm,
                                         topic,
                                         vote_bytes,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                     &mut gossip_cache,
                                     );
 
@@ -3141,7 +3144,7 @@ impl PydeNode {
                                                 &mut swarm,
                                                 topic.clone(),
                                                 fv_bytes,
-                                                &peer_manager,
+                                                &mut peer_manager,
                                             &mut gossip_cache,
                                             );
                                             if cert_formed {
@@ -3153,7 +3156,7 @@ impl PydeNode {
                                                         &mut swarm,
                                                         topic,
                                                         cp_bytes,
-                                                        &peer_manager,
+                                                        &mut peer_manager,
                                                     &mut gossip_cache,
                                                     );
                                                 }
@@ -3256,7 +3259,7 @@ impl PydeNode {
                                                                     &mut swarm,
                                                                     topic,
                                                                     share_bytes,
-                                                                    &peer_manager,
+                                                                    &mut peer_manager,
                                                                 &mut gossip_cache,
                                                                 );
                                                                 info!(
@@ -3398,7 +3401,7 @@ impl PydeNode {
                                         &mut swarm,
                                         topic,
                                         vc_bytes,
-                                        &peer_manager,
+                                        &mut peer_manager,
                                     &mut gossip_cache,
                                     );
                                     // audit 234 part 3: also process our own
@@ -3453,7 +3456,7 @@ impl PydeNode {
                                             &mut swarm,
                                             cons_topic,
                                             bytes,
-                                            &peer_manager,
+                                            &mut peer_manager,
                                         &mut gossip_cache,
                                         );
 
@@ -3481,7 +3484,8 @@ impl PydeNode {
                                             &mut swarm,
                                             blocks_topic,
                                             compact_bytes,
-                                        &mut gossip_cache,
+                                            &mut peer_manager,
+                                            &mut gossip_cache,
                                         );
 
                                         // 3) Apply the block locally so the
@@ -3834,7 +3838,7 @@ impl PydeNode {
                                     &mut swarm,
                                     topic,
                                     share_bytes,
-                                    &peer_manager,
+                                    &mut peer_manager,
                                     &mut gossip_cache,
                                 );
                                 debug!(
@@ -4229,7 +4233,7 @@ async fn cast_finality_vote_and_persist(
     state: &std::sync::Arc<tokio::sync::RwLock<crate::state_manager::StateManager>>,
     block_store: &crate::block_store::BlockStore,
     swarm: &mut libp2p::Swarm<pyde_net::node::PydeBehaviour>,
-    peer_manager: &pyde_net::peer::PeerManager,
+    peer_manager: &mut pyde_net::peer::PeerManager,
     gossip_cache: &mut crate::gossip_cache::GossipCache,
     qc_slot: u64,
     qc_block_hash: [u8; 32],
@@ -4284,7 +4288,7 @@ async fn maybe_kick_decryption_pipeline(
         >,
     >,
     swarm: &mut libp2p::Swarm<pyde_net::node::PydeBehaviour>,
-    peer_manager: &pyde_net::peer::PeerManager,
+    peer_manager: &mut pyde_net::peer::PeerManager,
     gossip_cache: &mut crate::gossip_cache::GossipCache,
     block: &pyde_consensus::block::Block,
     qc_slot: u64,
@@ -4386,7 +4390,7 @@ fn broadcast_consensus_with_rr_fallback(
     swarm: &mut libp2p::Swarm<pyde_net::node::PydeBehaviour>,
     topic: gossipsub::IdentTopic,
     data: Vec<u8>,
-    _peer_manager: &pyde_net::peer::PeerManager,
+    peer_manager: &mut pyde_net::peer::PeerManager,
     gossip_cache: &mut crate::gossip_cache::GossipCache,
 ) {
     // Best-effort gossip publish (cheap fan-out via mesh). On
@@ -4439,22 +4443,40 @@ fn broadcast_consensus_with_rr_fallback(
     //
     // Cost: at committee size N + F full nodes, each consensus
     // message is (N+F-1) RR send_requests on top of one gossip
-    // publish. At N=4 (devnet) ≈3 extra messages. At N=128 (mainnet)
-    // ≈127, well under 100KB per slot at FALCON sig sizes —
-    // negligible against the gossip mesh's own per-message cost.
+    // publish. At N=4 (devnet) ≈3 extra messages. At N=128
+    // (mainnet) ≈127, well under 100KB per slot at FALCON sig
+    // sizes — negligible against the gossip mesh's own
+    // per-message cost.
+    //
+    // TPL-504: gated on a per-peer in-flight cap so a stalled
+    // peer can't accumulate megabytes of queued outbound RR
+    // requests during a quadratic-fanout consensus round
+    // (N=128 broadcasting → 16K outstanding requests at FALCON
+    // sig sizes ≈ 16 MB without the cap). The gossip mesh
+    // covers happy-path delivery, so dropping a redundant RR
+    // when the queue's full is safe.
     let connected_peers: Vec<libp2p::PeerId> = swarm.connected_peers().copied().collect();
-    debug!(
-        n_peers = connected_peers.len(),
-        "consensus broadcast: RR fanout to connected peers"
-    );
-    for peer in connected_peers {
+    let mut sent = 0usize;
+    let mut dropped = 0usize;
+    for peer in &connected_peers {
+        if !peer_manager.try_acquire_rr_slot(peer) {
+            dropped += 1;
+            continue;
+        }
         swarm.behaviour_mut().consensus_rr.send_request(
-            &peer,
+            peer,
             pyde_net::consensus_protocol::ConsensusReq {
                 bytes: data.clone(),
             },
         );
+        sent += 1;
     }
+    debug!(
+        n_peers = connected_peers.len(),
+        sent,
+        dropped,
+        "consensus broadcast: RR fanout to connected peers"
+    );
 }
 
 /// Broadcast a Blocks-topic payload via gossipsub AND direct
@@ -4489,6 +4511,7 @@ fn broadcast_blocks_with_rr_fallback(
     swarm: &mut libp2p::Swarm<pyde_net::node::PydeBehaviour>,
     topic: gossipsub::IdentTopic,
     data: Vec<u8>,
+    peer_manager: &mut pyde_net::peer::PeerManager,
     gossip_cache: &mut crate::gossip_cache::GossipCache,
 ) {
     // Best-effort gossip publish (cheap fan-out via mesh). Same
@@ -4512,20 +4535,34 @@ fn broadcast_blocks_with_rr_fallback(
     // validators) avoids racing the auth handshake on
     // disconnect/reconnect; receivers FALCON-verify the block
     // header inside `validate_network_block` before applying.
+    //
+    // TPL-504: gated on the same per-peer in-flight cap as the
+    // consensus path. Compact-block + encrypted-tx-bundle payloads
+    // are larger than consensus messages, so the bandwidth blow-up
+    // when a peer stalls is even worse here without the cap.
     let connected_peers: Vec<libp2p::PeerId> = swarm.connected_peers().copied().collect();
-    debug!(
-        n_peers = connected_peers.len(),
-        bytes = data.len(),
-        "blocks broadcast: RR fanout to connected peers"
-    );
-    for peer in connected_peers {
+    let mut sent = 0usize;
+    let mut dropped = 0usize;
+    for peer in &connected_peers {
+        if !peer_manager.try_acquire_rr_slot(peer) {
+            dropped += 1;
+            continue;
+        }
         swarm.behaviour_mut().blocks_rr.send_request(
-            &peer,
+            peer,
             pyde_net::blocks_protocol::BlocksReq {
                 bytes: data.clone(),
             },
         );
+        sent += 1;
     }
+    debug!(
+        n_peers = connected_peers.len(),
+        sent,
+        dropped,
+        bytes = data.len(),
+        "blocks broadcast: RR fanout to connected peers"
+    );
 }
 
 /// Audit 234 follow-up: dial every peer the previous run was
@@ -5740,16 +5777,25 @@ fn handle_swarm_event(
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::ConsensusRr(
             request_response::Event::Message {
+                peer,
                 message: request_response::Message::Response { .. },
                 ..
             },
         )) => {
-            // Acks are best-effort confirmation; nothing to do.
+            // TPL-504: release the in-flight RR slot we acquired
+            // when the matching `send_request` fired so a follow-
+            // up broadcast can re-target this peer.
+            peer_manager.release_rr_slot(&peer);
+            // Acks are best-effort confirmation; nothing else to do.
             PostEventAction::None
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::ConsensusRr(
             request_response::Event::OutboundFailure { peer, error, .. },
         )) => {
+            // TPL-504: release the slot regardless of how the send
+            // ended — the substream is gone either way and no
+            // future event will fire for it.
+            peer_manager.release_rr_slot(&peer);
             // Audit 234 part 4 step 7 originally disconnected the
             // peer here on the theory that a failed RR send is the
             // canonical signal of a half-broken QUIC connection.
@@ -5903,16 +5949,23 @@ fn handle_swarm_event(
             )
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(request_response::Event::Message {
+            peer,
             message: request_response::Message::Response { .. },
             ..
         })) => {
+            // TPL-504: release the in-flight RR slot we acquired
+            // for this peer at send time.
+            peer_manager.release_rr_slot(&peer);
             // Acks (or DecodeError responses) from peers — best-effort
-            // confirmation, nothing to do.
+            // confirmation, nothing else to do.
             PostEventAction::None
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
             request_response::Event::OutboundFailure { peer, error, .. },
         )) => {
+            // TPL-504: release the slot — same rationale as the
+            // consensus-RR OutboundFailure arm.
+            peer_manager.release_rr_slot(&peer);
             // Same rationale as ConsensusRr OutboundFailure: only
             // disconnect on `Timeout`. Transient failures during slot-
             // tick fanout would otherwise trigger a feedback loop on

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -407,6 +407,53 @@ impl PydeNode {
         let mut pending_auth_nonces: std::collections::HashMap<libp2p::PeerId, [u8; 32]> =
             std::collections::HashMap::new();
 
+        // TPL-510: parse operator-supplied FALCON pubkey pins
+        // from `[network].bootstrap_pubkey_pins`. Map of
+        // base58 PeerId → hex FALCON pubkey, decoded once at
+        // startup into `HashMap<PeerId, Vec<u8>>` for the
+        // auth-handshake check. Invalid entries (unparseable
+        // PeerId or hex) are logged and skipped — better to
+        // start with fewer pins than refuse to start at all,
+        // since pinning is opt-in defense-in-depth on top of
+        // the existing PeerId+multiaddr check. An empty map
+        // preserves prior "trust whatever the peer attests"
+        // behavior.
+        let bootstrap_pubkey_pins: std::collections::HashMap<libp2p::PeerId, Vec<u8>> = {
+            let mut out = std::collections::HashMap::new();
+            for (peer_id_b58, pk_hex) in &self.config.network.bootstrap_pubkey_pins {
+                let peer_id = match peer_id_b58.parse::<libp2p::PeerId>() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        warn!(
+                            peer_id = peer_id_b58,
+                            error = %e,
+                            "skipping bootstrap_pubkey_pin: invalid PeerId"
+                        );
+                        continue;
+                    }
+                };
+                let pk_bytes = match hex::decode(pk_hex) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!(
+                            peer_id = peer_id_b58,
+                            error = %e,
+                            "skipping bootstrap_pubkey_pin: invalid hex"
+                        );
+                        continue;
+                    }
+                };
+                out.insert(peer_id, pk_bytes);
+            }
+            if !out.is_empty() {
+                info!(
+                    n_pins = out.len(),
+                    "loaded operator-supplied FALCON pubkey pins"
+                );
+            }
+            out
+        };
+
         // Audit 234 follow-up: persistent peer book. Loaded at
         // startup (used to seed the dial list below); populated
         // on every `ConnectionEstablished`; persisted on a 30 s
@@ -1000,6 +1047,7 @@ impl PydeNode {
                             &mut pinned_snapshot,
                             &mut peer_manager,
                             &mut pending_auth_nonces,
+                            &bootstrap_pubkey_pins,
                             last_outgoing_committee_size,
                             &committee_keys_for_validation,
                             &epoch_randomness_for_validation,
@@ -4630,6 +4678,7 @@ fn handle_swarm_event(
     pinned_snapshot: &mut Option<crate::sync::PinnedSnapshot>,
     peer_manager: &mut pyde_net::peer::PeerManager,
     pending_auth_nonces: &mut std::collections::HashMap<PeerId, [u8; 32]>,
+    bootstrap_pubkey_pins: &std::collections::HashMap<PeerId, Vec<u8>>,
     last_outgoing_committee_size: usize,
     // Audit 341: full-node validation fallback. Validators
     // override these via their engine; non-validator full nodes
@@ -5561,12 +5610,22 @@ fn handle_swarm_event(
                 .as_ref()
                 .map(|e| e.committee_keys.clone())
                 .unwrap_or_default();
+            // TPL-510: look up an operator-supplied FALCON pubkey
+            // pin for this peer. `Some(&[u8])` enforces a byte-
+            // equality match against the attested pubkey;
+            // `None` (peer not in the pin map) preserves the
+            // prior "trust whatever the peer attests" behavior
+            // for unpinned peers.
+            let pinned_pubkey = bootstrap_pubkey_pins
+                .get(&peer)
+                .map(|pk| pk.as_slice());
             let outcome = pyde_net::auth::apply_auth_response(
                 peer,
                 &response,
                 pending_auth_nonces,
                 peer_manager,
                 &committee_keys,
+                pinned_pubkey,
             );
             use pyde_net::auth::AuthOutcome;
             match outcome {
@@ -5590,6 +5649,16 @@ fn handle_swarm_event(
                 }
                 AuthOutcome::RebindRejected => {
                     warn!(%peer, "peer attempted to rebind FALCON pubkey — ignoring");
+                }
+                AuthOutcome::PinnedPubkeyMismatch => {
+                    // TPL-510: the peer's PeerId has an
+                    // operator-supplied pin and the attested
+                    // FALCON pubkey doesn't byte-match. Disconnect
+                    // — better a missed connection than a peer
+                    // forwarding consensus messages under the
+                    // wrong identity.
+                    warn!(%peer, "TPL-510: bootstrap pubkey pin mismatch — disconnecting");
+                    return PostEventAction::DisconnectStalePeer(peer);
                 }
             }
             PostEventAction::None

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4921,6 +4921,15 @@ fn handle_swarm_event(
                     // Unattested peers in either slot fall through to
                     // app-layer FALCON sig verification — which catches
                     // forgeries but pays the decode + verify cost.
+                    //
+                    // TPL-505: unattested propagation sources also pass
+                    // through a per-second admission budget so a peer
+                    // that opens a connection just to pump expensive
+                    // consensus messages can't burn unbounded
+                    // FALCON-verify cycles. Attested + authorized
+                    // committee peers bypass the budget; attested +
+                    // non-committee peers are hard-dropped above.
+                    let mut prop_attested_committee = false;
                     if let Some(engine) = validator_engine.as_ref() {
                         // Primary: immediate forwarder.
                         let prop_attested = peer_manager
@@ -4938,6 +4947,7 @@ fn handle_swarm_event(
                             }
                             return PostEventAction::None;
                         }
+                        prop_attested_committee = prop_attested && prop_authorized;
                         // Secondary: originator, when known.
                         if let Some(source) = message.source.as_ref() {
                             let src_attested = peer_manager.peer_falcon_pubkey(source).is_some();
@@ -4954,6 +4964,20 @@ fn handle_swarm_event(
                                 return PostEventAction::None;
                             }
                         }
+                    }
+                    // TPL-505: shed sustained unattested-source traffic
+                    // before the decode + FALCON-verify path. Skip the
+                    // gate entirely for attested + committee peers
+                    // (they're trusted on the channel by definition).
+                    if !prop_attested_committee
+                        && !peer_manager
+                            .try_consume_unattested_consensus_budget(&propagation_source)
+                    {
+                        debug!(
+                            forwarder = %propagation_source,
+                            "dropping consensus gossip from unattested source over per-second budget"
+                        );
+                        return PostEventAction::None;
                     }
                     if let Some(engine) = validator_engine.as_mut() {
                         // Check if it's a finality vote (different wire tag)

--- a/crates/node/src/slot_clock.rs
+++ b/crates/node/src/slot_clock.rs
@@ -41,9 +41,24 @@ impl SlotClock {
             // Genesis is now or in the future — start from current instant
             Instant::now()
         } else {
-            // Genesis was in the past — compute how far back
+            // Genesis was in the past — compute how far back.
+            //
+            // TPL-512: `Instant::now() - Duration::from_millis(elapsed_ms)`
+            // panics on platforms where the result would underflow the
+            // earliest representable `Instant` (e.g. macOS: subtracting
+            // ~30 years past process start). Pre-fix a node restoring
+            // from a stale snapshot or running with a clock-skewed
+            // host (NTP not converged at boot, container with a wrong
+            // clock) could crash before reaching the main loop.
+            // `checked_sub` returns `None` on underflow; fall back to
+            // anchoring at `Instant::now()`. Slot computations remain
+            // correct because `slot_timestamp(slot)` derives from
+            // `genesis_timestamp_ms` (Unix-ms wall clock), not the
+            // monotonic anchor.
             let elapsed_ms = now_ms - genesis_timestamp_ms;
-            Instant::now() - Duration::from_millis(elapsed_ms)
+            Instant::now()
+                .checked_sub(Duration::from_millis(elapsed_ms))
+                .unwrap_or_else(Instant::now)
         };
 
         Self {
@@ -143,5 +158,31 @@ mod tests {
         let clock = SlotClock::new(genesis_ts);
         assert_eq!(clock.slot_timestamp(0), genesis_ts);
         assert_eq!(clock.slot_timestamp(10), genesis_ts + 10 * BLOCK_TIME_MS);
+    }
+
+    /// TPL-512: a far-past `genesis_timestamp_ms` (so the implied
+    /// elapsed-ms exceeds what `Instant::now() - Duration` can
+    /// represent on this platform) must NOT panic during
+    /// construction. Pre-fix the unchecked subtraction crashed
+    /// the process before reaching the main loop.
+    ///
+    /// Lower bound `1` is chosen instead of `0` because `0` triggers
+    /// the "use current wall clock" branch — TPL-512 specifically
+    /// closes the still-positive-but-implausibly-old genesis path.
+    #[test]
+    fn tpl_512_far_past_genesis_does_not_panic() {
+        // Genesis at Unix-ms = 1: ~ Jan 1 1970, 56 years ago in
+        // 2026. Far enough back that the unchecked subtraction
+        // would underflow on macOS / iOS / similar.
+        let clock = SlotClock::with_block_time(1, BLOCK_TIME_MS);
+        // Surface property: clock works at all post-construction.
+        let slot = clock.current_slot();
+        let _ = clock.slot_timestamp(slot);
+        // No specific slot-value assertion — the platform may have
+        // anchored the monotonic instant at "now" via the fallback,
+        // in which case `current_slot` returns ~0; on platforms
+        // where the subtraction succeeded, `slot` is enormous.
+        // Either is acceptable post-fix; the regression-guard
+        // property is "no panic during construction".
     }
 }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -321,6 +321,22 @@ pub struct ValidatorEngine {
     /// unbounded FALCON cost per QC-formation attempt.
     /// Pruned alongside `view_changes` in the slot-prune loop.
     seen_view_changes: std::collections::HashSet<(u64, u8)>,
+    /// TPL-501: self-VC equivocation guard. Records every
+    /// view-change message THIS validator signed, keyed by
+    /// `slot` (target_height at sign time) with value
+    /// `(highest_qc_hash, signature)`. Persisted via
+    /// `ConsensusStateStore::save_seen_view_change_self`
+    /// BEFORE `on_timeout` returns the signed message — without
+    /// that ordering, a crash between sign + persist could let
+    /// the validator sign a different VC at the same slot post-
+    /// restart (different `highest_qc` survives the reboot,
+    /// FALCON sig over a different message → equivocation,
+    /// slashable).
+    ///
+    /// Pruned alongside `seen_proposals` / `seen_votes` in the
+    /// `advance_slot` retention loop and on disk via
+    /// `prune_evidence_before`.
+    seen_view_changes_self: std::collections::HashMap<u64, ([u8; 32], Vec<u8>)>,
     /// Audit 327: dedup set for incoming finality votes, keyed
     /// on `(slot, voter_index)`. Same rationale as
     /// `seen_view_changes` — `try_form_hard_finality` re-verifies
@@ -509,6 +525,7 @@ impl ValidatorEngine {
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
             seen_view_changes: std::collections::HashSet::new(),
+            seen_view_changes_self: std::collections::HashMap::new(),
             seen_finality_votes: std::collections::HashSet::new(),
             pending_evidence: Vec::new(),
             broadcast_evidence: Vec::new(),
@@ -599,10 +616,16 @@ impl ValidatorEngine {
         // skipped by the store loader; we take whatever comes back.
         let proposals = store.load_all_seen_proposals();
         let votes = store.load_all_seen_votes();
-        if !proposals.is_empty() || !votes.is_empty() {
+        // TPL-501: also restore self-VC records so on_timeout
+        // post-restart re-broadcasts the persisted signature
+        // (when highest_qc still hashes the same) instead of
+        // signing a fresh — potentially divergent — VC.
+        let view_changes_self = store.load_all_seen_view_changes_self();
+        if !proposals.is_empty() || !votes.is_empty() || !view_changes_self.is_empty() {
             info!(
                 proposals = proposals.len(),
                 votes = votes.len(),
+                view_changes_self = view_changes_self.len(),
                 "restoring equivocation evidence from disk"
             );
         }
@@ -611,6 +634,9 @@ impl ValidatorEngine {
         }
         for (key, value) in votes {
             self.seen_votes.insert(key, value);
+        }
+        for (slot, qc_hash_and_sig) in view_changes_self {
+            self.seen_view_changes_self.insert(slot, qc_hash_and_sig);
         }
 
         // Restore the ingest queues. Without this, a validator that
@@ -2483,6 +2509,44 @@ impl ValidatorEngine {
         // already moved past, leaving the original failed slot
         // permanently uncommitted.
         let slot = self.consensus.target_height;
+        let highest_qc_hash = self.consensus.highest_qc.hash();
+
+        // TPL-501: equivocation guard. If we already signed a
+        // VC at this slot, we MUST NOT sign a different one — a
+        // FALCON sig over `(slot=N, highest_qc=Q1)` paired with
+        // a sig over `(slot=N, highest_qc=Q2)` is the textbook
+        // double-VC slashable pattern. Branches:
+        //
+        // - persisted hash matches current highest_qc.hash() →
+        //   the message we'd sign is identical to one we
+        //   already signed; rebuild it from cached signature
+        //   bytes and return it (idempotent re-broadcast covers
+        //   crash-after-sign-before-broadcast).
+        // - persisted hash differs from current highest_qc.hash()
+        //   → highest_qc has advanced (or otherwise changed) at
+        //   the same target_height between sign and the
+        //   re-fire; signing a fresh VC would equivocate.
+        //   Return None — better to forfeit our VC contribution
+        //   for this round than self-slash.
+        if let Some((persisted_hash, persisted_sig)) = self.seen_view_changes_self.get(&slot) {
+            if *persisted_hash == highest_qc_hash {
+                debug!(slot, "TPL-501: re-broadcasting persisted view-change signature");
+                return Some(ViewChangeMessage {
+                    slot,
+                    highest_qc: self.consensus.highest_qc.clone(),
+                    voter_index: identity.committee_index,
+                    voter_address: identity.address,
+                    signature: persisted_sig.clone(),
+                });
+            } else {
+                warn!(
+                    slot,
+                    "TPL-501: refusing to sign new VC at slot we already signed for — would equivocate"
+                );
+                return None;
+            }
+        }
+
         match create_view_change(
             self.chain_id,
             slot,
@@ -2492,6 +2556,22 @@ impl ValidatorEngine {
             &identity.secret_key,
         ) {
             Ok(msg) => {
+                // TPL-501: persist BEFORE returning the signed
+                // message — same pattern as `seen_proposals` /
+                // `seen_votes`. A crash between this fsync and
+                // the broadcast leaves the seen-VC record on
+                // disk; on restart, the equivocation guard
+                // above triggers and we re-broadcast the same
+                // signature instead of signing a divergent one.
+                if let Some(store) = &self.consensus_store {
+                    if let Err(e) =
+                        store.save_seen_view_change_self(slot, &highest_qc_hash, &msg.signature)
+                    {
+                        self.signal_persist_failure("seen-view-change-self", &e.to_string());
+                    }
+                }
+                self.seen_view_changes_self
+                    .insert(slot, (highest_qc_hash, msg.signature.clone()));
                 info!(slot, "created view change message");
                 Some(msg)
             }
@@ -2923,6 +3003,10 @@ impl ValidatorEngine {
             // backing per-slot Vecs so the sets don't grow unbounded
             // for long-running validators.
             self.seen_view_changes.retain(|(s, _)| *s >= prune_before);
+            // TPL-501: prune the self-VC equivocation record
+            // alongside its peers. The on-disk copy is pruned
+            // by `store.prune_evidence_before` below.
+            self.seen_view_changes_self.retain(|s, _| *s >= prune_before);
             self.seen_finality_votes.retain(|(s, _)| *s >= prune_before);
             // Audit 326: `seen_evidence` is keyed on
             // `(slot, signer)` and gates evidence ingestion to
@@ -5920,6 +6004,93 @@ mod tests {
             "view-change must target the oldest unresolved height ({target_height}), \
              not the drifted current_slot ({drifted}). \
              See CONSENSUS_INVARIANTS.md L1."
+        );
+    }
+
+    /// TPL-501: `on_timeout` MUST cache the signed VC's
+    /// `(highest_qc.hash(), signature)` into
+    /// `seen_view_changes_self` BEFORE returning. The cache is
+    /// what the equivocation guard checks on a re-fire (post-
+    /// crash restart, retry within the same window, etc.) — if
+    /// it's missing, the guard's protective branch never trips
+    /// and the validator can sign a divergent VC at the same
+    /// target_height for slashing.
+    #[test]
+    fn tpl_501_on_timeout_caches_seen_vc_record_before_returning() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+        engine.consensus.target_height = 42;
+
+        let pre_count = engine.seen_view_changes_self.len();
+        let msg = engine
+            .on_timeout(&identities[0])
+            .expect("on_timeout should sign a fresh VC");
+
+        // Cache populated.
+        let cached = engine
+            .seen_view_changes_self
+            .get(&42)
+            .expect("seen_view_changes_self must contain the slot we just signed");
+        let qc_hash = engine.consensus.highest_qc.hash();
+        assert_eq!(cached.0, qc_hash, "cached qc_hash must match current");
+        assert_eq!(
+            cached.1, msg.signature,
+            "cached signature must match the returned VC's signature"
+        );
+        assert_eq!(engine.seen_view_changes_self.len(), pre_count + 1);
+    }
+
+    /// TPL-501: a second `on_timeout` call at the same slot
+    /// with the same `highest_qc` is idempotent — returns the
+    /// SAME signature bytes. This is the post-restart re-
+    /// broadcast branch: a crash between sign and broadcast
+    /// preserves the persisted record on disk; on restart we
+    /// re-derive the same VC instead of signing a fresh
+    /// (potentially-divergent) one.
+    #[test]
+    fn tpl_501_on_timeout_idempotent_when_highest_qc_unchanged() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+        engine.consensus.target_height = 42;
+
+        let first = engine.on_timeout(&identities[0]).unwrap();
+        let second = engine
+            .on_timeout(&identities[0])
+            .expect("re-fire should still return the cached signature");
+
+        assert_eq!(first.signature, second.signature);
+        assert_eq!(first.slot, second.slot);
+        assert_eq!(first.highest_qc.hash(), second.highest_qc.hash());
+    }
+
+    /// TPL-501: if `highest_qc` advances at the same
+    /// `target_height` between the first sign and a re-fire,
+    /// `on_timeout` MUST refuse to sign — signing a fresh VC
+    /// over the new (higher) QC at the same slot would
+    /// equivocate against the originally-signed message. Pre-
+    /// fix this returned `Some(...)` with a divergent
+    /// signature; post-fix it returns `None`.
+    #[test]
+    fn tpl_501_on_timeout_refuses_to_sign_when_highest_qc_advanced() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+        engine.consensus.target_height = 42;
+
+        let _first = engine
+            .on_timeout(&identities[0])
+            .expect("first sign should succeed");
+
+        // Mutate `highest_qc` to a different value at the same
+        // target_height — simulates a peer-vote QC arriving
+        // post-restart but pre-VC-broadcast that advances our
+        // local highest_qc to a new shape.
+        engine.consensus.highest_qc.slot = 41;
+        engine.consensus.highest_qc.block_hash = [0xCC; 32];
+        engine.consensus.highest_qc.voter_bitmap = 0b1011;
+        engine.consensus.highest_qc.signatures = vec![vec![0xAA; 666]; 3];
+
+        let second = engine.on_timeout(&identities[0]);
+        assert!(
+            second.is_none(),
+            "TPL-501: a different highest_qc at the same target_height MUST trip the equivocation guard, got {:?}",
+            second.map(|m| m.signature.len())
         );
     }
 

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -311,16 +311,24 @@ pub struct ValidatorEngine {
     /// Seen votes per slot: (slot, voter_index) → (block_hash, signature).
     /// Used to detect double-voting (equivocation).
     seen_votes: HashMap<(u64, u8), ([u8; 32], Vec<u8>)>,
-    /// Audit 327: dedup set for incoming view-change messages,
-    /// keyed on `(slot, voter_index)`. `on_view_change` checks
-    /// this BEFORE pushing to `view_changes` so a peer that
-    /// re-broadcasts the same VC message (legitimate gossip
+    /// Audit 327: dedup map for incoming view-change messages,
+    /// keyed on `(slot, voter_index)` with value
+    /// `(highest_qc_hash, signature)`. `on_view_change` checks
+    /// the key set BEFORE pushing to `view_changes` so a peer
+    /// that re-broadcasts the same VC message (legitimate gossip
     /// reflood) or floods adversarial repeats cannot inflate the
     /// per-slot Vec — `try_form_view_change_qc` runs FALCON
     /// verification once per entry, so an unbounded Vec means
     /// unbounded FALCON cost per QC-formation attempt.
     /// Pruned alongside `view_changes` in the slot-prune loop.
-    seen_view_changes: std::collections::HashSet<(u64, u8)>,
+    ///
+    /// TPL-502: the *value* (`(qc_hash, sig)`) is stored so that
+    /// when a second VC arrives at the same `(slot,
+    /// voter_index)` with a DIFFERENT `highest_qc.hash()`, we
+    /// can construct `DoubleViewChangeEvidence` from the cached
+    /// first signature + the incoming second one and route it
+    /// through the slashing pipeline.
+    seen_view_changes: HashMap<(u64, u8), ([u8; 32], Vec<u8>)>,
     /// TPL-501: self-VC equivocation guard. Records every
     /// view-change message THIS validator signed, keyed by
     /// `slot` (target_height at sign time) with value
@@ -350,6 +358,15 @@ pub struct ValidatorEngine {
     /// on the receiving node will re-verify signatures from state —
     /// SlashResult is just a local convenience.
     pub pending_evidence: Vec<DoubleSignEvidence>,
+    /// TPL-502: queue for VC equivocation evidence detected by
+    /// `on_view_change`. Held separately from `pending_evidence`
+    /// to keep wire compatibility with the existing Slash-tx
+    /// payload (which expects `DoubleSignEvidence` shape) while
+    /// the on-chain handler integration is staged. Drained by
+    /// `drain_pending_vc_evidence`. Dedup is the same `(slot,
+    /// signer)` pair keyed off `seen_evidence`, so a piece of
+    /// evidence is queued at most once.
+    pub pending_vc_evidence: Vec<pyde_consensus::slashing::DoubleViewChangeEvidence>,
     /// Epoch randomness collector (gathers VRF shares at epoch boundary).
     randomness_collector: Option<RandomnessCollector>,
     /// Audit 403: slot at which `try_finalize_randomness_on_slot` is
@@ -524,10 +541,11 @@ impl ValidatorEngine {
             voted_slots: std::collections::HashSet::new(),
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
-            seen_view_changes: std::collections::HashSet::new(),
+            seen_view_changes: HashMap::new(),
             seen_view_changes_self: std::collections::HashMap::new(),
             seen_finality_votes: std::collections::HashSet::new(),
             pending_evidence: Vec::new(),
+            pending_vc_evidence: Vec::new(),
             broadcast_evidence: Vec::new(),
             seen_evidence: std::collections::HashSet::new(),
             inclusion_violated_slots: std::collections::HashSet::new(),
@@ -2620,17 +2638,92 @@ impl ValidatorEngine {
         // `try_form_view_change_qc` runs FALCON verification on
         // every entry in the Vec, so a peer that floods repeats
         // of the same `(slot, voter_index)` would inflate the
-        // per-QC-attempt FALCON cost linearly. The HashSet entry
-        // is removed alongside the Vec in the slot-prune loop.
+        // per-QC-attempt FALCON cost linearly. The dedup map's
+        // entry is removed alongside the Vec in the slot-prune
+        // loop.
+        //
+        // TPL-502: the dedup map stores `(qc_hash, sig)` so a
+        // SECOND VC from the same `(slot, voter_index)` with a
+        // DIFFERENT `highest_qc.hash()` is detected here as
+        // equivocation. Honest validators sign at most one
+        // (slot, qc) pair via TPL-501; observing two distinct
+        // `qc_hash`es from the same voter at the same target
+        // slot is the slashable double-VC pattern.
         let dedup_key = (slot, msg.voter_index);
-        if !self.seen_view_changes.insert(dedup_key) {
-            debug!(
+        let incoming_qc_hash = msg.highest_qc.hash();
+        if let Some((prev_qc_hash, prev_sig)) = self.seen_view_changes.get(&dedup_key).cloned() {
+            if prev_qc_hash == incoming_qc_hash {
+                debug!(
+                    slot,
+                    voter_index = msg.voter_index,
+                    "dedup: replayed view-change dropped",
+                );
+                return false;
+            }
+            // Different qc_hash from the same voter at the same
+            // slot — equivocation. Verify the INCOMING sig (the
+            // first one's validity is implied by it having
+            // landed in the dedup map) before constructing
+            // evidence; a peer-injected forgery shouldn't be
+            // mistaken for an honest validator's equivocation.
+            //
+            // The verifier only proves `prev_sig` is well-formed
+            // FALCON-signed bytes against the prior preimage —
+            // we trusted it on first arrival. We re-verify
+            // `signature_2` here (the new arrival) to make sure
+            // we're not framing the offender on a corrupt sig.
+            let voter_idx = msg.voter_index as usize;
+            if voter_idx >= self.committee_keys.len() {
+                warn!(
+                    slot,
+                    voter_index = msg.voter_index,
+                    "VC voter_index outside committee — drop without ingesting evidence"
+                );
+                return false;
+            }
+            if !pyde_consensus::view_change::verify_view_change(
+                self.chain_id,
+                &msg,
+                &self.committee_keys[voter_idx],
+            ) {
+                warn!(
+                    slot,
+                    voter_index = msg.voter_index,
+                    "second VC's signature failed FALCON verify; not equivocation"
+                );
+                return false;
+            }
+            warn!(
                 slot,
                 voter_index = msg.voter_index,
-                "dedup: replayed view-change dropped",
+                offender = hex::encode(msg.voter_address),
+                "DOUBLE VIEW-CHANGE DETECTED — equivocation"
             );
+            let evidence = pyde_consensus::slashing::DoubleViewChangeEvidence {
+                slot,
+                qc_hash_1: prev_qc_hash,
+                signature_1: prev_sig,
+                qc_hash_2: incoming_qc_hash,
+                signature_2: msg.signature.clone(),
+                signer: msg.voter_address,
+                // Filled in on-chain by whichever validator
+                // broadcasts the Slash tx. The on-chain handler
+                // for double-VC evidence is a follow-up; for now
+                // the evidence is queued in
+                // `pending_vc_evidence` for the runtime to drain.
+                submitter: [0u8; 32],
+            };
+            if self.ingest_view_change_evidence(evidence) {
+                info!(
+                    slot,
+                    offender = hex::encode(msg.voter_address),
+                    "double-VC evidence queued for slashing"
+                );
+            }
             return false;
         }
+        self.seen_view_changes
+            .insert(dedup_key, (incoming_qc_hash, msg.signature.clone()));
 
         let entry = self.view_changes.entry(slot).or_default();
         entry.push(msg);
@@ -2898,6 +2991,87 @@ impl ValidatorEngine {
         true
     }
 
+    /// TPL-502: ingest VC equivocation evidence (mirror of
+    /// `ingest_evidence` for proposer/vote double-sign). The
+    /// flow is the same: dedup on `(slot, signer)`, reject if
+    /// the signer isn't in the current committee, FALCON-verify
+    /// both signatures under the local `chain_id`, queue.
+    ///
+    /// Returns `true` if the evidence was newly accepted. The
+    /// `seen_evidence` dedup key is shared with the proposer/
+    /// vote pipeline so a validator that's already been queued
+    /// for slashing once at a given slot doesn't double-queue.
+    /// (Slot-level slashing is unique per `(slot, signer)` —
+    /// the on-chain handler will reject the second instance
+    /// anyway, but pre-pipeline dedup keeps the queues lean.)
+    ///
+    /// Caveat: the on-chain Slash-tx handler currently only
+    /// understands `DoubleSignEvidence` (the proposer/vote
+    /// shape). Until the Slash payload's discriminator is
+    /// extended to cover VC equivocation, evidence queued here
+    /// stays in `pending_vc_evidence` for runtime drainage —
+    /// it isn't yet wrapped into an on-chain Slash tx. The
+    /// detection side (this method) is the security primitive;
+    /// the on-chain integration is staged separately so the
+    /// wire-format change can land in its own commit.
+    pub fn ingest_view_change_evidence(
+        &mut self,
+        evidence: pyde_consensus::slashing::DoubleViewChangeEvidence,
+    ) -> bool {
+        let key = (evidence.slot, evidence.signer);
+        if self.seen_evidence.contains(&key) {
+            return false;
+        }
+        let signer_pk = self
+            .committee_keys
+            .iter()
+            .find(|pk| pyde_account::address::derive_eoa_address(pk) == evidence.signer);
+        let pk_bytes = match signer_pk {
+            Some(pk) => pk.clone(),
+            None => {
+                debug!(
+                    slot = evidence.slot,
+                    signer = hex::encode(evidence.signer),
+                    "rejecting VC evidence: signer not in committee"
+                );
+                return false;
+            }
+        };
+        if !pyde_consensus::slashing::verify_double_view_change(
+            self.chain_id,
+            &evidence,
+            &pk_bytes,
+        ) {
+            debug!(
+                slot = evidence.slot,
+                signer = hex::encode(evidence.signer),
+                "rejecting VC evidence: signature verification failed"
+            );
+            return false;
+        }
+        self.seen_evidence.insert(key);
+        self.pending_vc_evidence.push(evidence);
+        // Persist `seen_evidence` so a crash between detection and
+        // drainage doesn't lose the dedup record (matches the
+        // proposer/vote ingest path's persistence).
+        self.persist_evidence_state();
+        true
+    }
+
+    /// TPL-502: take ownership of all queued VC equivocation
+    /// evidence, clearing the internal queue. Counterpart to
+    /// `drain_pending_evidence` for the double-sign queue.
+    /// Caller must re-queue if they fail to consume (e.g.
+    /// failed block build). Dead-code warning is expected
+    /// pre on-chain integration: this is the consumer API the
+    /// follow-up Slash-tx pipeline will call.
+    #[allow(dead_code)]
+    pub fn drain_pending_vc_evidence(
+        &mut self,
+    ) -> Vec<pyde_consensus::slashing::DoubleViewChangeEvidence> {
+        std::mem::take(&mut self.pending_vc_evidence)
+    }
+
     /// Drain the broadcast staging queue. Returns every piece of
     /// evidence that has been newly ingested (either locally detected
     /// or received via gossip) since the last call. The caller is
@@ -3002,7 +3176,7 @@ impl ValidatorEngine {
             // Audit 327: prune the dedup sets in lockstep with their
             // backing per-slot Vecs so the sets don't grow unbounded
             // for long-running validators.
-            self.seen_view_changes.retain(|(s, _)| *s >= prune_before);
+            self.seen_view_changes.retain(|(s, _), _| *s >= prune_before);
             // TPL-501: prune the self-VC equivocation record
             // alongside its peers. The on-disk copy is pruned
             // by `store.prune_evidence_before` below.
@@ -6091,6 +6265,124 @@ mod tests {
             second.is_none(),
             "TPL-501: a different highest_qc at the same target_height MUST trip the equivocation guard, got {:?}",
             second.map(|m| m.signature.len())
+        );
+    }
+
+    /// TPL-502: when a peer sends two view-change messages from
+    /// the same `(slot, voter_index)` covering different
+    /// `highest_qc.hash()`es, `on_view_change` constructs
+    /// `DoubleViewChangeEvidence` and routes it through
+    /// `ingest_view_change_evidence` — same slashing-pipeline
+    /// pattern as the proposer/vote double-sign path. Without
+    /// the equivocation guard the second VC was just dropped
+    /// at the dedup gate and the offender escaped slashing.
+    #[test]
+    fn tpl_502_on_view_change_detects_equivocation_at_same_slot() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+
+        // Two distinct QCs to sign over — same slot, different
+        // highest_qc.hash().
+        let qc_1 = pyde_consensus::block::QuorumCert::empty();
+        let mut qc_2 = pyde_consensus::block::QuorumCert::empty();
+        qc_2.slot = 1;
+        qc_2.block_hash = [0xCC; 32];
+        qc_2.voter_bitmap = 0b011;
+        qc_2.signatures = vec![vec![0xAA; 666]; 2];
+        // Sanity: hashes really are distinct.
+        assert_ne!(qc_1.hash(), qc_2.hash());
+
+        let target_slot = 42;
+        let attacker = &identities[1];
+        let vc_1 = pyde_consensus::view_change::create_view_change(
+            engine.chain_id,
+            target_slot,
+            &qc_1,
+            attacker.committee_index,
+            attacker.address,
+            &attacker.secret_key,
+        )
+        .unwrap();
+        let vc_2 = pyde_consensus::view_change::create_view_change(
+            engine.chain_id,
+            target_slot,
+            &qc_2,
+            attacker.committee_index,
+            attacker.address,
+            &attacker.secret_key,
+        )
+        .unwrap();
+        // VC's preimage is `view_change || chain_id || slot ||
+        // qc_hash`, so different qc → different sig.
+        assert_ne!(vc_1.signature, vc_2.signature);
+
+        // Bootstrap engine state so on_view_change accepts the
+        // VC at target_slot (target_height must be ≤ slot).
+        engine.consensus.target_height = target_slot;
+
+        // First VC: lands clean, populates dedup map, no
+        // evidence yet.
+        engine.on_view_change(vc_1.clone());
+        assert!(engine.pending_vc_evidence.is_empty());
+
+        // Second VC at the same (slot, voter) with a DIFFERENT
+        // qc_hash: equivocation. Evidence is constructed and
+        // ingested.
+        engine.on_view_change(vc_2.clone());
+
+        let queued = &engine.pending_vc_evidence;
+        assert_eq!(
+            queued.len(),
+            1,
+            "double-VC must produce exactly one queued evidence"
+        );
+        let ev = &queued[0];
+        assert_eq!(ev.slot, target_slot);
+        assert_eq!(ev.signer, attacker.address);
+        // The two qc_hashes carried by the evidence must match
+        // what the attacker signed, in either order.
+        let pair = (qc_1.hash(), qc_2.hash());
+        let evidence_pair_a = (ev.qc_hash_1, ev.qc_hash_2);
+        let evidence_pair_b = (ev.qc_hash_2, ev.qc_hash_1);
+        assert!(
+            evidence_pair_a == pair || evidence_pair_b == pair,
+            "evidence qc_hashes must be the two distinct values the attacker signed"
+        );
+
+        // The slot's `seen_evidence` dedup record is set so a
+        // re-arrival of either VC doesn't double-queue.
+        assert!(engine.seen_evidence.contains(&(target_slot, attacker.address)));
+    }
+
+    /// TPL-502 control: a benign re-broadcast of the SAME VC
+    /// (same qc_hash) is dropped at the dedup gate without
+    /// queuing evidence. Without this the equivocation
+    /// detector could be fooled by gossip refloods into
+    /// reporting honest validators.
+    #[test]
+    fn tpl_502_on_view_change_does_not_flag_dedup_replay() {
+        let (mut engine, identities) = make_engine_with_committee(4);
+
+        let qc_1 = pyde_consensus::block::QuorumCert::empty();
+        let target_slot = 42;
+        let voter = &identities[1];
+        let vc = pyde_consensus::view_change::create_view_change(
+            engine.chain_id,
+            target_slot,
+            &qc_1,
+            voter.committee_index,
+            voter.address,
+            &voter.secret_key,
+        )
+        .unwrap();
+        engine.consensus.target_height = target_slot;
+
+        engine.on_view_change(vc.clone());
+        engine.on_view_change(vc.clone()); // gossip reflood
+        engine.on_view_change(vc); // and again
+
+        assert!(
+            engine.pending_vc_evidence.is_empty(),
+            "same-qc replay must not be flagged as equivocation"
         );
     }
 

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -1841,11 +1841,20 @@ impl Vm {
 
         // Storage sharing: child inherits parent's accumulated overlay so it sees
         // writes from earlier calls in the same transaction (cross-contract visibility).
-        if is_delegate {
-            child.storage = std::mem::take(&mut self.storage);
-        } else {
-            child.storage = self.storage.clone();
-        }
+        //
+        // TPL-508: both delegate and non-delegate paths now move
+        // parent's storage into the child via `mem::take`, O(1).
+        // Pre-fix the non-delegate path cloned the entire
+        // accumulated storage map per CallExt — O(N) per call,
+        // quadratic across nested CallExt depths. Storage keys
+        // are derived per-contract (see `derive_storage_key`),
+        // so a child running with a different `self_address`
+        // cannot accidentally read sibling-contract entries
+        // even when the underlying HashMap is shared. After
+        // the call returns, child's writes — and any pre-call
+        // entries the child left untouched — return to parent
+        // via the success/failure merge below.
+        child.storage = std::mem::take(&mut self.storage);
 
         child.load(&bytecode).map_err(|_| Trap::MemoryFault)?;
         let output = child.execute();
@@ -1868,38 +1877,32 @@ impl Vm {
         let success = output.outcome == Outcome::Success;
 
         if success {
-            // Merge child's storage changes into parent
-            if is_delegate {
-                // Audit 309: delegate-success — child operated on
-                // parent's storage directly (`mem::take` at the
-                // call entry). Each Sstore the child ran already
-                // wrote a journal entry on `child.storage_journal`
-                // for the key. But that journal is owned by the
-                // child VM and dropped here; if the parent later
-                // reverts after this delegate call, those writes
-                // are no longer rollbackable. Re-journal each key
-                // child wrote so parent's revert path can undo it.
-                for k in child.storage_journal_keys.iter() {
-                    self.journal_storage_write(k);
-                }
-                self.storage = child.storage;
-            } else {
-                // Audit 309: non-delegate success. Journal each
-                // child-written key BEFORE the merge so a later
-                // parent revert restores the parent's pre-call
-                // value. Without this, a cross-contract write
-                // that succeeded inside an outer call which
-                // itself reverts later would survive — breaking
-                // atomicity of the whole tx. `journal_storage_
-                // write` is idempotent on already-journaled keys
-                // so re-journaling parent's own pre-call writes
-                // (which child inherited via `clone` at line
-                // 1678) is safe.
-                for (k, v) in &child.storage {
-                    self.journal_storage_write(k);
-                    self.storage.insert(*k, v.clone());
+            // TPL-508 + audit-309: merge child's storage journal
+            // into parent's BEFORE taking back child's storage.
+            // For each key child journaled (via its own Sstore)
+            // we move the journal entry — which carries the
+            // PRE-CHILD value — into parent's journal. The
+            // `journal_keys.insert` short-circuits keys parent
+            // had already journaled (parent's older entry wins),
+            // so a key parent wrote earlier in the tx, then
+            // child overwrote, restores to parent's pre-write
+            // value on parent revert (not child's value).
+            //
+            // Drain semantics: we move the journal vec out, so
+            // child's drop won't waste cycles iterating it
+            // again. Idempotent for keys already in parent's
+            // journal_keys.
+            for (key, old_value) in child.storage_journal.drain(..) {
+                if self.storage_journal_keys.insert(key) {
+                    self.storage_journal.push((key, old_value));
                 }
             }
+            // Take back child.storage. For non-delegate this
+            // includes both child's writes and parent's pre-
+            // call entries (child got the whole map via
+            // mem::take). For delegate the same — child
+            // operated on parent's storage by reference.
+            self.storage = child.storage;
             // TPL-205: merge child's balance changes into parent.
             // The local `balances` clone fed to the child held the
             // post-debit/credit map; the child may have further
@@ -1925,13 +1928,17 @@ impl Vm {
             self.logs.extend(output.logs);
             // Accumulate refunds
             self.gas_refund += output.gas_refund;
-        } else if is_delegate {
-            // Restore parent's storage on delegate failure. Child
-            // already rolled back its own writes via its own
-            // journal during `child.execute()`, so child.storage
-            // here equals parent's pre-call state. No journal
-            // re-entry needed (parent's journal was untouched
-            // for these keys during the delegate call).
+        } else {
+            // TPL-508: failure path — restore parent's storage
+            // by taking back child's. Child's own journal already
+            // rolled back its writes inside `child.execute()`
+            // (see lines 1572-1585), so `child.storage` at this
+            // point equals parent's pre-call state. No journal
+            // merge needed — parent's journal was untouched for
+            // these keys during the call. Pre-fix only the
+            // delegate path took child.storage back; non-
+            // delegate failure left parent.storage as the empty
+            // map left by `mem::take`. Now both paths recover.
             self.storage = child.storage;
         }
 
@@ -5554,6 +5561,68 @@ mod tests {
         assert!(
             !vm.storage.contains_key(&U256::from(2u32)),
             "audit 309: parent revert must drop new keys child introduced"
+        );
+    }
+
+    /// TPL-508: an ext-call success must merge child's
+    /// storage_journal into parent's so a later parent revert
+    /// restores values to what they were BEFORE the call —
+    /// not to what child wrote. Pre-fix the merge journaled
+    /// each key with its CURRENT value via `journal_storage_
+    /// write`, which captured child's NEW value (or `None`
+    /// for the delegate path's empty-storage moment), so a
+    /// parent revert could leak child's writes through the
+    /// rollback. This test exercises the merge-journal helper
+    /// directly with the post-fix shape.
+    #[test]
+    fn tpl_508_storage_journal_merge_preserves_pre_child_value() {
+        let mut vm = Vm::new();
+
+        // Parent's pre-call state seeded from a (simulated)
+        // backend Sload — value is in the storage map but NOT
+        // in parent's journal (Sload doesn't journal).
+        let key = U256::from(42u32);
+        let pre_call_value = b"backend-V".to_vec();
+        vm.storage.insert(key, pre_call_value.clone());
+        vm.storage_journal.clear();
+        vm.storage_journal_keys.clear();
+
+        // Now simulate the post-CallExt merge: a child wrote
+        // `key` to a new value, child's journal captured the
+        // pre-write value, child returned. The fix moves
+        // child's journal entry into parent's journal in the
+        // `success` branch of `do_ext_call`.
+        let mut child_storage = std::mem::take(&mut vm.storage);
+        // Child's Sstore: journal pre-child value, write new value.
+        let mut child_journal: Vec<(U256, Option<Vec<u8>>)> = Vec::new();
+        let mut child_journal_keys: std::collections::HashSet<U256> =
+            std::collections::HashSet::new();
+        if child_journal_keys.insert(key) {
+            child_journal.push((key, child_storage.get(&key).cloned()));
+        }
+        child_storage.insert(key, b"child-V".to_vec());
+
+        // Mirror the post-fix merge: drain child's journal into
+        // parent's, idempotent on keys parent already journaled.
+        for (k, old) in child_journal.drain(..) {
+            if vm.storage_journal_keys.insert(k) {
+                vm.storage_journal.push((k, old));
+            }
+        }
+        vm.storage = child_storage;
+
+        // Sanity: child's value is visible.
+        assert_eq!(vm.storage.get(&key), Some(&b"child-V".to_vec()));
+
+        // Parent reverts.
+        vm.rollback_storage_pub();
+
+        // Post-fix: parent restored to the value it saw BEFORE
+        // the child call (the backend Sload value), not to None.
+        assert_eq!(
+            vm.storage.get(&key),
+            Some(&pre_call_value),
+            "TPL-508: parent revert must restore the pre-call value, not None or child's value"
         );
     }
 

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -2109,8 +2109,26 @@ impl Vm {
             if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                 return Err(Trap::OutOfGas);
             }
-            if output.outcome != Outcome::Success {
-                return Err(Trap::MemoryFault); // constructor failed
+            // TPL-506: distinguish OOG from a constructor revert
+            // when bubbling. Pre-fix every non-Success outcome
+            // collapsed to `Trap::MemoryFault`, which the
+            // `Opcode::Create` caller catches in its `Err(_)` arm
+            // and writes a zero address to the parent register.
+            // That's the right behavior for a constructor REVERT
+            // (mirrors Ethereum: caller branches on zero), but
+            // the wrong behavior for OUT-OF-GAS — the caller's
+            // explicit `Err(Trap::OutOfGas) => return ...` arm at
+            // the Create dispatch site only fires when the inner
+            // trap actually IS OutOfGas, so a child OOG was
+            // silently swallowed pre-fix. Now: OutOfGas + child
+            // traps bubble through with their original variant;
+            // Revert maps to MemoryFault so the legacy
+            // address-zero behavior is preserved.
+            match output.outcome {
+                Outcome::Success => {}
+                Outcome::OutOfGas => return Err(Trap::OutOfGas),
+                Outcome::Trap(t) => return Err(t),
+                Outcome::Revert => return Err(Trap::MemoryFault),
             }
             // Merge constructor's storage writes (audit 309:
             // journal each key BEFORE the insert so a later
@@ -4487,6 +4505,161 @@ mod tests {
         // Contract should be registered
         assert!(vm.contracts.contains_key(&new_addr));
         assert_eq!(vm.contracts[&new_addr], init_code);
+    }
+
+    // ========== TPL-506: constructor OOG bubbles, doesn't collapse to MemoryFault ==========
+
+    /// Pre-fix `do_create` translated EVERY non-Success child
+    /// outcome to `Trap::MemoryFault`, and the `Opcode::Create`
+    /// dispatcher's `Err(_)` arm wrote a zero address and let
+    /// the parent CONTINUE executing. So a constructor that
+    /// ran out of gas was indistinguishable from a constructor
+    /// that reverted: both surfaced as parent.success +
+    /// address=0. That broke tx-level gas accounting (parent
+    /// kept burning gas after the child's OOG, so a
+    /// pathological constructor could be used as a cheap
+    /// gas-burner from inside another contract).
+    ///
+    /// Post-fix: child OOG bubbles as `Trap::OutOfGas` through
+    /// `do_create`, hits the `Opcode::Create` dispatcher's
+    /// `Err(Trap::OutOfGas) => return Err(Trap::OutOfGas)` arm,
+    /// and the parent's outcome is `OutOfGas`. Revert is
+    /// preserved as the legacy address-zero behavior so
+    /// existing contracts that branch on a zero CREATE result
+    /// keep working.
+    #[test]
+    fn tpl_506_constructor_oog_bubbles_as_outofgas_not_memoryfault() {
+        let heap = crate::memory::HEAP_START;
+
+        // Constructor: 1000 cheap ops at 1 gas each = 1000 gas
+        // total. With the parent budget below the child gets
+        // ~493 forwarded gas, so the constructor OOGs partway
+        // through — deterministic and independent of any opcode
+        // table tweaks.
+        let mut constructor: Vec<u8> = (0..1000)
+            .flat_map(|_| instr_ri(Opcode::Addi, 1, 0, 1))
+            .collect();
+        constructor.extend_from_slice(&instr_bytes(Opcode::Halt, 0, 0, 0));
+
+        // Runtime: just halt. We never get here in this test
+        // (the constructor OOGs first), but the deploy frame
+        // requires `rlen > 0` to be parsed as having a
+        // constructor block at all.
+        let runtime: Vec<u8> = instr_bytes(Opcode::Halt, 0, 0, 0).to_vec();
+
+        // Deploy frame: [clen:4 LE][rlen:4 LE][constructor][runtime]
+        let mut init_code: Vec<u8> = Vec::with_capacity(8 + constructor.len() + runtime.len());
+        init_code.extend_from_slice(&(constructor.len() as u32).to_le_bytes());
+        init_code.extend_from_slice(&(runtime.len() as u32).to_le_bytes());
+        init_code.extend_from_slice(&constructor);
+        init_code.extend_from_slice(&runtime);
+
+        let ctx = ExecutionContext {
+            self_address: addr(0x9999),
+            ..Default::default()
+        };
+        // Parent budget chosen so:
+        //   - Create base (32_000) leaves available ≈ 500
+        //   - max_forward = 500 - 7 = 493 < constructor cost (1000)
+        //   - After child charge (~493), parent has ~7 gas
+        //     remaining — pre-fix that's enough for the
+        //     Addi+Halt below to land, so a non-OOG outcome
+        //     would prove the bug. Post-fix the parent traps
+        //     OOG before reaching them.
+        let mut vm = Vm::with_gas_limit_and_context(32_500, ctx);
+
+        for (i, &b) in init_code.iter().enumerate() {
+            vm.memory.store8(heap + i as u32, b).unwrap();
+        }
+        vm.cpu.write_gp(2, heap as u64);
+        vm.cpu.write_gp(3, init_code.len() as u64);
+
+        // After CREATE, write 99 to GP register 4 if execution
+        // continues. Pre-fix this lands; post-fix it doesn't.
+        let code = bytecode(&[
+            instr_bytes(Opcode::Create, 1, 2, 0x03),
+            instr_ri(Opcode::Addi, 4, 0, 99),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        let output = vm.execute();
+
+        assert_eq!(
+            output.outcome,
+            Outcome::OutOfGas,
+            "constructor OOG must bubble through CREATE as parent OOG, not be swallowed as MemoryFault"
+        );
+        assert_eq!(
+            vm.cpu.read_gp(4),
+            0,
+            "parent must not continue past constructor OOG (Addi after Create should not run)"
+        );
+    }
+
+    /// TPL-506 control: a constructor that explicitly REVERTs
+    /// must keep its legacy "return zero address, parent
+    /// continues" semantics. The fix only re-routes OOG;
+    /// Revert is preserved as `Trap::MemoryFault` at the
+    /// `do_create` boundary so the dispatcher's `Err(_)` arm
+    /// still writes zero and the parent runs on. Without this
+    /// pairing the OOG fix would silently break every contract
+    /// pattern that probes a CREATE for failure by checking
+    /// the result address.
+    #[test]
+    fn tpl_506_constructor_revert_preserves_zero_address_behavior() {
+        let heap = crate::memory::HEAP_START;
+
+        // Constructor: a single REVERT-equivalent — `assert r0`
+        // (where r0 is hardwired 0) panics the constructor.
+        // `Opcode::Assert` returns `ExecResult::Revert` when
+        // the operand is zero, which `execute()` maps to
+        // `Outcome::Revert`.
+        let constructor = bytecode(&[
+            instr_bytes(Opcode::Assert, 0, 0, 0), // r0 == 0 → revert
+        ]);
+        let runtime: Vec<u8> = instr_bytes(Opcode::Halt, 0, 0, 0).to_vec();
+
+        let mut init_code: Vec<u8> = Vec::with_capacity(8 + constructor.len() + runtime.len());
+        init_code.extend_from_slice(&(constructor.len() as u32).to_le_bytes());
+        init_code.extend_from_slice(&(runtime.len() as u32).to_le_bytes());
+        init_code.extend_from_slice(&constructor);
+        init_code.extend_from_slice(&runtime);
+
+        let ctx = ExecutionContext {
+            self_address: addr(0xAAAA),
+            ..Default::default()
+        };
+        // Plenty of gas — the constructor reverts after one op,
+        // not OOGs. Parent must continue post-CREATE.
+        let mut vm = Vm::with_gas_limit_and_context(100_000, ctx);
+
+        for (i, &b) in init_code.iter().enumerate() {
+            vm.memory.store8(heap + i as u32, b).unwrap();
+        }
+        vm.cpu.write_gp(2, heap as u64);
+        vm.cpu.write_gp(3, init_code.len() as u64);
+
+        let code = bytecode(&[
+            instr_bytes(Opcode::Create, 1, 2, 0x03),
+            instr_ri(Opcode::Addi, 4, 0, 99),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        let output = vm.execute();
+
+        // Parent runs to completion; CREATE wrote zero address
+        // (constructor reverted), Addi wrote 99 to r4.
+        assert_eq!(output.outcome, Outcome::Success);
+        let new_addr: Address = vm.cpu.read_wide(1).to_le_bytes();
+        assert_eq!(
+            new_addr, ZERO_ADDRESS,
+            "constructor revert must yield zero address (legacy semantic preserved)"
+        );
+        assert_eq!(
+            vm.cpu.read_gp(4),
+            99,
+            "parent must continue executing past a reverting CREATE"
+        );
     }
 
     // ========== Audit 379: CREATE address is non-front-runnable ==========

--- a/crates/pvm/src/vm.rs
+++ b/crates/pvm/src/vm.rs
@@ -961,6 +961,11 @@ impl Vm {
                             if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                                 return Err(Trap::OutOfGas);
                             }
+                            // TPL-507: pre-trap on worst-case page gas
+                            // for the destination range so an Sload
+                            // of a multi-MB stored value can't ride
+                            // past the gas limit during the copy.
+                            self.precheck_bulk_page_budget(data.len())?;
                             self.memory
                                 .checked_write_slice(ptr, data)
                                 .map_err(|_| Trap::MemoryFault)?;
@@ -1039,6 +1044,10 @@ impl Vm {
                         if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                             return Err(Trap::OutOfGas);
                         }
+                        // TPL-507: pre-trap on worst-case page gas
+                        // for the read range BEFORE the slice copy
+                        // forces a host-side allocation.
+                        self.precheck_bulk_page_budget(len)?;
                         let data = self
                             .memory
                             .checked_read_slice(ptr, len)
@@ -1401,6 +1410,15 @@ impl Vm {
                     if self.gas_limit > 0 && self.gas_used_total > self.gas_limit {
                         return Err(Trap::OutOfGas);
                     }
+                    // TPL-507: pre-trap on worst-case page gas for
+                    // src+dst before doing the copy, so a multi-MB
+                    // Memcpy can't ride past the gas limit on the
+                    // post-step flush after the host has already
+                    // finished the work. `len.saturating_mul(2)`
+                    // accounts for the source AND destination
+                    // ranges; saturating so a near-MEMORY_SIZE len
+                    // won't wrap before precheck fires its own OOG.
+                    self.precheck_bulk_page_budget(len.saturating_mul(2))?;
                     let data = self
                         .memory
                         .checked_read_slice(src_ptr, len)
@@ -2182,6 +2200,39 @@ impl Vm {
         self.contracts.insert(new_addr, runtime_code);
 
         Ok(new_addr)
+    }
+
+    /// TPL-507: pre-trap `OutOfGas` if the worst-case
+    /// page-allocation gas for a bulk memory op of `bytes`
+    /// total would push the accumulator over `gas_limit`.
+    /// Non-mutating — actual `page_gas_used` accounting still
+    /// happens via `Memory::check_access` and flushes at the
+    /// end-of-step gate (line 1524-1535). Pre-fix the page
+    /// gas was charged ONLY at end-of-step, so a guest could
+    /// hand the VM a multi-MB Memcpy `len`, the host would
+    /// finish the copy, and only THEN the post-step flush
+    /// would OOG — work-then-fail, the exact pattern this
+    /// closes. `bytes` is the SUM of memory ranges that may
+    /// be newly touched: callers like Memcpy pass `2*len`
+    /// for source+destination; one-sided ops pass just `len`.
+    /// `bytes == 0` and `gas_limit == 0` (unlimited) short-
+    /// circuit to `Ok(())`.
+    fn precheck_bulk_page_budget(&self, bytes: usize) -> Result<(), Trap> {
+        if bytes == 0 || self.gas_limit == 0 {
+            return Ok(());
+        }
+        let pages = (bytes as u64).div_ceil(crate::memory::PAGE_SIZE as u64);
+        let worst = pages
+            .checked_mul(crate::memory::PAGE_ALLOC_GAS)
+            .ok_or(Trap::OutOfGas)?;
+        let projected = self
+            .gas_used_total
+            .checked_add(worst)
+            .ok_or(Trap::OutOfGas)?;
+        if projected > self.gas_limit {
+            return Err(Trap::OutOfGas);
+        }
+        Ok(())
     }
 
     /// Record a storage key's current value in the journal before writing.
@@ -4660,6 +4711,131 @@ mod tests {
             99,
             "parent must continue executing past a reverting CREATE"
         );
+    }
+
+    // ========== TPL-507: bulk memory ops pre-charge worst-case page gas ==========
+
+    /// Pre-fix Memcpy ran the full copy and only OOG'd at the
+    /// `step()` end-of-step page-gas flush — work-then-fail.
+    /// A guest could hand the VM a multi-MB `len`, make the
+    /// host complete the entire copy, and only THEN OOG. With
+    /// Memcpy fan-out across nested CALL boundaries this is a
+    /// cheap CPU-burn primitive: the parent's gas budget kept
+    /// burning through real allocation work even though the
+    /// final post-step charge was always going to bust the
+    /// limit.
+    ///
+    /// Post-fix `precheck_bulk_page_budget(2 * len)` runs
+    /// BEFORE the copy; if the worst-case page allocation
+    /// would push past `gas_limit`, OOG fires immediately and
+    /// the destination memory stays pristine. Memory is NOT
+    /// rolled back on OOG (only storage + balances are), so
+    /// the destination's pre-call value is the cleanest
+    /// observable proof that the copy did or didn't happen.
+    #[test]
+    fn tpl_507_memcpy_pre_traps_oog_before_doing_the_copy() {
+        let heap = crate::memory::HEAP_START;
+
+        // Pre-fill SOURCE with 0xFF and verify DESTINATION is 0x00.
+        let len: usize = 256 * crate::memory::PAGE_SIZE; // 1 MB → 256 pages
+
+        let mut vm = Vm::with_gas_limit_and_context(50_000, ExecutionContext::default());
+
+        let src_ptr = heap;
+        let dst_ptr = heap + len as u32; // non-overlapping
+
+        // Touch source pages by writing 0xFF — these page allocations
+        // happen before Memcpy and are charged at end-of-step for
+        // the setup. We separately want Memcpy itself to OOG, so
+        // skip pre-touching DESTINATION pages.
+        for offset in (0..len as u32).step_by(crate::memory::PAGE_SIZE) {
+            vm.memory.store8(src_ptr + offset, 0xFF).unwrap();
+        }
+        // Sanity: destination is still all 0x00.
+        assert_eq!(vm.memory.load8(dst_ptr).unwrap(), 0x00);
+        assert_eq!(
+            vm.memory.load8(dst_ptr + (len as u32) - 1).unwrap(),
+            0x00,
+            "destination's last byte must start at 0x00"
+        );
+
+        // Set up Memcpy operands: r1=dst, r2=src, r3=len.
+        // Encoding: memcpy rd_dst=1, rs1_src=2, imm=len_reg=3.
+        vm.cpu.write_gp(1, dst_ptr as u64);
+        vm.cpu.write_gp(2, src_ptr as u64);
+        vm.cpu.write_gp(3, len as u64);
+
+        let code = bytecode(&[
+            instr_bytes(Opcode::Memcpy, 1, 2, 0x03),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        let output = vm.execute();
+
+        // Memcpy should OOG before the copy lands.
+        // 50_000 - (~base + dynamic) leaves no room for 2*256
+        // pages * 200 = 102_400 worst-case page gas, so the
+        // precheck trips immediately.
+        assert_eq!(
+            output.outcome,
+            Outcome::OutOfGas,
+            "expected OOG; got {:?}",
+            output.outcome
+        );
+
+        // Destination memory remains 0x00 — the copy did not run.
+        // Memory is not rolled back on OOG (only storage +
+        // balances are), so the lingering 0x00 is hard
+        // evidence that we trapped BEFORE the copy.
+        assert_eq!(
+            vm.memory.load8(dst_ptr).unwrap(),
+            0x00,
+            "Memcpy must trap BEFORE writing to destination — pre-fix the entire copy ran first"
+        );
+        assert_eq!(
+            vm.memory.load8(dst_ptr + (len as u32) - 1).unwrap(),
+            0x00,
+            "destination's tail must remain pristine; pre-fix it would have been overwritten with 0xFF"
+        );
+    }
+
+    /// TPL-507 control: a small Memcpy that fits comfortably
+    /// in the gas budget MUST still complete. The precheck is
+    /// an upper-bound check only — when the worst case fits,
+    /// the actual copy runs and the post-step page-gas flush
+    /// charges the real (≤ worst) cost. Without this control
+    /// the OOG test could be passing for the wrong reason
+    /// (e.g., precheck always OOGs).
+    #[test]
+    fn tpl_507_small_memcpy_within_budget_still_runs() {
+        let heap = crate::memory::HEAP_START;
+        let len: usize = 64; // < 1 page; well within budget
+
+        let mut vm = Vm::with_gas_limit_and_context(50_000, ExecutionContext::default());
+
+        let src_ptr = heap;
+        let dst_ptr = heap + 4096; // adjacent page
+
+        for i in 0..len {
+            vm.memory.store8(src_ptr + i as u32, 0xAB).unwrap();
+        }
+
+        vm.cpu.write_gp(1, dst_ptr as u64);
+        vm.cpu.write_gp(2, src_ptr as u64);
+        vm.cpu.write_gp(3, len as u64);
+
+        let code = bytecode(&[
+            instr_bytes(Opcode::Memcpy, 1, 2, 0x03),
+            instr_bytes(Opcode::Halt, 0, 0, 0),
+        ]);
+        vm.load(&code).unwrap();
+        let output = vm.execute();
+
+        assert_eq!(output.outcome, Outcome::Success);
+        // Destination got the bytes.
+        for i in 0..len {
+            assert_eq!(vm.memory.load8(dst_ptr + i as u32).unwrap(), 0xAB);
+        }
     }
 
     // ========== Audit 379: CREATE address is non-front-runnable ==========

--- a/crates/tx/src/parallel.rs
+++ b/crates/tx/src/parallel.rs
@@ -314,7 +314,21 @@ pub fn schedule(txs: &[Transaction]) -> ExecutionSchedule {
 }
 
 /// Check if two access lists conflict (shared key with at least one write).
+///
+/// TPL-513: an uninformative access list (`access_list_is_uninformative`)
+/// is treated as touching EVERYTHING, exactly as `conflicts()` does
+/// for two transactions. Pre-fix this function only compared
+/// declared writes/reads, so two empty access lists or two
+/// `[{addr, [], []}]`-shaped lists came back as "no conflict" —
+/// the same TPL-001 hazard `conflicts()` already guards against.
+/// `block_builder`'s post-schedule sanity assert is the only
+/// in-tree consumer today, but mirroring the rule keeps the two
+/// helpers from drifting if a future caller uses
+/// `access_lists_conflict` for a real safety decision.
 pub fn access_lists_conflict(a: &[AccessEntry], b: &[AccessEntry]) -> bool {
+    if access_list_is_uninformative(a) || access_list_is_uninformative(b) {
+        return true;
+    }
     let writes_a: HashSet<(Address, [u8; 32])> = a
         .iter()
         .flat_map(|entry| entry.writes.iter().map(move |k| (entry.address, *k)))
@@ -856,6 +870,47 @@ mod tests {
         assert!(
             conflicts(&tx_keyed, &tx_uninformative),
             "uninformative AL must conflict regardless of arg order"
+        );
+    }
+
+    /// TPL-513: `access_lists_conflict` must reuse the same
+    /// uninformative-AL rule as `conflicts()`. Pre-fix it only
+    /// compared declared writes/reads, so two empty access lists
+    /// (or `[{addr, [], []}]`-shaped lists) came back as "no
+    /// conflict". A future caller using this helper for a real
+    /// safety decision would silently let two TPL-001-shaped txs
+    /// run in parallel.
+    #[test]
+    fn tpl_513_access_lists_conflict_uninformative_treated_as_conflict() {
+        let uninformative = vec![AccessEntry {
+            address: {
+                let mut a = ZERO_ADDRESS;
+                a[0] = 0xAB;
+                a
+            },
+            reads: vec![],
+            writes: vec![],
+        }];
+        let keyed = vec![write_access(0xCC, &[[0x77; 32]])];
+
+        // Empty AL ↔ empty AL.
+        assert!(
+            access_lists_conflict(&[], &[]),
+            "two empty ALs must conflict"
+        );
+        // Uninformative AL ↔ keyed AL — both directions.
+        assert!(
+            access_lists_conflict(&uninformative, &keyed),
+            "uninformative ↔ keyed must conflict"
+        );
+        assert!(
+            access_lists_conflict(&keyed, &uninformative),
+            "uninformative ↔ keyed must conflict regardless of arg order"
+        );
+        // Uninformative ↔ uninformative.
+        assert!(
+            access_lists_conflict(&uninformative, &uninformative),
+            "two uninformative ALs must conflict"
         );
     }
 


### PR DESCRIPTION
## Summary

13 fixes across consensus correctness, network DoS surface, PVM safety, and operator-facing security for the upcoming public testnet. Each commit is self-contained with regression tests; full workspace builds clean and all in-tree test suites pass.

## What changed

### Consensus correctness
- `1bf4c88` **TPL-501** — `on_timeout` persists the signed view-change record before returning, with an equivocation guard that re-broadcasts the cached signature on a re-fire and refuses to sign a divergent VC at the same `target_height`.
- `d7bdb0b` **TPL-502** — New `DoubleViewChangeEvidence` + verifier + slash function (consensus crate); `on_view_change` detects two distinct `qc_hash`es from the same voter at the same slot and queues evidence. *Follow-up*: on-chain Slash-tx pipeline integration needs a payload \`kind\` discriminator and is staged separately.
- `5c02042` **TPL-503** — `validate_network_block` accepts an optional `qc_previous_committee_keys` so epoch-boundary blocks verify the prior QC against the OUTGOING committee instead of failing audit-311.

### Network DoS hardening
- `06a61fe` **TPL-504** — Per-peer in-flight RR cap on `PeerManager` (`MAX_RR_INFLIGHT_PER_PEER = 8`), drops the worst-case quadratic fanout buffer from ~16 MB to ~1 MB at N=128.
- `7c718fc` **TPL-505** — `MAX_UNATTESTED_CONSENSUS_PER_SEC = 32` per-source rolling budget on the consensus topic; gates expensive FALCON-verify work behind a 1-second window when the propagation source isn't a committee-attested peer.

### PVM safety
- `e8d88a1` **TPL-506** — Constructor OOG now bubbles as `Trap::OutOfGas` through `do_create` instead of collapsing to `MemoryFault` (which the dispatcher swallowed as "address-zero, parent continues"). Revert path preserved.
- `f5abc1f` **TPL-507** — `precheck_bulk_page_budget` pre-traps OOG before bulk memory ops (`Memcpy`, `Sstore` mode 1, `Sload` mode 1) so a multi-MB `len` can't ride past the gas limit on the post-step page-gas flush.
- `2c58b68` **TPL-508** — `child.storage = std::mem::take(...)` replaces the per-CallExt `self.storage.clone()` (O(N) -> O(1)). Success path drains the child's storage journal into the parent's, fixing a subtle audit-309 leak path where the prior delegate code journaled `(k, None)` for keys that had pre-call values cached from backend reads.

### Crypto / mempool / clock
- `ddad3e6` **TPL-509** — Mempool's `evict_oldest` switched from `Vec::remove(0)` (O(n)) to `VecDeque::pop_front` (O(1)).
- `ff2134e` **TPL-512** — `SlotClock::with_block_time` uses `Instant::checked_sub` to clamp far-past `genesis_timestamp_ms` instead of panicking on platforms where the subtraction underflows.
- `29eaf83` **TPL-513** — `access_lists_conflict` aligned with `conflicts()`'s uninformative-AL rule (TPL-001 follow-up): empty or `[{addr, [], []}]`-shape lists short-circuit to `true`.

### Operator security
- `73f1e3d` **TPL-510** — `[network].bootstrap_pubkey_pins` operator config (peer_id_b58 -> falcon_pubkey_hex); `apply_auth_response` enforces byte-equality on attested FALCON pubkeys for pinned peers and disconnects on mismatch.
- `9e26828` **TPL-511** — Per-reason ban tiers on `Discovery` (`RateLimitAbuse` 10min -> `InvalidConsensusMessage` 7d) plus on-disk persistence under `bans.json` with absolute Unix-ms expiry. *Follow-up*: Discovery isn't currently in the production hot path; integration is staged separately.

## Notes

- Two follow-ups intentionally staged out of scope (on-chain double-VC slashing wire format, Discovery hot-path integration) — both call out the dependency in their commit messages.
- Test counts post-merge: 75 validator, 21 slashing, 33 block_processor, 352 pvm, 103 net, 333 node — all green.