### PR TITLE
fix(node): propagate execution_schedule via compact block (audit 408)

### DIFF
--- a/crates/net/src/propagation.rs
+++ b/crates/net/src/propagation.rs
@@ -18,19 +18,37 @@ pub const ERASURE_THRESHOLD: usize = 256 * 1024; // 256KB
 /// An 8-byte short transaction ID.
 pub type ShortId = [u8; SHORT_ID_LEN];
 
-/// Compact block: header + short IDs + prefilled txs.
-/// Reduces per-tx overhead from 32 bytes to 6 bytes.
+/// Compact block: header + short IDs + prefilled txs + execution schedule.
+/// Reduces per-tx overhead from 32 bytes to 8 bytes for short IDs +
+/// 2 bytes for group ID = 10 bytes total.
 #[derive(Clone, Debug)]
 pub struct CompactBlock {
     /// Block header bytes.
     pub header: Vec<u8>,
-    /// Short IDs: first 6 bytes of Poseidon2(tx_hash || nonce).
+    /// Short IDs: first 8 bytes of Poseidon2(tx_hash || nonce).
     pub short_tx_ids: Vec<ShortId>,
     /// Pre-filled transactions the sender expects the peer not to have.
     /// (index, raw tx bytes).
     pub prefilled_txs: Vec<(u16, Vec<u8>)>,
     /// Nonce used for short ID computation (randomized per announcement).
     pub nonce: u64,
+    /// Audit 408: per-tx execution-group ID. `group_ids[i]` is the
+    /// group containing the tx at position `i` in `short_tx_ids`. Two
+    /// txs share a group iff they share a group_id. Receivers
+    /// reconstruct the full `ExecutionSchedule` from this vector
+    /// rather than recomputing it locally — pre-fix the receiver
+    /// hardcoded a single sequential group at `node.rs:1833`,
+    /// throwing away the proposer's parallel plan and forcing every
+    /// non-proposer to take the sequential `block_processor` path
+    /// even when the proposer ran rayon-parallel. The schedule was
+    /// already in the full `encode_block` format (see
+    /// `crates/node/src/wire.rs:885`); this just propagates it
+    /// through the steady-state compact-block channel too. `u16`
+    /// supports up to 65535 distinct groups per block — well above
+    /// any realistic scheduler output (typical mainnet block has
+    /// tens to low hundreds of groups, capped by the active
+    /// sender / contract count).
+    pub group_ids: Vec<u16>,
 }
 
 /// Compute a short ID from a tx hash and nonce.
@@ -50,11 +68,15 @@ pub const PREFILL_FRESHNESS_MS: u64 = 200;
 impl CompactBlock {
     /// Build a compact block from a full block.
     /// Prefills transactions received within PREFILL_FRESHNESS_MS.
+    /// `group_ids[i]` is the execution-group label for the tx at
+    /// position `i`; pass an empty slice for legacy callers and the
+    /// receiver will fall back to a single sequential group.
     pub fn from_block(
         header_bytes: Vec<u8>,
         tx_hashes: &[[u8; 32]],
         prefill_indices: &[usize],
         prefill_tx_bytes: &[Vec<u8>],
+        group_ids: &[u16],
     ) -> Self {
         let nonce = rand_nonce();
         let short_tx_ids: Vec<ShortId> = tx_hashes
@@ -73,6 +95,7 @@ impl CompactBlock {
             short_tx_ids,
             prefilled_txs,
             nonce,
+            group_ids: group_ids.to_vec(),
         }
     }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2005,11 +2005,41 @@ impl PydeNode {
                             }
 
                             let tx_count = transactions.len();
-                            let exec_schedule = pyde_tx::parallel::ExecutionSchedule {
-                                groups: vec![pyde_tx::parallel::ExecutionGroup {
-                                    tx_indices: (0..tx_count).collect(),
-                                }],
-                                total_txs: tx_count,
+                            // Audit 408: prefer the proposer's
+                            // execution-group labels carried in
+                            // `cb.group_ids` so non-proposers run the
+                            // same parallel partition the proposer
+                            // built. Pre-fix this site hardcoded a
+                            // single sequential group, throwing away
+                            // the schedule and forcing every receiver
+                            // onto the slow `groups.len() <= 1` path
+                            // even when the proposer used rayon.
+                            // Length must match `transactions.len()`
+                            // because `group_ids` covers only the
+                            // plaintext prefix of the compact block;
+                            // any divergence (or empty group_ids from
+                            // a legacy sender) falls back to a single
+                            // sequential group.
+                            let exec_schedule = if !cb.group_ids.is_empty()
+                                && cb.group_ids.len() == tx_count
+                            {
+                                wire::group_ids_to_schedule(&cb.group_ids)
+                            } else {
+                                if !cb.group_ids.is_empty() {
+                                    warn!(
+                                        slot,
+                                        group_ids_len = cb.group_ids.len(),
+                                        tx_count,
+                                        "compact-block group_ids length mismatch \
+                                         — falling back to single-group sequential"
+                                    );
+                                }
+                                pyde_tx::parallel::ExecutionSchedule {
+                                    groups: vec![pyde_tx::parallel::ExecutionGroup {
+                                        tx_indices: (0..tx_count).collect(),
+                                    }],
+                                    total_txs: tx_count,
+                                }
                             };
                             let block = pyde_consensus::block::Block {
                                 header: header.clone(),
@@ -2745,11 +2775,21 @@ impl PydeNode {
                                             all_tx_hashes.push(etx.hash());
                                         }
                                     }
+                                    // Audit 408: include the proposer's
+                                    // execution-group labels for the plaintext
+                                    // tx prefix. Without this, every receiver
+                                    // hardcoded a single sequential group on
+                                    // line ~2008, throwing away the proposer's
+                                    // parallel scheduling work.
+                                    let group_ids = wire::schedule_to_group_ids(
+                                        &block.body.execution_schedule,
+                                    );
                                     let compact = pyde_net::propagation::CompactBlock::from_block(
                                         header_bytes,
                                         &all_tx_hashes,
                                         &[],
                                         &[],
+                                        &group_ids,
                                     );
                                     let compact_bytes = wire::encode_compact_block(&compact);
                                     let topic = pyde_net::node::topics::blocks();
@@ -3525,6 +3565,7 @@ impl PydeNode {
                                             &[], // no tx hashes (empty fallback)
                                             &[],
                                             &[],
+                                            &[], // empty group_ids — fallback path has no txs
                                         );
                                         let compact_bytes = wire::encode_compact_block(&compact);
                                         let blocks_topic = pyde_net::node::topics::blocks();

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -422,6 +422,55 @@ pub fn decode_reshare_state(data: &[u8]) -> Result<ReshareState, &'static str> {
 // Compact Block
 // ============================================================
 
+/// Audit 408: flatten an ExecutionSchedule into a per-tx group-id
+/// vector for compact-block transmission. `out[i]` is the group label
+/// of the tx at position `i` in `block.body.transactions`. Indices
+/// outside `total_txs` are silently dropped (defensive — should not
+/// occur with a well-formed schedule). Returns an empty vec when the
+/// schedule has more groups than `u16::MAX` can label, in which case
+/// the receiver falls back to single-group sequential apply.
+pub fn schedule_to_group_ids(
+    schedule: &pyde_tx::parallel::ExecutionSchedule,
+) -> Vec<u16> {
+    if schedule.groups.len() > u16::MAX as usize {
+        return Vec::new();
+    }
+    let mut out = vec![0u16; schedule.total_txs];
+    for (gidx, group) in schedule.groups.iter().enumerate() {
+        let label = gidx as u16;
+        for &tx_idx in &group.tx_indices {
+            if tx_idx < out.len() {
+                out[tx_idx] = label;
+            }
+        }
+    }
+    out
+}
+
+/// Inverse of `schedule_to_group_ids`: rebuild an ExecutionSchedule
+/// from the per-tx group labels. Group ordering in the rebuilt
+/// schedule is by ascending label value (BTreeMap iteration), which
+/// is deterministic but does not have to match the original group
+/// ordering — execution semantics depend only on the partition, not
+/// on group order.
+pub fn group_ids_to_schedule(
+    group_ids: &[u16],
+) -> pyde_tx::parallel::ExecutionSchedule {
+    use std::collections::BTreeMap;
+    let mut by_group: BTreeMap<u16, Vec<usize>> = BTreeMap::new();
+    for (tx_idx, &gid) in group_ids.iter().enumerate() {
+        by_group.entry(gid).or_default().push(tx_idx);
+    }
+    let groups: Vec<pyde_tx::parallel::ExecutionGroup> = by_group
+        .into_values()
+        .map(|tx_indices| pyde_tx::parallel::ExecutionGroup { tx_indices })
+        .collect();
+    pyde_tx::parallel::ExecutionSchedule {
+        groups,
+        total_txs: group_ids.len(),
+    }
+}
+
 pub fn encode_compact_block(cb: &pyde_net::propagation::CompactBlock) -> Vec<u8> {
     let mut enc = Encoder::new();
     enc.u8(tag::COMPACT_BLOCK);
@@ -437,6 +486,12 @@ pub fn encode_compact_block(cb: &pyde_net::propagation::CompactBlock) -> Vec<u8>
     for (idx, bytes) in &cb.prefilled_txs {
         enc.u16(*idx);
         enc.var_bytes(bytes);
+    }
+    // Audit 408: per-tx execution-group labels. Empty = legacy
+    // sender; receiver falls back to single sequential group.
+    enc.u32(cb.group_ids.len() as u32);
+    for &gid in &cb.group_ids {
+        enc.u16(gid);
     }
     enc.finish()
 }
@@ -466,11 +521,22 @@ pub fn decode_compact_block(
         let bytes = dec.var_bytes()?;
         prefilled_txs.push((idx, bytes));
     }
+    // Audit 408: empty group_ids = legacy compact block; receiver
+    // falls back to single sequential group at apply time.
+    let gid_count = dec.u32_count(MAX_TXS_PER_BLOCK)?;
+    if gid_count != 0 && gid_count != sid_count {
+        return Err("group_ids length mismatch");
+    }
+    let mut group_ids = Vec::with_capacity(gid_count);
+    for _ in 0..gid_count {
+        group_ids.push(dec.u16()?);
+    }
     Ok(pyde_net::propagation::CompactBlock {
         header,
         short_tx_ids,
         prefilled_txs,
         nonce,
+        group_ids,
     })
 }
 
@@ -1840,6 +1906,101 @@ mod tests {
         bytes.extend_from_slice(&((MAX_TXS_PER_BLOCK as u32) + 1).to_le_bytes());
         let result = decode_compact_block(&bytes);
         assert_eq!(result.err(), Some("decoded count exceeds max"));
+    }
+
+    #[test]
+    fn compact_block_group_ids_roundtrip() {
+        // Audit 408: build a CompactBlock with non-trivial group_ids,
+        // round-trip through encode+decode, confirm labels survive.
+        let cb = pyde_net::propagation::CompactBlock {
+            header: vec![1, 2, 3, 4],
+            short_tx_ids: vec![[0xaa; 8], [0xbb; 8], [0xcc; 8], [0xdd; 8]],
+            prefilled_txs: vec![(1, vec![9, 9, 9])],
+            nonce: 0xdead_beef_cafe_babe,
+            group_ids: vec![0, 1, 0, 2],
+        };
+        let bytes = encode_compact_block(&cb);
+        let restored = decode_compact_block(&bytes).expect("decode");
+        assert_eq!(restored.header, cb.header);
+        assert_eq!(restored.short_tx_ids, cb.short_tx_ids);
+        assert_eq!(restored.prefilled_txs, cb.prefilled_txs);
+        assert_eq!(restored.nonce, cb.nonce);
+        assert_eq!(restored.group_ids, cb.group_ids);
+    }
+
+    #[test]
+    fn compact_block_empty_group_ids_roundtrip() {
+        // Legacy compatibility: empty group_ids must survive the round
+        // trip so receivers can take the single-group fallback path.
+        let cb = pyde_net::propagation::CompactBlock {
+            header: vec![],
+            short_tx_ids: vec![[0u8; 8]; 3],
+            prefilled_txs: vec![],
+            nonce: 0,
+            group_ids: vec![],
+        };
+        let bytes = encode_compact_block(&cb);
+        let restored = decode_compact_block(&bytes).expect("decode");
+        assert!(restored.group_ids.is_empty());
+        assert_eq!(restored.short_tx_ids.len(), 3);
+    }
+
+    #[test]
+    fn compact_block_rejects_group_ids_length_mismatch() {
+        // group_ids length must be either 0 (legacy) or equal to
+        // short_tx_ids length. Any other length is a wire-format
+        // violation and the decoder must reject before any execution
+        // schedule is reconstructed.
+        let mut bytes = vec![tag::COMPACT_BLOCK];
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // header bytes len
+        bytes.extend_from_slice(&0u64.to_le_bytes()); // nonce
+        bytes.extend_from_slice(&3u32.to_le_bytes()); // 3 short ids
+        bytes.extend_from_slice(&[0u8; 8 * 3]);       // short ids
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // 0 prefilled
+        bytes.extend_from_slice(&2u32.to_le_bytes()); // 2 group_ids (mismatch)
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        let result = decode_compact_block(&bytes);
+        assert_eq!(result.err(), Some("group_ids length mismatch"));
+    }
+
+    #[test]
+    fn schedule_to_group_ids_partition_invariant() {
+        // The labeling encoding must round-trip through
+        // group_ids_to_schedule and produce a partition equivalent to
+        // the original — same equivalence classes on tx indices, even
+        // if group ordering or label values differ.
+        let schedule = pyde_tx::parallel::ExecutionSchedule {
+            groups: vec![
+                pyde_tx::parallel::ExecutionGroup { tx_indices: vec![0, 2, 5] },
+                pyde_tx::parallel::ExecutionGroup { tx_indices: vec![1, 4] },
+                pyde_tx::parallel::ExecutionGroup { tx_indices: vec![3] },
+            ],
+            total_txs: 6,
+        };
+        let gids = schedule_to_group_ids(&schedule);
+        assert_eq!(gids.len(), 6);
+        // 0 and 2 share a group; 1 and 4 share; 3 is alone.
+        assert_eq!(gids[0], gids[2]);
+        assert_eq!(gids[2], gids[5]);
+        assert_eq!(gids[1], gids[4]);
+        assert_ne!(gids[0], gids[1]);
+        assert_ne!(gids[0], gids[3]);
+        assert_ne!(gids[1], gids[3]);
+
+        let restored = group_ids_to_schedule(&gids);
+        assert_eq!(restored.total_txs, 6);
+        assert_eq!(restored.groups.len(), 3);
+        // Each restored group is a partition cell; sum of sizes = total.
+        let total: usize = restored.groups.iter().map(|g| g.tx_indices.len()).sum();
+        assert_eq!(total, 6);
+        // Each tx index appears exactly once across all groups.
+        let mut seen = std::collections::HashSet::new();
+        for g in &restored.groups {
+            for &i in &g.tx_indices {
+                assert!(seen.insert(i), "tx index {} appeared in two groups", i);
+            }
+        }
     }
 
     #[test]

--- a/crates/node/tests/multi_node_parallel_exec.rs
+++ b/crates/node/tests/multi_node_parallel_exec.rs
@@ -1,0 +1,293 @@
+//! Audit-408 regression: every node — proposer or not — runs
+//! multi-group blocks through the parallel-exec branch in
+//! `block_processor` AND every node converges on the same state
+//! root after each multi-group block. Pre-fix the receiver
+//! hardcoded a single sequential group when reconstructing a
+//! compact block (see `crates/node/src/node.rs:2008`), throwing
+//! away the proposer's parallel schedule and forcing every
+//! non-proposer onto the slow `groups.len() <= 1` path.
+//!
+//! The fix wires `cb.group_ids` (a per-tx group-label vector) into
+//! the compact-block wire format so receivers reconstruct the same
+//! `ExecutionSchedule` the proposer built. This test is the
+//! end-to-end witness:
+//!
+//!   1. Submit 3 bursts of 4 independently-scheduled txs, each from
+//!      a distinct signer with a non-overlapping access list.
+//!   2. After every burst, fetch `pyde_stateRoot` from all 4 nodes
+//!      and assert they're identical — a divergent root would mean
+//!      receivers applied a different partition than the proposer.
+//!   3. Assert all 4 nodes logged the parallel-exec line at least
+//!      once after the run completes.
+//!
+//! Why distinct AL keys per signer:
+//!   The scheduler in `crates/tx/src/parallel.rs` short-circuits to
+//!   a single sequential group when no tx in a block declares
+//!   informative `(address, key)` pairs (TPL-001). Loadgen workloads
+//!   use the uninformative `[{addr, [], []}]` shape and therefore
+//!   never exercise the parallel branch — see the comment in
+//!   `parallel.rs::access_list_is_uninformative`. We sidestep that
+//!   here by populating `writes` with a distinct key per signer,
+//!   yielding a 4-group schedule when the proposer batches all
+//!   4 txs into one block.
+
+mod common;
+
+use common::TestNetwork;
+use pyde_account::address::derive_eoa_address;
+use pyde_crypto::falcon::{falcon_sign, FalconSecretKey};
+use pyde_tx::types::{AccessEntry, FeePayer, Transaction, TransactionType};
+use std::time::Duration;
+
+const NUM_BURSTS: u64 = 3;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn parallel_exec_fires_on_non_proposers() {
+    // 4-node devnet (chain_id=31337). The audit-408 fix is independent
+    // of chain_id / sig-verification — the wire format and receiver
+    // schedule reconstruction are the same on devnet, testnet, and
+    // mainnet. We use devnet here for the same reasons every other
+    // multi-node test does: localhost binds, faster setup, no
+    // additional bootstrap-pubkey-pin gymnastics.
+    let net = TestNetwork::spawn(4, true)
+        .unwrap_or_else(|e| panic!("spawn 4v devnet: {}", e));
+
+    // 60s warm-up — 4-validator boot + FALCON keygen + libp2p mesh
+    // formation + first-slot block production occasionally exceeds
+    // 30s on a loaded machine.
+    net.wait_for_slot(3, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("warm-up: {}", e));
+
+    // Sanity: pre-test state_root must be identical on every node.
+    // If they diverge here we have a problem unrelated to audit-408
+    // and the rest of the test would be measuring noise.
+    let pre_roots: Vec<String> = (0..4)
+        .map(|i| {
+            net.state_root(i)
+                .unwrap_or_else(|e| panic!("pre-test state_root node-{}: {}", i, e))
+        })
+        .collect();
+    assert!(
+        pre_roots.windows(2).all(|w| w[0] == w[1]),
+        "pre-test state-root divergence (test setup is broken):\n{:?}",
+        pre_roots
+    );
+
+    // Load each validator's FALCON keypair. Validators are also EOAs
+    // funded at genesis with stake-bonded balances + a registered
+    // `AuthKeys::Single` pubkey, which is everything we need to
+    // build + sign a transfer from each one.
+    let mut signers: Vec<(FalconSecretKey, [u8; 32])> = Vec::with_capacity(4);
+    for i in 0..4 {
+        let (pk, sk_bytes) = net
+            .load_validator_key(i)
+            .unwrap_or_else(|e| panic!("load validator-{} key: {}", i, e));
+        let sk = FalconSecretKey::from_bytes(&sk_bytes)
+            .expect("invalid FALCON secret key in validator.key");
+        let addr = derive_eoa_address(&pk);
+        signers.push((sk, addr));
+    }
+
+    // One distinct recipient per signer. Same recipient across bursts
+    // so post-test convergence is `value * NUM_BURSTS` per recipient.
+    // Sharing a single recipient address across multiple txs in the
+    // same block would require the access list to declare that
+    // recipient's balance key as a shared write — otherwise the
+    // scheduler partitions the txs into independent groups and the
+    // parallel branches all race on `recipient.balance` (read-old,
+    // write-new, last-write-wins → silent value loss). That race is
+    // well-defined behavior for misdeclared ALs and not what we're
+    // here to test; per-signer recipients sidestep it.
+    let recipients: Vec<[u8; 32]> = (0..signers.len() as u8)
+        .map(|i| {
+            let mut a = [0u8; 32];
+            a[0] = 0x42;
+            a[31] = i + 1;
+            a
+        })
+        .collect();
+    let chain_id = 31337u64;
+    let value: u128 = 1_000_000;
+
+    // For each burst, construct 4 independent transfers with distinct
+    // AL write keys (one per signer × per burst) and submit. Wait
+    // for receipts on every node, then check state-root convergence.
+    for burst in 0..NUM_BURSTS {
+        let nonce = burst;
+        let mut tx_hashes: Vec<String> = Vec::with_capacity(signers.len());
+        for (i, (sk, sender_addr)) in signers.iter().enumerate() {
+            let mut write_key = [0u8; 32];
+            // distinct (signer × burst) → distinct keys across the
+            // whole run, so the scheduler never accidentally unions
+            // two txs across bursts.
+            write_key[0] = (i + 1) as u8;
+            write_key[1] = (burst + 1) as u8;
+            let access_list = vec![AccessEntry {
+                address: *sender_addr,
+                reads: vec![],
+                writes: vec![write_key],
+            }];
+            let mut tx = Transaction {
+                from: *sender_addr,
+                to: recipients[i],
+                value,
+                data: vec![],
+                gas_limit: 100_000,
+                nonce,
+                signature: vec![],
+                fee_payer: FeePayer::Sender,
+                access_list,
+                deadline: None,
+                chain_id,
+                tx_type: TransactionType::Standard,
+            };
+            let sig = falcon_sign(sk, &tx.hash()).expect("sign tx");
+            tx.signature = sig.as_bytes().to_vec();
+            let h = net
+                .submit_raw_tx(0, &tx.to_bytes())
+                .unwrap_or_else(|e| panic!("burst {} tx-{}: {}", burst, i, e));
+            tx_hashes.push(h);
+        }
+
+        // Wait for every tx in this burst to land on every node and
+        // assert success. A failed tx (insufficient balance, sig
+        // rejection, etc.) doesn't credit the recipient and would
+        // silently throw off the convergence check below.
+        for (i, h) in tx_hashes.iter().enumerate() {
+            let receipts = net
+                .wait_for_receipt_on_all(h, Duration::from_secs(60))
+                .unwrap_or_else(|e| panic!("burst {} tx-{} receipt: {}", burst, i, e));
+            for (n, r) in receipts.iter().enumerate() {
+                assert!(
+                    r.success,
+                    "burst {} tx-{} failed on node-{}: {}",
+                    burst, i, n, r.raw
+                );
+            }
+        }
+
+        // State convergence: audit-408 wires the proposer's
+        // partition to every receiver, so every node MUST commit the
+        // same post-state after applying a multi-group block. Pre-fix
+        // failure mode: non-proposers ran the txs sequentially while
+        // the proposer ran them in parallel; for these access-list-
+        // disjoint transfers the final balances *happened* to be
+        // identical (the writes are commutative on disjoint keys),
+        // but the test exists to catch the future case where the
+        // partition disagrees and the writes don't commute.
+        //
+        // We probe convergence on three different observables — any
+        // single one would catch divergence; together they triangulate:
+        //
+        //   1. Recipient balance: `value * 4 * (burst + 1)` total.
+        //      A non-proposer that applied a different subset of txs
+        //      lands on a different sum.
+        //   2. Per-sender nonce (`pyde_getTransactionCount`). After
+        //      the burst lands every sender's nonce should advance
+        //      to `burst + 1`. A non-proposer that dropped or
+        //      double-applied a tx lands elsewhere.
+        //   3. `pyde_stateRoot`. Even pre-finality this should be
+        //      consistent across nodes (chain.state_root is the
+        //      most recently advanced header's state_root, set in
+        //      `chain::ChainState::advance`).
+        // Each recipient should have received `value * (burst + 1)`
+        // PYDE total — one transfer per burst. All 4 nodes must
+        // report the same balance for each recipient (audit-408
+        // convergence: the proposer's parallel-exec partition is
+        // applied identically on every receiver).
+        let expected_per_recipient = value * (burst + 1) as u128;
+        for (i, recipient_addr) in recipients.iter().enumerate() {
+            let balances: Vec<u128> = (0..4)
+                .map(|n| {
+                    net.get_balance(n, recipient_addr).unwrap_or_else(|e| {
+                        panic!("burst {} recipient-{} balance node-{}: {}", burst, i, n, e)
+                    })
+                })
+                .collect();
+            assert!(
+                balances.windows(2).all(|w| w[0] == w[1]),
+                "burst {} recipient-{} balance divergence: {:?}",
+                burst,
+                i,
+                balances
+            );
+            assert_eq!(
+                balances[0], expected_per_recipient,
+                "burst {} recipient-{} balance wrong: got {}, expected {}",
+                burst, i, balances[0], expected_per_recipient
+            );
+        }
+
+        let expected_nonce = burst + 1;
+        for (sidx, (_sk, sender_addr)) in signers.iter().enumerate() {
+            let nonces: Vec<u64> = (0..4)
+                .map(|n| {
+                    net.get_nonce(n, sender_addr).unwrap_or_else(|e| {
+                        panic!("burst {} signer-{} nonce node-{}: {}", burst, sidx, n, e)
+                    })
+                })
+                .collect();
+            assert!(
+                nonces.windows(2).all(|w| w[0] == w[1]),
+                "burst {} signer-{} nonce divergence: {:?}",
+                burst,
+                sidx,
+                nonces
+            );
+            assert_eq!(
+                nonces[0], expected_nonce,
+                "burst {} signer-{} nonce wrong: got {}, expected {}",
+                burst, sidx, nonces[0], expected_nonce
+            );
+        }
+
+        let post_roots: Vec<String> = (0..4)
+            .map(|i| {
+                net.state_root(i).unwrap_or_else(|e| {
+                    panic!("burst {} post state_root node-{}: {}", burst, i, e)
+                })
+            })
+            .collect();
+        assert!(
+            post_roots.windows(2).all(|w| w[0] == w[1]),
+            "burst {} state-root divergence:\n{:#?}",
+            burst,
+            post_roots
+        );
+        eprintln!(
+            "burst {} ok — per-recipient balance={}, state_root={}",
+            burst, expected_per_recipient, post_roots[0]
+        );
+    }
+
+    // Audit-408 assertion. Each node's block_processor logs
+    // `"parallel execution: N groups on rayon threads"` whenever a
+    // multi-group block applies and produces writes — see
+    // `crates/node/src/block_processor.rs:444`. Pre-fix only the
+    // proposer would hit this line because non-proposers
+    // reconstructed the schedule as a single sequential group.
+    // Post-fix every node sees the same `groups.len() > 1` and
+    // takes the rayon-parallel branch.
+    //
+    // Three bursts of 4-group txs typically produce 1-3 multi-group
+    // blocks (depending on whether the proposer batches a burst's
+    // txs into one block or fragments across slots). We assert >= 1
+    // per node, which is the load-bearing invariant — that the
+    // parallel branch fires at all on every receiver.
+    for i in 0..4 {
+        let snapshot = net.nodes[i].output_snapshot();
+        let count = snapshot.matches("parallel execution:").count();
+        assert!(
+            count >= 1,
+            "node-{} never hit the parallel-exec branch: \
+             expected >= 1 'parallel execution:' log line, got {}. \
+             This is an audit-408 regression — non-proposers are \
+             running the single-group fallback path despite the \
+             proposer scheduling multiple independent groups",
+            i,
+            count
+        );
+        eprintln!("node-{}: parallel-exec lines = {}", i, count);
+    }
+}


### PR DESCRIPTION
## Summary

Pre-fix, when reconstructing a compact block, the receiver hardcoded a single sequential `ExecutionGroup` covering every plaintext tx, throwing away the proposer's parallel partition. Non-proposers always took the slow `groups.len() <= 1` path in `block_processor`, even when the proposer used the rayon-parallel branch. The full-block wire format already round-trips the schedule (`wire.rs::decode_block`); only the steady-state compact-block channel was missing it.

## Changes

- `CompactBlock.group_ids: Vec<u16>` — per-tx group labels. Two txs share a group iff they share a label
- `wire::schedule_to_group_ids(&ExecutionSchedule) -> Vec<u16>` — flatten partition to labels
- `wire::group_ids_to_schedule(&[u16]) -> ExecutionSchedule` — inverse
- Encoder appends `u32 count + N×u16 labels` to the compact-block frame after prefilled txs
- Decoder rejects `count != short_tx_ids.len()` (with `count == 0` allowed as legacy fallback)
- Proposer at `node.rs:~2787` derives `group_ids` from `block.body.execution_schedule`
- Receiver at `node.rs:~2008` reconstructs the schedule from `cb.group_ids` (length-mismatch / empty falls back to single-group sequential + warn log)

## Validation

**Unit tests** (`cargo test -p pyde-node --lib wire::`, 39/39 pass):
- `compact_block_group_ids_roundtrip` — encode + decode preserves a non-trivial 4-tx 3-group case
- `compact_block_empty_group_ids_roundtrip` — legacy fallback survives
- `compact_block_rejects_group_ids_length_mismatch` — wire validation
- `schedule_to_group_ids_partition_invariant` — round-trip through both helpers preserves the partition equivalence classes

**Integration test** (`multi_node_parallel_exec`, 4-validator devnet):
- 3 bursts × 4 multi-group txs (distinct signers, distinct recipients, informative ALs)
- After every burst, asserts on all 4 nodes:
  - per-recipient balance matches \`value × (burst + 1)\`
  - per-signer nonce matches \`burst + 1\`
  - chain state_root matches across nodes
- Final assertion: every node logs \`parallel execution: N groups on rayon threads\` ≥ 1× (observed 3× on each)

\`\`\`
node-0: parallel-exec lines = 3
node-1: parallel-exec lines = 3
node-2: parallel-exec lines = 3
node-3: parallel-exec lines = 3
\`\`\`