### PR TITLE
fix: wave 9 DoS / fairness hardening (TPL-921, 923, 924, 927, 931, 932, 935, 941)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "zeroize",

--- a/crates/mempool/src/pool.rs
+++ b/crates/mempool/src/pool.rs
@@ -507,8 +507,9 @@ impl Mempool {
         self.txs.iter().collect()
     }
 
-    /// Select transactions for a block in arrival order, respecting
-    /// the gas limit AND a per-block count cap.
+    /// Select transactions for a block, respecting the gas limit
+    /// AND a per-block count cap, using **round-robin per-sender
+    /// fairness** (TPL-921).
     ///
     /// `max_count` bounds the number of encrypted txs the proposer
     /// will include per block. Production callers pass
@@ -519,6 +520,46 @@ impl Mempool {
     /// the receive-side decrypt+apply pipeline falls indefinitely
     /// behind).
     ///
+    /// ## Fairness (TPL-921)
+    ///
+    /// Pre-fix the loop walked `self.txs` in raw arrival order. That
+    /// meant a single sender who had filled the mempool with 5 K txs
+    /// across the per-sender quota windows could claim every slot of
+    /// every block until their backlog drained — a self-spam DoS
+    /// against any other sender's tx submitted in the same window.
+    /// The new algorithm:
+    ///
+    ///   1. Group pending (non-expired) txs by sender, preserving
+    ///      per-sender arrival order via `VecDeque`.
+    ///   2. Walk senders in **first-appearance arrival order** — so
+    ///      ordering across senders still matches original arrival
+    ///      timing for the case "two senders, no contention".
+    ///   3. Per round, give each sender at most ONE inclusion (their
+    ///      next tx that fits the remaining gas budget). Repeat
+    ///      rounds until either we hit `max_count`, every sender's
+    ///      queue is exhausted, or no sender's frontmost tx fits the
+    ///      remaining gas.
+    ///
+    /// Properties:
+    ///
+    ///   * No single sender can occupy more than ⌈n/k⌉ slots of a
+    ///     block where `n = max_count` and `k` is the number of
+    ///     senders with pending txs in the block. With one sender,
+    ///     the algorithm degrades to FCFS arrival order; with
+    ///     `max_count` senders it gives every sender exactly one
+    ///     inclusion.
+    ///   * Gas-pressure semantics match the pre-fix path: a tx that
+    ///     doesn't fit the remaining budget is skipped (not
+    ///     selected, but also not popped from the sender's queue
+    ///     until we choose to give up on that sender). On the next
+    ///     round we retry the same tx — which is correct because
+    ///     `gas_used` only grows, so once the frontmost tx of a
+    ///     sender doesn't fit, their queue is effectively done for
+    ///     this block. We mark the sender exhausted to skip them in
+    ///     subsequent rounds.
+    ///   * Expired txs are filtered up front during the grouping
+    ///     pass; they never appear in any sender's queue.
+    ///
     /// The proposer VRF-shuffles the selected set after this.
     pub fn select_for_block(
         &self,
@@ -526,21 +567,76 @@ impl Mempool {
         max_count: usize,
         current_slot: u64,
     ) -> Vec<&EncryptedTx> {
-        let mut selected = Vec::new();
-        let mut gas_used = 0u64;
+        if max_count == 0 {
+            return Vec::new();
+        }
 
+        // Step 1: per-sender VecDeque of pending (non-expired) txs,
+        // preserving arrival order within each sender. `sender_order`
+        // captures first-appearance arrival timing — the order in
+        // which we'll round-robin walk senders below.
+        let mut per_sender: HashMap<Address, VecDeque<&EncryptedTx>> =
+            HashMap::with_capacity(self.txs.len().min(max_count));
+        let mut sender_order: Vec<Address> = Vec::new();
         for tx in &self.txs {
-            if selected.len() >= max_count {
-                break;
-            }
             if tx.is_expired(current_slot) {
                 continue;
             }
-            if gas_used.saturating_add(tx.gas_limit) > block_gas_limit {
-                continue; // skip this tx, try next (might fit)
+            let entry = per_sender.entry(tx.sender);
+            if let std::collections::hash_map::Entry::Vacant(_) = entry {
+                sender_order.push(tx.sender);
             }
-            gas_used += tx.gas_limit;
-            selected.push(tx);
+            per_sender
+                .entry(tx.sender)
+                .or_insert_with(VecDeque::new)
+                .push_back(tx);
+        }
+
+        // Step 2: round-robin selection. `exhausted` short-circuits
+        // senders whose frontmost tx didn't fit the remaining gas
+        // budget — they cannot recover this block (gas only grows).
+        let mut selected: Vec<&EncryptedTx> = Vec::with_capacity(max_count.min(self.txs.len()));
+        let mut gas_used = 0u64;
+        let mut exhausted: HashSet<Address> = HashSet::new();
+
+        loop {
+            if selected.len() >= max_count {
+                break;
+            }
+            let mut progressed_this_round = false;
+            for sender in &sender_order {
+                if selected.len() >= max_count {
+                    break;
+                }
+                if exhausted.contains(sender) {
+                    continue;
+                }
+                let queue = match per_sender.get_mut(sender) {
+                    Some(q) => q,
+                    None => continue,
+                };
+                let tx = match queue.front() {
+                    Some(tx) => *tx,
+                    None => {
+                        // Drained.
+                        exhausted.insert(*sender);
+                        continue;
+                    }
+                };
+                if gas_used.saturating_add(tx.gas_limit) > block_gas_limit {
+                    // Frontmost doesn't fit. Skip this sender for
+                    // the rest of the block.
+                    exhausted.insert(*sender);
+                    continue;
+                }
+                queue.pop_front();
+                gas_used += tx.gas_limit;
+                selected.push(tx);
+                progressed_this_round = true;
+            }
+            if !progressed_this_round {
+                break;
+            }
         }
 
         selected
@@ -628,6 +724,34 @@ mod tests {
 
     fn make_enc_tx(pk: &threshold::ThresholdPublicKey, gas: u64, nonce: u64) -> EncryptedTx {
         let sender = derive_eoa_address(&nonce.to_le_bytes());
+        let to = derive_eoa_address(b"to");
+        encrypt_transaction(
+            sender,
+            nonce,
+            gas,
+            dummy_access_list(),
+            None,
+            1,
+            dummy_signature(),
+            &to,
+            0,
+            b"",
+            pk,
+        )
+        .unwrap()
+    }
+
+    /// TPL-921: build a tx with an explicit sender so fairness tests
+    /// can stack many txs against the same address. The default
+    /// `make_enc_tx` derives a fresh sender from the nonce, which is
+    /// fine for FCFS coverage but useless for verifying round-robin
+    /// behaviour across senders.
+    fn make_enc_tx_for_sender(
+        pk: &threshold::ThresholdPublicKey,
+        sender: Address,
+        gas: u64,
+        nonce: u64,
+    ) -> EncryptedTx {
         let to = derive_eoa_address(b"to");
         encrypt_transaction(
             sender,
@@ -872,6 +996,99 @@ mod tests {
         }
         let selected = pool.select_for_block(1_000_000_000, MAX_ENCRYPTED_TXS_PER_BLOCK, 0);
         assert_eq!(selected.len(), MAX_ENCRYPTED_TXS_PER_BLOCK);
+    }
+
+    // ========== TPL-921: per-sender fairness in select_for_block ==========
+
+    #[test]
+    fn tpl_921_select_round_robins_across_senders() {
+        // Sender A has 50 pending txs, sender B has just 1. With a
+        // count cap of 10, the pre-fix FCFS-arrival selector would
+        // give all 10 slots to A (B's tx never reaches the front
+        // because it arrived after A's). The new round-robin selector
+        // gives B at least one inclusion in the first round and A
+        // takes the remaining 9.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_rate_limits(1_000, 1_000);
+        let alice = derive_eoa_address(b"tpl-921-alice");
+        let bob = derive_eoa_address(b"tpl-921-bob");
+        for nonce in 0..50 {
+            pool.add_unverified_for_devnet(make_enc_tx_for_sender(&pk, alice, 30_000, nonce))
+                .unwrap();
+        }
+        // Bob's single tx arrives last in the FCFS log.
+        pool.add_unverified_for_devnet(make_enc_tx_for_sender(&pk, bob, 30_000, 0))
+            .unwrap();
+
+        let selected = pool.select_for_block(1_000_000, 10, 0);
+        assert_eq!(selected.len(), 10);
+
+        let bob_count = selected.iter().filter(|tx| tx.sender == bob).count();
+        let alice_count = selected.iter().filter(|tx| tx.sender == alice).count();
+        assert_eq!(bob_count, 1, "bob must get at least one inclusion");
+        assert_eq!(alice_count, 9, "alice fills the remainder");
+
+        // Bob's slot must land in the first round (slot 0 or 1, since
+        // alice arrived first and gets the round-1 first pick).
+        let bob_position = selected.iter().position(|tx| tx.sender == bob).unwrap();
+        assert!(
+            bob_position <= 1,
+            "bob's tx must land in the first round-robin pass, got position {bob_position}"
+        );
+    }
+
+    #[test]
+    fn tpl_921_select_single_sender_falls_back_to_fcfs() {
+        // With one sender, round-robin degrades to FCFS arrival
+        // order — 5 txs, 5 slots, all selected in arrival order.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_rate_limits(100, 100);
+        let alice = derive_eoa_address(b"tpl-921-solo-alice");
+        for nonce in 0..5 {
+            pool.add_unverified_for_devnet(make_enc_tx_for_sender(
+                &pk,
+                alice,
+                30_000 + nonce, // unique gas per tx → unique hash
+                nonce,
+            ))
+            .unwrap();
+        }
+
+        let selected = pool.select_for_block(1_000_000, 100, 0);
+        assert_eq!(selected.len(), 5);
+        for (i, tx) in selected.iter().enumerate() {
+            assert_eq!(tx.gas_limit, 30_000 + i as u64, "arrival order must hold");
+        }
+    }
+
+    #[test]
+    fn tpl_921_select_skips_sender_when_frontmost_overflows_gas() {
+        // Sender A's first tx is huge and exceeds the remaining
+        // budget; sender B has small txs that fit. Round-robin must
+        // exhaust A (gas only grows, retrying A's frontmost would
+        // never succeed) and fill the block from B.
+        let pk = make_pk();
+        let mut pool = Mempool::new();
+        pool.set_rate_limits(100, 100);
+        let alice = derive_eoa_address(b"tpl-921-fat-alice");
+        let bob = derive_eoa_address(b"tpl-921-fit-bob");
+
+        // Alice's tx is bigger than the entire block budget below.
+        pool.add_unverified_for_devnet(make_enc_tx_for_sender(&pk, alice, 800_000, 0))
+            .unwrap();
+        // Bob has 3 small txs.
+        for nonce in 0..3 {
+            pool.add_unverified_for_devnet(make_enc_tx_for_sender(&pk, bob, 30_000, nonce))
+                .unwrap();
+        }
+
+        let selected = pool.select_for_block(500_000, 100, 0);
+        let alice_count = selected.iter().filter(|tx| tx.sender == alice).count();
+        let bob_count = selected.iter().filter(|tx| tx.sender == bob).count();
+        assert_eq!(alice_count, 0, "alice's oversize tx is skipped");
+        assert_eq!(bob_count, 3, "bob fills the block");
     }
 
     // ========== Prune expired ==========

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -44,6 +44,10 @@ metrics-exporter-prometheus = "0.16"
 
 # RPC
 jsonrpsee = { version = "0.24", features = ["server", "macros"] }
+# TPL-931: needed to define the per-connection rate-limit middleware
+# as a `tower::Layer<S>` for jsonrpsee's `set_rpc_middleware`. Pinned
+# to the same major version jsonrpsee 0.24 uses (`tower = "0.4"`).
+tower = "0.4"
 
 # WebSocket subscriptions (bypasses jsonrpsee sink delivery bug)
 tokio-tungstenite = "0.24"

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -9,14 +9,18 @@ use pyde_tx::types::Transaction;
 use std::time::Instant;
 use tracing::{debug, info, warn};
 
-/// Audit 325: maximum allowed clock-drift between a block's
+/// Audit 325 / TPL-924: maximum allowed clock-drift between a block's
 /// claimed timestamp and the local wall-clock at receive time, in
 /// milliseconds. A header with `timestamp > now_ms + DRIFT` is
-/// rejected. 15 s is generous (~37 slots at 400 ms) but matches
-/// realistic NTP skew between honest validators while still
-/// preventing arbitrary fake-future timestamps that smart contracts
-/// would observe via `block.timestamp`.
-pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 15_000;
+/// rejected. 5 s ≈ 12 slots at 400 ms — comfortably above realistic
+/// NTP skew between honest validators (sub-second on a well-managed
+/// pool) while bounding how far a Byzantine proposer can push
+/// `block.timestamp` ahead of true wall-clock. Smart contracts read
+/// `block.timestamp` via the PVM (e.g., time-locked withdrawals,
+/// expired-deadline races), so a tighter forward window directly
+/// shrinks that contract-level attack surface — was 15 s in the
+/// original audit-325 fix.
+pub const MAX_TIMESTAMP_DRIFT_MS: u64 = 5_000;
 
 /// Processes incoming blocks: validates header, executes transactions, updates state.
 pub struct BlockProcessor;

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -17,6 +17,7 @@ mod node;
 mod peer_book;
 mod receipt_store;
 mod rpc;
+mod rpc_rate_limit;
 mod shutdown;
 mod slot_clock;
 mod state_manager;

--- a/crates/node/src/peer_book.rs
+++ b/crates/node/src/peer_book.rs
@@ -95,10 +95,17 @@ impl PeerBook {
         book
     }
 
-    /// Atomically persist the current set. Writes to
-    /// `peer_book.json.tmp` then `rename`s into place so a
-    /// `kill -9` mid-write either lands the new file or leaves the
-    /// old one untouched.
+    /// Atomically persist the current set with mode `0o600` on Unix
+    /// (TPL-935). Pre-fix the save path called `fs::write(...)`
+    /// directly, which left the file at the operator's umask
+    /// (typically `0o644`, world-readable). The peer book leaks the
+    /// validator's recently-connected `(PeerId, Multiaddr)` set,
+    /// which is enough for a co-located unprivileged process to
+    /// enumerate the validator's peer mesh and feed it into a
+    /// targeted-eclipse / surveillance flow. Routed through the
+    /// shared `write_secret_file` helper so the same atomic-rename
+    /// + create-with-mode-0o600 + fsync sequence used for
+    /// validator.key / threshold.share also covers this file.
     pub fn save(&self, datadir: &Path) -> Result<(), String> {
         let entries: Vec<PeerEntry> = self
             .peers
@@ -111,10 +118,7 @@ impl PeerBook {
         let file = PeerBookFile { peers: entries };
         let bytes = serde_json::to_vec_pretty(&file).map_err(|e| e.to_string())?;
         let final_path = datadir.join(PEER_BOOK_FILENAME);
-        let tmp_path = datadir.join(format!("{}.tmp", PEER_BOOK_FILENAME));
-        std::fs::write(&tmp_path, bytes).map_err(|e| e.to_string())?;
-        std::fs::rename(&tmp_path, &final_path).map_err(|e| e.to_string())?;
-        Ok(())
+        crate::genesis::write_secret_file(&final_path, &bytes)
     }
 
     /// Record an observed `(peer, addr)` pair. Idempotent —
@@ -193,5 +197,27 @@ mod tests {
         std::fs::write(dir.path().join("peer_book.json"), b"not-json").unwrap();
         let book = PeerBook::load(dir.path());
         assert!(book.is_empty());
+    }
+
+    /// TPL-935: persisted peer_book.json must land at mode `0o600`,
+    /// not the umask-derived default. A co-located unprivileged
+    /// process should not be able to read the validator's
+    /// recently-connected peer set off disk.
+    #[cfg(unix)]
+    #[test]
+    fn tpl_935_save_writes_mode_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let mut book = PeerBook::new();
+        let (p, a) = random_peer_addr();
+        book.record(p, a);
+        book.save(dir.path()).unwrap();
+        let meta = std::fs::metadata(dir.path().join(PEER_BOOK_FILENAME)).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "expected peer_book.json at mode 0o600, got {:o}",
+            mode
+        );
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -10,6 +10,7 @@ use crate::tx_relay::TxRelay;
 use crate::wire;
 use jsonrpsee::core::async_trait;
 use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
 use jsonrpsee::server::Server;
 use jsonrpsee::types::ErrorObjectOwned;
 use pyde_tx::execution::Receipt;
@@ -1684,6 +1685,18 @@ pub async fn start_rpc_server(
     const MAX_RESPONSE_BODY_BYTES: u32 = 16_777_216; // 16 MB
     const MAX_CONNECTIONS: u32 = 1024;
     const MAX_REQUESTS_PER_BATCH: u32 = 32;
+
+    // TPL-931: per-connection request rate-limit. Without this, the
+    // body / batch / connection caps above still leave room for one
+    // peer to flood the RPC from a single TCP connection. The limiter
+    // is a token bucket per `ConnectionId`; see
+    // `crate::rpc_rate_limit` for the per-second / burst constants.
+    let rate_limit_state = crate::rpc_rate_limit::RpcRateLimitState::new();
+    let rpc_middleware = RpcServiceBuilder::new()
+        .layer(crate::rpc_rate_limit::RpcRateLimitLayer::new(
+            rate_limit_state,
+        ));
+
     let server = Server::builder()
         .max_request_body_size(MAX_REQUEST_BODY_BYTES)
         .max_response_body_size(MAX_RESPONSE_BODY_BYTES)
@@ -1691,6 +1704,7 @@ pub async fn start_rpc_server(
         .set_batch_request_config(jsonrpsee::server::BatchRequestConfig::Limit(
             MAX_REQUESTS_PER_BATCH,
         ))
+        .set_rpc_middleware(rpc_middleware)
         .build(addr)
         .await
         .map_err(|e| format!("failed to start RPC server: {}", e))?;

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -529,22 +529,7 @@ impl PydeApiServer for RpcServer {
         let chain_id = chain_r.chain_id;
         drop(chain_r);
 
-        // Auto-fetch nonce from state if not provided
-        let nonce: u64 = if let Some(n) = tx_obj.get("nonce").and_then(|v| v.as_u64()) {
-            n
-        } else {
-            let state_r = self.state.state.read().await;
-            let nonce_key = pyde_state::keys::nonce_key(&from);
-            // Audit 390: from_bytes is Option<Self>; missing /
-            // malformed both collapse to `base = 0`.
-            let n = state_r
-                .get(&nonce_key)
-                .and_then(|bytes| pyde_account::nonce::NonceState::from_bytes(&bytes))
-                .map(|ns| ns.base)
-                .unwrap_or(0);
-            drop(state_r);
-            n
-        };
+        let explicit_nonce = tx_obj.get("nonce").and_then(|v| v.as_u64());
 
         let tx_type = match tx_obj.get("txType").and_then(|v| v.as_str()) {
             Some("stakeDeposit") => pyde_tx::types::TransactionType::StakeDeposit,
@@ -569,6 +554,48 @@ impl PydeApiServer for RpcServer {
         // [clen:4 LE][rlen:4 LE][constructor][runtime][args]
         // Pass through as-is. The SDK/CLI constructs this format.
         let deploy_data = data;
+
+        // TPL-927: auto-fetch nonce, ingress validation, mempool dedup,
+        // and insert all happen under one `pending_txs.write()`. Pre-fix
+        // the auto-fetch read on-chain state with no awareness of
+        // in-flight pending txs from the same sender, so two concurrent
+        // dev-mode `send_transaction` calls would both pick the same N
+        // and the second one fell through to a duplicate-nonce error
+        // from the dedup pass. `ingress_validate` and the on-chain
+        // nonce read use independent locks (state, chain) and never
+        // touch `pending_txs`, so holding `pending` through them is
+        // deadlock-free given the codebase-wide convention that
+        // pending_txs is the outer lock.
+        let mut pending = self.state.pending_txs.write().await;
+
+        let nonce: u64 = if let Some(n) = explicit_nonce {
+            n
+        } else {
+            let on_chain = {
+                let state_r = self.state.state.read().await;
+                let nonce_key = pyde_state::keys::nonce_key(&from);
+                // Audit 390: from_bytes is Option<Self>; missing /
+                // malformed both collapse to `base = 0`.
+                state_r
+                    .get(&nonce_key)
+                    .and_then(|bytes| pyde_account::nonce::NonceState::from_bytes(&bytes))
+                    .map(|ns| ns.base)
+                    .unwrap_or(0)
+            };
+            // Walk pending txs from this sender so concurrent auto-fetch
+            // submissions don't both land on the same nonce. This is the
+            // same O(N) scan the dedup pass below already does; we just
+            // fold "max nonce for sender" into the same thinking.
+            let max_pending = pending
+                .values()
+                .filter(|t| t.from == from)
+                .map(|t| t.nonce)
+                .max();
+            match max_pending {
+                Some(p) => p.saturating_add(1).max(on_chain),
+                None => on_chain,
+            }
+        };
 
         let tx = pyde_tx::types::Transaction {
             from,
@@ -595,7 +622,6 @@ impl PydeApiServer for RpcServer {
 
         // Global cap (M3) + per-sender cap (M1) + (sender, nonce) dedup
         // (M6), all atomic with the insert under one write lock.
-        let mut pending = self.state.pending_txs.write().await;
         if pending.len() >= MEMPOOL_GLOBAL_CAP {
             return Err(rpc_err(
                 -32011,

--- a/crates/node/src/rpc_rate_limit.rs
+++ b/crates/node/src/rpc_rate_limit.rs
@@ -1,0 +1,225 @@
+//! Per-connection request rate-limit middleware for the JSON-RPC
+//! server (TPL-931).
+//!
+//! Bounds how many RPC requests a single TCP connection can issue
+//! per second. The existing connection cap (`MAX_CONNECTIONS = 1024`)
+//! and per-request body cap (`1 MB`) leave room for one peer to
+//! flood `pyde_call` / `pyde_getLogs` / `pyde_estimateGas` from a
+//! single connection — every request consumes a handler future, and
+//! back-to-back small requests can saturate the Tokio runtime well
+//! before either of those caps kicks in.
+//!
+//! Algorithm: token bucket per `ConnectionId`. Each connection
+//! starts with a full burst capacity and refills at a steady rate.
+//! Requests consume one token; when the bucket is empty the call is
+//! rejected with `-32429 "rate limit exceeded"`. Token-bucket lets
+//! bursty-but-honest clients (block explorers paginating receipts,
+//! wallets refreshing balance + nonce + logs in one tick) succeed
+//! while still capping sustained throughput.
+
+use futures_util::future::{ready, Either, Ready};
+use jsonrpsee::core::server::MethodResponse;
+use jsonrpsee::server::middleware::rpc::RpcServiceT;
+use jsonrpsee::types::{ErrorObject, Request};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tower::Layer;
+
+/// Sustained refill rate per connection, requests/second.
+const RATE_PER_SECOND: f64 = 100.0;
+
+/// Burst capacity per connection. A single connection can issue up
+/// to this many requests immediately before the per-second refill
+/// kicks in. 200 ≈ ~2 s of sustained traffic — comfortably above
+/// the typical "one tick of a wallet UI refresh" burst.
+const BURST_CAPACITY: f64 = 200.0;
+
+/// Soft ceiling on the per-connection state map. Beyond this, stale
+/// entries (no traffic for ≥ 60 s) are pruned. Keeps memory bounded
+/// across very long server uptimes — `ConnectionId` (a `usize`)
+/// monotonically increases per accepted TCP connection, so without
+/// pruning the map would grow forever.
+const STATE_MAP_SOFT_CAP: usize = 4096;
+
+/// Idle-eviction window. An entry whose `last_refill` is older than
+/// this is dropped during the soft-cap sweep.
+const STALE_ENTRY_AFTER: Duration = Duration::from_secs(60);
+
+/// JSON-RPC error code for rate-limit. `-32429` mirrors HTTP `429`
+/// semantically. jsonrpsee passes the error object through to the
+/// client unchanged, so picking a code outside the standard
+/// `-32000..-32099` range avoids collision with handler-level errors.
+const RATE_LIMIT_ERROR_CODE: i32 = -32429;
+
+#[derive(Clone, Copy, Debug)]
+struct ConnState {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+#[derive(Default)]
+struct InnerState {
+    map: HashMap<usize, ConnState>,
+}
+
+#[derive(Clone, Default)]
+pub struct RpcRateLimitState(Arc<Mutex<InnerState>>);
+
+impl RpcRateLimitState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn try_consume(&self, conn_id: usize) -> bool {
+        let now = Instant::now();
+        let mut g = self.0.lock().expect("rate-limit state poisoned");
+        if g.map.len() > STATE_MAP_SOFT_CAP {
+            // Cheap idle sweep — only fires when the map is already
+            // above the soft cap, so amortized cost is negligible.
+            let cutoff = now - STALE_ENTRY_AFTER;
+            g.map.retain(|_, s| s.last_refill >= cutoff);
+        }
+        let entry = g.map.entry(conn_id).or_insert(ConnState {
+            tokens: BURST_CAPACITY,
+            last_refill: now,
+        });
+        let elapsed_s = now.duration_since(entry.last_refill).as_secs_f64();
+        entry.tokens = (entry.tokens + elapsed_s * RATE_PER_SECOND).min(BURST_CAPACITY);
+        entry.last_refill = now;
+        if entry.tokens >= 1.0 {
+            entry.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RpcRateLimitLayer(RpcRateLimitState);
+
+impl RpcRateLimitLayer {
+    pub fn new(state: RpcRateLimitState) -> Self {
+        Self(state)
+    }
+}
+
+impl<S> Layer<S> for RpcRateLimitLayer {
+    type Service = RpcRateLimit<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcRateLimit {
+            inner,
+            state: self.0.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RpcRateLimit<S> {
+    inner: S,
+    state: RpcRateLimitState,
+}
+
+impl<'a, S> RpcServiceT<'a> for RpcRateLimit<S>
+where
+    S: RpcServiceT<'a>,
+{
+    type Future = Either<S::Future, Ready<MethodResponse>>;
+
+    fn call(&self, request: Request<'a>) -> Self::Future {
+        let conn_id = request
+            .extensions()
+            .get::<jsonrpsee::core::server::ConnectionId>()
+            .map(|c| c.0)
+            .unwrap_or(0);
+        if self.state.try_consume(conn_id) {
+            Either::Left(self.inner.call(request))
+        } else {
+            let id = request.id().into_owned();
+            let err = ErrorObject::owned(
+                RATE_LIMIT_ERROR_CODE,
+                format!(
+                    "rate limit exceeded: {} req/s sustained per connection (burst {})",
+                    RATE_PER_SECOND as u32, BURST_CAPACITY as u32
+                ),
+                None::<()>,
+            );
+            Either::Right(ready(MethodResponse::error(id, err)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_bucket_allows_burst_then_throttles() {
+        let state = RpcRateLimitState::new();
+        let conn = 1usize;
+        let mut allowed = 0;
+        // BURST_CAPACITY is 200; the first ~200 should pass even
+        // back-to-back. Use 250 to confirm a hard cut-off after the
+        // initial burst, with the per-second refill contributing only
+        // sub-millisecond fractional tokens during this loop.
+        for _ in 0..250 {
+            if state.try_consume(conn) {
+                allowed += 1;
+            }
+        }
+        assert!(
+            (BURST_CAPACITY as usize..=BURST_CAPACITY as usize + 1).contains(&allowed),
+            "expected ~{} allowed in tight loop, got {}",
+            BURST_CAPACITY as usize,
+            allowed
+        );
+    }
+
+    #[test]
+    fn token_bucket_isolates_connections() {
+        let state = RpcRateLimitState::new();
+        // Drain conn 1 to empty.
+        for _ in 0..(BURST_CAPACITY as usize + 50) {
+            state.try_consume(1);
+        }
+        // Conn 2 should still get its full burst.
+        let mut allowed_2 = 0;
+        for _ in 0..(BURST_CAPACITY as usize) {
+            if state.try_consume(2) {
+                allowed_2 += 1;
+            }
+        }
+        assert!(
+            allowed_2 >= BURST_CAPACITY as usize - 1,
+            "conn 2 starved by conn 1's rate-limit state: {} / {}",
+            allowed_2,
+            BURST_CAPACITY as usize
+        );
+    }
+
+    #[test]
+    fn token_bucket_refills_over_time() {
+        let state = RpcRateLimitState::new();
+        let conn = 7usize;
+        // Drain.
+        for _ in 0..(BURST_CAPACITY as usize + 10) {
+            state.try_consume(conn);
+        }
+        assert!(!state.try_consume(conn), "bucket should be empty");
+        // Sleep ~50 ms; at 100 req/s that refills ~5 tokens.
+        std::thread::sleep(Duration::from_millis(50));
+        let mut refilled_allowed = 0;
+        for _ in 0..10 {
+            if state.try_consume(conn) {
+                refilled_allowed += 1;
+            }
+        }
+        assert!(
+            (3..=8).contains(&refilled_allowed),
+            "expected ~5 tokens refilled in 50ms at 100 req/s, got {}",
+            refilled_allowed
+        );
+    }
+}

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -17,11 +17,53 @@ use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
 /// Umbrella cap on any length field decoded from an untrusted wire
 /// message before `Vec::with_capacity` is called with it. Prevents a
 /// peer from forcing huge preallocations by stuffing a giant u32/u16
-/// count into a well-formed frame. 1M items is well above any
-/// legitimate protocol structure; sites with a tighter semantic
-/// bound (committee size, multisig signer set, etc.) pass that
-/// instead via `u16_count` / `u32_count`.
+/// count into a well-formed frame. Every concrete decoder site below
+/// passes a tighter semantic bound (committee size, multisig signer
+/// set, block tx cap, etc.); this constant is retained as a last-line
+/// umbrella for any future site whose protocol shape doesn't bind to
+/// one of the tighter caps.
+#[allow(dead_code)]
 const MAX_DECODE_ITEMS: usize = 1_000_000;
+
+/// Maximum transactions in a single block, derived from the elastic
+/// gas ceiling: `BLOCK_GAS_MAX (1.6B) / MIN_TX_GAS (21k) ≈ 76k`,
+/// rounded up to 100k for headroom. Bounds `tx_count`, encrypted-tx
+/// count, execution-schedule group count, and per-group tx_indices
+/// count for any wire frame that carries a block-shaped payload
+/// (Block, CompactBlock, EncryptedTxBundle).
+const MAX_TXS_PER_BLOCK: usize = 100_000;
+
+/// Maximum entries in a transaction's EIP-2930-style access list.
+/// Each entry costs gas to declare; 1024 is far above any sane
+/// real-world access list while staying well below the u16 wire
+/// ceiling (65 535). A peer cannot force `access_list` allocation
+/// past this cap on a freshly-decoded transaction.
+const MAX_ACCESS_LIST_ENTRIES: usize = 1024;
+
+/// Maximum read or write storage keys per access-list entry. Each
+/// declared key costs gas; 1024 keys per entry is an order of
+/// magnitude above any observed access pattern, and bounds the
+/// per-entry inner allocations during `decode_access_entry`.
+const MAX_ACCESS_KEYS_PER_ENTRY: usize = 1024;
+
+/// Maximum pending votes or timeouts in a `ConsensusState` sync
+/// payload. HotStuff carries one vote and one timeout per validator
+/// per view; `4 * COMMITTEE_SIZE` allows several queued views during
+/// catch-up without giving a sync peer room to force a multi-MB
+/// `Vec::with_capacity`.
+const MAX_PENDING_CONSENSUS_PER_STATE: usize = COMMITTEE_SIZE * 4;
+
+/// Maximum slashing-evidence backlog (pending or broadcast queue) in
+/// an `EvidenceState` blob. One double-sign per validator over a
+/// pessimistic catch-up window is well under this; tighter than the
+/// 1M umbrella so a malicious sync responder can't force a
+/// 10M-entry evidence preallocation.
+const MAX_EVIDENCE_BACKLOG: usize = 10_000;
+
+/// Maximum dedup `(slot, signer)` pairs persisted in `EvidenceState`.
+/// One entry per (validator, slot) over a generous tail of recent
+/// slots; bounds the `seen` Vec allocation during decode.
+const MAX_EVIDENCE_SEEN: usize = 200_000;
 
 /// Message type tags for wire encoding.
 pub mod tag {
@@ -409,7 +451,7 @@ pub fn decode_compact_block(
     }
     let header = dec.var_bytes()?;
     let nonce = dec.u64()?;
-    let sid_count = dec.u32_count(MAX_DECODE_ITEMS)?;
+    let sid_count = dec.u32_count(MAX_TXS_PER_BLOCK)?;
     let mut short_tx_ids = Vec::with_capacity(sid_count);
     for _ in 0..sid_count {
         let mut sid = [0u8; pyde_net::propagation::SHORT_ID_LEN];
@@ -417,7 +459,7 @@ pub fn decode_compact_block(
         sid.copy_from_slice(raw);
         short_tx_ids.push(sid);
     }
-    let prefill_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let prefill_count = dec.u16_count(MAX_TXS_PER_BLOCK)?;
     let mut prefilled_txs = Vec::with_capacity(prefill_count);
     for _ in 0..prefill_count {
         let idx = dec.u16()?;
@@ -477,7 +519,7 @@ pub fn encode_encrypted_tx_bundle(bundle: &pyde_net::propagation::EncryptedTxBun
 }
 
 /// Decode an `EncryptedTxBundle`. Rejects oversized item counts via
-/// `u32_count(MAX_DECODE_ITEMS)`; per-entry byte length is indirectly
+/// `u32_count(MAX_TXS_PER_BLOCK)`; per-entry byte length is indirectly
 /// bounded by the channel's frame-size cap (4 MB for Blocks).
 pub fn decode_encrypted_tx_bundle(
     data: &[u8],
@@ -489,7 +531,7 @@ pub fn decode_encrypted_tx_bundle(
     }
     let slot = dec.u64()?;
     let block_hash = dec.bytes32()?;
-    let count = dec.u32_count(MAX_DECODE_ITEMS)?;
+    let count = dec.u32_count(MAX_TXS_PER_BLOCK)?;
     let mut encrypted_txs = Vec::with_capacity(count);
     for _ in 0..count {
         encrypted_txs.push(dec.var_bytes()?);
@@ -783,12 +825,12 @@ fn encode_access_entry(enc: &mut Encoder, entry: &AccessEntry) {
 
 fn decode_access_entry(dec: &mut Decoder) -> Result<AccessEntry, &'static str> {
     let address = dec.bytes32()?;
-    let read_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let read_count = dec.u16_count(MAX_ACCESS_KEYS_PER_ENTRY)?;
     let mut reads = Vec::with_capacity(read_count);
     for _ in 0..read_count {
         reads.push(dec.bytes32()?);
     }
-    let write_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let write_count = dec.u16_count(MAX_ACCESS_KEYS_PER_ENTRY)?;
     let mut writes = Vec::with_capacity(write_count);
     for _ in 0..write_count {
         writes.push(dec.bytes32()?);
@@ -850,7 +892,7 @@ pub fn decode_transaction(data: &[u8]) -> Result<Transaction, &'static str> {
         2 => FeePayer::Paymaster(dec.bytes32()?),
         _ => return Err("invalid fee_payer tag"),
     };
-    let access_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let access_count = dec.u16_count(MAX_ACCESS_LIST_ENTRIES)?;
     let mut access_list = Vec::with_capacity(access_count);
     for _ in 0..access_count {
         access_list.push(decode_access_entry(&mut dec)?);
@@ -924,7 +966,7 @@ pub fn decode_block(data: &[u8]) -> Result<Block, &'static str> {
     // Proposer signature
     let proposer_signature = dec.var_bytes()?;
     // Transactions
-    let tx_count = dec.u32_count(MAX_DECODE_ITEMS)?;
+    let tx_count = dec.u32_count(MAX_TXS_PER_BLOCK)?;
     let mut transactions = Vec::with_capacity(tx_count);
     for _ in 0..tx_count {
         let tx_bytes = dec.var_bytes()?;
@@ -932,7 +974,7 @@ pub fn decode_block(data: &[u8]) -> Result<Block, &'static str> {
     }
     // Encrypted transactions
     let enc_count = if dec.remaining() >= 4 {
-        dec.u32_count(MAX_DECODE_ITEMS)?
+        dec.u32_count(MAX_TXS_PER_BLOCK)?
     } else {
         0
     };
@@ -942,13 +984,13 @@ pub fn decode_block(data: &[u8]) -> Result<Block, &'static str> {
     }
     // Execution schedule
     let group_count = if dec.remaining() >= 2 {
-        dec.u16_count(MAX_DECODE_ITEMS)?
+        dec.u16_count(MAX_TXS_PER_BLOCK)?
     } else {
         0
     };
     let mut groups = Vec::with_capacity(group_count);
     for _ in 0..group_count {
-        let idx_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+        let idx_count = dec.u16_count(MAX_TXS_PER_BLOCK)?;
         let mut tx_indices = Vec::with_capacity(idx_count);
         for _ in 0..idx_count {
             tx_indices.push(dec.u32()? as usize);
@@ -1126,14 +1168,14 @@ pub fn decode_consensus_state(
     let target_height = dec.u64()?;
     let current_view = dec.u64()?;
 
-    let votes_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let votes_count = dec.u16_count(MAX_PENDING_CONSENSUS_PER_STATE)?;
     let mut pending_votes = Vec::with_capacity(votes_count);
     for _ in 0..votes_count {
         let msg_bytes = dec.var_bytes()?;
         pending_votes.push(decode_consensus_message(&msg_bytes)?);
     }
 
-    let timeouts_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let timeouts_count = dec.u16_count(MAX_PENDING_CONSENSUS_PER_STATE)?;
     let mut pending_timeouts = Vec::with_capacity(timeouts_count);
     for _ in 0..timeouts_count {
         let msg_bytes = dec.var_bytes()?;
@@ -1284,17 +1326,17 @@ pub fn decode_evidence_state(data: &[u8]) -> Result<EvidenceState, &'static str>
     if version != EVIDENCE_STATE_VERSION {
         return Err("unsupported evidence state version");
     }
-    let pending_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let pending_count = dec.u16_count(MAX_EVIDENCE_BACKLOG)?;
     let mut pending = Vec::with_capacity(pending_count);
     for _ in 0..pending_count {
         pending.push(decode_double_sign_evidence(&dec.var_bytes()?)?);
     }
-    let broadcast_count = dec.u16_count(MAX_DECODE_ITEMS)?;
+    let broadcast_count = dec.u16_count(MAX_EVIDENCE_BACKLOG)?;
     let mut broadcast = Vec::with_capacity(broadcast_count);
     for _ in 0..broadcast_count {
         broadcast.push(decode_double_sign_evidence(&dec.var_bytes()?)?);
     }
-    let seen_count = dec.u32_count(MAX_DECODE_ITEMS)?;
+    let seen_count = dec.u32_count(MAX_EVIDENCE_SEEN)?;
     let mut seen = Vec::with_capacity(seen_count);
     for _ in 0..seen_count {
         let slot = dec.u64()?;
@@ -1790,11 +1832,12 @@ mod tests {
     #[test]
     fn compact_block_rejects_huge_short_id_count() {
         // Construct a compact-block frame by hand with sid_count set to
-        // MAX_DECODE_ITEMS + 1, proving the cap is wired through.
+        // MAX_TXS_PER_BLOCK + 1, proving the per-message cap is wired
+        // through (TPL-923).
         let mut bytes = vec![tag::COMPACT_BLOCK];
         bytes.extend_from_slice(&0u32.to_le_bytes()); // var_bytes(header) len = 0
         bytes.extend_from_slice(&0u64.to_le_bytes()); // nonce
-        bytes.extend_from_slice(&((MAX_DECODE_ITEMS as u32) + 1).to_le_bytes());
+        bytes.extend_from_slice(&((MAX_TXS_PER_BLOCK as u32) + 1).to_le_bytes());
         let result = decode_compact_block(&bytes);
         assert_eq!(result.err(), Some("decoded count exceeds max"));
     }
@@ -1865,13 +1908,70 @@ mod tests {
     #[test]
     fn encrypted_bundle_rejects_huge_count() {
         // Hand-construct a frame whose declared count exceeds
-        // MAX_DECODE_ITEMS; decode must reject before allocating.
+        // MAX_TXS_PER_BLOCK; decode must reject before allocating
+        // (TPL-923 — per-message bound is the block tx ceiling, not
+        // the umbrella MAX_DECODE_ITEMS).
         let mut bytes = vec![tag::ENCRYPTED_TX_BUNDLE];
         bytes.extend_from_slice(&42u64.to_le_bytes()); // slot
         bytes.extend_from_slice(&[0u8; 32]); // block_hash
-        bytes.extend_from_slice(&((MAX_DECODE_ITEMS as u32) + 1).to_le_bytes());
+        bytes.extend_from_slice(&((MAX_TXS_PER_BLOCK as u32) + 1).to_le_bytes());
         assert_eq!(
             decode_encrypted_tx_bundle(&bytes).err(),
+            Some("decoded count exceeds max")
+        );
+    }
+
+    // ========== TPL-923: per-message tight bounds ==========
+
+    #[test]
+    fn tpl_923_evidence_state_rejects_over_backlog_pending() {
+        // Pending count one past MAX_EVIDENCE_BACKLOG must be rejected
+        // before the EvidenceState pending Vec is preallocated.
+        let mut bytes = vec![EVIDENCE_STATE_VERSION];
+        bytes.extend_from_slice(&((MAX_EVIDENCE_BACKLOG as u16) + 1).to_le_bytes());
+        assert_eq!(
+            decode_evidence_state(&bytes).err(),
+            Some("decoded count exceeds max")
+        );
+    }
+
+    #[test]
+    fn tpl_923_evidence_state_rejects_over_seen() {
+        // Seen-pair count one past MAX_EVIDENCE_SEEN must be rejected;
+        // pending and broadcast are zero so the decoder reaches seen.
+        let mut bytes = vec![EVIDENCE_STATE_VERSION];
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // pending = 0
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // broadcast = 0
+        bytes.extend_from_slice(&((MAX_EVIDENCE_SEEN as u32) + 1).to_le_bytes());
+        assert_eq!(
+            decode_evidence_state(&bytes).err(),
+            Some("decoded count exceeds max")
+        );
+    }
+
+    #[test]
+    fn tpl_923_consensus_state_rejects_over_max_pending_votes() {
+        // Pending-votes count one past MAX_PENDING_CONSENSUS_PER_STATE
+        // must be rejected before the consensus-state Vec is preallocated.
+        let mut bytes = vec![CONSENSUS_STATE_VERSION];
+        bytes.extend_from_slice(&0u64.to_le_bytes()); // current_slot
+        bytes.extend_from_slice(&0u64.to_le_bytes()); // current_epoch
+        // QC: slot, hash, bitmap, sig_count = 0 (no signatures)
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&[0u8; 32]);
+        bytes.extend_from_slice(&0u128.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        // last_voted_slot, last_committed_hash, last_committed_slot
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&[0u8; 32]);
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        // target_height, current_view
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        // votes_count: one past the cap
+        bytes.extend_from_slice(&((MAX_PENDING_CONSENSUS_PER_STATE as u16) + 1).to_le_bytes());
+        assert_eq!(
+            decode_consensus_state(&bytes).err(),
             Some("decoded count exceeds max")
         );
     }

--- a/crates/node/src/ws_sub.rs
+++ b/crates/node/src/ws_sub.rs
@@ -10,6 +10,53 @@ use tokio::sync::{broadcast, mpsc};
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, warn};
 
+/// TPL-932: per-subscription event rate-limit. Sustained refill rate
+/// of events the subscription is allowed to forward to the connection's
+/// outgoing channel. At a 400 ms slot time the chain produces ~2.5
+/// new heads / second, so 50/s gives 20× headroom for a `newHeads`
+/// subscription while still capping a runaway `logs` subscription
+/// that, on a busy contract slot, would otherwise be able to dump
+/// hundreds of events into the connection's bounded mpsc and starve
+/// other subscriptions on the same socket.
+const SUB_RATE_PER_SEC: f64 = 50.0;
+
+/// TPL-932: burst capacity per subscription. A subscription that has
+/// been idle accumulates up to this many tokens, so a brief burst of
+/// events (e.g., a backlog drain after a brief stall) clears without
+/// throttling.
+const SUB_BURST: f64 = 100.0;
+
+/// Lazy token-bucket: refilled on each `try_consume` call from
+/// `tokio::time::Instant` deltas, no background task. One per
+/// spawned subscription task, so each subscription's rate is
+/// isolated from siblings on the same WS connection.
+struct SubRateLimiter {
+    tokens: f64,
+    last_refill: tokio::time::Instant,
+}
+
+impl SubRateLimiter {
+    fn new() -> Self {
+        Self {
+            tokens: SUB_BURST,
+            last_refill: tokio::time::Instant::now(),
+        }
+    }
+
+    fn try_consume(&mut self) -> bool {
+        let now = tokio::time::Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * SUB_RATE_PER_SEC).min(SUB_BURST);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 pub async fn start_ws_server(
     listen: &str,
     port: u16,
@@ -111,9 +158,20 @@ async fn handle_connection(
                     );
 
                     tasks.push(tokio::spawn(async move {
+                        let mut rl = SubRateLimiter::new();
                         loop {
                             match rx.recv().await {
                                 Ok(header) => {
+                                    // TPL-932: per-subscription rate-limit.
+                                    // Drop events past the per-second cap so
+                                    // one runaway sub can't monopolize the
+                                    // connection's bounded outgoing channel.
+                                    // newHeads at ~2.5/s never trips the
+                                    // 50/s cap in practice.
+                                    if !rl.try_consume() {
+                                        debug!(sub_id, "newHeads sub rate-limit: dropped event (TPL-932)");
+                                        continue;
+                                    }
                                     let notif = serde_json::json!({
                                         "jsonrpc":"2.0",
                                         "method":"pyde_subscription",
@@ -166,6 +224,7 @@ async fn handle_connection(
                     debug!(sub_id, "logs subscription created");
 
                     tasks.push(tokio::spawn(async move {
+                        let mut rl = SubRateLimiter::new();
                         loop {
                             match rx.recv().await {
                                 Ok(log) => {
@@ -177,6 +236,15 @@ async fn handle_connection(
                                         if log_addr.as_deref() != Some(addr.as_str()) {
                                             continue;
                                         }
+                                    }
+                                    // TPL-932: per-subscription rate-limit.
+                                    // Caps how fast one logs sub can pump
+                                    // events into the connection's outgoing
+                                    // channel. Filter-pass is checked first
+                                    // so dropped logs don't burn tokens.
+                                    if !rl.try_consume() {
+                                        debug!(sub_id, "logs sub rate-limit: dropped event (TPL-932)");
+                                        continue;
                                     }
                                     let notif = serde_json::json!({
                                         "jsonrpc":"2.0",
@@ -213,4 +281,55 @@ async fn handle_connection(
         t.abort();
     }
     writer.abort();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn tpl_932_sub_rate_limiter_allows_burst_then_throttles() {
+        let mut rl = SubRateLimiter::new();
+        let mut allowed = 0;
+        for _ in 0..(SUB_BURST as usize + 50) {
+            if rl.try_consume() {
+                allowed += 1;
+            }
+        }
+        // The tight loop is fast enough that real-time refill during
+        // the loop contributes only sub-millisecond fractional tokens
+        // (≪ 1), so allowed ~= BURST. Allow ±1 of slop for the
+        // last_refill timestamp delta on slow CI machines.
+        assert!(
+            (SUB_BURST as usize..=SUB_BURST as usize + 1).contains(&allowed),
+            "expected ~{} allowed in tight loop, got {}",
+            SUB_BURST as usize,
+            allowed
+        );
+    }
+
+    #[test]
+    fn tpl_932_sub_rate_limiter_refills_over_time() {
+        let mut rl = SubRateLimiter::new();
+        // Drain the bucket.
+        for _ in 0..(SUB_BURST as usize) {
+            assert!(rl.try_consume());
+        }
+        assert!(!rl.try_consume(), "bucket should be empty");
+        // 100 ms at 50/s → ~5 tokens refilled.
+        std::thread::sleep(Duration::from_millis(100));
+        let mut after_refill = 0;
+        for _ in 0..10 {
+            if rl.try_consume() {
+                after_refill += 1;
+            }
+        }
+        assert!(
+            (4..=7).contains(&after_refill),
+            "100ms refill at {} req/s should yield ~5 tokens (got {})",
+            SUB_RATE_PER_SEC as u32,
+            after_refill
+        );
+    }
 }

--- a/crates/otic/src/safety.rs
+++ b/crates/otic/src/safety.rs
@@ -54,6 +54,22 @@ fn is_known_attribute(content: &str) -> bool {
     KNOWN_ATTRIBUTES.contains(&name)
 }
 
+/// TPL-941: macros that are allowed inside `#[view]` (pure) functions.
+/// Pre-fix the purity check used a *blocklist* (`cross_call`, `raw_call`)
+/// so any macro not in that list — `deploy!`, `create!`, future macros,
+/// or any user-defined macro the parser admits — slipped through and
+/// silently violated the view-purity contract that smart-contract
+/// callers, the optimizer, and the JMT-read-only execution path all
+/// rely on. Default-deny: only macros known to be side-effect-free and
+/// safe inside a read-only context belong here.
+///
+/// Allowed:
+///   * `require!` — branches on a condition; on failure reverts. No
+///     state mutation, no events, no external calls.
+///   * `assert!`  — same shape as `require!` without a custom error.
+///   * `revert!`  — terminates execution with an error; doesn't write.
+const VIEW_PURE_MACROS: &[&str] = &["require", "assert", "revert"];
+
 // ============================================================================
 // Safety Checker
 // ============================================================================
@@ -583,8 +599,17 @@ impl SafetyChecker {
 
     fn expr_is_impure(&self, expr: &Expr, call_targets: &mut Vec<String>) -> bool {
         match expr {
-            Expr::MacroCall(name, _, _) if name.name == "cross_call" => true,
-            Expr::MacroCall(name, _, _) if name.name == "raw_call" => true,
+            // TPL-941: any macro call not on the view-pure allowlist
+            // marks the enclosing function as impure for transitive
+            // purity propagation. Pre-fix this was a blocklist of
+            // `cross_call` + `raw_call`, so e.g. `deploy!` propagated
+            // as pure and a wrapper `fn x() { deploy!(...) }` was
+            // (silently) callable from a `#[view]` function.
+            Expr::MacroCall(name, _, _)
+                if !VIEW_PURE_MACROS.contains(&name.name.as_str()) =>
+            {
+                true
+            }
             _ if self.is_storage_mutating_call(expr) => true,
             Expr::If(_, then_block, else_clause, _) => {
                 let mut impure = self.scan_direct_impurity(then_block, call_targets);
@@ -697,20 +722,7 @@ impl SafetyChecker {
                 Stmt::For(f) => self.check_block_purity_direct(&f.body, func_name),
                 Stmt::While(w) => self.check_block_purity_direct(&w.body, func_name),
                 Stmt::Expr(e) => {
-                    if let Expr::MacroCall(name, _, _) = &e.expr {
-                        if name.name == "cross_call" {
-                            self.error(
-                                format!("#[view] function '{}' cannot make cross_call!", func_name),
-                                e.span,
-                            );
-                        }
-                        if name.name == "raw_call" {
-                            self.error(
-                                format!("#[view] function '{}' cannot make raw_call!", func_name),
-                                e.span,
-                            );
-                        }
-                    }
+                    self.check_view_macros_in_expr(&e.expr, func_name);
                     if self.is_storage_mutating_call(&e.expr) {
                         self.error(
                             format!(
@@ -722,8 +734,101 @@ impl SafetyChecker {
                     }
                     self.check_expr_purity_direct(&e.expr, func_name);
                 }
+                Stmt::Let(l) => {
+                    // TPL-941: a macro on the RHS of `let x = ...` is in
+                    // expression position, so it never reaches the
+                    // `Stmt::Expr` arm above. Pre-fix that meant
+                    // `let x = cross_call!(...)` slipped past the
+                    // direct-purity check. Walk the initializer through
+                    // the same allowlist-based check.
+                    self.check_view_macros_in_expr(&l.initializer, func_name);
+                }
+                Stmt::Return(r) => {
+                    if let Some(ref val) = r.value {
+                        // Same rationale as Stmt::Let above: the return
+                        // expression is in value position.
+                        self.check_view_macros_in_expr(val, func_name);
+                    }
+                }
                 _ => {}
             }
+        }
+    }
+
+    /// TPL-941: walk an expression tree and emit a purity error for
+    /// every macro call whose name is not on the `VIEW_PURE_MACROS`
+    /// allowlist. Recurses through binops, function-call args, struct
+    /// fields, etc. so a macro hidden inside an expression (e.g.
+    /// `let x = a + bad_macro!()`) is still caught.
+    fn check_view_macros_in_expr(&mut self, expr: &Expr, func_name: &str) {
+        match expr {
+            Expr::MacroCall(name, args, span) => {
+                if !VIEW_PURE_MACROS.contains(&name.name.as_str()) {
+                    self.error(
+                        format!(
+                            "#[view] function '{}' cannot use macro '{}!'; only require!, assert!, revert! are permitted in pure context (TPL-941)",
+                            func_name, name.name
+                        ),
+                        *span,
+                    );
+                }
+                for a in args {
+                    let inner = match a {
+                        MacroArg::Positional(e) => e,
+                        MacroArg::Named(_, e) => e,
+                    };
+                    self.check_view_macros_in_expr(inner, func_name);
+                }
+            }
+            Expr::Call(callee, args, _, _) => {
+                self.check_view_macros_in_expr(callee, func_name);
+                for a in args {
+                    self.check_view_macros_in_expr(a, func_name);
+                }
+            }
+            Expr::Binary(lhs, _, rhs, _) => {
+                self.check_view_macros_in_expr(lhs, func_name);
+                self.check_view_macros_in_expr(rhs, func_name);
+            }
+            Expr::Unary(_, operand, _) => {
+                self.check_view_macros_in_expr(operand, func_name)
+            }
+            Expr::FieldAccess(obj, _, _) => self.check_view_macros_in_expr(obj, func_name),
+            Expr::Index(obj, idx, _) => {
+                self.check_view_macros_in_expr(obj, func_name);
+                self.check_view_macros_in_expr(idx, func_name);
+            }
+            Expr::If(cond, _, _, _) => {
+                // The then/else blocks are walked separately by
+                // `check_expr_purity_direct` → `check_block_purity_direct`,
+                // which routes Stmt::Expr / Let / Return through here.
+                // Just check the condition position.
+                self.check_view_macros_in_expr(cond, func_name);
+            }
+            Expr::Match(scrut, arms, _) => {
+                self.check_view_macros_in_expr(scrut, func_name);
+                for arm in arms {
+                    self.check_view_macros_in_expr(&arm.body, func_name);
+                }
+            }
+            Expr::Cast(inner, _, _) | Expr::Try(inner, _) => {
+                self.check_view_macros_in_expr(inner, func_name)
+            }
+            Expr::Tuple(elems, _) | Expr::ArrayLiteral(elems, _) => {
+                for e in elems {
+                    self.check_view_macros_in_expr(e, func_name);
+                }
+            }
+            Expr::ArrayRepeat(val, _, _) => self.check_view_macros_in_expr(val, func_name),
+            Expr::StructInit(_, fields, _) => {
+                for f in fields {
+                    self.check_view_macros_in_expr(&f.value, func_name);
+                }
+            }
+            // Block expressions are walked by check_block_purity_direct
+            // via check_expr_purity_direct; no need to descend here.
+            // Leaves: Literal, SelfExpr, Ident, Path, Block — nothing to do.
+            _ => {}
         }
     }
 
@@ -1215,7 +1320,16 @@ mod tests {
             }
         "#,
         );
-        assert!(errors[0].message.contains("cannot make cross_call!"));
+        // TPL-941: switched from blocklist (`cannot make cross_call!`)
+        // to allowlist phrasing — still rejects, just with a more
+        // generic message that covers every disallowed macro.
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("cannot use macro 'cross_call!'")),
+            "expected default-deny rejection of cross_call! in #[view], got: {:?}",
+            errors
+        );
     }
 
     #[test]
@@ -1475,7 +1589,14 @@ mod tests {
             }
         "#,
         );
-        assert!(errors[0].message.contains("cannot make raw_call!"));
+        // TPL-941: see comment on `error_view_cross_call`.
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("cannot use macro 'raw_call!'")),
+            "expected default-deny rejection of raw_call! in #[view], got: {:?}",
+            errors
+        );
     }
 
     #[test]
@@ -1493,6 +1614,84 @@ mod tests {
                 }
             }
         "#,
+        );
+    }
+
+    /// TPL-941: `deploy!` is not on the view-pure allowlist — it's
+    /// state-mutating (creates a new contract). Pre-fix, the
+    /// `cross_call`/`raw_call`-only blocklist let it through.
+    #[test]
+    fn tpl_941_view_rejects_deploy_macro() {
+        let errors = check_err(
+            r#"
+            contract Inner {
+                pub fn x() -> u64 { return 1; }
+            }
+            contract T {
+                #[view]
+                pub fn bad() -> u64 {
+                    deploy!(Inner);
+                    return 0;
+                }
+            }
+        "#,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("cannot use macro 'deploy!'")),
+            "expected default-deny rejection of deploy! in #[view], got: {:?}",
+            errors
+        );
+    }
+
+    /// TPL-941: pure macros (`require!`, `assert!`, `revert!`) stay
+    /// allowed. This guards the allowlist boundary against an
+    /// over-broad fix that would lock out legitimate view code.
+    #[test]
+    fn tpl_941_view_allows_require_assert_revert() {
+        check_ok(
+            r#"
+            error MustBePositive { x: u64 }
+            contract T {
+                storage { count: u64, }
+                #[view]
+                pub fn check_pos(x: u64) -> u64 {
+                    require!(x > 0, MustBePositive { x: x });
+                    assert!(x < 1000);
+                    if x == 42 {
+                        revert!("not 42");
+                    }
+                    return x;
+                }
+            }
+        "#,
+        );
+    }
+
+    /// TPL-941: a macro on the RHS of `let` is in expression
+    /// position, so the pre-fix `Stmt::Expr`-only direct-purity
+    /// check missed it. Walking `Stmt::Let.initializer` through
+    /// the same allowlist closes the gap.
+    #[test]
+    fn tpl_941_view_rejects_macro_in_let_initializer() {
+        let errors = check_err(
+            r#"
+            contract T {
+                #[view]
+                pub fn bad() -> u64 {
+                    let x = raw_call!(msg.sender, 0);
+                    return 0;
+                }
+            }
+        "#,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("cannot use macro 'raw_call!'")),
+            "expected raw_call! in let initializer to be rejected, got: {:?}",
+            errors
         );
     }
 


### PR DESCRIPTION
## Summary

Wave 9 subset on the path to public testnet — bounds adversary leverage at every public surface that takes untrusted input.

- **TPL-921** mempool: round-robin per-sender fairness in `select_for_block`
- **TPL-923** node/wire: tighten per-message decode caps below the 1M umbrella
- **TPL-924** node: tighten `MAX_TIMESTAMP_DRIFT_MS` from 15 s to 5 s
- **TPL-927** node/rpc: atomic nonce-fetch + mempool-insert on the plaintext path
- **TPL-931** node/rpc: per-connection request rate-limit middleware
- **TPL-932** node/ws: per-subscription event rate-limit
- **TPL-935** node/peer_book: persist peer_book.json at mode 0o600
- **TPL-941** otic/safety: default-deny macros inside `#[view]` functions

Each commit is self-contained with rationale; the per-task scope was kept tight (one concern per commit) so each is independently revertible.