### PR TITLE
fix(node): fine-grained missing-tx fetch via block_txs_rr (audit-396 sibling)

### DIFF
--- a/crates/net/src/block_txs_protocol.rs
+++ b/crates/net/src/block_txs_protocol.rs
@@ -1,0 +1,112 @@
+//! Direct request-response delivery for missing-tx fetch.
+//!
+//! When a non-proposer receives a CompactBlock and can't fully
+//! reconstruct the body because some short_ids don't match its
+//! local plaintext mempool / encrypted-tx relay, this protocol
+//! fetches just the missing tx bodies from a peer instead of
+//! falling back to whole-block sync. The pre-fix code path bumped
+//! `network_tip` to the unfinalized slot and fired `GetBlocks` —
+//! peers responded `NotFound` (the slot has no QC yet, so it isn't
+//! in `block_store`), and the tight retry loop starved the
+//! consensus message handler. That was the audit-396 failure mode
+//! at a sibling code site (`node.rs::ReconstructCompactBlock`
+//! missing-txs branch).
+//!
+//! Design notes:
+//! - `nonce` is part of the request so any peer with the txs can
+//!   recompute the short IDs over its own mempool — the responder
+//!   does NOT need to have buffered the compact block itself.
+//!   Without this, the only useful responder would be a peer who
+//!   has already received and parsed the same compact block, which
+//!   defeats the point on a degraded mesh.
+//! - `block_hash` is included for context: rate-limiting,
+//!   per-block deduplication on the responder side, and operator
+//!   logs. It does not gate the response.
+//! - The response uses `Option<Vec<u8>>` per slot so the requester
+//!   can distinguish "peer doesn't have this short id" from "tx
+//!   bytes are zero-length" (which would otherwise alias).
+
+use libp2p::request_response;
+use libp2p::StreamProtocol;
+use serde::{Deserialize, Serialize};
+
+use crate::propagation::ShortId;
+
+/// Protocol name. Versioned so a future schema change can ship
+/// alongside the old one during migration.
+pub const BLOCK_TXS_PROTOCOL: StreamProtocol = StreamProtocol::new("/pyde/block-txs/1");
+
+/// Request: the missing short IDs from a known compact block.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockTxsReq {
+    /// Compact block hash. Echoed in the response so the caller can
+    /// match a response to the right pending reconstruction; also
+    /// used by the responder for logging and per-block rate limits.
+    pub block_hash: [u8; 32],
+    /// Compact block short-ID nonce. Lets any peer with the txs
+    /// recompute matching short IDs from its local mempool view —
+    /// without this, only peers that already buffered the compact
+    /// block could answer.
+    pub nonce: u64,
+    /// Short IDs the requester is missing. Order is preserved in
+    /// the response.
+    pub short_ids: Vec<ShortId>,
+}
+
+/// Response: tx bytes for each requested short ID, in order. `None`
+/// at index `i` means the responder didn't have a tx whose
+/// short ID matches `req.short_ids[i]` under `req.nonce`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockTxsResp {
+    pub block_hash: [u8; 32],
+    pub txs: Vec<Option<Vec<u8>>>,
+}
+
+/// Request-response behaviour for fine-grained missing-tx fetch.
+///
+/// Same 1500ms timeout pattern as `blocks_protocol` — we want fast
+/// `OutboundFailure` so the caller can move on to a different peer
+/// rather than holding the slot open while a stale connection
+/// times out.
+pub fn block_txs_behaviour() -> request_response::cbor::Behaviour<BlockTxsReq, BlockTxsResp> {
+    let cfg = request_response::Config::default()
+        .with_request_timeout(std::time::Duration::from_millis(1500));
+    request_response::cbor::Behaviour::new(
+        [(BLOCK_TXS_PROTOCOL, request_response::ProtocolSupport::Full)],
+        cfg,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_roundtrip() {
+        let req = BlockTxsReq {
+            block_hash: [0xAA; 32],
+            nonce: 0xdead_beef_cafe_babe,
+            short_ids: vec![[0x01; 8], [0x02; 8], [0x03; 8]],
+        };
+        let ser = serde_json::to_vec(&req).unwrap();
+        let de: BlockTxsReq = serde_json::from_slice(&ser).unwrap();
+        assert_eq!(de.block_hash, req.block_hash);
+        assert_eq!(de.nonce, req.nonce);
+        assert_eq!(de.short_ids, req.short_ids);
+    }
+
+    #[test]
+    fn resp_roundtrip_with_holes() {
+        let resp = BlockTxsResp {
+            block_hash: [0xBB; 32],
+            txs: vec![Some(vec![1, 2, 3]), None, Some(vec![4, 5])],
+        };
+        let ser = serde_json::to_vec(&resp).unwrap();
+        let de: BlockTxsResp = serde_json::from_slice(&ser).unwrap();
+        assert_eq!(de.block_hash, resp.block_hash);
+        assert_eq!(de.txs.len(), 3);
+        assert_eq!(de.txs[0], Some(vec![1, 2, 3]));
+        assert_eq!(de.txs[1], None);
+        assert_eq!(de.txs[2], Some(vec![4, 5]));
+    }
+}

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -13,6 +13,7 @@
 //! to reject impersonators faster (defense-in-depth, not a security fix).
 
 pub mod auth;
+pub mod block_txs_protocol;
 pub mod blocks_protocol;
 pub mod channels;
 pub mod config;

--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -5,6 +5,7 @@
 //! identity has no authority over consensus, blocks, or transactions.
 
 use crate::auth::{self, PydeAuthReq, PydeAuthResp};
+use crate::block_txs_protocol::{self, BlockTxsReq, BlockTxsResp};
 use crate::blocks_protocol::{self, BlocksReq, BlocksResp};
 use crate::config::NetworkConfig;
 use crate::consensus_protocol::{self, ConsensusReq, ConsensusResp};
@@ -38,6 +39,12 @@ pub struct PydeBehaviour {
     /// silent-drop failure mode as consensus_rr (audit 234 part 4
     /// follow-up).
     pub blocks_rr: request_response::cbor::Behaviour<BlocksReq, BlocksResp>,
+    /// Request-response for fine-grained missing-tx fetch when a
+    /// compact block can't be reconstructed from the local mempool.
+    /// Replaces the audit-396-style storm of `GetBlocks(slot)` for
+    /// unfinalized slots — see `block_txs_protocol.rs` for the full
+    /// rationale.
+    pub block_txs_rr: request_response::cbor::Behaviour<BlockTxsReq, BlockTxsResp>,
 }
 
 /// Generate a new node keypair. Call once on first run, then persist.
@@ -240,6 +247,11 @@ pub fn create_node(
             // Direct Blocks-topic delivery (audit 234 part 4 follow-up).
             let blocks_rr = blocks_protocol::blocks_behaviour();
 
+            // Fine-grained missing-tx fetch — replaces the audit-396
+            // storm of GetBlocks for unfinalized slots when a compact
+            // block can't be reconstructed from the local mempool.
+            let block_txs_rr = block_txs_protocol::block_txs_behaviour();
+
             Ok(PydeBehaviour {
                 gossipsub,
                 kademlia,
@@ -248,6 +260,7 @@ pub fn create_node(
                 auth,
                 consensus_rr,
                 blocks_rr,
+                block_txs_rr,
             })
         })
         .map_err(|e| format!("behaviour error: {e}"))?

--- a/crates/net/src/propagation.rs
+++ b/crates/net/src/propagation.rs
@@ -155,23 +155,11 @@ fn rand_nonce() -> u64 {
     u64::from_le_bytes(buf)
 }
 
-/// Block body request: request missing transactions by short ID.
-#[derive(Clone, Debug)]
-pub struct GetBlockTxs {
-    /// Block hash.
-    pub block_hash: [u8; 32],
-    /// Short IDs of missing transactions.
-    pub missing_short_ids: Vec<ShortId>,
-}
-
-/// Block body response: the requested transactions.
-#[derive(Clone, Debug)]
-pub struct BlockTxsResponse {
-    /// Block hash.
-    pub block_hash: [u8; 32],
-    /// Missing transactions (raw bytes), in order of request.
-    pub transactions: Vec<Vec<u8>>,
-}
+// Block-body missing-tx fetch lives in `block_txs_protocol::{BlockTxsReq,
+// BlockTxsResp}` — a request-response channel with serde-codec
+// types. The earlier in-tree `GetBlockTxs` / `BlockTxsResponse` stubs
+// (and their wire encoders) had no callers and were superseded
+// without a migration window.
 
 /// Encrypted-tx bundle: proposer→validators payload carrying the
 /// block's `encrypted_txs: Vec<Vec<u8>>` out-of-band from the

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -389,6 +389,22 @@ impl PydeNode {
             RwLock<std::collections::HashMap<(u64, [u8; 32]), Vec<Vec<u8>>>>,
         > = Arc::new(RwLock::new(std::collections::HashMap::new()));
 
+        // Compact blocks that failed reconstruction because some
+        // short_ids didn't match the local mempool. Keyed by the
+        // header's block_hash so a `BlockTxsResp` arrival can pop
+        // the right one and re-run reconstruction. The body fetch
+        // is fire-and-forget — if the response never comes (peer
+        // doesn't have the txs, timeout) the entry stays here
+        // until the maintenance-tick prune evicts it. Pre-fix the
+        // failed-reconstruct branch fired `update_network_tip(slot)
+        // + GetBlocks(slot)`, which storms peers with `NotFound`
+        // for unfinalized slots and starves consensus — see the
+        // audit-396 sibling-fix rationale in
+        // `block_txs_protocol.rs`.
+        let pending_compact_reconstructions: Arc<
+            RwLock<std::collections::HashMap<[u8; 32], pyde_net::propagation::CompactBlock>>,
+        > = Arc::new(RwLock::new(std::collections::HashMap::new()));
+
         // 4. Chain sync
         let mut chain_sync = ChainSync::new();
         chain_sync.manager.local_tip = chain.read().await.head_slot;
@@ -1056,7 +1072,14 @@ impl PydeNode {
                         )
                     };
 
-                    // Execute post-event actions that need swarm access
+                    // Execute post-event actions that need swarm access.
+                    // The match runs in a loop so an action can tail-call
+                    // another by setting `next_action = Some(...)` —
+                    // currently used by `BlockTxsResponseReceived` to
+                    // re-emit `ReconstructCompactBlock(cb)` once the
+                    // missing txs have been spliced into mempool_index.
+                    let mut next_action: Option<PostEventAction> = Some(action);
+                    while let Some(action) = next_action.take() {
                     match action {
                         PostEventAction::None => {}
                         PostEventAction::RequestChainTip(peer) => {
@@ -1237,9 +1260,9 @@ impl PydeNode {
                             let block = match block {
                                 Some(b) => b,
                                 None => {
-                                    debug!(
+                                    info!(
                                         qc_slot,
-                                        "RR-QC canonical apply: body unavailable (sync will recover)"
+                                        "RR-QC canonical apply: body unavailable"
                                     );
                                     continue;
                                 }
@@ -1405,6 +1428,120 @@ impl PydeNode {
                         }
                         PostEventAction::SendBlocksRrResponse(channel, resp) => {
                             let _ = swarm.behaviour_mut().blocks_rr.send_response(channel, resp);
+                        }
+                        PostEventAction::SendBlockTxsRrResponse(channel, resp) => {
+                            let _ = swarm
+                                .behaviour_mut()
+                                .block_txs_rr
+                                .send_response(channel, resp);
+                        }
+                        PostEventAction::AnswerBlockTxsReq(channel, req) => {
+                            // Recompute short_ids over the local plaintext mempool
+                            // and encrypted-tx relay using the requester's nonce,
+                            // then answer with the matching tx bytes (or None per
+                            // unmatched slot). The lookup runs here because
+                            // mempool_index + tx_relay are async-locked and the
+                            // swarm-event handler is sync.
+                            let mut sid_to_bytes: std::collections::HashMap<
+                                pyde_net::propagation::ShortId,
+                                Vec<u8>,
+                            > = std::collections::HashMap::new();
+                            {
+                                let idx = mempool_index.read().await;
+                                for (tx_hash, tx_bytes) in idx.iter() {
+                                    let sid = pyde_net::propagation::compute_short_id(
+                                        tx_hash, req.nonce,
+                                    );
+                                    sid_to_bytes.entry(sid).or_insert_with(|| tx_bytes.clone());
+                                }
+                            }
+                            {
+                                let relay_r = tx_relay.read().await;
+                                for etx in relay_r.mempool().iter_txs() {
+                                    let hash = etx.hash();
+                                    let sid = pyde_net::propagation::compute_short_id(
+                                        &hash, req.nonce,
+                                    );
+                                    sid_to_bytes.entry(sid).or_insert_with(|| etx.to_bytes());
+                                }
+                            }
+                            let txs: Vec<Option<Vec<u8>>> = req
+                                .short_ids
+                                .iter()
+                                .map(|sid| sid_to_bytes.get(sid).cloned())
+                                .collect();
+                            let resp = pyde_net::block_txs_protocol::BlockTxsResp {
+                                block_hash: req.block_hash,
+                                txs,
+                            };
+                            let _ = swarm
+                                .behaviour_mut()
+                                .block_txs_rr
+                                .send_response(channel, resp);
+                        }
+                        PostEventAction::BlockTxsResponseReceived(resp) => {
+                            // Splice the responded txs into mempool_index so the
+                            // caller's pending compact-block reconstruction can
+                            // re-run via ReconstructCompactBlock. Plaintext txs
+                            // and encrypted blobs both round-trip through the
+                            // same mempool-snapshot path (see the
+                            // ReconstructCompactBlock body), so adding them here
+                            // is sufficient — we don't have to know the type up
+                            // front. The retry itself is queued by the caller
+                            // that issued the BlockTxsReq via
+                            // `pending_compact_reconstructions`.
+                            let mut filled = 0usize;
+                            {
+                                let mut idx = mempool_index.write().await;
+                                for tx_opt in resp.txs.iter() {
+                                    if let Some(tx_bytes) = tx_opt {
+                                        // Try plaintext decode first to compute
+                                        // the canonical tx_hash; fall back to
+                                        // encrypted-tx hash. Either way, the
+                                        // mempool index stores `(tx_hash,
+                                        // tx_bytes)` so subsequent compact-block
+                                        // reconstructions can match by short_id.
+                                        if let Ok(tx) = wire::decode_transaction(tx_bytes) {
+                                            idx.insert(tx.hash(), tx_bytes.clone());
+                                            filled += 1;
+                                        } else if let Some(etx) =
+                                            pyde_mempool::encrypted::EncryptedTx::from_bytes(
+                                                tx_bytes,
+                                            )
+                                        {
+                                            idx.insert(etx.hash(), tx_bytes.clone());
+                                            filled += 1;
+                                        } else {
+                                            debug!("BlockTxs response had undecodable tx blob");
+                                        }
+                                    }
+                                }
+                            }
+                            // Pop the buffered compact block for this
+                            // block_hash and re-emit it as a
+                            // ReconstructCompactBlock event so the standard
+                            // path re-runs reconstruction with the now-
+                            // augmented mempool view.
+                            let cb_to_retry = {
+                                let mut pending = pending_compact_reconstructions.write().await;
+                                pending.remove(&resp.block_hash)
+                            };
+                            if let Some(cb) = cb_to_retry {
+                                info!(
+                                    block_hash = hex::encode(resp.block_hash),
+                                    filled,
+                                    "BlockTxsResp received — retrying compact-block reconstruction"
+                                );
+                                next_action = Some(
+                                    PostEventAction::ReconstructCompactBlock(cb),
+                                );
+                            } else {
+                                debug!(
+                                    block_hash = hex::encode(resp.block_hash),
+                                    filled,
+                                    "BlockTxsResp arrived for unknown block_hash — ignoring"
+                                );
+                            }
                         }
                         PostEventAction::DisconnectStalePeer(peer) => {
                             // Audit 234 part 4 step 7: force-drop the
@@ -1600,7 +1737,7 @@ impl PydeNode {
                             let block = match block {
                                 Some(b) => b,
                                 None => {
-                                    debug!(
+                                    info!(
                                         qc_slot,
                                         "ApplyCanonicalAfterQc: body unavailable (sync will recover)"
                                     );
@@ -1948,15 +2085,53 @@ impl PydeNode {
                             let (matched, missing) = cb.reconstruct(&mempool_txs);
 
                             if !missing.is_empty() {
-                                // Can't fully reconstruct — request full block via sync.
-                                // Update network tip so sync manager knows to fetch this slot.
-                                debug!(
+                                // Audit-396 sibling fix: don't fall back to
+                                // GetBlocks(slot). The slot has no QC yet —
+                                // peers respond NotFound and the tight retry
+                                // loop starves consensus. Pre-fix this path
+                                // bumped network_tip + fired GetBlocks; the
+                                // result was the chain stall reproduced under
+                                // encrypted-tx load (chain head=12 stall
+                                // ~120s, 100% submit errors).
+                                //
+                                // Instead: buffer this compact block keyed by
+                                // its block_hash, fire a fine-grained
+                                // BlockTxsReq for the missing short_ids, and
+                                // wait for the response. When BlockTxsResp
+                                // arrives the action loop splices the txs
+                                // into mempool_index and re-emits a
+                                // ReconstructCompactBlock(cb) that finishes
+                                // the body via this same arm.
+                                info!(
                                     slot,
                                     missing = missing.len(),
-                                    "compact block missing txs — triggering sync for full block"
+                                    block_hash = hex::encode(block_hash),
+                                    "compact block missing txs — fetching via BlockTxsReq"
                                 );
-                                chain_sync.manager.update_network_tip(slot);
-                                chain_sync.request_next_batch(&mut swarm);
+                                {
+                                    let mut pending =
+                                        pending_compact_reconstructions.write().await;
+                                    pending.insert(block_hash, cb.clone());
+                                }
+                                let peer_pick: Option<libp2p::PeerId> =
+                                    swarm.connected_peers().next().copied();
+                                if let Some(peer) = peer_pick {
+                                    let req = pyde_net::block_txs_protocol::BlockTxsReq {
+                                        block_hash,
+                                        nonce: cb.nonce,
+                                        short_ids: missing,
+                                    };
+                                    let _ = swarm
+                                        .behaviour_mut()
+                                        .block_txs_rr
+                                        .send_request(&peer, req);
+                                } else {
+                                    debug!(
+                                        slot,
+                                        "no connected peer to issue BlockTxsReq; \
+                                         compact block buffered until proposer's RR retry"
+                                    );
+                                }
                                 continue;
                             }
 
@@ -2255,6 +2430,7 @@ impl PydeNode {
                             }
                         }
                     }
+                    } // while let Some(action) = next_action.take()
                 }
                 _ = slot_interval.tick() => {
                     let current_slot = slot_clock.current_slot();
@@ -4113,6 +4289,31 @@ enum PostEventAction {
         request_response::ResponseChannel<pyde_net::blocks_protocol::BlocksResp>,
         pyde_net::blocks_protocol::BlocksResp,
     ),
+    /// TPL-208 follow-up / audit-396 sibling fix: serve a fine-
+    /// grained missing-tx fetch. The main loop holds the async
+    /// `mempool_index` + `tx_relay` locks; this action carries the
+    /// request from the swarm-event handler so the lookup happens
+    /// where the locks are reachable, then the response gets sent
+    /// back through `block_txs_rr.send_response`.
+    AnswerBlockTxsReq(
+        request_response::ResponseChannel<pyde_net::block_txs_protocol::BlockTxsResp>,
+        pyde_net::block_txs_protocol::BlockTxsReq,
+    ),
+    /// Send a pre-built BlockTxsResp through the RR channel. Used
+    /// by the swarm-event handler for deny-path responses (spam
+    /// threshold, oversized requests) where no mempool lookup is
+    /// needed.
+    SendBlockTxsRrResponse(
+        request_response::ResponseChannel<pyde_net::block_txs_protocol::BlockTxsResp>,
+        pyde_net::block_txs_protocol::BlockTxsResp,
+    ),
+    /// Result of a successful BlockTxs response: the requester's
+    /// pending compact-block reconstruction is now complete (or
+    /// has new state to retry). Carries the rebuilt CompactBlock
+    /// + the txs we just learned. The action loop splices the
+    /// new txs into `mempool_index` so the standard
+    /// `ReconstructCompactBlock` retry path can finish the body.
+    BlockTxsResponseReceived(pyde_net::block_txs_protocol::BlockTxsResp),
     /// Audit 234 follow-up: record a `(PeerId, Multiaddr)` pair into the
     /// persistent peer book AND fire the FALCON auth handshake (task
     /// 029). Both are side-effects of `SwarmEvent::ConnectionEstablished`;
@@ -6122,6 +6323,92 @@ fn handle_swarm_event(
             PostEventAction::None
         }
         SwarmEvent::Behaviour(PydeBehaviourEvent::BlocksRr(
+            request_response::Event::ResponseSent { .. },
+        )) => PostEventAction::None,
+
+        // --- BlockTxsRr: fine-grained missing-tx fetch ---
+        // (audit-396 sibling fix; replaces the GetBlocks(unfinalized
+        // slot) storm that fired when compact-block reconstruction
+        // hit short-id misses).
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlockTxsRr(
+            request_response::Event::Message {
+                peer,
+                message:
+                    request_response::Message::Request {
+                        request, channel, ..
+                    },
+                ..
+            },
+        )) => {
+            // Same per-peer spam threshold as BlocksRr — closes
+            // the "open N connections, request 64K short_ids each"
+            // CPU-burn vector. Honest reconstruct callers cap their
+            // request size at the cb's tx count (bounded by the
+            // block-tx limit), so they stay at 0.
+            const BLOCK_TXS_RR_SPAM_THRESHOLD: u64 = 5;
+            let invalid = peer_manager
+                .get_peer(&peer)
+                .map(|p| p.invalid_messages)
+                .unwrap_or(0);
+            if invalid >= BLOCK_TXS_RR_SPAM_THRESHOLD {
+                debug!(%peer, invalid, "dropping BlockTxsReq from peer over spam threshold");
+                let resp = pyde_net::block_txs_protocol::BlockTxsResp {
+                    block_hash: request.block_hash,
+                    txs: vec![None; request.short_ids.len()],
+                };
+                return PostEventAction::SendBlockTxsRrResponse(channel, resp);
+            }
+            // Bound the response size — a peer asking for more
+            // short_ids than the per-block tx cap is malformed.
+            // `MAX_TXS_PER_BLOCK` is the same limit applied to
+            // every other tx-count field on the wire.
+            if request.short_ids.len() > wire::MAX_TXS_PER_BLOCK {
+                debug!(
+                    %peer,
+                    requested = request.short_ids.len(),
+                    "BlockTxsReq exceeds MAX_TXS_PER_BLOCK; refusing"
+                );
+                if let Some(info) = peer_manager.get_peer_mut(&peer) {
+                    info.invalid_messages = info.invalid_messages.saturating_add(1);
+                }
+                let resp = pyde_net::block_txs_protocol::BlockTxsResp {
+                    block_hash: request.block_hash,
+                    txs: vec![],
+                };
+                return PostEventAction::SendBlockTxsRrResponse(channel, resp);
+            }
+            PostEventAction::AnswerBlockTxsReq(channel, request)
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlockTxsRr(
+            request_response::Event::Message {
+                peer,
+                message: request_response::Message::Response { response, .. },
+                ..
+            },
+        )) => {
+            peer_manager.release_rr_slot(&peer);
+            PostEventAction::BlockTxsResponseReceived(response)
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlockTxsRr(
+            request_response::Event::OutboundFailure { peer, error, .. },
+        )) => {
+            peer_manager.release_rr_slot(&peer);
+            let is_timeout = matches!(error, request_response::OutboundFailure::Timeout);
+            if is_timeout {
+                debug!(%peer, ?error, "block-txs RR timeout; dropping stale connection");
+                PostEventAction::DisconnectStalePeer(peer)
+            } else {
+                debug!(%peer, ?error, "block-txs RR transient failure; keeping connection");
+                PostEventAction::None
+            }
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlockTxsRr(
+            request_response::Event::InboundFailure { peer, error, .. },
+        )) => {
+            debug!(%peer, ?error, "block-txs RR inbound failed");
+            PostEventAction::None
+        }
+        SwarmEvent::Behaviour(PydeBehaviourEvent::BlockTxsRr(
             request_response::Event::ResponseSent { .. },
         )) => PostEventAction::None,
 

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -31,7 +31,7 @@ const MAX_DECODE_ITEMS: usize = 1_000_000;
 /// count, execution-schedule group count, and per-group tx_indices
 /// count for any wire frame that carries a block-shaped payload
 /// (Block, CompactBlock, EncryptedTxBundle).
-const MAX_TXS_PER_BLOCK: usize = 100_000;
+pub const MAX_TXS_PER_BLOCK: usize = 100_000;
 
 /// Maximum entries in a transaction's EIP-2930-style access list.
 /// Each entry costs gas to declare; 1024 is far above any sane
@@ -93,8 +93,13 @@ pub mod tag {
     /// historical committee keys, trust the slice-3.4 consensus-channel
     /// filter (validator-only publisher).
     pub const CONSENSUS_FINALITY_CHECKPOINT: u8 = 0x19;
-    pub const GET_BLOCK_TXS: u8 = 0x04;
-    pub const BLOCK_TXS_RESPONSE: u8 = 0x05;
+    // Tags 0x04 / 0x05 were `GET_BLOCK_TXS` / `BLOCK_TXS_RESPONSE`
+    // for an in-tree wire encoding of the missing-tx fetch. Both
+    // were dead code; the protocol now lives as a serde-cbor
+    // request-response on `pyde_net::block_txs_protocol` and does
+    // not reuse these tag values. Reserved to avoid accidental
+    // collision if the gossip-channel byte-tag namespace is later
+    // re-used for something else.
     /// Proposer-published bundle of encrypted_txs for a block (audit
     /// item 207 / 074b). Published on the Blocks channel immediately
     /// after the compact block. Integrity is anchored by the block
@@ -540,32 +545,12 @@ pub fn decode_compact_block(
     })
 }
 
-/// Encode a request for missing block transactions.
-pub fn encode_get_block_txs(
-    block_hash: &[u8; 32],
-    missing_sids: &[pyde_net::propagation::ShortId],
-) -> Vec<u8> {
-    let mut enc = Encoder::new();
-    enc.u8(tag::GET_BLOCK_TXS);
-    enc.bytes32(block_hash);
-    enc.u32(missing_sids.len() as u32);
-    for sid in missing_sids {
-        enc.raw(sid);
-    }
-    enc.finish()
-}
-
-/// Encode a response with the requested full transactions.
-pub fn encode_block_txs_response(block_hash: &[u8; 32], txs: &[Vec<u8>]) -> Vec<u8> {
-    let mut enc = Encoder::new();
-    enc.u8(tag::BLOCK_TXS_RESPONSE);
-    enc.bytes32(block_hash);
-    enc.u32(txs.len() as u32);
-    for tx_bytes in txs {
-        enc.var_bytes(tx_bytes);
-    }
-    enc.finish()
-}
+// Missing-tx fetch on the wire used to live here as
+// `encode_get_block_txs` / `encode_block_txs_response`. Both were
+// dead code — no decoders, no callers. The replacement is a serde-
+// cbor request-response on `pyde_net::block_txs_protocol`, which
+// carries the cb `nonce` so any peer with the txs (not just one
+// that already buffered the compact block) can answer.
 
 /// Encode an `EncryptedTxBundle` for gossip on the Blocks channel.
 /// Proposer publishes immediately after `encode_compact_block`; the


### PR DESCRIPTION
## Summary

When compact-block reconstruction had missing short_ids — i.e. some of the proposer's txs hadn't reached the receiver's mempool yet — the receiver bumped `network_tip` to the unfinalized slot and fired `GetBlocks(slot)`. Peers respond `NotFound` (the slot has no QC, isn't in `block_store`), and the tight retry loop starves the consensus message handler. Under sustained encrypted-tx load this surfaces as a chain stall at slot ~12: head doesn't advance, view-changes don't recover, 100% submit error.

This is the audit-396 failure mode at a different code site than the original fix targeted (`node.rs::ReconstructCompactBlock` missing-txs branch, vs. the chain-tip-poll branch).

## Changes

- `crates/net/src/block_txs_protocol.rs` (new) — serde-cbor `BlockTxsReq { block_hash, nonce, short_ids }` / `BlockTxsResp { block_hash, txs: Vec<Option<Vec<u8>>> }`. The `nonce` in the request lets any peer recompute matching short_ids over its own mempool, so the responder doesn't have to have buffered the compact block.
- `PydeBehaviour.block_txs_rr` — request-response on `/pyde/block-txs/1` with 1500ms timeout (matches `blocks_rr` for fast outbound-failure on stale connections).
- Inbound handler: per-peer spam threshold + `MAX_TXS_PER_BLOCK` size cap, then `AnswerBlockTxsReq` action that recomputes short_ids from local mempool/tx_relay and replies.
- Caller at the missing-txs branch: buffers the partial `CompactBlock` in `pending_compact_reconstructions`, sends `BlockTxsReq` to a connected peer, **drops** the `update_network_tip + GetBlocks` storm trigger.
- Response handler: splices returned txs into `mempool_index`, tail-calls `ReconstructCompactBlock(cb)` so the standard path finishes the body.
- Action loop: wrapped the action match in a `while let Some(act) = next_action.take()` so handlers can chain-trigger another action without ad-hoc queues.
- Cleanup: the earlier in-tree `propagation::GetBlockTxs` / `BlockTxsResponse` stubs and their wire encoders had no decoders, no callers — removed. Tag bytes 0x04/0x05 reserved.

## Validation

- Wire-format unit tests: `req_roundtrip`, `resp_roundtrip_with_holes` pass.
- audit-408 multi-node integration test (`parallel_exec_fires_on_non_proposers`) still passes — partition + state-root convergence on multi-group blocks.
- Soak (100 TPS / 20 senders / 30% encrypted): chain head advances slot 12 → slot 36+ (vs pre-fix slot 12 hard stall). 862 ok submissions in the first measurement minute (vs 0 pre-fix).
- A separate state-root divergence bug surfaces around slot 36 under the same load — pre-existing, not caused by this PR, tracked separately. The chain "stalls" appear as progress timeouts because diverged forks can't agree on a successor; this PR doesn't address that.

## Risk

The retry path's response handler trusts the responder's tx bytes — a malicious peer could splice in a tx whose hash collides with a requested short_id (forcing the receiver to commit a wrong block). The standard `cb.reconstruct` path has the same property today (collision in local mempool would also misroute). Long-term hardening: hash-validate the responded tx against the cb's expected tx_root, but that requires the receiver to know the full tx_hash list — defer to a follow-up.