### PR TITLE
feat(node): per-validator Kyber KEM keypair (task #95)

### DIFF
--- a/crates/consensus/src/validator.rs
+++ b/crates/consensus/src/validator.rs
@@ -43,6 +43,13 @@ pub struct Validator {
     pub status: ValidatorStatus,
     /// Epoch when registered.
     pub registered_epoch: u64,
+    /// Task #95: Kyber-768 KEM public key for receiving encrypted DKG
+    /// shares during per-epoch key generation. `None` for legacy
+    /// validators that registered before KEM-key registration was
+    /// required; they can join the committee but cannot participate
+    /// in DKG (other members would have nowhere to send their share
+    /// rows). Genesis-bundled validators always have this populated.
+    pub kem_pk: Option<Vec<u8>>,
 }
 
 /// The active committee for an epoch.
@@ -125,6 +132,7 @@ impl ValidatorSet {
             stake: VALIDATOR_STAKE, // exactly 10K, excess returned
             status: ValidatorStatus::Active,
             registered_epoch: current_epoch,
+            kem_pk: None,
         });
 
         Ok(())

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -258,6 +258,15 @@ pub struct GenesisValidator {
     pub public_key: String,
     /// Staked amount in quanta as string.
     pub stake: String,
+    /// Task #95: hex-encoded Kyber-768 KEM public key. Optional for
+    /// backward compatibility with pre-task-#95 genesis bundles —
+    /// missing means the validator can't receive encrypted DKG shares
+    /// at registration time and must register a KEM key via a future
+    /// StakeDeposit / KEM-rotation transaction before participating in
+    /// the next DKG round. Genesis bundles produced by `pyde testnet`
+    /// always populate this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kem_public_key: Option<String>,
 }
 
 impl GenesisValidator {
@@ -265,6 +274,20 @@ impl GenesisValidator {
         self.stake
             .parse::<u128>()
             .map_err(|e| format!("invalid stake '{}': {}", self.stake, e))
+    }
+
+    /// Decode the hex-encoded KEM pk into raw bytes, or `None` if the
+    /// validator didn't supply one at genesis.
+    pub fn kem_pk_bytes(&self) -> Result<Option<Vec<u8>>, String> {
+        match &self.kem_public_key {
+            Some(hex_pk) => {
+                let stripped = hex_pk.strip_prefix("0x").unwrap_or(hex_pk);
+                let raw = hex::decode(stripped)
+                    .map_err(|e| format!("invalid kem_public_key hex: {}", e))?;
+                Ok(Some(raw))
+            }
+            None => Ok(None),
+        }
     }
 }
 
@@ -458,12 +481,14 @@ pub fn initialize_genesis(
             hex::decode(pk_hex).map_err(|e| format!("invalid validator pk for registry: {}", e))?;
         let stake = val.stake_u128()?;
 
+        let kem_pk = val.kem_pk_bytes()?;
         let entry = pyde_tx::pipeline::ValidatorEntry {
             pk: pk_bytes,
             stake,
             status: 0x00, // Active
             last_claimed_at: 0,
             exit_block: None,
+            kem_pk,
         };
 
         let key = pyde_state::keys::validator_key(&address);
@@ -1009,8 +1034,22 @@ pub fn generate_testnet(
     let mut validators = Vec::new();
     let mut accounts = Vec::new();
 
-    // Generate FALCON keypairs for each validator
+    // Task #95: per-validator KEM keypair, generated ahead of the
+    // accounts loop so each `GenesisValidator` can be populated with
+    // its `kem_public_key` inline. Same trust boundary as the FALCON
+    // keypairs that follow — this binary holds all secrets briefly
+    // and writes them out per node directory; the operator is
+    // expected to distribute and discard.
+    let mut kem_keypairs: Vec<(pyde_crypto::kyber::KyberPublicKey, pyde_crypto::kyber::KyberSecretKey)> =
+        Vec::with_capacity(num_validators);
     for _ in 0..num_validators {
+        let kp = pyde_crypto::kyber::kyber_keygen()
+            .map_err(|e| format!("validator kem keygen failed: {}", e))?;
+        kem_keypairs.push(kp);
+    }
+
+    // Generate FALCON keypairs for each validator
+    for i in 0..num_validators {
         let (pk, sk) = falcon_keygen().map_err(|e| format!("keygen failed: {}", e))?;
         let address = derive_eoa_address(pk.as_bytes());
 
@@ -1026,6 +1065,7 @@ pub fn generate_testnet(
             address: hex::encode(address),
             public_key: hex::encode(pk.as_bytes()),
             stake: funding.to_string(),
+            kem_public_key: Some(hex::encode(kem_keypairs[i].0.as_bytes())),
         });
 
         accounts.push(DevnetAccount {
@@ -1124,6 +1164,11 @@ pub fn generate_testnet(
         pyde_crypto::threshold::threshold_keygen(num_validators, threshold)
             .map_err(|e| format!("threshold keygen failed: {}", e))?;
 
+    // Task #95: the per-validator KEM keypairs were already generated
+    // above (before the accounts loop) so each `GenesisValidator` could
+    // be populated with its `kem_public_key` inline. They live in
+    // `kem_keypairs[i]` and are written to per-node `kem.key` below.
+
     // Pre-generate node identity keys (Ed25519 for libp2p) so we know peer IDs
     // and can write full bootstrap multiaddrs in each config.
     //
@@ -1171,6 +1216,20 @@ pub fn generate_testnet(
         // Write threshold public key (shared — same for all nodes)
         fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
             .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+
+        // Task #95: write per-validator KEM keypair as
+        // `pk_len(4 LE) || pk || sk` — same format
+        // `load_or_generate_kem_key` in node.rs expects. 0o600 via
+        // `write_secret_file` because `sk` is signing material for
+        // share-receipt during DKG.
+        let kem_pk_bytes = kem_keypairs[i].0.as_bytes();
+        let kem_sk_bytes = kem_keypairs[i].1.as_bytes();
+        let mut kem_buf =
+            Vec::with_capacity(4 + kem_pk_bytes.len() + kem_sk_bytes.len());
+        kem_buf.extend_from_slice(&(kem_pk_bytes.len() as u32).to_le_bytes());
+        kem_buf.extend_from_slice(kem_pk_bytes);
+        kem_buf.extend_from_slice(kem_sk_bytes);
+        write_secret_file(&node_dir.join("kem.key"), &kem_buf)?;
 
         // Copy genesis.toml into each node's directory
         fs::write(node_dir.join("genesis.toml"), genesis_config.to_toml())

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -6683,13 +6683,71 @@ fn load_validator_identity(datadir: &Path, chain_id: u64) -> Result<ValidatorIde
         None
     };
 
+    let (kem_pk, kem_sk) = load_or_generate_kem_key(datadir)?;
+
     Ok(ValidatorIdentity {
         address,
         public_key: pk,
         secret_key: sk,
         committee_index: 0, // assigned when joining committee
         key_share,
+        kem_public_key: kem_pk,
+        kem_secret_key: kem_sk,
     })
+}
+
+/// Task #95: load the validator's long-lived KEM keypair from
+/// `<datadir>/kem.key`, generating + persisting a fresh one if the
+/// file doesn't exist. The KEM pk goes on-chain in the validator's
+/// `ValidatorEntry`; the sk stays on this validator's disk
+/// indefinitely. Used by other committee members to encrypt DKG share
+/// rows to this validator during per-epoch key generation.
+///
+/// File format: `pk_len(4 LE) || pk || sk`. Mode 0o600 via
+/// `genesis::write_secret_file`. Silent-regeneration is allowed
+/// because the KEM key is a per-validator local artifact — unlike
+/// `validator.key` where regeneration desyncs the validator from
+/// its on-chain stake position, a regenerated KEM key just means
+/// the validator can't decrypt shares addressed to its old kem_pk
+/// until the on-chain entry is updated (a self-healing condition,
+/// not a chain corruption).
+fn load_or_generate_kem_key(
+    datadir: &Path,
+) -> Result<(pyde_crypto::kyber::KyberPublicKey, pyde_crypto::kyber::KyberSecretKey), String> {
+    use pyde_crypto::kyber::{KyberPublicKey, KyberSecretKey};
+    let kem_path = datadir.join("kem.key");
+    if kem_path.exists() {
+        let buf = std::fs::read(&kem_path)
+            .map_err(|e| format!("failed to read {}: {}", kem_path.display(), e))?;
+        if buf.len() < 4 {
+            return Err(format!("{} is corrupted (too short)", kem_path.display()));
+        }
+        let pk_len = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+        if buf.len() < 4 + pk_len {
+            return Err(format!("{} pk truncated", kem_path.display()));
+        }
+        let pk = KyberPublicKey::from_bytes(&buf[4..4 + pk_len])
+            .ok_or_else(|| format!("{} has invalid kem pk", kem_path.display()))?;
+        let sk = KyberSecretKey::from_bytes(&buf[4 + pk_len..])
+            .ok_or_else(|| format!("{} has invalid kem sk", kem_path.display()))?;
+        info!("loaded kem.key (Kyber-768 KEM identity)");
+        Ok((pk, sk))
+    } else {
+        let (pk, sk) = pyde_crypto::kyber::kyber_keygen()
+            .map_err(|e| format!("kem keygen failed: {}", e))?;
+        let pk_bytes = pk.as_bytes();
+        let sk_bytes = sk.as_bytes();
+        let mut buf = Vec::with_capacity(4 + pk_bytes.len() + sk_bytes.len());
+        buf.extend_from_slice(&(pk_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(pk_bytes);
+        buf.extend_from_slice(sk_bytes);
+        crate::genesis::write_secret_file(&kem_path, &buf)?;
+        info!(
+            path = %kem_path.display(),
+            "generated new validator KEM keypair"
+        );
+        Ok((pk, sk))
+    }
 }
 
 /// Load node identity from disk, or generate and persist a new one.

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -41,6 +41,21 @@ pub struct ValidatorIdentity {
     pub committee_index: u8,
     /// Threshold decryption key share for MEV-protected mempool.
     pub key_share: Option<KeyShare>,
+    /// Task #95: long-lived per-validator KEM keypair used for
+    /// receiving encrypted shares during DKG. Other committee members
+    /// encrypt this validator's `delta[v]` row to `kem_public_key`
+    /// using Kyber-KEM + AEAD; only the holder of `kem_secret_key`
+    /// can decrypt their share. Persisted at `<datadir>/kem.key`,
+    /// pk is published on-chain as part of the validator's
+    /// `ValidatorEntry` so peers can discover it.
+    ///
+    /// Long-lived rather than per-epoch: simpler bookkeeping at the
+    /// cost of forward secrecy — a stolen `kem_secret_key` lets the
+    /// attacker decrypt every past DKG share addressed to this
+    /// validator. Forward-secret per-epoch ephemeral KEM keys are a
+    /// follow-up once the long-lived path is stable.
+    pub kem_public_key: pyde_crypto::kyber::KyberPublicKey,
+    pub kem_secret_key: pyde_crypto::kyber::KyberSecretKey,
 }
 
 /// Verify that a validator has sufficient stake on-chain.
@@ -112,6 +127,7 @@ pub fn load_validator_set_from_state(
                 stake: entry.stake,
                 status,
                 registered_epoch: 0,
+                kem_pk: entry.kem_pk,
             });
         }
     }
@@ -3437,12 +3453,15 @@ mod tests {
         let (pk, sk) = falcon_keygen().unwrap();
         let pk_bytes = pk.as_bytes().to_vec();
         let address = derive_eoa_address(&pk_bytes);
+        let (kem_pk, kem_sk) = pyde_crypto::kyber::kyber_keygen().unwrap();
         ValidatorIdentity {
             address,
             public_key: pk,
             secret_key: sk,
             committee_index: index,
             key_share: None,
+            kem_public_key: kem_pk,
+            kem_secret_key: kem_sk,
         }
     }
 
@@ -4980,12 +4999,15 @@ mod tests {
         // is the validator that will build the block and submit evidence.
         let (pk, sk) = falcon_keygen().unwrap();
         let submitter_addr = pyde_account::address::derive_eoa_address(pk.as_bytes());
+        let (kem_pk, kem_sk) = pyde_crypto::kyber::kyber_keygen().unwrap();
         let identity = ValidatorIdentity {
             address: submitter_addr,
             public_key: pk.clone(),
             secret_key: sk,
             committee_index: 0,
             key_share: None,
+            kem_public_key: kem_pk,
+            kem_secret_key: kem_sk,
         };
 
         let mut engine = ValidatorEngine::new(TEST_CHAIN_ID, [0xAA; 32]);
@@ -5039,6 +5061,7 @@ mod tests {
             status: 0x00,
             last_claimed_at: 0,
             exit_block: None,
+            kem_pk: None,
         };
         smt.insert(
             pyde_state::keys::validator_key(&offender_addr),
@@ -5084,12 +5107,15 @@ mod tests {
             .to_vec();
 
         // Push into the engine's queue, exactly as the detection site does.
+        let (sub_kem_pk, sub_kem_sk) = pyde_crypto::kyber::kyber_keygen().unwrap();
         let identity = ValidatorIdentity {
             address: submitter_addr,
             public_key: submitter_pk,
             secret_key: submitter_sk,
             committee_index: 0,
             key_share: None,
+            kem_public_key: sub_kem_pk,
+            kem_secret_key: sub_kem_sk,
         };
         // Engine is bound to the same chain_id as the block context so
         // its `ingest_evidence` (when used) and on-chain handler agree.
@@ -5338,6 +5364,7 @@ mod tests {
 
         // Create threshold keys and assign one share
         let (tpk, key_shares) = pyde_crypto::threshold::threshold_keygen(3, 2).unwrap();
+        let (kem_pk_a, kem_sk_a) = pyde_crypto::kyber::kyber_keygen().unwrap();
 
         let identity = ValidatorIdentity {
             address,
@@ -5345,6 +5372,8 @@ mod tests {
             secret_key: sk,
             committee_index: 0,
             key_share: Some(key_shares[0].clone()),
+            kem_public_key: kem_pk_a,
+            kem_secret_key: kem_sk_a,
         };
 
         // Create an encrypted tx to generate shares for
@@ -5381,6 +5410,7 @@ mod tests {
         let address = derive_eoa_address(&pk_bytes);
 
         let (tpk, key_shares) = pyde_crypto::threshold::threshold_keygen(3, 2).unwrap();
+        let (kem_pk_b, kem_sk_b) = pyde_crypto::kyber::kyber_keygen().unwrap();
 
         let identity = ValidatorIdentity {
             address,
@@ -5388,6 +5418,8 @@ mod tests {
             secret_key: sk,
             committee_index: 0,
             key_share: Some(key_shares[0].clone()),
+            kem_public_key: kem_pk_b,
+            kem_secret_key: kem_sk_b,
         };
 
         let to = derive_eoa_address(b"to");

--- a/crates/tx/src/pipeline.rs
+++ b/crates/tx/src/pipeline.rs
@@ -1442,6 +1442,17 @@ pub struct ValidatorEntry {
     /// Block at which unbonding was initiated. Only populated when
     /// `status == 0x01` (Unbonding).
     pub exit_block: Option<u64>,
+    /// Task #95: long-lived Kyber-768 KEM public key. Committee
+    /// members encrypt this validator's DKG share rows to `kem_pk`
+    /// during per-epoch key generation; only the validator (holding
+    /// the matching sk on disk) can decrypt. Optional for backward
+    /// compatibility with pre-task-#95 entries — `None` means the
+    /// validator hasn't registered a KEM key on-chain yet and can
+    /// receive DKG shares only via fallback paths (or be excluded
+    /// from the round). Genesis bundles populate this; post-genesis
+    /// `StakeDeposit` carries it as a follow-up wire change (see
+    /// task #95 Phase A4 followups).
+    pub kem_pk: Option<Vec<u8>>,
 }
 
 impl ValidatorEntry {
@@ -1462,10 +1473,35 @@ impl ValidatorEntry {
         let last_claimed_at =
             u128::from_le_bytes(bytes[claim_start..claim_start + 16].try_into().ok()?);
         let exit_start = claim_start + 16;
-        let exit_block = if status == 0x01 && bytes.len() >= exit_start + 8 {
-            Some(u64::from_le_bytes(
-                bytes[exit_start..exit_start + 8].try_into().ok()?,
-            ))
+        let (exit_block, mut tail_pos) = if status == 0x01 && bytes.len() >= exit_start + 8 {
+            (
+                Some(u64::from_le_bytes(
+                    bytes[exit_start..exit_start + 8].try_into().ok()?,
+                )),
+                exit_start + 8,
+            )
+        } else {
+            (None, exit_start)
+        };
+        // Task #95: optional kem_pk trailer — `kem_pk_len(4 LE) || kem_pk`.
+        // Older entries (genesis pre-task-#95, or any entry that
+        // hasn't re-keyed) end at `tail_pos`; the trailer is absent
+        // and `kem_pk` is `None`. Newer entries append it. Reading
+        // it is non-fatal: a malformed trailer downgrades to `None`
+        // rather than rejecting the whole entry, so a forward-going
+        // operator can't lose a validator's stake position by
+        // garbling the KEM bytes.
+        let kem_pk = if bytes.len() >= tail_pos + 4 {
+            let kem_pk_len =
+                u32::from_le_bytes(bytes[tail_pos..tail_pos + 4].try_into().ok()?) as usize;
+            tail_pos += 4;
+            if kem_pk_len > 0 && bytes.len() >= tail_pos + kem_pk_len {
+                Some(bytes[tail_pos..tail_pos + kem_pk_len].to_vec())
+            } else if kem_pk_len == 0 {
+                None
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -1475,11 +1511,14 @@ impl ValidatorEntry {
             status,
             last_claimed_at,
             exit_block,
+            kem_pk,
         })
     }
 
     pub fn encode(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(VALIDATOR_ENTRY_BASE_LEN + 8);
+        let kem_pk_len = self.kem_pk.as_ref().map(|b| b.len()).unwrap_or(0);
+        let mut buf =
+            Vec::with_capacity(VALIDATOR_ENTRY_BASE_LEN + 8 + 4 + kem_pk_len);
         buf.extend_from_slice(&(self.pk.len() as u32).to_le_bytes());
         buf.extend_from_slice(&self.pk);
         buf.extend_from_slice(&self.stake.to_le_bytes());
@@ -1487,6 +1526,14 @@ impl ValidatorEntry {
         buf.extend_from_slice(&self.last_claimed_at.to_le_bytes());
         if let Some(eb) = self.exit_block {
             buf.extend_from_slice(&eb.to_le_bytes());
+        }
+        // Task #95: kem_pk trailer. Absence is encoded as `0_u32`,
+        // so a new decoder reading a pre-task-#95 entry (no trailer
+        // bytes) and a new decoder reading an explicit-absent
+        // trailer reach the same `kem_pk = None`.
+        buf.extend_from_slice(&(kem_pk_len as u32).to_le_bytes());
+        if let Some(kp) = &self.kem_pk {
+            buf.extend_from_slice(kp);
         }
         buf
     }
@@ -4364,6 +4411,7 @@ mod tests {
             status: status_byte,
             last_claimed_at: 0,
             exit_block: None,
+            kem_pk: None,
         };
         let key = pyde_state::keys::validator_key(addr);
         smt.insert(key, entry.encode()).unwrap();


### PR DESCRIPTION
## Summary

Foundation for real DKG (task #95). Every validator now has a
long-lived Kyber-768 KEM keypair used to receive encrypted DKG
share rows during per-epoch key generation. The pk goes on-chain
in `ValidatorEntry`; the sk stays on disk at `<datadir>/kem.key`.

## Layered changes

- `ValidatorIdentity` gains `kem_public_key` + `kem_secret_key`
- `load_or_generate_kem_key` persists `<datadir>/kem.key` at 0o600;
  generates on first boot if missing
- `pyde testnet` genesis bundle generates a Kyber keypair per
  validator, writes `kem.key` per `node-i/`, and populates
  `GenesisValidator.kem_public_key` in `genesis.toml`
- `ValidatorEntry` wire format appends an optional `kem_pk` trailer
  (`kem_pk_len(4 LE) || kem_pk`). Backward-compatible decode:
  pre-task-#95 entries and entries explicitly encoding absence
  (`0_u32`) both reach `kem_pk = None`
- `consensus::Validator` carries `kem_pk: Option<Vec<u8>>`;
  `load_validator_set_from_state` reads from the chain

## Design notes

- **Long-lived rather than per-epoch ephemeral**: simpler
  bookkeeping at the cost of forward secrecy. A stolen `kem_sk`
  lets the attacker decrypt every past DKG share addressed to this
  validator. Per-epoch ephemeral KEM keys are a follow-up.
- **`StakeDeposit` doesn't yet carry `kem_pk`** — only
  genesis-registered validators have on-chain KEM keys. Post-
  genesis registrants can join the committee but are excluded from
  DKG rounds. The `StakeDeposit` wire change ships in the next
  task-#95 increment.
- **No consumers yet** — DKG itself comes in follow-ups. This PR
  is safe to land in isolation; no existing behaviour changes.

## Results

- workspace builds clean
- `pyde-tx` lib: 258/258
- `pyde-consensus` lib: 140/140
- `pyde-node` validator: 74/74
- `pyde-aot` lib: 403/403