### PR TITLE
fix(consensus): chain wedge structural fix (task #94)

### DIFF
--- a/crates/consensus/src/hotstuff.rs
+++ b/crates/consensus/src/hotstuff.rs
@@ -98,8 +98,15 @@ pub struct ConsensusState {
     pub current_epoch: u64,
     /// The highest QC this validator has seen.
     pub highest_qc: QuorumCert,
-    /// The last voted slot (prevent double voting).
+    /// Last voted slot, paired with `last_voted_view` to form the
+    /// HotStuff `(slot, view)` lex-monotonic safety predicate. A
+    /// vote on `(N, 0)` does not preclude a vote on `(N, V≥1)` —
+    /// the higher-view vote is the recovery proposal that breaks
+    /// happy-path wedges (audit-94).
     pub last_voted_slot: u64,
+    /// View of the last vote. 0 for happy-path proposals, ≥1 for
+    /// fallback recovery proposals.
+    pub last_voted_view: u64,
     /// The last committed block hash.
     pub last_committed_hash: [u8; 32],
     /// Last committed slot.
@@ -123,6 +130,7 @@ impl ConsensusState {
             current_epoch: 0,
             highest_qc: QuorumCert::empty(),
             last_voted_slot: 0,
+            last_voted_view: 0,
             last_committed_hash: [0u8; 32],
             last_committed_slot: 0,
             // Genesis is at slot 0; the first slot we try to commit is 1.
@@ -182,7 +190,11 @@ impl Default for ConsensusState {
 ///
 /// Safety rule: only vote if:
 /// 1. The proposal extends the highest QC we've seen
-/// 2. We haven't voted for this slot yet
+/// 2. `(slot, proposal_view)` is strictly greater than
+///    `(last_voted_slot, last_voted_view)` in lex order — the
+///    HotStuff `(slot, view)` monotonic-voting predicate.
+///    Voting at `(N, 0)` does not lock out `(N, V≥1)` recovery
+///    (audit-94).
 pub fn create_vote(
     chain_id: u64,
     state: &mut ConsensusState,
@@ -192,8 +204,16 @@ pub fn create_vote(
     voter_sk: &pyde_crypto::falcon::FalconSecretKey,
     committee_keys: &[Vec<u8>],
 ) -> Result<Option<ConsensusMessage>, &'static str> {
-    // Safety: don't double-vote
-    if header.slot <= state.last_voted_slot {
+    // Decode the proposal's view from `vrf_proof`: encoded by
+    // `encode_fallback_proof` for fallback proposals, absent
+    // (raw VRF bytes) for happy-path proposals which are
+    // implicitly view 0.
+    let proposal_view = crate::view_change::decode_fallback_proof(&header.vrf_proof)
+        .map(|(_, v)| v)
+        .unwrap_or(0);
+    // Safety: lex monotonicity over `(slot, view)`. Strictly
+    // greater — equality is "we already cast this exact vote".
+    if (header.slot, proposal_view) <= (state.last_voted_slot, state.last_voted_view) {
         return Ok(None);
     }
 
@@ -225,6 +245,7 @@ pub fn create_vote(
         pyde_crypto::falcon::falcon_sign(voter_sk, &vote_msg).map_err(|_| "vote signing failed")?;
 
     state.last_voted_slot = header.slot;
+    state.last_voted_view = proposal_view;
 
     Ok(Some(ConsensusMessage::Vote {
         slot: header.slot,

--- a/crates/net/src/sync_protocol.rs
+++ b/crates/net/src/sync_protocol.rs
@@ -23,6 +23,14 @@ pub enum SyncReq {
     GetStateSnapshot,
     /// Request a single chunk of a state snapshot (for large states).
     GetStateSnapshotChunk { chunk_index: u32, chunk_size: u32 },
+    /// Task #94: request a single block by its block_hash. Used by
+    /// the QC-apply body-unavailable recovery path: we have the QC
+    /// (so we know the canonical block_hash) but no body — slot-
+    /// based GetBlocks is useless here because every peer at the
+    /// same head reports "I'm at slot N too" without distinguishing
+    /// who actually has the body. The proposer always does, and
+    /// will respond. Other peers respond with `BlockByHash(None)`.
+    GetBlockByHash([u8; 32]),
 }
 
 /// Sync response from peer.
@@ -49,6 +57,14 @@ pub enum SyncResp {
         chunk_hash: [u8; 32],
         entries: Vec<(Vec<u8>, Vec<u8>)>,
     },
+    /// Task #94: response to `GetBlockByHash`. `Some(bytes)` is the
+    /// wire-encoded full block (header + body + proposer_signature)
+    /// keyed by the requested block_hash; `None` means the peer
+    /// doesn't have it. Distinct from top-level `NotFound` so the
+    /// caller can tell "peer doesn't have THIS block" (try another
+    /// peer) from "peer didn't understand the request" (protocol
+    /// error).
+    BlockByHash(Option<Vec<u8>>),
     /// Peer doesn't have the requested data.
     NotFound,
 }
@@ -90,5 +106,36 @@ mod tests {
         let resp = SyncResp::NotFound;
         let bytes = serde_json::to_vec(&resp).unwrap();
         assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn get_block_by_hash_roundtrip() {
+        // Task #94: GetBlockByHash carries a 32-byte hash and the
+        // response is `Option<Vec<u8>>` so receivers can distinguish
+        // "I don't have this block" from "I don't understand this
+        // request". Cover both cases.
+        let req = SyncReq::GetBlockByHash([0xAB; 32]);
+        let req_bytes = serde_json::to_vec(&req).unwrap();
+        let req_back: SyncReq = serde_json::from_slice(&req_bytes).unwrap();
+        match req_back {
+            SyncReq::GetBlockByHash(h) => assert_eq!(h, [0xAB; 32]),
+            _ => panic!("wrong variant after roundtrip"),
+        }
+
+        let resp_some = SyncResp::BlockByHash(Some(b"block-bytes".to_vec()));
+        let bytes = serde_json::to_vec(&resp_some).unwrap();
+        let back: SyncResp = serde_json::from_slice(&bytes).unwrap();
+        match back {
+            SyncResp::BlockByHash(Some(b)) => assert_eq!(b, b"block-bytes"),
+            other => panic!("wrong variant: {:?}", other),
+        }
+
+        let resp_none = SyncResp::BlockByHash(None);
+        let bytes = serde_json::to_vec(&resp_none).unwrap();
+        let back: SyncResp = serde_json::from_slice(&bytes).unwrap();
+        match back {
+            SyncResp::BlockByHash(None) => {}
+            other => panic!("wrong variant: {:?}", other),
+        }
     }
 }

--- a/crates/node/src/consensus_store.rs
+++ b/crates/node/src/consensus_store.rs
@@ -580,6 +580,7 @@ mod tests {
                 signatures: vec![vec![0x11; 600], vec![0x22; 600]],
             },
             last_voted_slot: 100,
+            last_voted_view: 0,
             last_committed_hash: [0xCD; 32],
             last_committed_slot: 98,
             target_height: 100,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1290,9 +1290,18 @@ impl PydeNode {
                             let block = match block {
                                 Some(b) => b,
                                 None => {
+                                    // Task #94: same recovery path as the
+                                    // gossip-VC body-unavailable site below.
+                                    let fired = chain_sync.request_block_by_hash(
+                                        &mut swarm,
+                                        qc_slot,
+                                        qc_block_hash,
+                                        4,
+                                    );
                                     info!(
                                         qc_slot,
-                                        "RR-QC canonical apply: body unavailable"
+                                        recovery_requests = fired,
+                                        "RR-QC canonical apply: body unavailable — fired GetBlockByHash"
                                     );
                                     continue;
                                 }
@@ -1804,9 +1813,30 @@ impl PydeNode {
                             let block = match block {
                                 Some(b) => b,
                                 None => {
+                                    // Task #94: fire `GetBlockByHash` to a few
+                                    // connected peers. The proposer holds the
+                                    // body in its `block_store`; the response
+                                    // handler will populate
+                                    // `pending_block_bodies` and re-emit
+                                    // `ApplyCanonicalAfterQc` so this branch
+                                    // retries the apply with the body in hand.
+                                    // Without this recovery path the QC apply
+                                    // here was silent — sync's `GetBlocks`
+                                    // is slot-keyed and useless under load
+                                    // because every peer reports the same
+                                    // head; only a hash-keyed request can
+                                    // reach the one peer that actually has
+                                    // the body.
+                                    let fired = chain_sync.request_block_by_hash(
+                                        &mut swarm,
+                                        qc_slot,
+                                        qc_block_hash,
+                                        4,
+                                    );
                                     info!(
                                         qc_slot,
-                                        "ApplyCanonicalAfterQc: body unavailable (sync will recover)"
+                                        recovery_requests = fired,
+                                        "ApplyCanonicalAfterQc: body unavailable — fired GetBlockByHash"
                                     );
                                     continue;
                                 }
@@ -1910,6 +1940,57 @@ impl PydeNode {
                                     );
                                 }
                             }
+                        }
+                        PostEventAction::RecoveredBlockByHashForQc {
+                            qc_slot,
+                            qc_block_hash,
+                            block_bytes,
+                        } => {
+                            // Task #94: a peer responded to our
+                            // GetBlockByHash recovery request. Decode
+                            // the bytes, validate the header hashes
+                            // to the expected `qc_block_hash`
+                            // (defense-in-depth against a peer
+                            // returning the wrong block — the QC
+                            // ultimately gates apply but we'd rather
+                            // not pollute `pending_block_bodies`),
+                            // seed the body buffer, and tail-call
+                            // `ApplyCanonicalAfterQc` to retry the
+                            // apply with the recovered body in hand.
+                            let block = match wire::decode_block(&block_bytes) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    warn!(
+                                        qc_slot,
+                                        error = e,
+                                        "task #94: GetBlockByHash response failed to decode"
+                                    );
+                                    continue;
+                                }
+                            };
+                            let actual_hash = block.header.hash();
+                            if actual_hash != qc_block_hash {
+                                warn!(
+                                    qc_slot,
+                                    expected = hex::encode(qc_block_hash),
+                                    got = hex::encode(actual_hash),
+                                    "task #94: GetBlockByHash response hash mismatch — discarding"
+                                );
+                                continue;
+                            }
+                            {
+                                let mut pbb = pending_block_bodies.write().await;
+                                pbb.insert(actual_hash, block);
+                            }
+                            info!(
+                                qc_slot,
+                                qc_block_hash = hex::encode(qc_block_hash),
+                                "task #94: recovered block via GetBlockByHash — retrying canonical apply"
+                            );
+                            next_action = Some(PostEventAction::ApplyCanonicalAfterQc {
+                                qc_slot,
+                                qc_block_hash,
+                            });
                         }
                         PostEventAction::BufferCompetingBlock(block) => {
                             // Audit 232: a competing block at our head slot
@@ -3229,9 +3310,24 @@ impl PydeNode {
                                                     }
                                                 }
                                                 None => {
-                                                    debug!(
+                                                    // Task #94: same recovery
+                                                    // path as the other two
+                                                    // body-unavailable sites
+                                                    // — fan out
+                                                    // `GetBlockByHash` so the
+                                                    // proposer (who has the
+                                                    // body in `block_store`)
+                                                    // can serve it back.
+                                                    let fired = chain_sync.request_block_by_hash(
+                                                        &mut swarm,
+                                                        qc_slot,
+                                                        qc_hash,
+                                                        4,
+                                                    );
+                                                    info!(
                                                         slot = qc_slot,
-                                                        "own-vote-QC inline apply: body unavailable for non-empty block (sync will recover)"
+                                                        recovery_requests = fired,
+                                                        "own-vote-QC inline apply: body unavailable — fired GetBlockByHash"
                                                     );
                                                     continue;
                                                 }
@@ -4314,6 +4410,21 @@ enum PostEventAction {
     ApplyCanonicalAfterQc {
         qc_slot: u64,
         qc_block_hash: [u8; 32],
+    },
+    /// Task #94: a `GetBlockByHash` response arrived carrying a
+    /// candidate full-block payload for `qc_block_hash`. The async
+    /// handler decodes the bytes, validates the header hashes to
+    /// the expected QC block_hash (rejects byte-flips and
+    /// peer-injected mismatches), seeds `pending_block_bodies`,
+    /// and re-emits `ApplyCanonicalAfterQc` so the canonical apply
+    /// path retries with the recovered body in hand. Drives the
+    /// QC-apply body-unavailable recovery path — without this the
+    /// chain wedges any time the compact-block gossip is dropped
+    /// before reaching all peers.
+    RecoveredBlockByHashForQc {
+        qc_slot: u64,
+        qc_block_hash: [u8; 32],
+        block_bytes: Vec<u8>,
     },
     /// Reply to an inbound `PydeAuthReq` with a signed attestation over
     /// `(nonce, our_peer_id)`. The response channel holds the pending
@@ -5855,6 +5966,42 @@ fn handle_swarm_event(
                 },
             ..
         })) => {
+            // Task #94: special-case `BlockByHash` BEFORE the
+            // batch-style `on_response` dispatch. This response
+            // shape carries one full-block bytes blob keyed by the
+            // hash we requested at the body-unavailable recovery
+            // site; we validate the hash, populate
+            // `pending_block_bodies`, and re-emit
+            // `ApplyCanonicalAfterQc` so the apply path retries
+            // with the recovered body. Pre-handling here keeps
+            // `on_response` focused on the slot-keyed batch path.
+            if let SyncResp::BlockByHash(maybe_bytes) = &response {
+                let pending_entry = chain_sync
+                    .pending_block_by_hash
+                    .remove(&request_id);
+                chain_sync.release_pending(request_id);
+                if let Some((qc_slot, qc_block_hash)) = pending_entry {
+                    if let Some(bytes) = maybe_bytes {
+                        return PostEventAction::RecoveredBlockByHashForQc {
+                            qc_slot,
+                            qc_block_hash,
+                            block_bytes: bytes.clone(),
+                        };
+                    } else {
+                        debug!(
+                            qc_slot,
+                            qc_block_hash = hex::encode(qc_block_hash),
+                            "task #94: BlockByHash recovery — peer didn't have the block"
+                        );
+                        return PostEventAction::None;
+                    }
+                } else {
+                    debug!(
+                        "task #94: BlockByHash response with no matching pending entry"
+                    );
+                    return PostEventAction::None;
+                }
+            }
             // Audit 241: hand the snapshot path the full WS anchor
             // (slot + state_root) so it can reject snapshots that
             // either regress past the checkpoint or land on a

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1198,6 +1198,36 @@ impl PydeNode {
                             &mut gossip_cache,
                             );
                         }
+                        PostEventAction::SendConsensusRrResponseAndBroadcastFallbackProposalAndBufferBody(
+                            channel,
+                            resp,
+                            block,
+                            bytes,
+                        ) => {
+                            // Task #94: ack the RR sender, seed the body
+                            // buffer, then broadcast. Same ordering
+                            // rationale as the gossip-side variant.
+                            let _ = swarm.behaviour_mut().consensus_rr.send_response(channel, resp);
+                            let block_hash = block.header.hash();
+                            let slot = block.header.slot;
+                            {
+                                let mut pbb = pending_block_bodies.write().await;
+                                pbb.insert(block_hash, block);
+                            }
+                            debug!(
+                                slot,
+                                block_hash = hex::encode(block_hash),
+                                "task #94: seeded own fallback block into pending_block_bodies (RR-VC-QC)"
+                            );
+                            let topic = pyde_net::node::topics::consensus();
+                            broadcast_consensus_with_rr_fallback(
+                                &mut swarm,
+                                topic,
+                                bytes,
+                                &mut peer_manager,
+                                &mut gossip_cache,
+                            );
+                        }
                         PostEventAction::SendConsensusRrResponseAndApplyQcd(
                             channel,
                             resp,
@@ -1630,6 +1660,43 @@ impl PydeNode {
                                     data,
                                     &mut peer_manager,
                                 &mut gossip_cache,
+                                );
+                            }
+                        }
+                        PostEventAction::BroadcastFallbackProposalAndBufferBody { block, bytes } => {
+                            // Task #94: same audit-218 egress check as
+                            // BroadcastConsensus.
+                            if !is_validator {
+                                warn!(
+                                    "non-validator attempted BroadcastFallbackProposalAndBufferBody; \
+                                     dropped (audit 218)"
+                                );
+                            } else {
+                                // Seed the body buffer FIRST so a fast
+                                // QC arrival sees it on its
+                                // `pending_block_bodies` lookup. The
+                                // gossip-broadcast and the QC race
+                                // (especially with the RR fallback
+                                // pushing votes synchronously), so
+                                // ordering matters.
+                                let block_hash = block.header.hash();
+                                let slot = block.header.slot;
+                                {
+                                    let mut pbb = pending_block_bodies.write().await;
+                                    pbb.insert(block_hash, block);
+                                }
+                                debug!(
+                                    slot,
+                                    block_hash = hex::encode(block_hash),
+                                    "task #94: seeded own fallback block into pending_block_bodies"
+                                );
+                                let topic = pyde_net::node::topics::consensus();
+                                broadcast_consensus_with_rr_fallback(
+                                    &mut swarm,
+                                    topic,
+                                    bytes,
+                                    &mut peer_manager,
+                                    &mut gossip_cache,
                                 );
                             }
                         }
@@ -4195,6 +4262,19 @@ enum PostEventAction {
         encrypted_blocks_to_decrypt: Vec<pyde_consensus::block::Block>,
     },
     BroadcastConsensus(Vec<u8>),
+    /// Task #94: broadcast our own VC fallback Proposal AND seed the
+    /// full block into `pending_block_bodies`. The deterministic
+    /// fallback proposer never sees its own gossip publish, and the
+    /// sync `handle_swarm_event` context can't take the async
+    /// `pending_block_bodies` write lock. Carry the block via this
+    /// action so the main loop's async handler does the insert +
+    /// broadcast atomically — see
+    /// `build_and_encode_fallback_proposal` for the failure mode
+    /// this addresses.
+    BroadcastFallbackProposalAndBufferBody {
+        block: pyde_consensus::block::Block,
+        bytes: Vec<u8>,
+    },
     /// Batch-publish multiple consensus messages in one post-event
     /// action. Used for slashing evidence: a single received proposal
     /// can cause the engine to queue several messages at once (e.g. if
@@ -4261,6 +4341,16 @@ enum PostEventAction {
     SendConsensusRrResponseAndBroadcast(
         request_response::ResponseChannel<pyde_net::consensus_protocol::ConsensusResp>,
         pyde_net::consensus_protocol::ConsensusResp,
+        Vec<u8>,
+    ),
+    /// Task #94: same as `SendConsensusRrResponseAndBroadcast`, but
+    /// also seeds `pending_block_bodies` with the proposer's own
+    /// fallback block. RR-VC-QC twin of
+    /// `BroadcastFallbackProposalAndBufferBody`.
+    SendConsensusRrResponseAndBroadcastFallbackProposalAndBufferBody(
+        request_response::ResponseChannel<pyde_net::consensus_protocol::ConsensusResp>,
+        pyde_net::consensus_protocol::ConsensusResp,
+        pyde_consensus::block::Block,
         Vec<u8>,
     ),
     /// Path A: an RR-receive of a Vote closed the soft QC. The
@@ -4389,7 +4479,7 @@ fn build_and_encode_fallback_proposal(
     engine: &mut ValidatorEngine,
     identity: Option<&ValidatorIdentity>,
     chain: &ChainState,
-) -> Option<Vec<u8>> {
+) -> Option<(pyde_consensus::block::Block, Vec<u8>)> {
     let identity = identity?;
     let parent_hash = chain
         .headers
@@ -4399,11 +4489,35 @@ fn build_and_encode_fallback_proposal(
     // state_root is intentionally [0u8;32] at proposal time — see the
     // primary `build_proposal` call site for the rationale.
     let block = engine.try_build_fallback_proposal(identity, parent_hash, [0u8; 32])?;
+    // Task #94: return the full block alongside the encoded proposal
+    // so the caller can seed it into `pending_block_bodies` before
+    // broadcasting. Without this, the deterministic VC fallback
+    // proposer never has its own block in any local lookup table —
+    // gossip never echoes its own publish — so when the vote-QC
+    // forms and the canonical-apply path checks
+    // `pending_block_bodies.get(qc_block_hash)` it misses, the
+    // synthesize-empty-body fallback's `buffered_proposal_for`
+    // also misses (the proposer never buffered its own header
+    // either), and the proposer silently skips applying its own
+    // slot. Every later slot then applies onto state one slot
+    // behind the rest of the cluster — every state_root from
+    // there diverges (witnessed in soak v15 baseline:
+    // multi_node_state_convergence catches this in 5/5 runs).
+    //
+    // We deliberately do NOT call `engine.buffer_proposal` here:
+    // that would push the proposal into `buffered_proposals` with
+    // `vrf_score = proposer_idx` (small), distorting the
+    // min-by-vrf_score tie-break in `select_and_vote` and
+    // shifting cluster-wide vote dynamics. Witnessed regression
+    // when tried earlier this session: 50/50 wallet funding ->
+    // 0/50 pubkey registrations under sustained load. The body
+    // buffer is the only state we need — vote selection stays
+    // untouched.
     let msg = pyde_consensus::hotstuff::ConsensusMessage::Proposal {
-        header: block.header,
-        proposer_signature: block.proposer_signature,
+        header: block.header.clone(),
+        proposer_signature: block.proposer_signature.clone(),
     };
-    Some(wire::encode_consensus_message(&msg))
+    Some((block, wire::encode_consensus_message(&msg)))
 }
 
 /// Path A canonical-apply sub-helper: synchronously commit the
@@ -5652,12 +5766,17 @@ fn handle_swarm_event(
                                             };
                                         if engine.on_view_change(vc_msg) {
                                             info!(slot, "view change QC formed — fallback proposer can proceed");
-                                            if let Some(bytes) = build_and_encode_fallback_proposal(
-                                                engine,
-                                                validator_identity.as_ref(),
-                                                chain,
-                                            ) {
-                                                return PostEventAction::BroadcastConsensus(bytes);
+                                            if let Some((block, bytes)) =
+                                                build_and_encode_fallback_proposal(
+                                                    engine,
+                                                    validator_identity.as_ref(),
+                                                    chain,
+                                                )
+                                            {
+                                                return PostEventAction::BroadcastFallbackProposalAndBufferBody {
+                                                    block,
+                                                    bytes,
+                                                };
                                             }
                                         }
                                     }
@@ -5971,6 +6090,16 @@ fn handle_swarm_event(
             // the auth handshake re-completion after restart cycles —
             // exactly the failure mode this RR fallback exists to fix.
             let mut pending_fallback_broadcast: Option<Vec<u8>> = None;
+            // Task #94: separate slot for the deterministic VC fallback
+            // proposal so we can also seed the body buffer (carries the
+            // full Block alongside the broadcast bytes). The existing
+            // `pending_fallback_broadcast` is overloaded — the
+            // hard-finality-checkpoint path also uses it — so we can't
+            // change its type without spilling into that handler.
+            let mut pending_fallback_proposal_with_body: Option<(
+                pyde_consensus::block::Block,
+                Vec<u8>,
+            )> = None;
             let mut pending_share_msg: Option<wire::DecryptionShareMsg> = None;
             // Path A: when an RR-fallback Vote closes the soft QC, the
             // bottom-of-arm dispatch emits a combo action that acks the
@@ -6045,12 +6174,15 @@ fn handle_swarm_event(
                                 };
                                 if engine.on_view_change(vc_msg) {
                                     info!(slot, "view change QC formed (via RR fallback) — fallback proposer can proceed");
-                                    if let Some(bytes) = build_and_encode_fallback_proposal(
-                                        engine,
-                                        validator_identity.as_ref(),
-                                        chain,
-                                    ) {
-                                        pending_fallback_broadcast = Some(bytes);
+                                    if let Some((block, bytes)) =
+                                        build_and_encode_fallback_proposal(
+                                            engine,
+                                            validator_identity.as_ref(),
+                                            chain,
+                                        )
+                                    {
+                                        pending_fallback_proposal_with_body =
+                                            Some((block, bytes));
                                     }
                                 }
                             }
@@ -6114,14 +6246,18 @@ fn handle_swarm_event(
                     pyde_net::consensus_protocol::ConsensusResp::DecodeError
                 }
             };
-            // Four-way dispatch: ack the RR sender, then route the
+            // Five-way dispatch: ack the RR sender, then route the
             // decoded payload through the same PostEventAction queue
-            // as the gossip-receive arm. The four pending_* slots
-            // are mutually exclusive because the decode branches are.
+            // as the gossip-receive arm. The pending_* slots are
+            // mutually exclusive because the decode branches are.
             if let Some(share_msg) = pending_share_msg {
                 PostEventAction::SendConsensusRrResponseAndAddShares(channel, resp, share_msg)
             } else if let Some((qc_slot, qc_hash)) = pending_apply_qcd {
                 PostEventAction::SendConsensusRrResponseAndApplyQcd(channel, resp, qc_slot, qc_hash)
+            } else if let Some((block, bytes)) = pending_fallback_proposal_with_body {
+                PostEventAction::SendConsensusRrResponseAndBroadcastFallbackProposalAndBufferBody(
+                    channel, resp, block, bytes,
+                )
             } else {
                 match pending_fallback_broadcast {
                     Some(bytes) => {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -2075,7 +2075,14 @@ impl PydeNode {
                                             mempool_txs.push((etx.hash(), bytes));
                                         }
                                     }
-                                    debug!(
+                                    // Task #94: info — same diagnostic
+                                    // rationale as `compact block
+                                    // reconstructed and buffered`. The
+                                    // encrypted-tx bundle arrives on a
+                                    // separate gossipsub message; loss
+                                    // here is a known cause of body-
+                                    // unavailable cascades.
+                                    info!(
                                         slot,
                                         "reassembled compact block using queued encrypted-tx bundle"
                                     );
@@ -2322,12 +2329,24 @@ impl PydeNode {
                                 let mut pbb = pending_block_bodies.write().await;
                                 pbb.insert(block_hash, block.clone());
                             }
-                            debug!(
+                            // Task #94: keep this at info. Distinguishing
+                            // "compact block never arrived" from "arrived
+                            // but failed to reconstruct" from "arrived,
+                            // reconstructed, but apply skipped" requires
+                            // seeing the success path in operator logs.
+                            // Pre-promotion the reconstruct-success path
+                            // was silent at info level, so the only
+                            // visible chain-stall signal was
+                            // `body unavailable` — which fires on multiple
+                            // upstream causes — and root-causing took
+                            // hours of guesswork. ~1 line per (node, slot)
+                            // under healthy operation, an acceptable cost.
+                            info!(
                                 slot,
                                 block_hash = hex::encode(block_hash),
                                 txs = block.body.transactions.len(),
                                 encrypted = block.body.encrypted_txs.len(),
-                                "compact block reconstructed and buffered (awaiting QC)"
+                                "compact block reconstructed and buffered"
                             );
                         }
                         PostEventAction::BlockProcessed { slot, receipts: receipts_list, tx_hashes } => {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -151,6 +151,19 @@ pub trait PydeApi {
     #[method(name = "pyde_stateRoot")]
     async fn state_root(&self) -> Result<String, ErrorObjectOwned>;
 
+    /// Live SMT root from `StateManager::root()` — the root that
+    /// `block_processor` logs as `state_root` after each apply.
+    /// Distinct from `pyde_stateRoot` which returns
+    /// `chain.state_root` (the field copied from the most recently
+    /// applied header). Header-side `state_root` is `[0u8; 32]` for
+    /// most current-codebase blocks because proposers leave it
+    /// blank, so the older RPC is not a useful cross-node
+    /// convergence signal. Task #94: this method exists so the
+    /// chain-wedge regression test can assert that all 4 nodes hold
+    /// identical state after each applied slot.
+    #[method(name = "pyde_smtRoot")]
+    async fn smt_root(&self) -> Result<String, ErrorObjectOwned>;
+
     #[method(name = "pyde_syncing")]
     async fn syncing(&self) -> Result<serde_json::Value, ErrorObjectOwned>;
 
@@ -432,6 +445,11 @@ impl PydeApiServer for RpcServer {
     async fn state_root(&self) -> Result<String, ErrorObjectOwned> {
         let chain = self.state.chain.read().await;
         Ok(format!("0x{}", hex::encode(chain.state_root)))
+    }
+
+    async fn smt_root(&self) -> Result<String, ErrorObjectOwned> {
+        let state = self.state.state.read().await;
+        Ok(format!("0x{}", hex::encode(state.root())))
     }
 
     async fn syncing(&self) -> Result<serde_json::Value, ErrorObjectOwned> {

--- a/crates/node/src/sync.rs
+++ b/crates/node/src/sync.rs
@@ -31,6 +31,15 @@ pub struct ChainSync {
     pub manager: SyncManager,
     /// Outstanding outbound requests: request_id → peer.
     pending: HashMap<OutboundRequestId, PeerId>,
+    /// Task #94: outstanding `GetBlockByHash` requests:
+    /// `request_id → (qc_slot, qc_block_hash)`. Populated when the
+    /// QC-apply body-unavailable branch fires the request and
+    /// drained when the response arrives. Carrying both qc_slot
+    /// and qc_block_hash lets the response handler validate the
+    /// returned bytes hash to the expected QC and re-emit
+    /// `ApplyCanonicalAfterQc` so the apply path retries with the
+    /// recovered body now seeded into `pending_block_bodies`.
+    pub pending_block_by_hash: HashMap<OutboundRequestId, (u64, [u8; 32])>,
     /// Whether initial sync has completed at least once.
     pub initial_sync_done: bool,
     /// Chunked snapshot receiver state.
@@ -57,6 +66,7 @@ impl ChainSync {
         Self {
             manager: SyncManager::new(),
             pending: HashMap::new(),
+            pending_block_by_hash: HashMap::new(),
             initial_sync_done: false,
             snapshot_chunks: Vec::new(),
             snapshot_expected_root: None,
@@ -170,6 +180,65 @@ impl ChainSync {
             .sync
             .send_request(&peer, SyncReq::GetChainTip);
         debug!(%peer, "requested chain tip");
+    }
+
+    /// Task #94: fan out `GetBlockByHash` to up to `max_peers`
+    /// connected peers for the recovery path that runs when
+    /// QC-apply hits body-unavailable. Each request is registered
+    /// in `pending_block_by_hash` so the response handler can
+    /// validate the returned bytes match `qc_block_hash` and
+    /// re-trigger the canonical apply for `qc_slot`.
+    ///
+    /// Why fan-out: the proposer always has the body in its
+    /// `block_store`, but we don't know which connected peer is
+    /// the proposer. Asking 3-4 peers minimises latency without
+    /// generating a request flood (per-peer rate-limit lives at
+    /// the responder side).
+    ///
+    /// Returns the number of requests fired. 0 means we have no
+    /// connected peers — caller should retry on the next sync
+    /// tick.
+    /// Task #94: drop a `pending` entry without going through
+    /// `on_response`. The BlockByHash recovery path special-cases
+    /// the response in `node.rs` and so won't visit
+    /// `on_response.pending.remove(...)`; it calls this helper
+    /// instead so we don't leak request_ids.
+    pub fn release_pending(&mut self, request_id: OutboundRequestId) {
+        self.pending.remove(&request_id);
+    }
+
+    pub fn request_block_by_hash(
+        &mut self,
+        swarm: &mut Swarm<PydeBehaviour>,
+        qc_slot: u64,
+        qc_block_hash: [u8; 32],
+        max_peers: usize,
+    ) -> usize {
+        let peers: Vec<PeerId> = swarm
+            .connected_peers()
+            .copied()
+            .take(max_peers)
+            .collect();
+        let mut fired = 0;
+        for peer in peers {
+            let request_id = swarm
+                .behaviour_mut()
+                .sync
+                .send_request(&peer, SyncReq::GetBlockByHash(qc_block_hash));
+            self.pending_block_by_hash
+                .insert(request_id, (qc_slot, qc_block_hash));
+            self.pending.insert(request_id, peer);
+            fired += 1;
+        }
+        if fired > 0 {
+            info!(
+                qc_slot,
+                qc_block_hash = hex::encode(qc_block_hash),
+                fired,
+                "task #94: GetBlockByHash fan-out for body recovery"
+            );
+        }
+        fired
     }
 
     /// Request a state snapshot from a peer (for fast sync when far behind).
@@ -614,6 +683,15 @@ impl ChainSync {
                 }
                 (0, Vec::new(), Vec::new())
             }
+            SyncResp::BlockByHash(_) => {
+                // Task #94: handled outside `on_response` (the swarm
+                // event arm in node.rs special-cases this variant
+                // before calling here). Reaching this branch means
+                // a malformed request_id mapping or a peer responded
+                // to an unexpected request — log and ignore.
+                debug!("on_response: unexpected BlockByHash — request was not registered");
+                (0, Vec::new(), Vec::new())
+            }
         }
     }
 
@@ -762,6 +840,21 @@ impl ChainSync {
                     chunk_hash,
                     entries: chunk_entries,
                 }
+            }
+            SyncReq::GetBlockByHash(hash) => {
+                // Task #94: hash-based block lookup. Resolve to slot
+                // via the chain's `hash_to_slot` index, then fetch
+                // the wire-encoded full block from `block_store`.
+                // `BlockByHash(None)` is the "I don't have this
+                // block" signal — distinct from top-level `NotFound`
+                // so the caller knows the request was understood
+                // and the peer just doesn't hold this hash, vs a
+                // protocol-level error.
+                let resp = chain
+                    .hash_to_slot
+                    .get(hash)
+                    .and_then(|slot| block_store.get_block_raw(*slot));
+                SyncResp::BlockByHash(resp)
             }
         }
     }

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -303,8 +303,28 @@ pub struct ValidatorEngine {
     finality_votes: HashMap<u64, Vec<FinalityVote>>,
     /// Buffered proposals per slot (collected during proposal phase, voted after selection).
     buffered_proposals: HashMap<u64, Vec<BufferedProposal>>,
-    /// Whether we've already voted for a given slot (after proposal selection).
-    voted_slots: std::collections::HashSet<u64>,
+    /// Highest view at which we've voted on each slot (audit-94).
+    /// Voting at `(slot, view=0)` does NOT lock out voting at
+    /// `(slot, view=1)` on the deterministic recovery proposal —
+    /// that's the case the view change exists to recover from.
+    /// Sentinel `u64::MAX` means inclusion-violated: voting on
+    /// this slot is permanently disabled regardless of view.
+    voted_view_per_slot: std::collections::HashMap<u64, u64>,
+    /// audit-94: highest view at which this validator has built a
+    /// fallback proposal for each slot. Prevents the double-build
+    /// race where both the gossip and RR view-change-QC paths
+    /// trigger `try_build_fallback_proposal` for the same
+    /// `(slot, view)`. Each build re-stamps `timestamp = now_ms()`
+    /// → different `block_hash` → peers split their fallback votes
+    /// across the two versions → vote-QC never forms → chain
+    /// wedges at the slot the fallback was supposed to recover.
+    /// The companion `buffered_proposals`-based dedup at the top
+    /// of `try_build_fallback_proposal` doesn't catch this: the
+    /// proposer deliberately omits its own fallback from
+    /// `buffered_proposals` (Phase 2 — preserves the
+    /// min-by-`vrf_score` tie-break for cluster-wide vote
+    /// dynamics). This map IS the proposer-side dedup.
+    last_built_fallback_view_per_slot: std::collections::HashMap<u64, u64>,
     /// Seen proposals per slot: (slot, proposer_address) → (header, signature).
     /// Used to detect double-proposing.
     seen_proposals: HashMap<(u64, Address), (BlockHeader, Vec<u8>)>,
@@ -538,7 +558,8 @@ impl ValidatorEngine {
             view_changes: HashMap::new(),
             finality_votes: HashMap::new(),
             buffered_proposals: HashMap::new(),
-            voted_slots: std::collections::HashSet::new(),
+            voted_view_per_slot: std::collections::HashMap::new(),
+            last_built_fallback_view_per_slot: std::collections::HashMap::new(),
             seen_proposals: HashMap::new(),
             seen_votes: HashMap::new(),
             seen_view_changes: HashMap::new(),
@@ -1706,10 +1727,23 @@ impl ValidatorEngine {
     pub fn buffer_proposal(&mut self, header: &BlockHeader, proposer_signature: &[u8]) -> bool {
         let slot = header.slot;
 
-        // Don't buffer if we've already voted for this slot
-        if self.voted_slots.contains(&slot) {
-            debug!(slot, "ignoring late proposal (already voted)");
-            return false;
+        // View-aware late-proposal dedup (audit-94). Voting at view 0
+        // (happy path) does not block buffering a fallback recovery
+        // proposal at view ≥1 — splitting view-0 votes across the
+        // committee is exactly the case the recovery exists for.
+        let proposal_view = pyde_consensus::view_change::decode_fallback_proof(&header.vrf_proof)
+            .map(|(_, v)| v)
+            .unwrap_or(0);
+        if let Some(&voted_view) = self.voted_view_per_slot.get(&slot) {
+            if proposal_view <= voted_view {
+                debug!(
+                    slot,
+                    proposal_view,
+                    voted_view,
+                    "ignoring late proposal (already voted at this or higher view)"
+                );
+                return false;
+            }
         }
 
         // Audit 234 part 3: fallback proposals (built by the
@@ -1916,6 +1950,28 @@ impl ValidatorEngine {
             .map(|p| (p.header.clone(), p.proposer_signature.clone()))
     }
 
+    /// audit-94: resolve the view a buffered proposal was produced
+    /// at by decoding `vrf_proof`. Used by `on_vote`'s equivocation
+    /// detection to distinguish a legit cross-view re-vote (view
+    /// 0 happy-path → view 1 fallback recovery) from a genuine
+    /// same-view double-vote that warrants slashing.
+    ///
+    /// Returns `None` when no buffered proposal at this slot
+    /// matches the hash — caller defensively treats unknown views
+    /// as the same view, preserving the safety property of the
+    /// pre-audit-94 slashing path under partial buffer state.
+    fn view_for_block_hash(&self, slot: u64, block_hash: &[u8; 32]) -> Option<u64> {
+        self.buffered_proposals
+            .get(&slot)?
+            .iter()
+            .find(|p| p.header.hash() == *block_hash)
+            .map(|p| {
+                pyde_consensus::view_change::decode_fallback_proof(&p.header.vrf_proof)
+                    .map(|(_, v)| v)
+                    .unwrap_or(0)
+            })
+    }
+
     /// Flag a slot as having failed the mandatory-inclusion audit (task 026).
     /// Caller is the compact-block reception path in node.rs. A flagged slot
     /// causes `select_and_vote` to skip its vote for this proposal, whatever
@@ -1952,10 +2008,16 @@ impl ValidatorEngine {
     /// actively trying to commit.
     pub fn select_and_vote(&mut self, identity: &ValidatorIdentity) -> Option<ConsensusMessage> {
         let slot = self.consensus.target_height;
+        let current_view = self.consensus.current_view;
 
-        // Don't double-vote
-        if self.voted_slots.contains(&slot) {
-            return None;
+        // View-aware double-vote dedup (audit-94). Re-open the gate
+        // when a view-change-QC has bumped current_view past what we
+        // last voted at, so the fallback recovery proposal becomes
+        // votable.
+        if let Some(&voted_view) = self.voted_view_per_slot.get(&slot) {
+            if voted_view >= current_view {
+                return None;
+            }
         }
 
         // Task 026 — skip vote if the local inclusion audit flagged this slot.
@@ -1964,35 +2026,58 @@ impl ValidatorEngine {
         // the proposal while gas budget remained.
         if self.inclusion_violated_slots.contains(&slot) {
             warn!(slot, "skipping vote: mandatory-inclusion audit failed");
-            // Mark voted so a later arriving compact block that clears the
-            // flag doesn't cause us to belatedly cast a vote. The decision
-            // is final for this slot.
-            self.voted_slots.insert(slot);
+            // Mark voted at MAX view so a later arriving compact block that
+            // clears the flag — even at a higher view — doesn't cause us to
+            // belatedly cast a vote. The decision is final for this slot.
+            self.voted_view_per_slot.insert(slot, u64::MAX);
             return None;
         }
 
+        // View-aware proposal selection. After a VC QC bumps
+        // current_view, only proposals at the current view are
+        // legitimate candidates: a stale view-0 happy-path proposal
+        // sitting in the buffer would otherwise win min-by-vrf-score
+        // (raw VRF bytes can be smaller than fallback's
+        // committee_index) and pull us back into voting on the
+        // wrong view. Filter buffered proposals to those whose
+        // encoded view matches `current_view`.
         let proposals = self.buffered_proposals.get(&slot)?;
         if proposals.is_empty() {
             return None;
         }
-
-        // Pick the proposal with the lowest VRF score (clone to release borrow)
-        let best = proposals.iter().min_by_key(|p| p.vrf_score)?;
+        let best = proposals
+            .iter()
+            .filter(|p| {
+                let v = pyde_consensus::view_change::decode_fallback_proof(&p.header.vrf_proof)
+                    .map(|(_, v)| v)
+                    .unwrap_or(0);
+                v == current_view
+            })
+            .min_by_key(|p| p.vrf_score)?;
         let best_header = best.header.clone();
         let best_score = best.vrf_score;
         let best_proposer = best.header.proposer;
 
         info!(
             slot,
+            current_view,
             vrf_score = best_score,
             proposer = hex::encode(best_proposer),
             "selected best proposal"
         );
 
-        // Vote for the best proposal
+        // Vote for the best proposal. The view we record matches
+        // the proposal's encoded view (= current_view, by filter).
         let vote = self.on_proposal(&best_header, identity);
         if vote.is_some() {
-            self.voted_slots.insert(slot);
+            self.voted_view_per_slot
+                .entry(slot)
+                .and_modify(|v| {
+                    if current_view > *v {
+                        *v = current_view;
+                    }
+                })
+                .or_insert(current_view);
         }
         vote
     }
@@ -2196,12 +2281,48 @@ impl ValidatorEngine {
             mine = identity.committee_index,
             "DBG fallback: I am the deterministic leader for (target_height, current_view); building"
         );
-        // Don't double-build.
-        if self
-            .buffered_proposals
-            .get(&slot)
-            .is_some_and(|v| v.iter().any(|p| p.header.proposer == identity.address))
-        {
+        // audit-94: proposer-side build dedup. Both the gossip-VC and
+        // the RR-VC paths can independently trigger this builder
+        // within the same view-change-QC formation window — without
+        // this gate, we build TWO fallback proposals at the same
+        // `(slot, view)`. Each carries `timestamp = now_ms()` so
+        // their `block_hash`es differ. Peers receive both, vote-split
+        // 1+1+1 across the two block_hashes, and the vote-QC never
+        // reaches quorum even though three legitimate votes were
+        // cast. The chain wedges at the very slot the fallback was
+        // supposed to recover. Witness: diag stall, slot 1, two
+        // back-to-back "built fallback proposal" logs ~1.4ms apart,
+        // zero subsequent "QC formed" until the test panics.
+        //
+        // The `buffered_proposals`-based dedup just below is a
+        // separate guard against happy-path proposal interference;
+        // it can't catch this one because the proposer deliberately
+        // omits its own fallback from `buffered_proposals`.
+        if let Some(&built_view) = self.last_built_fallback_view_per_slot.get(&slot) {
+            if built_view >= view {
+                info!(
+                    slot,
+                    view,
+                    built_view,
+                    "fallback skip: already built fallback at this view"
+                );
+                return None;
+            }
+        }
+        // Don't double-build at the SAME (slot, view) via the
+        // buffered-proposals path either: a happy-path (view-0)
+        // proposal from this node MUST NOT block building a
+        // higher-view fallback recovery proposal — that's exactly
+        // the case the view change exists to recover from. Only skip
+        // if a fallback proposal from this node at THIS exact view
+        // is already buffered (e.g. via a gossip-echo round-trip).
+        if self.buffered_proposals.get(&slot).is_some_and(|v| {
+            v.iter().any(|p| {
+                p.header.proposer == identity.address
+                    && pyde_consensus::view_change::decode_fallback_proof(&p.header.vrf_proof)
+                        .is_some_and(|(_, v)| v == view)
+            })
+        }) {
             return None;
         }
 
@@ -2231,8 +2352,20 @@ impl ValidatorEngine {
 
         info!(
             slot,
+            view,
             "built fallback proposal as deterministic view-change fallback proposer"
         );
+        // Record the (slot, view) build so the second trigger from
+        // the dual gossip+RR view-change-QC path bails out instead
+        // of producing a second timestamped block_hash.
+        self.last_built_fallback_view_per_slot
+            .entry(slot)
+            .and_modify(|v| {
+                if view > *v {
+                    *v = view;
+                }
+            })
+            .or_insert(view);
         Some(Block {
             header,
             body: BlockBody {
@@ -2411,42 +2544,97 @@ impl ValidatorEngine {
         }
 
         // --- Double-vote (equivocation) detection ---
-        // Note: `vote_key` is already declared above for the audit-327
-        // dedup short-circuit. We re-use the same binding here.
-        // Clone the prior vote out so we can drop the `seen_votes` borrow
-        // before calling `ingest_evidence` (which needs `&mut self`).
+        // audit-94: equivocation is defined within a single
+        // `(slot, view)` window. A validator that votes at view 0
+        // (happy-path) and again at view 1 (deterministic recovery
+        // after the view-change-QC) signs two different block_hashes
+        // for the same `(slot, voter_index)` — but those are
+        // legitimate, non-equivocating votes. Pre-audit-94 the check
+        // here was view-blind and would slash honest validators
+        // wedged into recovery. We resolve each block_hash's view
+        // via `view_for_block_hash` (which inspects buffered
+        // proposals) and only slash when both votes were cast at
+        // the same view.
+        //
+        // Defensive default: when a view is unknown (proposal not
+        // buffered locally), treat it as the same view as the other
+        // — preserves the original slashing behaviour under partial
+        // buffer state, accepting some false-positive risk over
+        // missing a real equivocation.
         if let Some((prev_hash, prev_sig)) = self.seen_votes.get(&vote_key).cloned() {
             if prev_hash != block_hash {
-                warn!(
-                    slot,
-                    voter_index,
-                    offender = hex::encode(voter_address),
-                    "DOUBLE VOTE DETECTED — equivocation"
+                let prev_view = self.view_for_block_hash(slot, &prev_hash);
+                let cur_view = self.view_for_block_hash(slot, &block_hash);
+                // Only slash when we KNOW both votes were cast at the
+                // SAME view. Unknown view = vote arrived before its
+                // proposal was buffered (legitimate race under load) —
+                // treat as cross-view and track the new vote rather
+                // than risk slashing an honest validator. This loses
+                // some real-equivocation detection coverage; a
+                // malicious slasher could still construct evidence
+                // and submit it as a Slash tx, and the chain-side
+                // `verify_double_sign` would still accept it. Mainnet
+                // hardening requires committing `view` to the vote
+                // signature so the on-chain verifier can refuse
+                // cross-view evidence.
+                let confirmed_same_view = matches!(
+                    (prev_view, cur_view),
+                    (Some(p), Some(c)) if p == c
                 );
-                // Construct evidence from both votes and route through
-                // `ingest_evidence`, mirroring the double-propose path.
-                // ingest_evidence re-verifies both signatures, dedups on
-                // (slot, signer), pushes to pending + broadcast queues,
-                // and persists to disk before returning — a crash between
-                // detection and the next slot can no longer drop the
-                // evidence (finder's-fee + slashing preserved).
-                let evidence = DoubleSignEvidence {
-                    slot,
-                    block_hash_1: prev_hash,
-                    signature_1: prev_sig,
-                    block_hash_2: block_hash,
-                    signature_2: vote_sig.clone(),
-                    signer: voter_address,
-                    // Filled in by whichever validator broadcasts the
-                    // Slash tx — typically the next block proposer.
-                    submitter: [0u8; 32],
-                };
-                if self.ingest_evidence(evidence) {
-                    info!(
+                if confirmed_same_view {
+                    warn!(
                         slot,
+                        voter_index,
                         offender = hex::encode(voter_address),
-                        "double-vote evidence queued for slashing"
+                        "DOUBLE VOTE DETECTED — equivocation"
                     );
+                    // Construct evidence from both votes and route through
+                    // `ingest_evidence`, mirroring the double-propose path.
+                    // ingest_evidence re-verifies both signatures, dedups on
+                    // (slot, signer), pushes to pending + broadcast queues,
+                    // and persists to disk before returning — a crash between
+                    // detection and the next slot can no longer drop the
+                    // evidence (finder's-fee + slashing preserved).
+                    let evidence = DoubleSignEvidence {
+                        slot,
+                        block_hash_1: prev_hash,
+                        signature_1: prev_sig,
+                        block_hash_2: block_hash,
+                        signature_2: vote_sig.clone(),
+                        signer: voter_address,
+                        // Filled in by whichever validator broadcasts the
+                        // Slash tx — typically the next block proposer.
+                        submitter: [0u8; 32],
+                    };
+                    if self.ingest_evidence(evidence) {
+                        info!(
+                            slot,
+                            offender = hex::encode(voter_address),
+                            "double-vote evidence queued for slashing"
+                        );
+                    }
+                } else {
+                    debug!(
+                        slot,
+                        voter_index,
+                        prev_view = ?prev_view,
+                        cur_view = ?cur_view,
+                        "cross-view re-vote — not equivocation, tracking new vote"
+                    );
+                    // Track the latest vote so future same-view re-votes
+                    // from this voter are still detected.
+                    if let Some(store) = &self.consensus_store {
+                        if let Err(e) = store.save_seen_vote(
+                            slot,
+                            voter_index as u8,
+                            &block_hash,
+                            &vote_sig,
+                        ) {
+                            self.signal_persist_failure("seen-vote", &e.to_string());
+                        }
+                    }
+                    self.seen_votes
+                        .insert(vote_key, (block_hash, vote_sig.clone()));
                 }
             }
         } else {
@@ -3163,14 +3351,30 @@ impl ValidatorEngine {
         self.persist_consensus();
         let new_slot = self.consensus.current_slot;
 
-        // Clean up old vote/view-change data (keep last 10 slots)
+        // Clean up old vote/view-change data (keep last 10 slots).
+        // audit-94: NEVER prune `target_height` itself, regardless of
+        // how far wall-clock has raced ahead. Pre-fix, a wedged
+        // target_height + 10+-slot wall-clock drift erased the
+        // recovery data for the wedged slot, making the wedge
+        // permanent. The `prune_floor = min(prune_before, target)`
+        // clamp keeps target_height (and everything above) intact
+        // on the wedged path while preserving the original 10-slot
+        // window on the healthy path. Equivocation-detection state
+        // (`seen_votes`, `seen_proposals`, `seen_view_changes`)
+        // still anchors on the original wall-clock window so its
+        // gossip-replay protection isn't affected by wedges.
         if new_slot > 10 {
             let prune_before = new_slot - 10;
-            self.votes.retain(|s, _| *s >= prune_before);
-            self.view_changes.retain(|s, _| *s >= prune_before);
-            self.finality_votes.retain(|s, _| *s >= prune_before);
-            self.buffered_proposals.retain(|s, _| *s >= prune_before);
-            self.voted_slots.retain(|s| *s >= prune_before);
+            let prune_floor = std::cmp::min(prune_before, self.consensus.target_height);
+            self.votes.retain(|s, _| *s >= prune_floor);
+            self.view_changes.retain(|s, _| *s >= prune_floor);
+            self.finality_votes.retain(|s, _| *s >= prune_floor);
+            self.buffered_proposals
+                .retain(|s, _| *s >= prune_floor);
+            self.voted_view_per_slot
+                .retain(|s, _| *s >= prune_floor);
+            self.last_built_fallback_view_per_slot
+                .retain(|s, _| *s >= prune_floor);
             self.seen_proposals.retain(|(s, _), _| *s >= prune_before);
             self.seen_votes.retain(|(s, _), _| *s >= prune_before);
             // Audit 327: prune the dedup sets in lockstep with their
@@ -3222,6 +3426,28 @@ impl ValidatorEngine {
     pub fn set_slot_anchor(&mut self, genesis_timestamp_ms: u64, block_time_ms: u64) {
         self.genesis_timestamp_ms = genesis_timestamp_ms;
         self.block_time_ms = block_time_ms;
+
+        // Audit-94: re-anchor the *initial* TimeoutTracker now that
+        // the slot clock is known. The tracker created in `new()`
+        // was anchored to engine-creation-time because the genesis
+        // timestamp wasn't available yet — and engine creation
+        // typically runs 100–300 ms before slot 1's wall-clock
+        // window begins. Without this re-anchor, the 200 ms
+        // `PROPOSAL_TIMEOUT_MS` expires before slot 1 even starts,
+        // firing a spurious view-change. That early VC cascades:
+        // peers form a VC-QC at slot 1, then every subsequent
+        // wall-clock tick layers a happy-path proposal on top of
+        // a chain still in recovery, splitting votes between
+        // forward progress and the fallback candidate and wedging
+        // the chain permanently at startup.
+        //
+        // Only the initial tracker needs this fix; `advance_target_
+        // height` (audit 408) already anchors to the new slot's
+        // wall-clock start once the chain is moving.
+        if !self.timeout.proposal_received && self.timeout.view_change_qc.is_none() {
+            let slot_start_ms = self.slot_start_ms_for_target(self.timeout.slot);
+            self.timeout.slot_start_ms = slot_start_ms;
+        }
     }
 
     /// Wall-clock instant (Unix ms) when slot `target` begins.
@@ -3617,7 +3843,7 @@ mod tests {
         // engine should treat the slot as "voted" for this round, so that
         // a compact block that clears the flag late cannot cause a
         // belated vote.
-        assert!(engine.voted_slots.contains(&slot));
+        assert!(engine.voted_view_per_slot.contains_key(&slot));
         assert!(engine.select_and_vote(&identities[1]).is_none());
     }
 
@@ -4831,7 +5057,14 @@ mod tests {
         // produce DoubleSignEvidence in `pending_evidence` instead of
         // just a log line. Before this fix, a validator that crashed
         // between detection and the next slot lost the slashing signal.
+        //
+        // Audit-94 update: equivocation slashing is now view-aware to
+        // avoid false-positives on honest cross-view re-votes. The
+        // detector requires KNOWN same-view for both votes (via the
+        // proposals buffered for those hashes); construct two real
+        // headers at view 0 and buffer them so the lookup resolves.
         use pyde_consensus::hotstuff::{proposer_sign_message, ConsensusMessage};
+        use pyde_consensus::block::{BlockHeader, QuorumCert};
         use pyde_crypto::falcon::{falcon_keygen, falcon_sign};
 
         let (pk, sk) = falcon_keygen().unwrap();
@@ -4843,8 +5076,32 @@ mod tests {
         engine.set_committee(vec![pk_bytes]);
 
         let slot = 7u64;
-        let hash_a = [0x01u8; 32];
-        let hash_b = [0x02u8; 32];
+
+        // Build two distinct headers at view 0 (vrf_proof omitted →
+        // decode_fallback_proof returns None → view defaults to 0).
+        let mut header_a = BlockHeader {
+            slot,
+            epoch: 0,
+            parent_hash: [0u8; 32],
+            proposer: signer,
+            vrf_proof: vec![],
+            qc_previous: QuorumCert::empty(),
+            tx_root: [0u8; 32],
+            state_root: [0u8; 32],
+            timestamp: 100,
+        };
+        let mut header_b = header_a.clone();
+        header_b.timestamp = 200; // differ in one byte → different hash
+        let hash_a = header_a.hash();
+        let hash_b = header_b.hash();
+        assert_ne!(hash_a, hash_b);
+
+        engine.buffered_proposals.entry(slot).or_default().push(
+            BufferedProposal { header: header_a, proposer_signature: vec![], vrf_score: 0 },
+        );
+        engine.buffered_proposals.entry(slot).or_default().push(
+            BufferedProposal { header: header_b, proposer_signature: vec![], vrf_score: 0 },
+        );
 
         let sign_vote = |h: &[u8; 32]| -> Vec<u8> {
             falcon_sign(&sk, &proposer_sign_message(TEST_CHAIN_ID, slot, h))
@@ -5273,6 +5530,11 @@ mod tests {
             },
         );
 
+        // Audit-94: prune_floor = min(slot - 10, target_height). To
+        // exercise the steady-state pruning path (not the wedged-
+        // chain protective clamp), advance target_height beyond
+        // the prune_before cutoff so the floor is `slot - 10`.
+        engine.consensus.target_height = 10;
         // Advance past slot 15 to trigger pruning (prune < slot - 10 = 5)
         engine.consensus.current_slot = 14;
         engine.advance_slot(); // now at 15

--- a/crates/node/src/wire.rs
+++ b/crates/node/src/wire.rs
@@ -1178,7 +1178,11 @@ pub fn decode_consensus_message(data: &[u8]) -> Result<ConsensusMessage, &'stati
 /// `current_view` after the existing fields. Pre-mainnet: no
 /// migration support — devnets/tests start with a fresh store on
 /// version mismatch.
-const CONSENSUS_STATE_VERSION: u8 = 2;
+// v3 (audit-94): added `last_voted_view` after `last_voted_slot` so
+// the `(slot, view)` lex-monotonic HotStuff safety predicate
+// survives restarts. v2 state files are pre-mainnet — nodes
+// carrying a v2 file fail decode and start fresh from genesis.
+const CONSENSUS_STATE_VERSION: u8 = 3;
 
 pub fn encode_consensus_state(state: &pyde_consensus::hotstuff::ConsensusState) -> Vec<u8> {
     let mut enc = Encoder::new();
@@ -1187,6 +1191,7 @@ pub fn encode_consensus_state(state: &pyde_consensus::hotstuff::ConsensusState) 
     enc.u64(state.current_epoch);
     encode_qc(&mut enc, &state.highest_qc);
     enc.u64(state.last_voted_slot);
+    enc.u64(state.last_voted_view);
     enc.bytes32(&state.last_committed_hash);
     enc.u64(state.last_committed_slot);
     enc.u64(state.target_height);
@@ -1214,6 +1219,7 @@ pub fn decode_consensus_state(
     let current_epoch = dec.u64()?;
     let highest_qc = decode_qc(&mut dec)?;
     let last_voted_slot = dec.u64()?;
+    let last_voted_view = dec.u64()?;
     let last_committed_hash = dec.bytes32()?;
     let last_committed_slot = dec.u64()?;
     let target_height = dec.u64()?;
@@ -1238,6 +1244,7 @@ pub fn decode_consensus_state(
         current_epoch,
         highest_qc,
         last_voted_slot,
+        last_voted_view,
         last_committed_hash,
         last_committed_slot,
         target_height,
@@ -1681,6 +1688,7 @@ mod tests {
             current_epoch: 3,
             highest_qc: dummy_qc(41),
             last_voted_slot: 42,
+            last_voted_view: 1,
             last_committed_hash: [0x77; 32],
             last_committed_slot: 40,
             target_height: 41,
@@ -2107,7 +2115,8 @@ mod tests {
         bytes.extend_from_slice(&[0u8; 32]);
         bytes.extend_from_slice(&0u128.to_le_bytes());
         bytes.extend_from_slice(&0u16.to_le_bytes());
-        // last_voted_slot, last_committed_hash, last_committed_slot
+        // last_voted_slot, last_voted_view, last_committed_hash, last_committed_slot
+        bytes.extend_from_slice(&0u64.to_le_bytes());
         bytes.extend_from_slice(&0u64.to_le_bytes());
         bytes.extend_from_slice(&[0u8; 32]);
         bytes.extend_from_slice(&0u64.to_le_bytes());

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -512,6 +512,16 @@ impl TestNetwork {
         rpc_state_root(&self.nodes[node_idx].rpc_url())
     }
 
+    /// Live SMT root via `pyde_smtRoot`. Use this for cross-node
+    /// convergence assertions — `state_root` (`pyde_stateRoot`)
+    /// returns `chain.state_root` which today is `[0u8; 32]` for
+    /// most blocks because proposers don't fill in the header field.
+    /// Task #94 regression tests rely on `smt_root` to detect actual
+    /// post-apply state divergence across the cluster.
+    pub fn smt_root(&self, node_idx: usize) -> Result<String, String> {
+        rpc_smt_root(&self.nodes[node_idx].rpc_url())
+    }
+
     // --------------------------------------------------------------
     // Slashing helpers (slice 6.6)
     // --------------------------------------------------------------
@@ -1284,6 +1294,11 @@ fn rpc_block_number(rpc_url: &str) -> Result<u64, String> {
 
 fn rpc_state_root(rpc_url: &str) -> Result<String, String> {
     let resp = rpc_call(rpc_url, "pyde_stateRoot", "[]")?;
+    parse_hex_result(&resp)
+}
+
+fn rpc_smt_root(rpc_url: &str) -> Result<String, String> {
+    let resp = rpc_call(rpc_url, "pyde_smtRoot", "[]")?;
     parse_hex_result(&resp)
 }
 

--- a/crates/node/tests/multi_node_state_convergence.rs
+++ b/crates/node/tests/multi_node_state_convergence.rs
@@ -1,0 +1,117 @@
+//! Task #94 regression: every node in a 4-validator testnet MUST
+//! hold the same SMT root after each applied slot.
+//!
+//! Witness motivating the test (soak v15 against clean main):
+//! - Slot 1: deterministic VC fallback proposer (node-2 in that run)
+//!   builds + broadcasts its empty block but never seeds it into
+//!   `pending_block_bodies` or `buffered_proposals`. The QC-formed
+//!   apply path looks up neither, the synthesize-empty-body fallback
+//!   gives up, and the proposer silently skips applying its own
+//!   slot.
+//! - Slot 2 onward: node-2's pre-apply state is one slot behind the
+//!   rest of the cluster, so even when it applies the same block
+//!   the resulting SMT root differs. Cascades for the rest of the
+//!   run.
+//!
+//! Why a dedicated test (not just a soak):
+//! - `multi_node_parallel_exec` reads `pyde_stateRoot` (header field,
+//!   `[0u8; 32]` for current-codebase blocks) — it can't see the
+//!   divergence the soak logs prove. `pyde_smtRoot` (added for
+//!   #94) returns the live SMT root the `block_processor` logs as
+//!   `state_root` after each apply.
+//! - Soak runs are long, flaky on contended boxes, and mix many
+//!   failure modes. This test isolates the convergence invariant:
+//!   spawn → light traffic → check SMT root parity. ~10s.
+//!
+//! Why CHAIN_ID 7331 instead of devnet (31337):
+//! - 7331 is the canonical public-testnet id. Slot 1 there always
+//!   takes the fallback path (no view-0 happy-path proposer in the
+//!   first slot), exercising the bug. Devnet has the same code
+//!   path but FALCON-skip side-channels mask other failure modes
+//!   under load.
+
+use std::time::Duration;
+
+mod common;
+use common::TestNetwork;
+
+const CHAIN_ID: u64 = 7331;
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn smt_root_converges_across_4_validators() {
+    // ── Spawn a 4-validator testnet ──────────────────────────────
+    let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id={}: {}", CHAIN_ID, e));
+
+    // Warm-up: let the chain reach slot 5. Slot 1 is the
+    // diagnostic-critical one — it's where the fallback-proposer
+    // self-buffer bug surfaces — but on a healthy chain we should
+    // see at least 5 slots applied within a few seconds. Anything
+    // longer than 30s is a separate stall problem (covered by
+    // `multi_node_finality`).
+    net.wait_for_slot(5, Duration::from_secs(30))
+        .unwrap_or_else(|e| panic!("warm-up to slot 5: {}", e));
+
+    // ── Sample SMT roots from every node ─────────────────────────
+    let roots: Vec<String> = (0..4)
+        .map(|i| {
+            net.smt_root(i)
+                .unwrap_or_else(|e| panic!("smt_root node-{}: {}", i, e))
+        })
+        .collect();
+
+    // Defensive: roots should be 0x-prefixed hex of length 66.
+    for (i, r) in roots.iter().enumerate() {
+        assert!(
+            r.starts_with("0x") && r.len() == 66,
+            "node-{} smt_root malformed: {:?}",
+            i,
+            r
+        );
+    }
+
+    // ── The invariant ────────────────────────────────────────────
+    // Every node ran the same sequence of canonical blocks against
+    // the same genesis state, so every node must hold the same
+    // SMT root. Anything else means at least one node skipped or
+    // applied-out-of-order. The error message dumps every node's
+    // root so a single failure run shows which node is the odd one
+    // out.
+    let same = roots.windows(2).all(|w| w[0] == w[1]);
+    assert!(
+        same,
+        "smt_root divergence after warm-up — task #94 regression:\n\
+         node-0: {}\nnode-1: {}\nnode-2: {}\nnode-3: {}",
+        roots[0], roots[1], roots[2], roots[3]
+    );
+
+    // ── Sample again after a few more slots to catch the cascade ─
+    // Even when slot 1 applies cleanly, the under-load body-
+    // propagation bug surfaces around slots 19+ on multi-tx blocks.
+    // For this minimal test we don't generate load (the soak does
+    // that), so converging at slot 10 is a reasonable bar — just
+    // long enough that any slot-1 cascade would be visible.
+    net.wait_for_slot(10, Duration::from_secs(15))
+        .unwrap_or_else(|e| panic!("warm-up to slot 10: {}", e));
+
+    let roots2: Vec<String> = (0..4)
+        .map(|i| {
+            net.smt_root(i)
+                .unwrap_or_else(|e| panic!("smt_root node-{} @ slot10: {}", i, e))
+        })
+        .collect();
+
+    let same2 = roots2.windows(2).all(|w| w[0] == w[1]);
+    assert!(
+        same2,
+        "smt_root divergence at ~slot 10 — task #94 regression:\n\
+         node-0: {}\nnode-1: {}\nnode-2: {}\nnode-3: {}",
+        roots2[0], roots2[1], roots2[2], roots2[3]
+    );
+
+    eprintln!(
+        "smt root converged across all 4 nodes — slot5={} slot10={}",
+        roots[0], roots2[0]
+    );
+}


### PR DESCRIPTION
## Summary

Closes the testnet-launch chain-wedge blocker (task #94). Three
commits cover the diagnosis, the regression test scaffold, and the
view-aware safety fixes:

- `test(consensus)`: 4-validator multi-node regression test + slot-
  level observability so future wedges produce actionable logs.

- `fix(consensus)`: seed the fallback proposer's own block into
  `pending_block_bodies` so the QC-apply path can locate it when the
  proposer is also the leader. Without this, the proposer's own
  block was missing from its local buffer and the QC could not be
  applied locally.

- `fix(consensus)`: view-aware voting + initial timeout anchor —
  the structural fix. Root cause is that the initial TimeoutTracker
  was anchored to engine-creation time, not slot 1's wall-clock
  start; the 200 ms PROPOSAL_TIMEOUT_MS expired before slot 1
  began, firing a spurious view-change that cascaded across every
  subsequent wall-clock tick. Companion sub-fixes:
    - view-aware vote dedup (`voted_view_per_slot`)
    - HotStuff lex-monotonic `(slot, view)` safety
    - view-aware equivocation (`view_for_block_hash`)
    - proposer-side fallback build dedup
    - prune anchor at `min(slot - 10, target_height)`
    - Phase 3 `GetBlockByHash` recovery in QC-apply path

## Results

- diag chain-wedge warm-up: 15/15 PASS
- validator unit tests: 74/74 PASS
- multi-node SMT-root convergence: PASS at slot 5 + 10
- consensus lib: 140/140 PASS

## Known follow-ups (not in this PR)

- `comprehensive_soak` fails at step 2 (50-sender funding) under
  sustained load — distinct from the wedge, needs separate
  investigation
- Mainnet hardening: vote signatures should include `view` (for
  safe slashing on cross-view double-vote)
- DKG replacement for the single-dealer threshold setup at
  `genesis.rs:1123` (task #94 follow-up)