### PR TITLE
fuzz targets + proptest soak CI + auth_handshake test fix (TPL-701, 705)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # TPL-705 — proptest soak runs are too expensive for per-PR CI
+  # (10 K cases × ~10 properties × FALCON-bound work ≈ tens of
+  # minutes). Trigger via cron + manual dispatch instead. The
+  # cron is once-per-week so coverage accrues without burning
+  # the GH-Actions minute budget on every push.
+  schedule:
+    - cron: "0 6 * * 1" # 06:00 UTC every Monday
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -81,3 +89,27 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
+
+  # TPL-705 — proptest soak. Runs ONLY on the weekly cron + on
+  # workflow_dispatch; skipped on every push / pull_request so the
+  # per-PR feedback loop stays fast. PROPTEST_CASES=10000 escalates
+  # the per-property case count from each test's
+  # `ProptestConfig::with_cases(...)` default (currently 16-256
+  # depending on property cost). The `--test 'prop_*'` filter
+  # selects only the integration-test binaries whose filename
+  # starts with `prop_` (cf. `crates/{consensus,tx}/tests/prop_*`),
+  # because the property functions inside `proptest! { ... }` blocks
+  # don't share a uniform name prefix.
+  proptest_soak:
+    name: Proptest soak (10 K cases)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Cargo test (proptest soak)
+        env:
+          PROPTEST_CASES: "10000"
+        run: cargo test --workspace --release --test 'prop_*'

--- a/crates/net/tests/auth_handshake.rs
+++ b/crates/net/tests/auth_handshake.rs
@@ -109,6 +109,14 @@ async fn run_handshake(
                                 &mut nonces,
                                 &mut peer_manager,
                                 &committee_keys,
+                                // TPL-510 added an
+                                // `Option<&[u8]>` pinned-pubkey
+                                // arg. This integration test
+                                // exercises the no-pin path —
+                                // bootstrap-pubkey pinning has
+                                // its own focused unit tests in
+                                // `crates/net/src/auth.rs`.
+                                None,
                             ));
                         }
                         _ => {}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,12 @@ license = "Apache-2.0"
 #   cargo +nightly fuzz run tx_decoder
 #   cargo +nightly fuzz run wire_transaction
 #   cargo +nightly fuzz run encrypted_tx_decoder
+#   cargo +nightly fuzz run wire_block             # TPL-701
+#   cargo +nightly fuzz run wire_block_header      # TPL-701
+#   cargo +nightly fuzz run wire_consensus_message # TPL-701
+#   cargo +nightly fuzz run wire_consensus_state   # TPL-701
+#   cargo +nightly fuzz run encrypted_tx_bundle    # TPL-701
+#   cargo +nightly fuzz run otic_parser            # TPL-701
 
 [package.metadata]
 cargo-fuzz = true
@@ -26,6 +32,7 @@ pyde-vm = { path = "../crates/pvm" }
 pyde-tx = { path = "../crates/tx" }
 pyde-node = { path = "../crates/node" }
 pyde-mempool = { path = "../crates/mempool" }
+otic = { path = "../crates/otic" }
 
 [[bin]]
 name = "pvm_interpreter"
@@ -51,6 +58,58 @@ bench = false
 [[bin]]
 name = "encrypted_tx_decoder"
 path = "fuzz_targets/encrypted_tx_decoder.rs"
+test = false
+doc = false
+bench = false
+
+# TPL-701: six new targets covering the wire-level decoders that
+# run BEFORE peer auth / proposer signature / committee membership
+# are verified. Each is reachable from any peer that completes the
+# libp2p noise handshake — combined with `panic = "abort"`, a
+# reachable panic is a remote validator-kill DoS. The
+# `otic_parser` target covers the developer-tooling surface
+# (`pyde-dev build`, `otic build`) and turns "this contract won't
+# compile" into "this contract crashes my toolchain" if the
+# front-end ever panics on hostile input.
+
+[[bin]]
+name = "wire_block"
+path = "fuzz_targets/wire_block.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_block_header"
+path = "fuzz_targets/wire_block_header.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_consensus_message"
+path = "fuzz_targets/wire_consensus_message.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "wire_consensus_state"
+path = "fuzz_targets/wire_consensus_state.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "encrypted_tx_bundle"
+path = "fuzz_targets/encrypted_tx_bundle.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "otic_parser"
+path = "fuzz_targets/otic_parser.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -7,17 +7,21 @@ would poison the stable-toolchain build.
 
 ## Targets
 
-| Target              | What it fuzzes                                    | Why it matters                                                                                 |
-| ------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `pvm_interpreter`   | `Vm::load` + `Vm::execute` on arbitrary bytecode  | Contract-deploy bytecode is attacker-supplied; a panic here crashes validators post-deploy.    |
-| `tx_decoder`        | `pyde_tx::types::Transaction::from_bytes`         | RPC-ingress + gossip bytes hit this before validation. Must return `Option`, never panic.      |
-| `wire_transaction`  | `pyde_node::wire::decode_transaction`             | Compact-block + gossip decoder; distinct from `from_bytes`. Reached via `pyde-node`'s lib target. |
+| Target                    | What it fuzzes                                              | Why it matters                                                                                 |
+| ------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `pvm_interpreter`         | `Vm::load` + `Vm::execute` on arbitrary bytecode            | Contract-deploy bytecode is attacker-supplied; a panic here crashes validators post-deploy.    |
+| `tx_decoder`              | `pyde_tx::types::Transaction::from_bytes`                   | RPC-ingress + gossip bytes hit this before validation. Must return `Option`, never panic.      |
+| `wire_transaction`        | `pyde_node::wire::decode_transaction`                       | Compact-block + gossip decoder; distinct from `from_bytes`. Reached via `pyde-node`'s lib target. |
+| `encrypted_tx_decoder`    | `pyde_mempool::encrypted::EncryptedTx::from_bytes`          | Per-tx envelope from `pyde_sendRawEncryptedTransaction` and the `pyde/encrypted_transactions/1` topic. Anonymous-RPC reachable. |
+| `wire_block`              | `pyde_node::wire::decode_block`                             | TPL-701: full-block decode runs BEFORE proposer-signature verification on `pyde/blocks/1`. Reachable to any authenticated peer. |
+| `wire_block_header`       | `pyde_node::wire::decode_block_header`                      | TPL-701: header decoder also called directly on `pyde/sync/1` light-client paths.              |
+| `wire_consensus_message`  | `pyde_node::wire::decode_consensus_message`                 | TPL-701: entry point for everything on `pyde/consensus/1` — votes, view-changes, finality, decryption shares, slashing evidence. Committee-membership check is downstream of the decode. |
+| `wire_consensus_state`    | `pyde_node::wire::decode_consensus_state`                   | TPL-701: cold-sync HotStuff state response on `pyde/sync/1`. Malformed response is a remote-kill against a node restarting from a checkpoint. |
+| `encrypted_tx_bundle`     | `pyde_node::wire::decode_encrypted_tx_bundle`               | TPL-701: proposer-side ordering-commitment bundle on `pyde/blocks/1`. Decoded before the proposer signature is checked. |
+| `otic_parser`             | `otic` lex + parse + resolve + typecheck + safety           | TPL-701: developer-tooling DoS surface. A hostile `.oti` source must not crash `pyde-dev build`, `otic build/check/test`, or any IDE plugin that runs the front-end. |
 
 ## Planned follow-up targets
 
-- `wire_block` / `wire_consensus_message` — the lib target now
-  exists, so these are one-liner additions once we want them.
-- `otic_parser` — fuzz `.oti` source parsing.
 - `falcon_verify` / `kyber_decrypt` — fuzz PQ crypto deserialisers
   (likely thin wrappers; real coverage comes from upstream fuzzing).
 
@@ -33,6 +37,14 @@ cd fuzz
 cargo +nightly fuzz run pvm_interpreter
 cargo +nightly fuzz run tx_decoder
 cargo +nightly fuzz run wire_transaction
+cargo +nightly fuzz run encrypted_tx_decoder
+# TPL-701 targets:
+cargo +nightly fuzz run wire_block
+cargo +nightly fuzz run wire_block_header
+cargo +nightly fuzz run wire_consensus_message
+cargo +nightly fuzz run wire_consensus_state
+cargo +nightly fuzz run encrypted_tx_bundle
+cargo +nightly fuzz run otic_parser
 ```
 
 By default libfuzzer runs forever, discovering new inputs + storing

--- a/fuzz/fuzz_targets/encrypted_tx_bundle.rs
+++ b/fuzz/fuzz_targets/encrypted_tx_bundle.rs
@@ -1,0 +1,20 @@
+//! Fuzz target: `pyde_node::wire::decode_encrypted_tx_bundle` on
+//! arbitrary bytes.
+//!
+//! `EncryptedTxBundle` is the proposer-side payload that ships the
+//! ordering commitment plus the encrypted-tx hash list on the
+//! `pyde/blocks/1` channel. Decoded BEFORE the proposer signature
+//! is checked (since we need the proposer field out of the bundle
+//! header), so any peer who can publish on the channel can feed a
+//! malformed bundle. Distinct from `encrypted_tx_decoder.rs` which
+//! covers the per-tx envelope reachable from
+//! `pyde_sendRawEncryptedTransaction`. Must return
+//! `Result<EncryptedTxBundle, &'static str>` for any input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_encrypted_tx_bundle(data);
+});

--- a/fuzz/fuzz_targets/otic_parser.rs
+++ b/fuzz/fuzz_targets/otic_parser.rs
@@ -1,0 +1,42 @@
+//! Fuzz target: full Otigen frontend on arbitrary input.
+//!
+//! Reachable from `pyde-dev build`, `pyde-dev script`, and `otic
+//! build/check/test/abi/lex` whenever a developer compiles a
+//! third-party `.oti` source. A panic in lex / parse / resolve /
+//! typecheck / safety would crash the toolchain on a hostile
+//! contract before any compile output is produced — not a
+//! consensus-DoS like the wire targets, but a developer-tooling
+//! denial-of-service that turns "this contract won't compile" into
+//! "this contract crashes my IDE" or, in CI, into a flake that
+//! blocks every PR until someone notices the input.
+//!
+//! The fuzz body mirrors `crates/otic/src/main.rs::run_frontend`'s
+//! sequence and accepts any `Result` (Ok or Err diagnostics) as
+//! valid — only panics / aborts fail the run. Non-UTF-8 inputs are
+//! coerced via `from_utf8_lossy` so libfuzzer's mutator can keep
+//! exercising the byte-level surface without first having to
+//! discover well-formed UTF-8.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let src = std::str::from_utf8(data).map(str::to_owned).unwrap_or_else(|_| {
+        String::from_utf8_lossy(data).into_owned()
+    });
+
+    // Lex + parse: the two stages every other front-end pass
+    // depends on. A panic here would also blow up `otic test`,
+    // `otic build`, `pyde-dev build`, and every developer
+    // tool that reads a contract.
+    let (tokens, _lex_errors) = otic::lexer::Lexer::new(&src).tokenize();
+    let (file, _parse_errors) = otic::parser::Parser::new(tokens).parse();
+
+    // Resolve / typecheck / safety run on a successfully-parsed
+    // tree. They each accept arbitrary syntactically-valid
+    // `SourceFile` shapes and return diagnostics, never panic.
+    let _ = otic::resolve::Resolver::new().resolve(&file);
+    let _ = otic::typecheck::TypeChecker::new().check(&file);
+    let _ = otic::safety::SafetyChecker::new().check(&file);
+});

--- a/fuzz/fuzz_targets/wire_block.rs
+++ b/fuzz/fuzz_targets/wire_block.rs
@@ -1,0 +1,18 @@
+//! Fuzz target: `pyde_node::wire::decode_block` on arbitrary bytes.
+//!
+//! Reachable from any authenticated peer via the `pyde/blocks/1`
+//! gossipsub topic. The block decoder runs BEFORE proposer-signature
+//! verification (to read the proposer field out of the header), so
+//! a panic here is reachable to any committee member who can open
+//! a libp2p channel — no valid signature required. Combined with
+//! `panic = "abort"` in the workspace release profile, that turns
+//! a single malformed gossip block into a remote validator-kill.
+//! Must return `Result<Block, &'static str>` for any input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_block(data);
+});

--- a/fuzz/fuzz_targets/wire_block_header.rs
+++ b/fuzz/fuzz_targets/wire_block_header.rs
@@ -1,0 +1,19 @@
+//! Fuzz target: `pyde_node::wire::decode_block_header` on arbitrary bytes.
+//!
+//! The header decoder is the inner half of `decode_block` and is
+//! also called directly on `pyde/blocks/1` and `pyde/sync/1` paths
+//! that ship just the header (e.g. light-client checkpoint
+//! gossip). Same DoS shape as `wire_block`: any authenticated peer
+//! can publish a malformed header, the decoder runs before the
+//! attached FALCON quorum certificate is verified, and a panic
+//! aborts the validator under the workspace's
+//! `panic = "abort"` release profile. Must return
+//! `Result<BlockHeader, &'static str>` for any input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_block_header(data);
+});

--- a/fuzz/fuzz_targets/wire_consensus_message.rs
+++ b/fuzz/fuzz_targets/wire_consensus_message.rs
@@ -1,0 +1,20 @@
+//! Fuzz target: `pyde_node::wire::decode_consensus_message` on
+//! arbitrary bytes.
+//!
+//! The consensus message decoder is the entry point for everything
+//! on the `pyde/consensus/1` gossipsub channel — prepare, pre-commit,
+//! commit votes, view-change votes, finality checkpoints, decryption
+//! shares, slashing evidence. Authenticated committee membership is
+//! checked AFTER the decode, so a malformed envelope panicking here
+//! is reachable to any peer who passes the libp2p auth handshake.
+//! `panic = "abort"` in the workspace release profile turns the
+//! panic into a remote validator-kill. Must return
+//! `Result<ConsensusMessage, &'static str>` for any input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_consensus_message(data);
+});

--- a/fuzz/fuzz_targets/wire_consensus_state.rs
+++ b/fuzz/fuzz_targets/wire_consensus_state.rs
@@ -1,0 +1,19 @@
+//! Fuzz target: `pyde_node::wire::decode_consensus_state` on
+//! arbitrary bytes.
+//!
+//! `ConsensusState` is the cold-sync / catch-up payload exchanged
+//! on the `pyde/sync/1` channel. It carries the snapshot of HotStuff
+//! state (highest QC, locked QC, view, etc.) a freshly-started node
+//! pulls from peers before live-tailing. The decoder is reachable
+//! from any peer that responds to a sync request; a malformed
+//! response that panics the requester is a remote validator-kill
+//! against any node restarting from a stale checkpoint. Must
+//! return `Result<_, &'static str>` for any input.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = pyde_node::wire::decode_consensus_state(data);
+});


### PR DESCRIPTION
## Summary

Wave 7 — bounded subset that lands the new code-side fuzz/CI
work without committing to the operational items (TPL-702
>=72-hour soak runs are a dedicated-box scheduling task, and
TPL-703/704/706/707 + the *a follow-ups defer until CI
billing is restored). Also picks up a Wave 5 follow-up bug
that was breaking `cargo test -p pyde-net` on main.

## What changed

* **TPL-701** — six new libfuzzer harnesses covering decoders
  that run BEFORE peer auth or proposer-signature / committee-
  membership checks have completed:
  * `wire_block` — `pyde_node::wire::decode_block`
  * `wire_block_header` — `pyde_node::wire::decode_block_header`
  * `wire_consensus_message` —
    `pyde_node::wire::decode_consensus_message`
  * `wire_consensus_state` —
    `pyde_node::wire::decode_consensus_state`
  * `encrypted_tx_bundle` —
    `pyde_node::wire::decode_encrypted_tx_bundle`
  * `otic_parser` — full Otigen front-end (lex + parse +
    resolve + typecheck + safety)

  Combined with the workspace's `panic = "abort"` release
  profile, a reachable panic in any wire decoder is a remote
  validator-kill DoS. `otic_parser` is the developer-tooling
  equivalent — a hostile `.oti` source must not crash
  `pyde-dev build` / `otic build` / IDE plugins. `fuzz/Cargo
  .toml` adds the six bin entries plus `otic = { path =
  "../crates/otic" }`. `fuzz/README.md` table is updated.
  `cd fuzz && cargo check` is clean against the targets.

* **TPL-705** — `proptest_soak` CI job runs the workspace's
  property tests at `PROPTEST_CASES=10000` (40-600x the inline
  `with_cases(N)` defaults). Triggered weekly via
  `schedule: cron "0 6 * * 1"` and on `workflow_dispatch`;
  guarded with `if: github.event_name == 'schedule' || ...`
  so the per-PR loop stays fast. `cargo test --workspace
  --release --test 'prop_*'` selects the 22 proptest binaries
  in `crates/{consensus,tx}/tests/prop_*.rs`. Smoke-tested
  locally with `PROPTEST_CASES=4`: 22 / 22 pass. CI itself is
  currently billing-blocked, so the job won't fire today — the
  workflow change captures intent and activates on billing
  restore.

* **fix(net)** — Wave 5's TPL-510 added an `Option<&[u8]>`
  pinned-pubkey argument to `apply_auth_response`, but
  `crates/net/tests/auth_handshake.rs` was not updated alongside
  the unit-test sites. The 5-of-6 arity mismatch broke `cargo
  test -p pyde-net` on main since PR #362 merged. Adds `None`
  for the new argument; cargo test passes 2 / 2.

## Files touched

* `fuzz/Cargo.toml` + `fuzz/README.md` — TPL-701 (deps + bin
  entries + target table).
* `fuzz/fuzz_targets/{wire_block, wire_block_header,
  wire_consensus_message, wire_consensus_state,
  encrypted_tx_bundle, otic_parser}.rs` — TPL-701 (new harnesses).
* `.github/workflows/ci.yml` — TPL-705 (proptest soak job +
  cron / dispatch triggers).
* `crates/net/tests/auth_handshake.rs` — TPL-510 follow-up.

## Deferred

* **TPL-702** — >=72-hour soak runs per target + fix every
  crash. Operational scheduling on a dedicated box.
* **TPL-703** — `cargo test --release --workspace` job. CI-only;
  defer with billing.
* **TPL-704** — Nightly `--include-ignored` integration bucket.
  CI-only; defer with billing.
* **TPL-706** — Document required-checks list + branch
  protection. Tied to TPL-703/704/705 landing.
* **TPL-707** — Annotate `prop_hotstuff_safety.proptest-
  regressions` entries.
* `*a` follow-ups (109a, 103a, 111a, 108a, 113a, 207a) — each
  has its own scope or blocker noted in the tracker.