### PR TITLE
chore(node): gate MEV-protection pipeline behind compile-time const

### DIFF
--- a/crates/net/src/node.rs
+++ b/crates/net/src/node.rs
@@ -405,18 +405,21 @@ pub fn dial_bootstrap_peers(swarm: &mut Swarm<PydeBehaviour>, bootstrap_peers: &
 pub fn subscribe_topics(
     swarm: &mut Swarm<PydeBehaviour>,
     is_validator: bool,
+    mev_protection_enabled: bool,
 ) -> Result<(), String> {
-    // All nodes subscribe to transactions (plaintext + encrypted), blocks, sync
+    // All nodes subscribe to transactions (plaintext), blocks, sync
     swarm
         .behaviour_mut()
         .gossipsub
         .subscribe(&topics::transactions())
         .map_err(|e| format!("subscribe error: {e}"))?;
-    swarm
-        .behaviour_mut()
-        .gossipsub
-        .subscribe(&topics::encrypted_transactions())
-        .map_err(|e| format!("subscribe error: {e}"))?;
+    if mev_protection_enabled {
+        swarm
+            .behaviour_mut()
+            .gossipsub
+            .subscribe(&topics::encrypted_transactions())
+            .map_err(|e| format!("subscribe error: {e}"))?;
+    }
     swarm
         .behaviour_mut()
         .gossipsub
@@ -550,14 +553,14 @@ mod tests {
     async fn create_validator_node() {
         let config = NetworkConfig::validator(30303);
         let (mut swarm, _) = create_node(&config, generate_keypair()).unwrap();
-        subscribe_topics(&mut swarm, true).unwrap();
+        subscribe_topics(&mut swarm, true, true).unwrap();
     }
 
     #[tokio::test]
     async fn create_full_node() {
         let config = NetworkConfig::full_node(30304);
         let (mut swarm, _) = create_node(&config, generate_keypair()).unwrap();
-        subscribe_topics(&mut swarm, false).unwrap();
+        subscribe_topics(&mut swarm, false, true).unwrap();
     }
 
     #[tokio::test]

--- a/crates/node/src/genesis.rs
+++ b/crates/node/src/genesis.rs
@@ -1160,6 +1160,17 @@ pub fn generate_testnet(
     // PSS refresh is wired into epoch boundary (node.rs:767, validator.rs:284).
     // Multi-party ceremony: use `pyde testnet` for distributed keygen.
     let threshold = pyde_consensus::block::quorum_for_committee(num_validators);
+    // When MEV protection is disabled at compile time, the
+    // encrypted-mempool pipeline is fully off (gossipsub topic
+    // unsubscribed, RPC endpoints return errors, proposer selects
+    // no encrypted txs). Threshold keygen still has to run because
+    // downstream consumers (validator-set wire format, RPC state)
+    // expect a `ThresholdPublicKey` to exist — but we use the
+    // generated material only to populate that scaffolding; the
+    // shares are never written to disk and the pubkey is never
+    // gossiped. Result: a fresh testnet bundle with MEV off
+    // contains NO threshold-share files, no per-validator escrow,
+    // and no on-disk encrypted-mempool keying material.
     let (threshold_pk, key_shares) =
         pyde_crypto::threshold::threshold_keygen(num_validators, threshold)
             .map_err(|e| format!("threshold keygen failed: {}", e))?;
@@ -1210,12 +1221,17 @@ pub fn generate_testnet(
             .map_err(|e| format!("failed to serialize node key: {}", e))?;
         write_secret_file(&node_dir.join("node.key"), &node_key_bytes)?;
 
-        // Write threshold key share (binary) for MEV-protected decryption
-        write_secret_file(&node_dir.join("threshold.share"), &key_shares[i].to_bytes())?;
+        // Write threshold key share (binary) for MEV-protected
+        // decryption. Skipped entirely when MEV protection is off
+        // — no on-disk encrypted-mempool keying material exists in
+        // that build.
+        if crate::MEV_PROTECTION_ENABLED {
+            write_secret_file(&node_dir.join("threshold.share"), &key_shares[i].to_bytes())?;
 
-        // Write threshold public key (shared — same for all nodes)
-        fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
-            .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+            // Write threshold public key (shared — same for all nodes)
+            fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
+                .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+        }
 
         // Task #95: write per-validator KEM keypair as
         // `pk_len(4 LE) || pk || sk` — same format
@@ -1367,9 +1383,12 @@ json = false
             .map_err(|e| format!("failed to serialize node key: {}", e))?;
         write_secret_file(&node_dir.join("node.key"), &node_key_bytes)?;
 
-        // threshold.pk (shared — same for every node).
-        fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
-            .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+        // threshold.pk (shared — same for every node). Skipped
+        // when MEV protection is disabled at compile time.
+        if crate::MEV_PROTECTION_ENABLED {
+            fs::write(node_dir.join("threshold.pk"), threshold_pk.to_bytes())
+                .map_err(|e| format!("failed to write threshold.pk: {}", e))?;
+        }
 
         // Copy genesis.toml.
         fs::write(node_dir.join("genesis.toml"), genesis_config.to_toml())

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -1,3 +1,40 @@
+/// Chain-wide compile-time gate for the encrypted-mempool (MEV-
+/// protection) pipeline.
+///
+/// When `false`, the encrypted-tx path is fully disabled end-to-end:
+/// - The RPC endpoints `pyde_sendRawEncryptedTransaction` and
+///   `pyde_getThresholdPublicKey` return errors.
+/// - The node does not subscribe to or publish on the
+///   `pyde/encrypted_transactions/1` gossip topic.
+/// - Block proposers select no encrypted txs and do not emit an
+///   `EncryptedTxBundle`.
+/// - Genesis does not write `threshold.pk` or per-validator key
+///   shares.
+///
+/// This is a **compile-time** const rather than a runtime config
+/// flag because the encrypted path is a consensus-level concern:
+/// every node in the network must agree on whether encrypted txs
+/// are part of the protocol. A binary built with this flag flipped
+/// is incompatible at the consensus layer with one where it is not
+/// flipped. Treat it as a hard-fork-level switch — don't mix
+/// builds on the same network.
+///
+/// **Currently off** while we soak-test correctness, throughput
+/// and stability without the threshold-encryption layer. The
+/// underlying primitives (Kyber-768 threshold KEM via `pyde-crypto`,
+/// per-block decryption coordinator, encrypted gossip topic) stay
+/// compiled in and exercised by their own unit tests; we are only
+/// removing them from the runtime pipeline.
+///
+/// **Trust framing for marketing copy:** the threshold-encryption
+/// design in this codebase is rotating-dealer per-epoch key
+/// escrow, NOT trustless threshold ML-KEM (which is a 2025-2026
+/// research frontier). Re-enabling this flag for production
+/// requires either landing the post-fundraise lattice-DKG work
+/// (task #101) or explicit documented acceptance of the rotating-
+/// dealer trust model.
+pub const MEV_PROTECTION_ENABLED: bool = false;
+
 mod aot_cache;
 mod block_builder;
 mod block_processor;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -689,7 +689,7 @@ impl PydeNode {
         info!(%local_peer_id, port = self.config.network.port, "P2P transport ready");
 
         // 7. Subscribe to gossipsub topics
-        subscribe_topics(&mut swarm, is_validator)?;
+        subscribe_topics(&mut swarm, is_validator, crate::MEV_PROTECTION_ENABLED)?;
         info!("gossipsub topics subscribed");
 
         // 8. Dial bootstrap peers. Audit 219: the
@@ -2944,7 +2944,7 @@ impl PydeNode {
                                     // and the chain falls indefinitely behind. See the
                                     // const's doc-comment in `pyde-mempool::pool` for the
                                     // measurement that motivates the value.
-                                    let encrypted_blobs = {
+                                    let encrypted_blobs: Vec<Vec<u8>> = if crate::MEV_PROTECTION_ENABLED {
                                         let relay_r = tx_relay.read().await;
                                         let selected = relay_r.mempool().select_for_block(
                                             gas_ceiling,
@@ -2952,7 +2952,16 @@ impl PydeNode {
                                             current_slot,
                                         );
                                         // Serialize each EncryptedTx to bytes for block inclusion
-                                        selected.iter().map(|etx| etx.to_bytes()).collect::<Vec<Vec<u8>>>()
+                                        selected.iter().map(|etx| etx.to_bytes()).collect()
+                                    } else {
+                                        // MEV protection disabled — never include
+                                        // encrypted txs in proposed blocks. The
+                                        // encrypted mempool path stays unsubscribed
+                                        // at the network layer, so this list is
+                                        // already always empty in practice; the
+                                        // explicit short-circuit keeps the slot-hot
+                                        // path off the mempool read lock entirely.
+                                        Vec::new()
                                     };
 
                                     // Always produce blocks to advance the chain.

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1290,6 +1290,12 @@ impl PydeApiServer for RpcServer {
     }
 
     async fn get_threshold_public_key(&self) -> Result<String, ErrorObjectOwned> {
+        if !crate::MEV_PROTECTION_ENABLED {
+            return Err(rpc_err(
+                -32000,
+                "MEV protection disabled in this build".to_string(),
+            ));
+        }
         let pk =
             self.state.threshold_pk.as_ref().ok_or_else(|| {
                 rpc_err(-32000, "threshold encryption not configured".to_string())
@@ -1301,6 +1307,12 @@ impl PydeApiServer for RpcServer {
         &self,
         tx_obj: serde_json::Value,
     ) -> Result<String, ErrorObjectOwned> {
+        if !crate::MEV_PROTECTION_ENABLED {
+            return Err(rpc_err(
+                -32000,
+                "MEV protection disabled in this build".to_string(),
+            ));
+        }
         let tpk =
             self.state.threshold_pk.as_ref().ok_or_else(|| {
                 rpc_err(-32000, "threshold encryption not configured".to_string())
@@ -1438,6 +1450,12 @@ impl PydeApiServer for RpcServer {
         &self,
         tx_hex: String,
     ) -> Result<String, ErrorObjectOwned> {
+        if !crate::MEV_PROTECTION_ENABLED {
+            return Err(rpc_err(
+                -32000,
+                "MEV protection disabled in this build".to_string(),
+            ));
+        }
         // Decode hex-encoded EncryptedTx wire frame produced by the
         // client via `EncryptedTx::to_bytes`.
         let tx_bytes = hex::decode(tx_hex.strip_prefix("0x").unwrap_or(&tx_hex))

--- a/crates/node/tests/loadgen_mixed.rs
+++ b/crates/node/tests/loadgen_mixed.rs
@@ -16,11 +16,16 @@
 //!     gossip + post-QC seal-then-execute. The MEV-protected path
 //!     real DeFi traffic uses.
 //!
-//! The default 60/30/10 mix matches what most L1 production traffic
-//! looks like in practice (most txs are simple value movement; a
-//! large minority is contract activity; a small slice is the
-//! MEV-target DeFi/swap traffic that self-selects encrypted). Tunable
-//! via `PYDE_LOADGEN_MIX=transfer:60,call:30,encrypted:10`.
+//! The intended 60/30/10 mix matches what most L1 production
+//! traffic looks like in practice (most txs are simple value
+//! movement; a large minority is contract activity; a small slice
+//! is the MEV-target DeFi/swap traffic that self-selects
+//! encrypted). While the MEV-protection pipeline is disabled at
+//! compile time (see `MEV_PROTECTION_ENABLED` in
+//! `crates/node/src/main.rs`), the default falls back to 70/30/0
+//! — encrypted txs would be rejected at the RPC layer. Tunable
+//! via `PYDE_LOADGEN_MIX=transfer:60,call:30,encrypted:10` once
+//! the encrypted-tx path is re-enabled.
 //!
 //! Output: per-type submit/inclusion counts plus aggregate. The
 //! aggregate is the headline number quotable at testnet launch —
@@ -37,7 +42,7 @@
 //!   PYDE_LOADGEN_DURATION    — measurement duration in seconds (default 300)
 //!   PYDE_LOADGEN_WARMUP      — warm-up in seconds (default 30)
 //!   PYDE_LOADGEN_SENDERS     — funded sender count (default 200)
-//!   PYDE_LOADGEN_MIX         — weight string (default "transfer:60,call:30,encrypted:10")
+//!   PYDE_LOADGEN_MIX         — weight string (default "transfer:70,call:30,encrypted:0" while MEV is off; intended mix once re-enabled is "transfer:60,call:30,encrypted:10")
 //!   PYDE_LOADGEN_FUND        — per-sender fund override
 //!
 //! # On sender count
@@ -117,10 +122,14 @@ struct MixWeights {
 
 impl MixWeights {
     fn parse(s: &str) -> Self {
-        // "transfer:60,call:30,encrypted:10" → MixWeights{60,30,10}
-        let mut transfer = 60u32;
+        // "transfer:70,call:30,encrypted:0" → MixWeights{70,30,0}
+        // Default encrypted=0 while MEV protection is disabled in
+        // the build (see `MEV_PROTECTION_ENABLED` in
+        // `crates/node/src/main.rs`). Override the mix string once
+        // the encrypted path is wired back in.
+        let mut transfer = 70u32;
         let mut call = 30u32;
-        let mut encrypted = 10u32;
+        let mut encrypted = 0u32;
         for part in s.split(',') {
             if let Some((k, v)) = part.split_once(':') {
                 let val = v.trim().parse::<u32>().unwrap_or(0);

--- a/crates/node/tests/loadgen_soak.rs
+++ b/crates/node/tests/loadgen_soak.rs
@@ -428,7 +428,11 @@ fn comprehensive_soak() {
     let duration_s: u64 = env_var_u64("PYDE_SOAK_DURATION", 3600);
     let warmup_s: u64 = env_var_u64("PYDE_SOAK_WARMUP", 60);
     let num_senders: usize = env_var_u64("PYDE_SOAK_SENDERS", 50) as usize;
-    let encrypted_pct: u32 = env_var_u64("PYDE_SOAK_ENCRYPTED_PCT", 30) as u32;
+    // Default is 0 while MEV protection is disabled in the build
+    // (see `MEV_PROTECTION_ENABLED` in `crates/node/src/main.rs`).
+    // Override with PYDE_SOAK_ENCRYPTED_PCT once the encrypted-tx
+    // path is wired back in.
+    let encrypted_pct: u32 = env_var_u64("PYDE_SOAK_ENCRYPTED_PCT", 0) as u32;
 
     println!("╔══════════════════════════════════════════════════════════╗");
     println!("║  Pyde Comprehensive Soak Test                            ║");


### PR DESCRIPTION
## Summary

Introduce `MEV_PROTECTION_ENABLED` in `crates/node/src/main.rs`
and flip it to `false`. The encrypted-tx (MEV-protection) pipeline
is disabled end-to-end without deleting any code: flipping the
const back to `true` re-enables it.

## Why

External research (Lapiha-Prest 2025/1958, eprint 2026/021,
Micciancio-Suhl 2023/1728) confirms that production-grade
threshold ML-KEM does not exist today. The current Shamir-of-seed
threshold scheme is best framed as "rotating-ephemeral-key escrow
with t-of-n reconstruction within an epoch" — not "trustless
threshold ML-KEM". Rather than ship a feature whose security
framing dilutes the trustless-decentralization marketing claim,
we're pulling the encrypted path out of the pipeline, soak-testing
without it, and bringing it back alongside a cryptographer-
engaged Path B implementation (task #101).

The DKG primitives shipped in earlier PRs (committee VRF, share
envelopes, complaints, contribution aggregation) stay compiled and
unit-tested in `pyde-crypto` — they're not being deleted, only
disconnected from the runtime path.

## Gate sites

- **RPC** (`rpc.rs`): all three encrypted-tx endpoints return
  `"MEV protection disabled in this build"` before touching state.
- **Net** (`net/src/node.rs`): `subscribe_topics` takes a third
  `mev_protection_enabled` parameter; gossipsub layer skips the
  `pyde/encrypted_transactions/1` topic when off.
- **Proposer** (`node.rs:~2947`): encrypted-tx selection short-
  circuits to an empty `Vec` without acquiring the mempool lock.
- **Bundle publish** (`node.rs:~3170`): already guarded by
  `!block.body.encrypted_txs.is_empty()`, naturally inert when
  the proposer never selects encrypted txs.
- **Genesis** (`genesis.rs`): per-node `threshold.share` and global
  `threshold.pk` writes are gated. `threshold_keygen()` still
  runs (the downstream `ValidatorEntry` wire format expects a
  `ThresholdPublicKey` to exist) but its outputs are discarded
  when MEV is off — no on-disk encrypted-mempool keying material
  in this build.
- **Loadgen defaults**: `loadgen_soak` `PYDE_SOAK_ENCRYPTED_PCT`
  defaults to 0; `loadgen_mixed` default mix is 70/30/0 (was
  60/30/10); `loadgen_sustained` `PYDE_LOADGEN_ENCRYPTED` was
  already false-by-default.

## Why compile-time, not runtime config

The encrypted path is a consensus-level concern. Mixing builds
with the flag flipped differently on the same network is a hard-
fork. A const guarantees protocol agreement. Once task #101
lands, this will become a genesis-config flag.

## Verification

- Workspace builds clean (only pre-existing `kem_public_key` /
  `kem_secret_key` dead-code warning from earlier KEM work).
- 39 lib tests pass.
- 346 node binary tests pass.
- 4-node subprocess `multi_node_state_convergence` test passes:
  SMT root converges across all 4 nodes at slots 5 and 10.

## What's next

- Soak + benchmark the chain without MEV protection.
- Re-enable the path alongside the Path B implementation
  (task #101) before mainnet.