### PR TITLE
fix(node): decouple bind/QUIC config from dev_mode (TPL-208)

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -77,6 +77,24 @@ pub struct NetworkSection {
     /// through `handle_swarm_event` to `apply_auth_response`.
     #[serde(default)]
     pub bootstrap_pubkey_pins: std::collections::HashMap<String, String>,
+    /// TPL-208: bind libp2p TCP on `127.0.0.1` instead of
+    /// `0.0.0.0`. Production default is `false` (bind all
+    /// interfaces); set to `true` for multi-validator localhost
+    /// testnets to keep peers on the loopback path. Pre-TPL-208
+    /// this was implicit in `node.dev_mode`, conflating the
+    /// loopback-bind ergonomic with the unsigned-RPC unlock —
+    /// they're now independent so a non-devnet chain_id can run
+    /// the bind ergonomic without tripping TPL-207.
+    #[serde(default)]
+    pub bind_loopback: bool,
+    /// TPL-208: skip QUIC listener startup, leaving libp2p
+    /// TCP-only. Used by multi-validator localhost tests where
+    /// the dual-transport (TCP + QUIC) race produces flapping
+    /// connections via libp2p's per-transport dedupe — see the
+    /// comment in `node.rs` near the listen-on calls. Default
+    /// `false` (QUIC enabled) for production.
+    #[serde(default)]
+    pub disable_quic: bool,
 }
 
 impl Default for NetworkSection {
@@ -89,6 +107,8 @@ impl Default for NetworkSection {
             rate_limit_per_ip: 5,
             bootstrap_peers: Vec::new(),
             bootstrap_pubkey_pins: std::collections::HashMap::new(),
+            bind_loopback: false,
+            disable_quic: false,
         }
     }
 }

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -969,6 +969,25 @@ pub fn generate_testnet(
         ));
     }
 
+    // TPL-208 + TPL-207: `dev_mode = true` is only legal on devnet
+    // (`chain_id == 31337`). The runtime gate in `main.rs` refuses
+    // to start with it set on any other chain_id, so emit
+    // `dev_mode = false` for non-devnet configs even when --dev was
+    // passed at genesis time. The other --dev effects (auto-funded
+    // faucet at genesis, localhost binds at runtime) are independent
+    // of `node.dev_mode` and stay active under their own controls.
+    let effective_dev_mode = dev_mode && chain_id == pyde_net::discovery::DEVNET_CHAIN_ID;
+
+    // TPL-208: when --dev is set and we're generating a localhost
+    // setup (no `--node-addrs` host file), enable the loopback bind
+    // + TCP-only ergonomics that prevent libp2p's per-transport
+    // dedupe from flapping connections in a fully meshed local
+    // devnet/testnet. For distributed setups the production binds
+    // (0.0.0.0 + QUIC) remain correct because real peers come from
+    // different hosts and multi-address advertising is what makes
+    // connectivity work through NAT/firewall paths.
+    let local_test_ergonomics = dev_mode && node_addrs.is_none();
+
     let total_nodes = num_validators + num_full_nodes;
     if let Some(addrs) = node_addrs {
         if addrs.len() != total_nodes {
@@ -1227,6 +1246,8 @@ max_inbound = 30
 max_outbound = 20
 rate_limit_per_ip = 5
 bootstrap_peers = {bootstrap}
+bind_loopback = {bind_loopback}
+disable_quic = {disable_quic}
 
 [consensus]
 block_time_ms = {block_time_ms}
@@ -1257,12 +1278,14 @@ json = false
 "#,
             region_comment = region_comment,
             datadir = node_dir.display(),
-            dev = dev_mode,
+            dev = effective_dev_mode,
             p2p_port = p2p_port,
             rpc_port = rpc_port,
             metrics_port = metrics_port,
             fast_tx_port = fast_tx_port,
             bootstrap = bootstrap,
+            bind_loopback = local_test_ergonomics,
+            disable_quic = local_test_ergonomics,
             block_time_ms = block_time_ms,
         );
 
@@ -1352,6 +1375,8 @@ max_inbound = 30
 max_outbound = 20
 rate_limit_per_ip = 5
 bootstrap_peers = {bootstrap}
+bind_loopback = {bind_loopback}
+disable_quic = {disable_quic}
 
 [consensus]
 block_time_ms = {block_time_ms}
@@ -1382,12 +1407,14 @@ json = false
 "#,
             region_comment = region_comment,
             datadir = node_dir.display(),
-            dev = dev_mode,
+            dev = effective_dev_mode,
             p2p_port = p2p_port,
             rpc_port = rpc_port,
             metrics_port = metrics_port,
             fast_tx_port = fast_tx_port,
             bootstrap = bootstrap,
+            bind_loopback = local_test_ergonomics,
+            disable_quic = local_test_ergonomics,
             block_time_ms = block_time_ms,
         );
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -706,8 +706,10 @@ impl PydeNode {
         // resolution; QUIC is available so peers that prefer it can
         // negotiate it from a `/udp/PORT/quic-v1` address.
         //
-        // In dev mode, bind only to loopback and skip QUIC entirely.
-        // Two reasons:
+        // Multi-validator localhost testnets bind 127.0.0.1 + skip
+        // QUIC via `network.bind_loopback` / `network.disable_quic`.
+        // Two reasons (TPL-208 made these explicit, previously gated
+        // implicitly on `dev_mode`):
         //  - 0.0.0.0 binds advertise every reachable interface
         //    (loopback + LAN + others) via Identify. With every node
         //    running on the same host, peers learn 2-3 addresses for
@@ -718,13 +720,13 @@ impl PydeNode {
         //    churn and drop ~33% of consensus messages.
         //  - QUIC + TCP simultaneously is the same problem one
         //    layer down: same peer reachable via two transports,
-        //    libp2p tries both. Single-transport dev mode dodges
-        //    that race.
+        //    libp2p tries both. Single-transport binds dodge that
+        //    race.
         // Production binds remain on 0.0.0.0 with both transports
         // because real peers come from different hosts and the
         // multi-address advertising is what makes connectivity work
         // through NAT/firewall paths.
-        let bind_ip = if self.config.node.dev_mode {
+        let bind_ip = if self.config.network.bind_loopback {
             "127.0.0.1"
         } else {
             "0.0.0.0"
@@ -737,7 +739,7 @@ impl PydeNode {
             .listen_on(tcp_listen_addr)
             .map_err(|e| format!("failed to listen on tcp: {}", e))?;
 
-        if !self.config.node.dev_mode {
+        if !self.config.network.disable_quic {
             let quic_listen_addr: libp2p::Multiaddr =
                 format!("/ip4/0.0.0.0/udp/{}/quic-v1", self.config.network.port)
                     .parse()

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -1181,7 +1181,7 @@ fn run_testnet_cli(
     Ok(())
 }
 
-fn start_node(node: &mut TestNode, pyde: &Path, dev: bool) -> Result<(), String> {
+fn start_node(node: &mut TestNode, pyde: &Path, _dev: bool) -> Result<(), String> {
     let config_path = node.datadir.join("config.toml");
     let mut cmd = Command::new(pyde);
     cmd.arg("run")
@@ -1193,9 +1193,12 @@ fn start_node(node: &mut TestNode, pyde: &Path, dev: bool) -> Result<(), String>
         .arg(&node.datadir)
         .arg("--log-level")
         .arg("info");
-    if dev {
-        cmd.arg("--dev");
-    }
+    // TPL-208: don't pass `--dev` to `pyde run`. The node-side
+    // TPL-207 gate refuses startup with `dev_mode = true` on
+    // chain_id != 31337, and the localhost ergonomics that used
+    // to ride on `--dev` (loopback bind, TCP-only) now flow
+    // through `network.bind_loopback` / `network.disable_quic`
+    // which `pyde testnet --dev` writes into config.toml.
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd
         .spawn()


### PR DESCRIPTION
## Summary

`dev_mode` conflated three independent concerns:
1. unsigned-RPC unlock (`pyde_sendTransaction`)
2. localhost-bind ergonomic (127.0.0.1 over 0.0.0.0)
3. TCP-only transport (skip QUIC listener)

TPL-207 refused startup with `dev_mode = true` on `chain_id != 31337` to guard against unsigned-RPC misuse on testnet/mainnet. That gate also shut down the bind/QUIC ergonomics for any test or operator running a non-devnet localhost setup — `loadgen_soak` (chain_id=7331) panicked at startup because the harness passes `--dev`.

## Changes

- `network.bind_loopback` + `network.disable_quic` added to NetworkSection
- Runtime bind / QUIC checks in `node.rs` read the new fields instead of `node.dev_mode`
- `pyde testnet --dev` writes the new fields under `[network]` and emits `dev_mode = true` only when `chain_id == 31337` (so non-devnet configs are TPL-207-clean)
- Test harness drops `--dev` from `pyde run` (the config TOML carries the bind/QUIC choices independently)

## Validation

- `cargo build --workspace` clean
- `cargo test -p pyde-node --lib wire::` 39/39 pass
- 4-validator devnet soak (chain_id=31337, encrypted_pct=0): healthy chain progression, head 211→361, 0 submit errors, all 8 workload buckets exercised
- Behavior unchanged on devnet (effective_dev_mode still true; bind/QUIC ergonomics still on)
- Behavior change on testnet/mainnet localhost: bind/QUIC ergonomics now available without unsigned-RPC unlock