### PR TITLE
toolchain + SDK production polish (TPL-601..607)

### DIFF
--- a/crates/aot/src/lib.rs
+++ b/crates/aot/src/lib.rs
@@ -541,7 +541,7 @@ mod tests {
                 pub fn get_count() -> u64 { return self.count; }
             }
         "#;
-        let results = otic::compile_all_unchecked(src);
+        let results = otic::__compile_all_unchecked(src);
         assert_eq!(results.len(), 1);
         let (_, compiled) = &results[0];
         let runtime = &compiled.runtime_bytecode;
@@ -721,7 +721,7 @@ mod tests {
                 }
             }
         "#;
-        let results = otic::compile_all_unchecked(src);
+        let results = otic::__compile_all_unchecked(src);
         assert_eq!(results.len(), 1);
         let (_, compiled) = &results[0];
         let runtime = &compiled.runtime_bytecode;
@@ -915,7 +915,7 @@ mod tests {
                 }
             }
         "#;
-        let all = otic::compile_all_unchecked(src);
+        let all = otic::__compile_all_unchecked(src);
         assert_eq!(all.len(), 2, "Should compile Token and Factory");
         let (_, factory_compiled) = &all[1];
         let runtime = &factory_compiled.runtime_bytecode;

--- a/crates/node/tests/bench_mempool.rs
+++ b/crates/node/tests/bench_mempool.rs
@@ -109,7 +109,7 @@ fn bench_preloaded_mempool() {
     let num_contracts = 20usize;
     println!("  Deploying {} complex contracts...", num_contracts);
 
-    let compiled = otic::compile_all_unchecked(
+    let compiled = otic::__compile_all_unchecked(
         r#"
         struct Stats { sum: u256, count: u64, min: u64, max: u64 }
         contract HeavyWork {

--- a/crates/node/tests/benchmark.rs
+++ b/crates/node/tests/benchmark.rs
@@ -91,7 +91,7 @@ fn make_transfer(from: [u8; 32], to: [u8; 32], nonce: u64) -> Transaction {
 }
 
 fn compile(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/full_benchmark.rs
+++ b/crates/node/tests/full_benchmark.rs
@@ -57,7 +57,7 @@ struct BlockMetrics {
 // ═══════════════════════════════════════════════════════════════════
 
 fn compile_single(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());
@@ -68,7 +68,7 @@ fn compile_single(source: &str) -> Vec<u8> {
 }
 
 fn compile_last(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     let (_, c) = compiled.last().unwrap();
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/integration.rs
+++ b/crates/node/tests/integration.rs
@@ -121,7 +121,7 @@ fn call_tx(
 }
 
 fn compile_contract(source: &str) -> (Vec<u8>, String) {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     assert!(!compiled.is_empty(), "compilation produced no contracts");
     let (name, contract) = &compiled[0];
     let clen = contract.constructor_bytecode.len() as u32;
@@ -739,7 +739,7 @@ fn cross_contract_storage_visibility() {
     // Driver deploys Vault, calls withdraw twice, reads balance back.
     // Tests that Vault.withdraw()'s storage changes are visible to
     // the next Vault.get_balance() call within the same transaction.
-    let compiled = otic::compile_all_unchecked(
+    let compiled = otic::__compile_all_unchecked(
         r#"
         contract Vault {
             storage { balance: u64, }
@@ -814,7 +814,7 @@ fn reentrancy_attack_blocked() {
     // Vault: withdraw calls back to caller via raw_call! (simulates ETH transfer callback).
     // Attacker: on_hook() tries to re-enter Vault.withdraw().
     // Without #[reentrant], the guard should block the re-entry.
-    let compiled = otic::compile_all_unchecked(
+    let compiled = otic::__compile_all_unchecked(
         r#"
         contract Vault {
             storage { balance: u64, }

--- a/crates/node/tests/lifecycle_bench.rs
+++ b/crates/node/tests/lifecycle_bench.rs
@@ -34,7 +34,7 @@ fn sign(tx: &mut Transaction, sk: &pyde_crypto::falcon::FalconSecretKey) {
     tx.signature = falcon_sign(sk, &tx.hash()).unwrap().as_bytes().to_vec();
 }
 fn compile(src: &str) -> Vec<u8> {
-    let c = otic::compile_all_unchecked(src);
+    let c = otic::__compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut d = Vec::new();
     d.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/loadgen.rs
+++ b/crates/node/tests/loadgen.rs
@@ -173,7 +173,7 @@ fn load_test_full_pipeline() {
             }
         }
     "#;
-    let compiled = otic::compile_all_unchecked(heavy_source);
+    let compiled = otic::__compile_all_unchecked(heavy_source);
     let (_, cc) = &compiled[0];
     let mut deploy_data = Vec::new();
     deploy_data.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/loadgen_mixed.rs
+++ b/crates/node/tests/loadgen_mixed.rs
@@ -92,7 +92,7 @@ contract Counter {
 /// shape `pyde_tx::pipeline` expects (4-byte LE constructor length +
 /// 4-byte LE runtime length + constructor bytes + runtime bytes).
 fn compile_deploy_payload(src: &str) -> Vec<u8> {
-    let c = otic::compile_all_unchecked(src);
+    let c = otic::__compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut out = Vec::with_capacity(8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len());
     out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/multi_node_contract_sigs.rs
+++ b/crates/node/tests/multi_node_contract_sigs.rs
@@ -258,7 +258,7 @@ fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
 /// Mirrors `production_sigs.rs::compile` — this is the canonical
 /// on-chain deploy envelope.
 fn compile_deploy_payload(src: &str) -> Vec<u8> {
-    let c = otic::compile_all_unchecked(src);
+    let c = otic::__compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut out = Vec::with_capacity(8 + cc.constructor_bytecode.len() + cc.runtime_bytecode.len());
     out.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/production_e2e.rs
+++ b/crates/node/tests/production_e2e.rs
@@ -259,7 +259,7 @@ fn production_signed_deploy_and_call() {
     };
 
     // Compile Counter contract
-    let compiled = otic::compile_all_unchecked(
+    let compiled = otic::__compile_all_unchecked(
         r#"
         contract Counter {
             storage { count: u64, }

--- a/crates/node/tests/production_sigs.rs
+++ b/crates/node/tests/production_sigs.rs
@@ -22,7 +22,7 @@ fn sign(tx: &mut Transaction, sk: &pyde_crypto::falcon::FalconSecretKey) {
 }
 
 fn compile(src: &str) -> Vec<u8> {
-    let c = otic::compile_all_unchecked(src);
+    let c = otic::__compile_all_unchecked(src);
     let (_, cc) = &c[0];
     let mut d = Vec::new();
     d.extend_from_slice(&(cc.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/node/tests/production_sim.rs
+++ b/crates/node/tests/production_sim.rs
@@ -38,7 +38,7 @@ struct FundedAccount {
 }
 
 fn compile_single(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     let (_, c) = &compiled[0];
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());
@@ -52,7 +52,7 @@ fn compile_single(source: &str) -> Vec<u8> {
 /// (the one that references earlier contracts via deploy!/at()).
 #[allow(dead_code)]
 fn compile_last(source: &str) -> Vec<u8> {
-    let compiled = otic::compile_all_unchecked(source);
+    let compiled = otic::__compile_all_unchecked(source);
     let (_, c) = compiled.last().unwrap();
     let mut data = Vec::new();
     data.extend_from_slice(&(c.constructor_bytecode.len() as u32).to_le_bytes());

--- a/crates/otic/src/codegen.rs
+++ b/crates/otic/src/codegen.rs
@@ -8403,10 +8403,10 @@ mod tests {
             }
         "#;
 
-        // Audit 404: codegen tests use the lax `compile_all_unchecked`
+        // Audit 404: codegen tests use the lax `__compile_all_unchecked`
         // because they probe lower / codegen invariants directly,
         // not the full frontend.
-        let results = crate::compile_all_unchecked(src);
+        let results = crate::__compile_all_unchecked(src);
         assert_eq!(results.len(), 2);
 
         let (name, factory) = &results[1];
@@ -8469,7 +8469,7 @@ mod tests {
         // Audit 404: codegen-internal determinism check uses the lax
         // path so the test stays focused on lower / codegen output.
         let runs = (0..5)
-            .map(|_| crate::compile_all_unchecked(src))
+            .map(|_| crate::__compile_all_unchecked(src))
             .collect::<Vec<_>>();
         // All 5 compilations produce one Token contract.
         for r in &runs {

--- a/crates/otic/src/lib.rs
+++ b/crates/otic/src/lib.rs
@@ -152,7 +152,19 @@ fn extract_all_contract_signatures(
 /// production callers through the strict `compile_all`; this
 /// function survives only behind an opt-in name so the lax path
 /// can never be picked accidentally.
-pub fn compile_all_unchecked(src: &str) -> Vec<(String, codegen::CompiledContract)> {
+///
+/// TPL-604: marked `#[doc(hidden)]` and renamed to
+/// `__compile_all_unchecked` so that an out-of-workspace toolchain
+/// browsing the otic crate's rustdoc does not discover the
+/// frontend-bypassing path. The double-underscore prefix is the
+/// Rust convention for "implementation detail; do not call." All
+/// in-workspace callers that legitimately have already run the
+/// frontend (`pyde-dev build`, `otic build`, the aot/node/tx test
+/// suites) are updated to the new name; new callers should use
+/// `compile_all` unless they can document why bypassing safety is
+/// correct.
+#[doc(hidden)]
+pub fn __compile_all_unchecked(src: &str) -> Vec<(String, codegen::CompiledContract)> {
     let (tokens, _) = lexer::Lexer::new(src).tokenize();
     let (file, _) = parser::Parser::new(tokens).parse();
 
@@ -224,7 +236,7 @@ pub fn compile_all_unchecked(src: &str) -> Vec<(String, codegen::CompiledContrac
 /// Use this everywhere except where you've already run the frontend
 /// in a wider build context (`pyde-dev build`, `otic` CLI) or in
 /// compiler-internal lower/codegen tests. See
-/// [`compile_all_unchecked`] for those narrow cases.
+/// [`__compile_all_unchecked`] for those narrow cases.
 ///
 /// # Audit 404
 ///
@@ -334,5 +346,5 @@ pub fn compile_all(src: &str) -> Result<Vec<(String, codegen::CompiledContract)>
     })?;
 
     // All frontend passes clean — lower + optimize + codegen.
-    Ok(compile_all_unchecked(src))
+    Ok(__compile_all_unchecked(src))
 }

--- a/crates/otic/src/lower.rs
+++ b/crates/otic/src/lower.rs
@@ -1235,7 +1235,7 @@ impl Lowerer {
                     // Pre-audit-405 this branch always emitted
                     // `AddressOfSelf` regardless of argument, which
                     // silently produced wrong bytecode whenever the
-                    // typechecker's lax (compile_all_unchecked) path
+                    // typechecker's lax (__compile_all_unchecked) path
                     // let `address(child)` through — the factory got
                     // its OWN address back instead of the deployed
                     // child's. The strict path now rejects that

--- a/crates/otic/src/main.rs
+++ b/crates/otic/src/main.rs
@@ -228,72 +228,178 @@ fn cmd_test(path: &str) {
     let (file, _src) = run_frontend(path);
 
     // Lower + codegen (no optimize for tests — preserve all test functions)
-    let ir = otic::lower::lower(&file);
+    let mut ir = otic::lower::lower(&file);
 
-    let test_fns: Vec<&otic::ir::IrFunction> = ir.functions.iter().filter(|f| f.is_test).collect();
+    // Snapshot the test set + per-test metadata before mutating IR.
+    let test_metas: Vec<(String, bool, Option<String>)> = ir
+        .functions
+        .iter()
+        .filter(|f| f.is_test)
+        .map(|f| (f.name.clone(), f.should_panic, f.expected_error.clone()))
+        .collect();
 
-    if test_fns.is_empty() {
+    if test_metas.is_empty() {
         println!("  {} — no #[test] functions found", path);
         return;
     }
 
+    // Promote test fns to pub so codegen includes them in the dispatch table.
+    for func in &mut ir.functions {
+        if func.is_test {
+            func.is_pub = true;
+            func.is_test = false;
+        }
+    }
+
+    // TPL-602: contracts compile with default `emit_guards = true` and the
+    // tests dispatch through the runtime selector, so reentrancy + payable
+    // guard prologues run on every test call — the pre-fix path stripped
+    // them out and let test fixtures pass against bytecode that diverged
+    // from what the chain would deploy. Pure-library files (`module foo;`
+    // with no contract block) have no contract surface to guard, so they
+    // keep the single-fn-as-entry path; the guard machinery doesn't apply.
+    let is_contract = !ir.contract_name.is_empty();
+
     let mut passed = 0;
     let mut failed = 0;
 
-    for func in &test_fns {
-        // Build a minimal program with just this test function
-        let mut test_ir = ir.clone();
-        test_ir.functions = vec![(*func).clone()];
-        // Mark as pub so codegen treats it as entry
-        test_ir.functions[0].is_pub = true;
-        test_ir.functions[0].is_test = false;
+    if is_contract {
+        let codegen = otic::codegen::CodeGen::new();
+        let compiled = codegen.generate(&ir);
 
-        let mut codegen = otic::codegen::CodeGen::new();
-        codegen.emit_guards = false;
-        let compiled = codegen.generate(&test_ir);
-
-        // Run on PVM
-        let mut vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
-        if let Err(e) = vm.load(&compiled.bytecode) {
-            eprintln!("failed to load bytecode: {:?}", e);
-            std::process::exit(1);
-        }
-
-        let mut steps = 0;
-        let mut result = None;
-        loop {
-            match vm.step() {
-                Ok(Some(r)) => {
-                    result = Some(r);
-                    break;
+        // Run constructor (if any) to seed shared storage state.
+        let constructor_storage: std::collections::HashMap<_, _> =
+            if !compiled.constructor_bytecode.is_empty() {
+                let mut vm = pyde_vm::vm::Vm::with_gas_limit(100_000_000);
+                if let Err(e) = vm.load(&compiled.constructor_bytecode) {
+                    eprintln!("constructor load error: {:?}", e);
+                    process::exit(1);
                 }
-                Ok(None) => {
-                    steps += 1;
-                    if steps > 100_000 {
-                        break;
-                    }
+                let output = vm.execute();
+                if output.outcome != pyde_vm::vm::Outcome::Success {
+                    eprintln!("constructor failed: {:?}", output.outcome);
+                    process::exit(1);
                 }
-                Err(_) => break,
+                vm.storage.clone()
+            } else {
+                std::collections::HashMap::new()
+            };
+
+        for (name, should_panic, expected_error) in &test_metas {
+            // Snapshot per test for isolation.
+            let snapshot = constructor_storage.clone();
+
+            // 4-byte selector dispatch. Setting `vm.calldata` BEFORE `load`
+            // matches the pyde-dev runner so `map_calldata()` runs during load.
+            let selector = otic::codegen::compute_selector(name);
+            let calldata = selector.to_be_bytes().to_vec();
+
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit(100_000_000);
+            vm.calldata = calldata;
+            if let Err(e) = vm.load(&compiled.runtime_bytecode) {
+                println!("  test {} ... FAILED (load: {:?})", name, e);
+                failed += 1;
+                continue;
+            }
+            vm.storage = snapshot;
+
+            let output = vm.execute();
+
+            let ok = if *should_panic {
+                match output.outcome {
+                    pyde_vm::vm::Outcome::Revert => match expected_error {
+                        Some(expected) => {
+                            let expected_selector = otic::codegen::compute_selector(expected);
+                            let actual_selector = if vm.return_data.len() >= 8 {
+                                u64::from_le_bytes(vm.return_data[..8].try_into().unwrap_or([0; 8]))
+                            } else {
+                                0
+                            };
+                            actual_selector == expected_selector as u64
+                        }
+                        None => true,
+                    },
+                    _ => false,
+                }
+            } else {
+                matches!(output.outcome, pyde_vm::vm::Outcome::Success)
+            };
+
+            if ok {
+                println!("  test {} ... ok", name);
+                passed += 1;
+            } else {
+                println!("  test {} ... FAILED ({:?})", name, output.outcome);
+                failed += 1;
             }
         }
+    } else {
+        // Library / module path: no contract dispatcher to thread tests
+        // through. Compile each test in isolation as the single entry, with
+        // guards disabled — there is no contract storage state for a
+        // reentrancy guard to key on. This is the pre-fix `otic test` flow
+        // preserved verbatim for library files; `cargo test` against the
+        // `tests/` integration suite is the path that exercises helper-fn
+        // calls, so this CLI stays as a quick-check for self-contained
+        // `#[test]` fns.
+        for (name, should_panic, _expected_error) in &test_metas {
+            let func = match ir.functions.iter().find(|f| &f.name == name) {
+                Some(f) => f.clone(),
+                None => {
+                    println!("  test {} ... FAILED (missing in IR)", name);
+                    failed += 1;
+                    continue;
+                }
+            };
 
-        let should_panic = func
-            .doc
-            .as_ref()
-            .is_some_and(|d| d.contains("should_panic"));
+            let mut entry = func;
+            entry.is_pub = true;
+            entry.is_test = false;
+            let mut test_ir = ir.clone();
+            test_ir.functions = vec![entry];
 
-        let ok = match result {
-            Some(pyde_vm::vm::ExecResult::Halt) => !should_panic,
-            Some(pyde_vm::vm::ExecResult::Revert) => should_panic,
-            _ => false,
-        };
+            let mut codegen = otic::codegen::CodeGen::new();
+            codegen.emit_guards = false;
+            let compiled = codegen.generate(&test_ir);
 
-        if ok {
-            println!("  test {} ... ok", func.name);
-            passed += 1;
-        } else {
-            println!("  test {} ... FAILED", func.name);
-            failed += 1;
+            let mut vm = pyde_vm::vm::Vm::with_gas_limit(1_000_000);
+            if let Err(e) = vm.load(&compiled.bytecode) {
+                println!("  test {} ... FAILED (load: {:?})", name, e);
+                failed += 1;
+                continue;
+            }
+
+            let mut steps = 0;
+            let mut result = None;
+            loop {
+                match vm.step() {
+                    Ok(Some(r)) => {
+                        result = Some(r);
+                        break;
+                    }
+                    Ok(None) => {
+                        steps += 1;
+                        if steps > 100_000 {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            let ok = match result {
+                Some(pyde_vm::vm::ExecResult::Halt) => !*should_panic,
+                Some(pyde_vm::vm::ExecResult::Revert) => *should_panic,
+                _ => false,
+            };
+
+            if ok {
+                println!("  test {} ... ok", name);
+                passed += 1;
+            } else {
+                println!("  test {} ... FAILED", name);
+                failed += 1;
+            }
         }
     }
 

--- a/crates/otic/src/main.rs
+++ b/crates/otic/src/main.rs
@@ -155,10 +155,10 @@ fn cmd_build(path: &str) {
     //
     // Audit 404: this binary already ran the full frontend (resolve +
     // typecheck + safety) inside `run_frontend(path)` above, so we
-    // intentionally use the lax `compile_all_unchecked` here to avoid
+    // intentionally use the lax `__compile_all_unchecked` here to avoid
     // re-running the same checks. The strict `compile_all` is for
     // callers that haven't yet run the frontend separately.
-    let results = otic::compile_all_unchecked(&src);
+    let results = otic::__compile_all_unchecked(&src);
 
     if results.is_empty() {
         eprintln!("error: no contracts found in {}", path);

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -62,6 +62,17 @@ pub struct SafetyChecker {
     errors: Vec<SafetyError>,
     /// All function names in the current contract (for callback validation).
     contract_functions: Vec<String>,
+    /// Names of storage fields whose declared type is `Map<K, V>` in the
+    /// current contract. Populated at the top of `check_contract` and
+    /// cleared at the end so the set never bleeds across contracts in the
+    /// same `SourceFile`. Used by the for-loop iteration diagnostic
+    /// (TPL-603) to flag `for _ in self.<map_field> { ... }` — the IR
+    /// codegen has no `StorageMapIter` opcode (see `crates/otic/src/ir.rs`
+    /// at the StorageMapGet/Set comments around L256-259), so iteration
+    /// over a `Map` lowers to nothing useful and silently runs an empty
+    /// body. Catching it in the safety pass turns the silent-no-op into a
+    /// loud compile error pointing at the offending `for` line.
+    storage_maps: HashSet<String>,
 }
 
 impl Default for SafetyChecker {
@@ -75,6 +86,7 @@ impl SafetyChecker {
         Self {
             errors: Vec::new(),
             contract_functions: Vec::new(),
+            storage_maps: HashSet::new(),
         }
     }
 
@@ -138,6 +150,20 @@ impl SafetyChecker {
         for item in &contract.items {
             if let ContractItem::Function(f) = item {
                 self.contract_functions.push(f.name.name.clone());
+            }
+        }
+
+        // TPL-603: collect names of storage fields declared as `Map<K, V>`
+        // (or any nesting where the outer type is `Map`) so the for-loop
+        // diagnostic can fire on `for _ in self.<map_field>`.
+        self.storage_maps.clear();
+        for item in &contract.items {
+            if let ContractItem::Storage(storage) = item {
+                for field in &storage.fields {
+                    if matches!(field.ty, Type::Map(..)) {
+                        self.storage_maps.insert(field.name.name.clone());
+                    }
+                }
             }
         }
 
@@ -221,10 +247,105 @@ impl SafetyChecker {
                 self.check_receive_rules(f);
                 self.check_fallback_rules(f);
                 self.check_cross_call_callbacks(f);
+                self.check_map_iteration(&f.body);
             }
         }
 
         self.contract_functions.clear();
+        self.storage_maps.clear();
+    }
+
+    // ========================================================================
+    // TPL-603 — Map iteration diagnostic
+    // ========================================================================
+
+    /// Walk a block looking for `for _ in self.<storage_map_field>`. The
+    /// IR has no `StorageMapIter` opcode, so an iterator like that lowers
+    /// to a no-op body that runs zero times — silently. Emit a loud
+    /// compile error pointing at the `for` line so authors don't write
+    /// contract logic that depends on iteration that never happens.
+    fn check_map_iteration(&mut self, block: &Block) {
+        for stmt in &block.stmts {
+            self.check_stmt_map_iteration(stmt);
+        }
+    }
+
+    fn check_stmt_map_iteration(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::For(f) => {
+                if let Some(name) = self.iterator_targets_storage_map(&f.iterator) {
+                    self.error(
+                        format!(
+                            "iteration over `Map` is not supported: storage field `self.{}` is `Map<K, V>`, which has no in-IR iterator. Track keys explicitly via a `Vec<K>` companion field, or rewrite the loop to walk the key set you maintain on writes.",
+                            name
+                        ),
+                        f.span,
+                    );
+                }
+                self.check_map_iteration(&f.body);
+            }
+            Stmt::While(w) => self.check_map_iteration(&w.body),
+            Stmt::Expr(e) => self.check_expr_map_iteration(&e.expr),
+            Stmt::Let(l) => self.check_expr_map_iteration(&l.initializer),
+            Stmt::Assign(a) => {
+                self.check_expr_map_iteration(&a.target);
+                self.check_expr_map_iteration(&a.value);
+            }
+            Stmt::Return(r) => {
+                if let Some(v) = &r.value {
+                    self.check_expr_map_iteration(v);
+                }
+            }
+            Stmt::Emit(e) => {
+                for f in &e.fields {
+                    self.check_expr_map_iteration(&f.value);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn check_expr_map_iteration(&mut self, expr: &Expr) {
+        match expr {
+            Expr::If(_, then_block, else_clause, _) => {
+                self.check_map_iteration(then_block);
+                if let Some(clause) = else_clause {
+                    match clause {
+                        ElseClause::ElseBlock(b) => self.check_map_iteration(b),
+                        ElseClause::ElseIf(e) => self.check_expr_map_iteration(e),
+                    }
+                }
+            }
+            Expr::Match(_, arms, _) => {
+                for arm in arms {
+                    if let Expr::Block(b) = &arm.body {
+                        self.check_map_iteration(b);
+                    }
+                }
+            }
+            Expr::Block(block) => self.check_map_iteration(block),
+            _ => {}
+        }
+    }
+
+    /// If the iterator expression is `self.<field>` (or `(self.<field>)`)
+    /// and `<field>` is a known storage Map, return its name. Otherwise
+    /// return None (the iterator is some other expression — a Vec, a
+    /// range, a function-returned iterator, etc., all of which are
+    /// supported and not the concern of this diagnostic).
+    fn iterator_targets_storage_map(&self, expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::FieldAccess(obj, field, _) => {
+                if matches!(obj.as_ref(), Expr::SelfExpr(_))
+                    && self.storage_maps.contains(&field.name)
+                {
+                    Some(field.name.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
     // ========================================================================
@@ -1534,5 +1655,69 @@ mod tests {
         assert!(errors[0]
             .message
             .contains("#[constructor] and #[test] cannot be combined"));
+    }
+
+    // ========== TPL-603: Map iteration diagnostic ==========
+
+    #[test]
+    fn error_for_iterates_storage_map() {
+        let errors = check_err(
+            r#"
+            contract T {
+                storage { balances: Map<Address, u256>, count: u64, }
+                pub fn walk() {
+                    for entry in self.balances {
+                        self.count = self.count + 1u64;
+                    }
+                }
+            }
+        "#,
+        );
+        assert!(errors
+            .iter()
+            .any(|e| e.message.contains("iteration over `Map` is not supported")
+                && e.message.contains("self.balances")));
+    }
+
+    #[test]
+    fn for_iterates_storage_vec_ok() {
+        // Vec iteration is supported and must NOT fire the new diagnostic.
+        check_ok(
+            r#"
+            contract T {
+                storage { items: Vec<u64>, }
+                pub fn sum() -> u64 {
+                    let mut total: u64 = 0u64;
+                    for x in self.items {
+                        total = total + x;
+                    }
+                    return total;
+                }
+            }
+        "#,
+        );
+    }
+
+    #[test]
+    fn error_nested_for_in_storage_map() {
+        // The diagnostic must reach `for` loops nested inside `if`/`while`,
+        // not just top-level statements.
+        let errors = check_err(
+            r#"
+            contract T {
+                storage { balances: Map<Address, u256>, count: u64, }
+                pub fn walk(flag: bool) {
+                    if flag {
+                        for entry in self.balances {
+                            self.count = self.count + 1u64;
+                        }
+                    }
+                }
+            }
+        "#,
+        );
+        assert!(errors
+            .iter()
+            .any(|e| e.message.contains("iteration over `Map` is not supported")));
     }
 }

--- a/crates/otic/src/typecheck.rs
+++ b/crates/otic/src/typecheck.rs
@@ -1312,7 +1312,7 @@ impl TypeChecker {
                             //     already emits a contract handle that IS
                             //     the deployed child's address. Pre-audit-
                             //     405 this only worked through the lax
-                            //     `compile_all_unchecked` path which produced
+                            //     `__compile_all_unchecked` path which produced
                             //     INCORRECT bytecode (the lowerer emitted
                             //     `AddressOfSelf` for any `address(...)`
                             //     call, regardless of argument — so the

--- a/crates/pyde-crypto-wasm/src/lib.rs
+++ b/crates/pyde-crypto-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use pyde_crypto::falcon::FalconSecretKey;
 use pyde_crypto::poseidon2::poseidon2_hash;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 use wasm_bindgen::prelude::*;
 
@@ -18,7 +18,7 @@ use wasm_bindgen::prelude::*;
 // hex string, and never get accidentally logged.
 //
 // `FalconSecretKey` already derives `ZeroizeOnDrop` (audit 358), so
-// removing the entry from the map (via `HashMap::remove` →
+// removing the entry from the map (via `BTreeMap::remove` →
 // `Drop::drop`) actually zeroes the secret bytes in place.
 //
 // Why a process-global Mutex: wasm32 is currently single-threaded on
@@ -27,6 +27,23 @@ use wasm_bindgen::prelude::*;
 // than a thread_local!) means we don't need wasm-bindgen's
 // thread-local plumbing, and the API stays callable from any
 // future worker context without additional setup.
+//
+// TPL-607: backed by `BTreeMap<u32, FalconSecretKey>` rather than
+// `HashMap`. Two reasons:
+//   1. `HashMap`'s default `RandomState` hasher pulls per-process
+//      entropy from `getrandom`, which on wasm32 means an extra
+//      JS-side RNG call (and a panic path on hosts that don't yet
+//      provide one). `BTreeMap` has no RNG dependency, so the
+//      keystore initializes deterministically on every WASM host.
+//   2. Iteration order (when we add diagnostics or snapshot
+//      coverage) is sorted by handle, which is what JS-side tests
+//      and operator dumps will expect. The current API only does
+//      insert / get / remove, so the ordering change is
+//      observable-equivalent today, but locks in deterministic
+//      behaviour ahead of any future iter use-site.
+// The audit-358 zeroize story is unchanged: `BTreeMap::remove`
+// returns the value by move, dropping it triggers `ZeroizeOnDrop`
+// identically to the previous `HashMap::remove` path.
 //
 // Handle exhaustion: u32 gives 4G distinct handles before wrap.
 // The wallet UX is one keypair per browser tab, so 4G is effectively
@@ -37,14 +54,14 @@ use wasm_bindgen::prelude::*;
 // instead of silently signing under a different key.
 struct KeyTable {
     next_handle: u32,
-    keys: HashMap<u32, FalconSecretKey>,
+    keys: BTreeMap<u32, FalconSecretKey>,
 }
 
 impl KeyTable {
     fn new() -> Self {
         Self {
             next_handle: 1, // 0 is reserved as "no handle"
-            keys: HashMap::new(),
+            keys: BTreeMap::new(),
         }
     }
 }

--- a/crates/pyde-dev/src/build.rs
+++ b/crates/pyde-dev/src/build.rs
@@ -316,10 +316,10 @@ pub fn build_project(config: &ProjectConfig, root: &Path) -> Result<BuildResult,
         //
         // Audit 404: `run_frontend` above already ran resolve +
         // typecheck + safety on this source. Use the lax
-        // `compile_all_unchecked` so we don't repeat the same
+        // `__compile_all_unchecked` so we don't repeat the same
         // checks; if `run_frontend` had any failures we already
         // continued past this contract via `had_errors = true`.
-        let contracts = otic::compile_all_unchecked(source);
+        let contracts = otic::__compile_all_unchecked(source);
         if contracts.is_empty() {
             println!("  {} — no contracts", rel.display());
             continue;

--- a/crates/pyde-dev/src/project.rs
+++ b/crates/pyde-dev/src/project.rs
@@ -81,6 +81,47 @@ fn default_out() -> String {
     "out".into()
 }
 
+/// TPL-605: validate that a path string is safe to join under the
+/// project root — must be relative and must not contain any `..`
+/// (parent-dir) components. Pre-fix, `compiler.{src,test,out}` from
+/// `pyde.toml` and `pyde-dev script <file>` from the CLI were both
+/// passed through `root.join(...)` without checking, so a malicious
+/// pyde.toml could redirect `out` to `../../../some/path` and a
+/// malicious script argument could read `../../etc/passwd`. The
+/// canonical Rust path-jail is to walk `Path::components()` and
+/// refuse `Component::ParentDir` plus any absolute-prefix marker.
+///
+/// `label` appears in the error message (e.g. `compiler.out`,
+/// `script file`) so the operator can tell which path tripped the
+/// check.
+pub fn ensure_path_within_root(value: &str, label: &str) -> Result<(), String> {
+    let p = std::path::Path::new(value);
+    if p.is_absolute() {
+        return Err(format!(
+            "{}: absolute paths are not allowed (got `{}`)",
+            label, value
+        ));
+    }
+    for component in p.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                return Err(format!(
+                    "{}: `..` (parent-dir) components are not allowed (got `{}`)",
+                    label, value
+                ));
+            }
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                return Err(format!(
+                    "{}: absolute paths are not allowed (got `{}`)",
+                    label, value
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 /// Find pyde.toml by walking up from the current directory.
 /// Returns (config, project_root_dir).
 pub fn load_config() -> Result<(ProjectConfig, PathBuf), String> {
@@ -94,6 +135,15 @@ pub fn load_config() -> Result<(ProjectConfig, PathBuf), String> {
                 .map_err(|e| format!("cannot read {}: {}", config_path.display(), e))?;
             let config: ProjectConfig =
                 toml::from_str(&content).map_err(|e| format!("invalid pyde.toml: {}", e))?;
+
+            // TPL-605: validate compiler.{src,test,out} so a hostile
+            // pyde.toml cannot redirect build / test / artifact writes
+            // outside the project root via `..` traversal or an
+            // absolute path.
+            ensure_path_within_root(&config.compiler.src, "compiler.src")?;
+            ensure_path_within_root(&config.compiler.test, "compiler.test")?;
+            ensure_path_within_root(&config.compiler.out, "compiler.out")?;
+
             return Ok((config, dir));
         }
         if !dir.pop() {
@@ -217,4 +267,49 @@ pub fn get_rpc_url(network: &str) -> Result<String, String> {
         .get(network)
         .ok_or_else(|| format!("network '{}' not found in pyde.toml", network))?;
     Ok(net.rpc_url.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TPL-605 — path-jail helper coverage.
+
+    #[test]
+    fn path_jail_accepts_simple_relative() {
+        ensure_path_within_root("src", "compiler.src").unwrap();
+        ensure_path_within_root("script", "compiler.test").unwrap();
+        ensure_path_within_root("out", "compiler.out").unwrap();
+        ensure_path_within_root("Counter.oti", "script file").unwrap();
+    }
+
+    #[test]
+    fn path_jail_accepts_nested_relative() {
+        ensure_path_within_root("src/contracts", "compiler.src").unwrap();
+        ensure_path_within_root("script/deploy/Token.oti", "script file").unwrap();
+    }
+
+    #[test]
+    fn path_jail_rejects_parent_dir() {
+        let err = ensure_path_within_root("..", "x").unwrap_err();
+        assert!(err.contains("`..`"), "{err}");
+        let err = ensure_path_within_root("../etc/passwd", "x").unwrap_err();
+        assert!(err.contains("`..`"), "{err}");
+        let err = ensure_path_within_root("script/../../etc", "x").unwrap_err();
+        assert!(err.contains("`..`"), "{err}");
+        let err = ensure_path_within_root("a/b/../c", "x").unwrap_err();
+        assert!(err.contains("`..`"), "{err}");
+    }
+
+    #[test]
+    fn path_jail_rejects_absolute_unix() {
+        let err = ensure_path_within_root("/etc/passwd", "x").unwrap_err();
+        assert!(err.contains("absolute"), "{err}");
+    }
+
+    #[test]
+    fn path_jail_label_appears_in_error() {
+        let err = ensure_path_within_root("..", "compiler.out").unwrap_err();
+        assert!(err.starts_with("compiler.out:"), "{err}");
+    }
 }

--- a/crates/pyde-dev/src/script.rs
+++ b/crates/pyde-dev/src/script.rs
@@ -45,6 +45,18 @@ pub fn run(file: &str, network: &str, signer: &crate::signer::Signer) -> Result<
         (file, None)
     };
 
+    // TPL-605: path-jail on the user-supplied script argument.
+    // Reject absolute paths and any `..` components before touching
+    // the filesystem. Without this gate, `pyde-dev script
+    // /etc/passwd` would happily read an absolute path because the
+    // first branch only checks `Path::new(file_part).exists()`,
+    // and `pyde-dev script ../../etc/passwd` would resolve the
+    // second `root.join("script").join(file_part)` branch out of
+    // `root/script/` and into the operator's filesystem. Both
+    // surfaces are closed by the same `ensure_path_within_root`
+    // helper that `pyde.toml` config values go through.
+    project::ensure_path_within_root(file_part, "script file")?;
+
     // Resolve script file path
     let script_path = if Path::new(file_part).exists() {
         file_part.to_string()

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -219,6 +219,26 @@ impl Wallet {
     ///   3. Call `wallet.register_pubkey(&provider).await?` once.
     ///   4. From now on, `transfer` / `send_call` etc. work normally.
     pub async fn register_pubkey(&self, provider: &Provider) -> Result<Receipt> {
+        // TPL-606: refuse to send a `RegisterPubkey` whose address-from-
+        // pubkey derivation does not match `self.address`. The chain
+        // enforces `from == Poseidon2(pubkey)` (audit 229) and would
+        // reject the tx anyway, but this surfaces as a network round-trip
+        // followed by an opaque execution failure on the caller's side.
+        // Catching the mismatch before we open an RPC connection turns
+        // it into a clear, immediate `AddressMismatch` error that the
+        // caller can act on — and rules out a subtle class of bug where
+        // a `Wallet` was constructed (e.g., via `from_keystore` against a
+        // tampered file) with a public key that no longer hashes to the
+        // recorded address.
+        let derived = derive_eoa_address(self.public_key.as_bytes());
+        if derived != self.address {
+            return Err(SdkError::Signing(format!(
+                "RegisterPubkey aborted: Poseidon2(public_key) = {} but wallet.address = {} — wallet keypair / address are inconsistent",
+                format_address(&derived),
+                format_address(&self.address),
+            )));
+        }
+
         let (nonce, chain_id) = provider.get_nonce_and_chain_id(&self.address).await?;
         let tx = Transaction {
             from: self.address,

--- a/crates/pyde-rust-sdk/src/wallet.rs
+++ b/crates/pyde-rust-sdk/src/wallet.rs
@@ -238,6 +238,15 @@ impl Wallet {
     }
 
     /// Build, sign, send a native transfer. Returns receipt (errors on revert).
+    ///
+    /// TPL-601: gas limit is fetched via `provider.estimate_gas_with` against
+    /// the live node rather than hardcoded at 21,000. The 21,000 fallback was
+    /// only correct for transfers to an already-warm EOA with no payable
+    /// fallback; transfers that touch a cold account or land on a contract
+    /// address (which then runs the payable receive path) cost more, and the
+    /// pre-fix code over-shipped under-priced txs that reverted at the gas
+    /// gate. The override carries `from = self.address` and `value = amount`
+    /// so the simulator sees the same fee-deduction the real tx will incur.
     pub async fn transfer(
         &self,
         provider: &Provider,
@@ -246,12 +255,24 @@ impl Wallet {
     ) -> Result<Receipt> {
         let (nonce, chain_id) = provider.get_nonce_and_chain_id(&self.address).await?;
 
+        let gas_limit = provider
+            .estimate_gas_with(
+                to,
+                &[],
+                Some(&CallOverrides {
+                    from: Some(self.address),
+                    value: Some(amount),
+                    gas_limit: None,
+                }),
+            )
+            .await?;
+
         let mut tx = Transaction {
             from: self.address,
             to: *to,
             value: amount,
             data: vec![],
-            gas_limit: 21_000,
+            gas_limit,
             nonce,
             signature: vec![],
             fee_payer: FeePayer::Sender,

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -3287,7 +3287,7 @@ mod tests {
                 pub fn get_value() -> u64 { return self.value; }
             }
         "#;
-        let compiled = otic::compile_all_unchecked(src);
+        let compiled = otic::__compile_all_unchecked(src);
         assert!(!compiled.is_empty());
         let (_, contract) = &compiled[0];
 
@@ -3382,7 +3382,7 @@ mod tests {
                 pub fn set_value(v: u64) { self.value = v; }
             }
         "#;
-        let compiled = otic::compile_all_unchecked(src);
+        let compiled = otic::__compile_all_unchecked(src);
         let (_, contract) = &compiled[0];
 
         let clen = contract.constructor_bytecode.len() as u32;
@@ -3468,7 +3468,7 @@ mod tests {
                 pub fn increment() { self.count = self.count + 1; }
             }
         "#;
-        let compiled = otic::compile_all_unchecked(src);
+        let compiled = otic::__compile_all_unchecked(src);
         let (_, contract) = &compiled[0];
 
         let clen = contract.constructor_bytecode.len() as u32;

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -1,0 +1,293 @@
+# Pyde Sync Protocol
+
+How a fresh `pyde-node` reaches the live chain head and joins the network.
+Audience: validator operators reading the source for the first time,
+security auditors, future contributors. For the operator runbook
+("which command do I run?") see [`connect-to-testnet.md`](./connect-to-testnet.md).
+
+> **Status note.** Parts of this document describe the target shape of
+> the sync protocol as Pyde moves from devnet → public testnet. Items
+> marked **(planned)** are the contract the sync-infrastructure work
+> (task tracker #82) validates itself against. Items without that
+> marker reflect the current implementation in `crates/node/src/sync.rs`,
+> `crates/node/src/state_manager.rs`, and `crates/net/src/propagation.rs`.
+
+## Why this exists
+
+Pyde is post-quantum and targets high throughput at mainnet. Under the
+**projected** sustained-load assumption of ~300K TPS and ~84 MB blocks
+(FALCON-512 sigs at ~660 bytes/tx dominate block size — this is a
+design target, not a measured number; see task #86 for the measurement
+work), downloading every block since genesis is impossible: a year of
+chain history projects to multiple petabytes, and re-verifying every
+signature would take a single CPU literal years. Even at one or two
+orders of magnitude lower throughput, the constraint is the same shape
+— and it hits every L1 at scale. The standard answer is
+**weak-subjectivity (WS) checkpoint + state snapshot + replay forward**.
+Pyde follows that pattern.
+
+This doc walks the lifecycle stage by stage, calls out the trust
+assumption planted at each step, and shows how every byte after the
+checkpoint is cryptographically verified.
+
+## The trust chain
+
+There is exactly one operator-trusted input: **the genesis file**,
+which ships with the binary and contains:
+
+- `chain_id`
+- Initial committee FALCON public keys
+- Initial threshold pubkey (Kyber-768 + Shamir share aggregate)
+- Genesis state hash (root of the JMT at slot 0)
+- Block time, epoch length, etc. — protocol parameters
+
+Everything downstream chains back to those bytes:
+
+```
+  genesis_file
+    │  (operator trust)
+    ▼
+  initial committee FALCON pubkeys
+    │  used to verify ▼
+  WS checkpoint multisig                  ──→ trust state_root @ slot S
+    │  used to anchor ▼
+  state snapshot at slot S                ──→ rebuild JMT, verify root
+    │  used to ground replay ▼
+  block headers S+1, S+2, …               ──→ parent_hash chain + QC sigs
+    │  bodies executed against ▼
+  state at slot S → state at head         ──→ post-block state_root
+    │  matches next block's qc_previous ▼
+  live head, byte-identical to honest peers
+```
+
+The single trust point is the genesis file (and, transitively, whoever
+signed off on the WS checkpoint that's quorum-signed by initial-committee
+keys). Every other byte is verified.
+
+## Lifecycle
+
+A new node moves through nine stages on its way to live participation.
+Stage 9 is validators-only.
+
+### Stage 0 — Boot
+
+| Has         | Genesis file, an empty datadir, the binary                                   |
+| Does        | Generate a libp2p identity keypair, open RPC port, start logging            |
+| Trust delta | Genesis is loaded — operator-side trust anchor                              |
+| Failure     | Wrong/tampered genesis file → wrong chain_id mismatches every later peer    |
+
+```
+$ pyde-node --datadir ~/.pyde --bootstrap-from <bootstrap-list>
+```
+
+### Stage 1 — Peer discovery
+
+| Has         | Identity, bootstrap list                                                     |
+| Does        | Dial bootstrap peers; libp2p Identify exchanges peer info; Kademlia DHT populates more peers; AutoNAT v2 reports public addressability; Circuit Relay v2 establishes if behind NAT *(planned, task #79 lever 3)* |
+| Produces    | Live peer set, each tagged with FALCON pubkey ↔ libp2p PeerId mapping        |
+| Failure     | All bootstrap peers dead → node hangs at this stage; clear timeout + error required |
+
+### Stage 2 — Fetch a signed WS checkpoint **(planned)**
+
+| Has         | Live peers, knowledge of who's in the *initial* committee (from genesis)    |
+| Does        | Send `GetLatestCheckpoint` to several peers; receive `WSCheckpoint { slot, block_hash, state_root, FALCON_multisig[] }`; verify each FALCON sig in the multisig against a pubkey from the committee active at `slot`; require ≥ 2/3 stake quorum |
+| Produces    | Verified `(slot S, block_hash H, state_root R)` — canonical chain pin       |
+| Trust delta | "I trust the chain at slot S because 2/3 of slot-S's committee signed for it" |
+| Failure     | All peers serve invalid/stale checkpoints → eclipse attack suspected; refuse to proceed; require operator override |
+
+The bootstrap edge case: at first connection, the new node only knows
+the *initial* committee from the genesis file. If the chain has been
+running long enough that the active committee has rotated multiple
+times, the new node needs to follow the rotation chain to find the
+committee active at slot S. Concretely: trust initial committee →
+verify checkpoint at end of epoch 1 → that checkpoint carries the
+committee for epoch 2 → verify checkpoint at end of epoch 2, and so
+on. Standard pattern; same shape as Tendermint / Cosmos light client.
+
+### Stage 3 — Download state snapshot **(planned)**
+
+| Has         | Verified `(S, H, R)`                                                         |
+| Does        | Send `GetSnapshotManifest(slot=S)` to a peer; receive a JMT-subtree descriptor `[(subtree_path, subtree_root_hash, byte_size)]`; request subtrees in parallel from multiple peers via `GetSnapshotSubtree(path)`; rebuild each subtree locally; verify subtree roots; compose to global root; verify equals `R` |
+| Produces    | Full world state at slot S — every account, every contract slot, every config entry |
+| Verifies    | Cryptographic match against the WS-checkpoint state root                    |
+| Failure     | Subtree mismatch → discard, request from another peer; persistent mismatch → eclipse-attack suspected |
+
+Reed-Solomon parity *(planned — currently stubbed at
+`crates/net/src/propagation.rs:225`)* lets a slow or dropping peer's
+chunks be reconstructed from other peers' parity, so the snapshot
+download isn't capped by the slowest peer.
+
+### Stage 4 — Fetch headers from S+1 to head
+
+| Has         | State at S, list of peers, current chain tip from peers                      |
+| Does        | `GetHeaders(start=S+1, count=N)` in batches; verify `header[i+1].parent_hash == header[i].block_hash`; verify each header's QC FALCON sigs against the committee active at that slot |
+| Produces    | Cryptographically continuous header chain from S+1 to head                  |
+| Failure     | Parent-hash break → peer is malicious or on a fork; switch peer             |
+
+### Stage 5 — Fetch block bodies
+
+| Has         | Header chain, peer set                                                       |
+| Does        | Parallel block-body fetch across peers *(planned — current `chain_sync` is single-peer per request)*; once mempool starts populating, compact-block reconstruction with `GetBlockTxs` *(planned per task #80)* fills only the missing txs instead of redownloading whole blocks |
+| Produces    | Full block bodies S+1..head, persisted to local block store                 |
+
+### Stage 6 — Replay blocks (execute forward)
+
+| Has         | Bodies + headers from S+1, state at S                                        |
+| Does        | Apply each block sequentially via `process_full_block_with_aot_and_checkpoint`; sigs already verified at fetch time per the verify-once architecture *(planned per task #80)*; each block's post-state root matches the next block's `qc_previous` commitment |
+| Produces    | State at the block-store head (which may be behind live head)               |
+| Verifies    | Post-execution state root agrees with chain consensus at every step         |
+| Failure     | State-root mismatch → peer fed wrong body for a real header; invalidate, re-fetch |
+
+### Stage 7 — Catch up to the moving target
+
+The chain has been advancing while Stages 4-6 ran. Repeat fetch-and-replay
+until the new node's catch-up rate exceeds the chain's production rate.
+At sustained 300K TPS this only converges if sync throughput beats
+block-production throughput.
+
+`pyde-node sync-status` *(planned)* shows progress:
+
+```
+state:  45/200 GB     ETA  3h 20m
+blocks: 1234/12000    ETA    12m
+head_slot: 12000      gap: 56 slots
+```
+
+Operator UX requirement: progress is visible, ETA is honest, "we are
+sync'd" is a clear binary indicator.
+
+### Stage 8 — Transition to live consensus
+
+| Has         | State at live head                                                           |
+| Does        | Subscribe to gossip topics (blocks, votes, view-change, decryption shares, randomness); listen-only for ~few slots to confirm clean apply; declare "synced" via metrics; if a validator, begin participating in HotStuff (proposing on VRF win, voting on proposals) |
+| Failure     | Wall-clock skew → proposals are early/late; NTP is required at the operator level |
+
+### Stage 9 — Committee membership + threshold share *(validators only)*
+
+This is **separate from chain sync**. Chain sync makes you a *full
+node*; becoming a *validator* requires:
+
+1. Stake registered on-chain (see `docs/run-validator.md`)
+2. Election to the committee at the next epoch boundary
+3. Threshold-share state for the new committee, delivered via the
+   cross-committee resharing protocol already on-chain
+
+At the epoch boundary, if elected, you receive your share via the
+resharing artifacts in committed state. From that slot onward you
+participate in encrypted-tx decryption alongside the rest of the
+committee.
+
+## Wire formats
+
+Sketches; canonical encoders live in `crates/node/src/wire.rs`.
+
+### `WSCheckpoint` *(planned)*
+
+```
+{
+  slot: u64,
+  block_hash: [u8; 32],
+  state_root: [u8; 32],
+  committee_epoch: u64,                 // which committee signed
+  signatures: Vec<{                     // FALCON multisig
+    voter_index: u8,
+    signature: Vec<u8>,                 // FALCON-512, ~660 bytes each
+  }>,
+}
+```
+
+Multisig requires ≥ ceil(2/3 × committee_size) entries. Each entry's
+`voter_index` selects a pubkey from the committee active at
+`committee_epoch`.
+
+### `GetSnapshotManifest` / `SnapshotManifest` *(planned)*
+
+```
+GetSnapshotManifest { slot: u64 }
+
+SnapshotManifest {
+  slot: u64,
+  state_root: [u8; 32],
+  subtrees: Vec<{
+    subtree_path: Vec<u8>,              // path bits in the JMT
+    subtree_root_hash: [u8; 32],        // for verification
+    byte_size: u32,                     // for download budgeting
+  }>,
+  reed_solomon_params: { k: u8, m: u8 } // when finished
+}
+```
+
+### `GetSnapshotSubtree` / `SnapshotSubtree` *(planned)*
+
+```
+GetSnapshotSubtree { slot: u64, subtree_path: Vec<u8> }
+
+SnapshotSubtree {
+  subtree_path: Vec<u8>,
+  entries: Vec<(key: [u8; 32], value: Vec<u8>)>,
+  internal_nodes: Vec<JmtInternalNode>,
+}
+```
+
+Receiver rebuilds the subtree, computes its root, MUST match the
+`subtree_root_hash` from the manifest.
+
+### `GetHeaders` / `Headers`
+
+Already implemented; see `crates/node/src/sync.rs`. Multi-peer
+parallel fetch *(planned)* on top of the existing single-peer-per-request
+shape.
+
+### `GetBlockTxs` / `BlockTxsResponse`
+
+Half-built. Types and wire encoders exist
+(`crates/net/src/propagation.rs:137,146`,
+`crates/node/src/wire.rs:436,451`); the request/response wiring is the
+work in task #80. Lets a syncing node fetch *only* the missing txs from
+a partially-reconstructable block instead of the whole-block-sync
+fallback the current `node.rs:1812` code uses.
+
+## Failure modes
+
+| Stage | Failure                                | Recovery                                     |
+|-------|----------------------------------------|----------------------------------------------|
+| 0     | Wrong genesis file                     | Operator error; clear chain_id mismatch log  |
+| 1     | All bootstrap peers unreachable        | Timeout + actionable error                   |
+| 2     | All peers serve invalid checkpoints    | Refuse to proceed; require operator override |
+| 3     | Subtree root mismatch                  | Discard, request from another peer           |
+| 4     | Header chain break (parent_hash mismatch) | Switch peer                              |
+| 4     | QC sigs invalid                        | Peer is malicious; ban + score down          |
+| 5     | Body unavailable for a header          | Re-request from another peer                 |
+| 6     | State root mismatch after execution    | Body is wrong; invalidate, re-fetch          |
+| 7     | Cannot catch up to live head           | Throughput problem; needs operator visibility |
+| 8     | Wall-clock skew                        | Operator NTP issue; clear diagnostic         |
+| 9     | Threshold share missing                | Wait for next reshare; check committee membership |
+
+## Eclipse-resistance assumptions
+
+The protocol assumes that not all of a new node's peers are byzantine.
+Specifically:
+
+- At Stage 2, the new node trusts the WS checkpoint that ≥ 2/3 of
+  slot-S's committee signed. An adversary controlling 2/3 of stake at
+  slot S can fake a checkpoint, but at that point they control consensus
+  anyway.
+- At Stages 3-5, peers serving wrong data are detected by cryptographic
+  mismatch (subtree roots, parent_hash chain, QC sigs). The new node
+  discards and re-requests. Worst case: it fails to find an honest peer
+  and times out.
+- The bootstrap list (CLI / genesis-shipped fallback) is the operator's
+  initial peer set. It must contain *at least one* honest endpoint; the
+  protocol's later stages can recover from byzantine majorities at any
+  *runtime* peer set.
+
+## See also
+
+- [`connect-to-testnet.md`](./connect-to-testnet.md) — operator runbook for joining as a full node
+- [`run-validator.md`](./run-validator.md) — extension for becoming a validator (Stage 9)
+- [`testnet-bringup.md`](./testnet-bringup.md) — coordinator runbook for the genesis ceremony
+- [`oncall.md`](./oncall.md) — operator response procedures
+- `crates/node/src/sync.rs` — current sync orchestration
+- `crates/node/src/state_manager.rs` — `import_snapshot` / `export_snapshot` entry points
+- `crates/net/src/propagation.rs` — compact-block + erasure-coding primitives
+- `crates/node/src/wire.rs` — canonical wire encoders / decoders


### PR DESCRIPTION
## Summary

Wave 6 — toolchain / SDK production polish, in numerical order.
Closes the seven items the tracker calls out as the last
pre-testnet bounded-scope polish. No protocol-layer changes.

## What changed

* **TPL-601** — `Wallet::transfer` now calls
  `provider.estimate_gas_with(to, &[], CallOverrides{from, value})`
  instead of hardcoding `gas_limit = 21_000`. The 21,000 fallback
  was only correct for transfers to an already-warm EOA with no
  payable fallback; cold-account transfers and contract-payable
  transfers cost more and reverted at the gas gate as opaque
  execution failures.

* **TPL-602** — `otic test` for **contracts** now compiles with
  default `emit_guards = true` and dispatches each test through
  the runtime via 4-byte selector — mirrors the `pyde-dev test`
  flow that was already correct. Pre-fix, every test ran with
  guards stripped from the dispatch prologue, so fixtures passed
  against bytecode that diverged from what gets deployed.
  Library / module files keep the single-fn-as-entry path
  unchanged (no contract storage for a guard to key on).

* **TPL-603** — Safety pass flags `for _ in self.<map>` over a
  storage `Map<K, V>`. The IR has no `StorageMapIter` opcode, so
  the loop body lowered to a no-op that ran zero times —
  silently. Three new unit tests cover positive, Vec parity, and
  nested-`if` reach. 38 / 38 safety tests pass.

* **TPL-604** — `compile_all_unchecked` renamed to
  `__compile_all_unchecked` and marked `#[doc(hidden)]`. The
  unchecked compile path bypasses resolve / typecheck / safety;
  it exists for two narrow workspace-internal reasons. Rust has
  no native "workspace-only" visibility, so this picks the
  practical equivalent: invisible in rustdoc, name signals "do
  not call." 19 in-workspace call sites (otic, aot, pyde-dev,
  tx, ~12 node integration tests) renamed.

* **TPL-605** — Path-jail on `pyde-dev script <file>` and on
  `compiler.{src,test,out}` from `pyde.toml`. Pre-fix,
  `pyde-dev script /etc/passwd` and `pyde-dev script
  ../../etc/passwd` both worked, and a hostile pyde.toml could
  redirect every artifact write outside the project root.
  `project::ensure_path_within_root(value, label)` walks
  `Path::components()` and rejects `Component::ParentDir` plus
  any absolute-prefix marker. Five new unit tests cover the
  accept / reject matrix.

* **TPL-606** — `Wallet::register_pubkey` derives
  `Poseidon2(self.public_key)` and compares against
  `self.address` before opening the RPC connection. The chain
  enforces this equality (audit 229), but pre-fix a `Wallet`
  whose address had drifted from its public key (e.g.
  `from_keystore` against a tampered file) would round-trip to
  the node and surface as an opaque RPC error. Now returns a
  clear `SdkError::Signing` with both 0x-hex addresses on
  mismatch.

* **TPL-607** — `KeyTable.keys` switched from `HashMap<u32, _>`
  to `BTreeMap<u32, _>`. `HashMap`'s default `RandomState`
  hasher pulls per-process entropy from `getrandom` on every
  init — an extra JS-side RNG call on wasm32 and a panic path on
  hosts without it. `BTreeMap` is RNG-free. Iteration order is
  now sorted by handle, locking in deterministic behaviour ahead
  of any future iter use-site. Audit-361 / audit-358 zeroize
  story unchanged. 14 / 14 wasm-crypto tests pass.

## Files touched

* `crates/pyde-rust-sdk/src/wallet.rs` — TPL-601 (transfer
  estimate_gas) + TPL-606 (register_pubkey pre-check).
* `crates/otic/src/main.rs` — TPL-602 (test runner refactor).
* `crates/otic/src/safety.rs` — TPL-603 (Map iteration
  diagnostic + 3 tests).
* `crates/otic/src/lib.rs` + 18 caller files across otic, aot,
  pyde-dev, tx, node tests — TPL-604 (rename +
  `#[doc(hidden)]`).
* `crates/pyde-dev/src/project.rs` + `script.rs` — TPL-605
  (path-jail helper, `load_config` validation, script-file
  validation, 5 tests).
* `crates/pyde-crypto-wasm/src/lib.rs` — TPL-607
  (`HashMap → BTreeMap`).