### PR TITLE
fix(consensus): test-mode timing + skipped-slot fee determinism

### DIFF
--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -209,6 +209,21 @@ impl BlockProcessor {
             }
         }
 
+        // Skipped-slot base-fee catch-up: if this block is more than
+        // one slot ahead of head, treat the intermediate (skipped)
+        // slots as empty blocks for fee math. Without this, a node
+        // that misses slot N-1's gossip but receives slot N applies
+        // slot N with a stale `chain.base_fee` — fee receipts and
+        // burn accounting then diverge from peers who saw the full
+        // slot sequence, even though everyone agrees on the canonical
+        // block contents (audit: TPL-?? fee-receipt divergence
+        // surfaced by `multi_node_propagation` + `_full_node_relay`).
+        let gas_target_for_catchup = pyde_tx::fee::GAS_TARGET;
+        let slots_to_skip = slot.saturating_sub(chain.head_slot.saturating_add(1));
+        for _ in 0..slots_to_skip {
+            chain.base_fee =
+                adjust_base_fee(chain.base_fee, 0, gas_target_for_catchup);
+        }
         let block_ctx = BlockContext {
             height: slot,
             timestamp: block.header.timestamp,
@@ -646,7 +661,16 @@ impl BlockProcessor {
         Self::validate_header_with_checkpoint(&header, chain, ws_checkpoint_slot)?;
 
         let gas_target = pyde_tx::fee::GAS_TARGET;
-        chain.base_fee = adjust_base_fee(chain.base_fee, 0, gas_target);
+        // Skipped-slot base-fee catch-up — same rationale as
+        // `process_full_block_with_aot_and_checkpoint`. Header-only
+        // apply means total_gas at *this* block is 0 (no body to
+        // observe), but we still need to fold in adjustments for
+        // every skipped slot between `head_slot+1` and `header.slot`
+        // inclusive. After the loop we've covered all of them.
+        let slots_to_advance = header.slot.saturating_sub(chain.head_slot);
+        for _ in 0..slots_to_advance {
+            chain.base_fee = adjust_base_fee(chain.base_fee, 0, gas_target);
+        }
         chain.advance(header);
 
         Ok((0, 0))

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -981,7 +981,17 @@ impl PydeNode {
         let mut last_slot = slot_clock.current_slot();
 
         // Periodic timers
-        let mut slot_interval = tokio::time::interval(std::time::Duration::from_millis(100)); // check slot every 100ms
+        // Poll the slot clock 4× per slot so slot transitions are
+        // detected promptly and per-tick consensus actions (proposal
+        // selection at ~25 % into the slot) actually fire — a fixed
+        // 100 ms cadence works for the production 400 ms slot but
+        // collapses to one tick per slot at faster test cadences,
+        // missing the proposal-selection threshold. Clamp keeps the
+        // poll loop from spinning sub-10 ms or sleeping longer than
+        // 100 ms regardless of the configured slot time.
+        let poll_interval_ms = (block_time_ms / 4).clamp(10, 100);
+        let mut slot_interval =
+            tokio::time::interval(std::time::Duration::from_millis(poll_interval_ms));
         let mut maintenance_interval = tokio::time::interval(std::time::Duration::from_secs(10));
         let mut sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
         // Gossip retry: re-publish uncommitted pending txs every 2 slots.
@@ -1041,8 +1051,11 @@ impl PydeNode {
         // from `(key_share, ciphertext)` so regeneration is cheap
         // and `BlockDecryptor::add_share` is idempotent (set-insert)
         // on the receiver side.
+        // Decryption-share retry cadence tracks the slot poll
+        // cadence — re-broadcast unacked shares ≈4× per slot until
+        // the receiver acks or the slot moves on.
         let mut decryption_share_retry_interval =
-            tokio::time::interval(std::time::Duration::from_millis(100));
+            tokio::time::interval(std::time::Duration::from_millis(poll_interval_ms));
         decryption_share_retry_interval.tick().await; // skip immediate first firing
 
         loop {
@@ -3242,14 +3255,19 @@ impl PydeNode {
                         }
                     }
 
-                    // --- Per-tick consensus actions (run every 100ms, not just on new slots) ---
+                    // --- Per-tick consensus actions (fire each poll tick, not just on new slots) ---
                     if let Some(engine) = validator_engine.as_mut() {
                         let current_slot = slot_clock.current_slot();
                         let ms_in_slot = slot_clock.ms_into_slot();
 
-                        // Proposal selection phase: 100ms into the slot, select the
-                        // best proposal (lowest VRF score) and vote for it.
-                        if ms_in_slot >= 100 {
+                        // Proposal selection phase: 25% into the slot,
+                        // select the best proposal (lowest VRF score) and
+                        // vote for it. Threshold scales with slot time so
+                        // the same "wait a quarter slot for proposals to
+                        // settle, then vote" logic holds at faster test
+                        // cadences (at 400 ms slot this is 100 ms; at
+                        // 100 ms slot it is 25 ms).
+                        if ms_in_slot >= block_time_ms / 4 {
                             if let Some(identity) = validator_identity.as_ref() {
                                 if let Some(vote) = engine.select_and_vote(identity) {
                                     // Add own vote to collection

--- a/crates/node/tests/common/mod.rs
+++ b/crates/node/tests/common/mod.rs
@@ -522,6 +522,22 @@ impl TestNetwork {
         rpc_smt_root(&self.nodes[node_idx].rpc_url())
     }
 
+    /// Fetch the committee's threshold public key via
+    /// `pyde_getThresholdPublicKey`. The returned bytes encode a
+    /// `ThresholdPublicKey`. PSS share refresh preserves the
+    /// underlying secret, so the pubkey bytes are stable across
+    /// epoch boundaries even though each validator's share rotates.
+    pub fn get_threshold_pubkey(&self, node_idx: usize) -> Result<Vec<u8>, String> {
+        let resp = rpc_call(
+            &self.nodes[node_idx].rpc_url(),
+            "pyde_getThresholdPublicKey",
+            "[]",
+        )?;
+        let hex_str = parse_hex_result(&resp)?;
+        hex::decode(hex_str.trim_start_matches("0x"))
+            .map_err(|e| format!("decode threshold pk hex: {}", e))
+    }
+
     // --------------------------------------------------------------
     // Slashing helpers (slice 6.6)
     // --------------------------------------------------------------

--- a/crates/node/tests/loadgen_mixed.rs
+++ b/crates/node/tests/loadgen_mixed.rs
@@ -71,7 +71,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const CHAIN_ID: u64 = 1;
+// audit 383: `pyde testnet` refuses chain_id=1 (mainnet). 7331 is the
+// canonical public testnet id and still triggers production-mode sig
+// verification — `dev_skip_signature` only fires at 31337.
+const CHAIN_ID: u64 = 7331;
 const RECIPIENT: [u8; 32] = [0x42u8; 32];
 const TX_VALUE: u128 = 1;
 // 1 PYDE = 10^9 quanta. Each sender gets enough headroom to cover
@@ -219,9 +222,9 @@ fn mixed_workload_load_test() {
     println!("╚══════════════════════════════════════════════════════╝");
 
     // ── Phase 0: spawn 4-validator testnet ──────────────────────
-    println!("\n[0/4] Spawning 4-validator native testnet at chain_id = 1…");
+    println!("\n[0/4] Spawning 4-validator native testnet at chain_id = {CHAIN_ID}…");
     let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id={CHAIN_ID}: {}", e));
     net.wait_for_slot(3, Duration::from_secs(30))
         .unwrap_or_else(|e| panic!("chain warm-up: {}", e));
 

--- a/crates/node/tests/loadgen_sustained.rs
+++ b/crates/node/tests/loadgen_sustained.rs
@@ -2,8 +2,9 @@
 //! instrument.
 //!
 //! Spawns its own 4-validator network via `common::TestNetwork` (native
-//! subprocess `pyde` binaries at `chain_id = 1`, FALCON sig verification
-//! ON), funds N senders from the faucet, then holds a target submit
+//! subprocess `pyde` binaries at `chain_id = 7331`, FALCON sig verification
+//! ON — audit 383 refuses `chain_id = 1` at the testnet generator), funds
+//! N senders from the faucet, then holds a target submit
 //! rate for a configurable duration and records steady-state throughput
 //! + inclusion. Native subprocesses (not Docker) — removes the Linux-VM
 //! hop on macOS.
@@ -70,7 +71,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-const CHAIN_ID: u64 = 1;
+// audit 383: `pyde testnet` refuses chain_id=1 (mainnet). 7331 is the
+// canonical public testnet id and still triggers production-mode sig
+// verification — `dev_skip_signature` only fires at 31337.
+const CHAIN_ID: u64 = 7331;
 const RECIPIENT: [u8; 32] = [0x42u8; 32];
 const TX_VALUE: u128 = 1;
 // 1 000 000 000 PYDE (= 10^18 base units). Fee per tx is gas_limit * base_fee,
@@ -156,9 +160,9 @@ fn sustained_rate_load_test() {
     println!("╚══════════════════════════════════════════════════════╝");
 
     // --- Phase 0: spawn 4-validator testnet ---
-    println!("\n[0/3] Spawning 4-validator native testnet at chain_id = 1…");
+    println!("\n[0/3] Spawning 4-validator native testnet at chain_id = {CHAIN_ID}…");
     let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id={CHAIN_ID}: {}", e));
 
     // Wait for chain to warm up.
     net.wait_for_slot(3, Duration::from_secs(30))

--- a/crates/node/tests/multi_node_contract_sigs.rs
+++ b/crates/node/tests/multi_node_contract_sigs.rs
@@ -18,7 +18,8 @@
 //!     — `pyde_call(get_count)` from every node must return 42.
 //!
 //! Flow:
-//!  - 4 validators at chain_id=1 (production mode).
+//!  - 4 validators at chain_id=7331 (production mode — audit 383
+//!    refuses mainnet id 1 at the testnet generator).
 //!  - Compile the on-chain `Counter` contract (same source used by
 //!    `production_sigs.rs` — has `init()`, `set_count(n)`,
 //!    `get_count()`).
@@ -53,11 +54,13 @@ contract Counter {
 #[test]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 fn contract_deploy_and_call_with_real_sigs() {
-    // chain_id=1 → block processor enforces FALCON sig verification
-    // on every tx. See `crates/node/src/block_processor.rs` — the
-    // `dev_skip_signature` flag is false for any chain_id != 31337.
-    let net = TestNetwork::spawn_with_chain_id(4, 1)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+    // chain_id=7331 (canonical public testnet id) → block processor
+    // still enforces FALCON sig verification on every tx because
+    // `dev_skip_signature` is only true at 31337. audit 383 refuses
+    // the mainnet id (1) at the `pyde testnet` generator, so we use
+    // 7331 for production-mode subprocess tests.
+    let net = TestNetwork::spawn_with_chain_id(4, 7331)
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=7331: {}", e));
 
     // Wait for chain to advance so the first tx has somewhere to land.
     net.wait_for_slot(3, Duration::from_secs(30))
@@ -100,7 +103,7 @@ fn contract_deploy_and_call_with_real_sigs() {
         fee_payer: FeePayer::Sender,
         access_list: vec![],
         deadline: None,
-        chain_id: 1,
+        chain_id: 7331,
         tx_type: TransactionType::Deploy,
     };
     sign_tx(&mut deploy_tx, &faucet_sk);
@@ -183,7 +186,7 @@ fn contract_deploy_and_call_with_real_sigs() {
         fee_payer: FeePayer::Sender,
         access_list: vec![],
         deadline: None,
-        chain_id: 1,
+        chain_id: 7331,
         tx_type: TransactionType::Standard,
     };
     sign_tx(&mut call_tx, &faucet_sk);

--- a/crates/node/tests/multi_node_encrypted_across_epoch.rs
+++ b/crates/node/tests/multi_node_encrypted_across_epoch.rs
@@ -1,0 +1,288 @@
+//! Encrypted-tx flow across an epoch boundary (PSS share-refresh coverage).
+//!
+//! Closes the integration gap that `multi_node_encrypted_lifecycle`
+//! (one tx, no rotation) and `multi_node_epoch_rotation` (rotation,
+//! no encrypted txs) leave: prove that the committee's threshold
+//! key shares stay coherent across the epoch boundary, so an
+//! encrypted tx submitted *after* PSS refresh still decrypts under
+//! the rotated shares.
+//!
+//! Flow:
+//!
+//!   1. Spawn 4-validator testnet at `block_time_ms=100` (epoch
+//!      boundary at slot 1000 = ~100 s wall clock — the same
+//!      test-acceleration cadence `multi_node_epoch_rotation` uses).
+//!   2. Warm-up to slot 30 — bootstrap + gossipsub mesh settled,
+//!      genesis-key DKG complete. A few extra slots vs. the
+//!      lifecycle test buys margin for the encrypted-tx submission
+//!      to land before the proposer-selection window of slot 30
+//!      closes at this faster cadence.
+//!   3. Snapshot the threshold pubkey via `pyde_getThresholdPublicKey`
+//!      on every node. Assert all 4 nodes agree.
+//!   4. Submit encrypted tx #1 (recipient = funded test acct).
+//!      Wait for the recipient's balance to credit on all 4 nodes
+//!      (proves decryption-share path works under epoch-0 shares).
+//!   5. Wait for slot 1005 — past `EPOCH_LENGTH = 1000`, plus 5
+//!      slots so every node has processed `rotate_to_epoch` +
+//!      broadcast its `start_pss_refresh` contribution.
+//!   6. Assert "committee rotated at epoch boundary" appears in
+//!      every validator's log (the same proof multi_node_epoch_rotation
+//!      uses).
+//!   7. Re-snapshot the threshold pubkey on every node. PSS refresh
+//!      preserves the secret `s` and therefore the pubkey `Y = g^s`,
+//!      so post-rotation bytes must equal pre-rotation bytes on
+//!      every node (if they don't, the test caught a coherence bug
+//!      and the second encrypted tx would have failed silently
+//!      anyway).
+//!   8. Submit encrypted tx #2. Wait for credit on all 4 nodes.
+//!      This is the actual proof: validators are using the
+//!      refreshed shares (the unit tests in
+//!      `pyde_crypto::threshold::tests::pss_*` guarantee old
+//!      shares can't decrypt post-refresh, so a successful
+//!      cooperative decrypt here means the new shares are wired
+//!      end-to-end through the validator dispatch path).
+//!   9. State-root convergence on all 4 nodes — fork-free.
+//!
+//! At 100 ms/slot this completes in ~150 s on a laptop. Marked
+//! `#[ignore]` so it doesn't run on every `cargo test`.
+
+mod common;
+
+use common::TestNetwork;
+use std::time::{Duration, Instant};
+
+const EPOCH_LENGTH: u64 = 1000;
+const TRANSFER_VALUE: u128 = 1_000_000_000; // 1 PYDE
+
+#[test]
+#[ignore = "multi-node — subprocess-based, run via --ignored"]
+fn encrypted_tx_decrypts_after_pss_refresh() {
+    // 100 ms/slot test acceleration — same cadence
+    // `multi_node_epoch_rotation` uses. Epoch boundary at slot 1000
+    // = ~100 s wall clock.
+    let net = TestNetwork::spawn_with_block_time(4, true, 100)
+        .unwrap_or_else(|e| panic!("spawn 4v at 100ms: {}", e));
+
+    // Warm-up to slot 30 (vs. the lifecycle test's 15 at 400 ms):
+    // gives the encrypted-tx submission a little more margin at
+    // this faster slot cadence for the mesh to converge.
+    net.wait_for_slot(30, Duration::from_secs(60))
+        .unwrap_or_else(|e| panic!("warm-up to slot 30: {}", e));
+
+    // Sender: validator-0's FALCON keypair (has AuthKeys::Single
+    // installed at genesis — required for try_decrypt_and_execute).
+    let (sender_pk, sender_sk) = net
+        .load_validator_key(0)
+        .unwrap_or_else(|e| panic!("load validator 0 key: {}", e));
+
+    // Recipient: a non-validator funded test acct (avoids
+    // validator-fee-credit accumulation muddling the assertion).
+    let funded = net
+        .funded_addresses()
+        .unwrap_or_else(|e| panic!("read funded: {}", e));
+    assert!(
+        funded.len() > 4,
+        "expected >4 funded addresses, got {}",
+        funded.len()
+    );
+    let recipient = funded[4];
+
+    // ── Pre-rotation snapshot ──────────────────────────────────────
+    let tpk_pre: Vec<Vec<u8>> = (0..net.nodes.len())
+        .map(|i| {
+            net.get_threshold_pubkey(i)
+                .unwrap_or_else(|e| panic!("pre tpk node-{}: {}", i, e))
+        })
+        .collect();
+    for (i, pk) in tpk_pre.iter().enumerate().skip(1) {
+        assert_eq!(
+            *pk, tpk_pre[0],
+            "pre-rotation threshold pubkey divergence: node-0 vs node-{}",
+            i
+        );
+    }
+    eprintln!("pre-rotation threshold pubkey ({} bytes)", tpk_pre[0].len());
+
+    // ── Pre-rotation encrypted tx ──────────────────────────────────
+    let pre_balances: Vec<u128> = (0..net.nodes.len())
+        .map(|i| {
+            net.get_balance(i, &recipient)
+                .unwrap_or_else(|e| panic!("pre balance node-{}: {}", i, e))
+        })
+        .collect();
+
+    let tx1_hash = net
+        .submit_encrypted_transfer(0, &sender_pk, &sender_sk, &recipient, TRANSFER_VALUE)
+        .unwrap_or_else(|e| panic!("submit encrypted tx #1: {}", e));
+    eprintln!("encrypted tx #1 submitted: {}", tx1_hash);
+
+    wait_for_recipient_credit(
+        &net,
+        &recipient,
+        &pre_balances,
+        TRANSFER_VALUE,
+        Duration::from_secs(60),
+        "tx#1 (pre-rotation)",
+    );
+    eprintln!("encrypted tx #1 credited on all 4 nodes");
+
+    // ── Cross the epoch boundary ───────────────────────────────────
+    let target_slot = EPOCH_LENGTH + 5;
+    eprintln!("waiting for slot {} (past epoch boundary)…", target_slot);
+    // At 100 ms/slot, slot 1005 ≈ 100 s nominal. 240 s ceiling
+    // gives ~2× headroom for laptop CPU contention — matches
+    // `multi_node_epoch_rotation`.
+    net.wait_for_slot(target_slot, Duration::from_secs(240))
+        .unwrap_or_else(|e| panic!("cross-epoch wait: {}\n{}", e, per_node_dump(&net)));
+    eprintln!("all 4 nodes past slot {}", target_slot);
+
+    // Epoch field sanity (mirrors multi_node_epoch_rotation).
+    let e0 = net
+        .epoch_of(0, EPOCH_LENGTH - 1)
+        .unwrap_or_else(|e| panic!("epoch_of {}: {}", EPOCH_LENGTH - 1, e))
+        .unwrap_or_else(|| panic!("missing block at slot {}", EPOCH_LENGTH - 1));
+    let e1 = net
+        .epoch_of(0, EPOCH_LENGTH)
+        .unwrap_or_else(|e| panic!("epoch_of {}: {}", EPOCH_LENGTH, e))
+        .unwrap_or_else(|| panic!("missing block at slot {}", EPOCH_LENGTH));
+    assert_eq!(e0, 0, "slot {} should be epoch 0, got {}", EPOCH_LENGTH - 1, e0);
+    assert_eq!(e1, 1, "slot {} should be epoch 1, got {}", EPOCH_LENGTH, e1);
+
+    // Rotation log on every validator — proof the rotate_to_epoch +
+    // PSS refresh path actually fired (not just that the epoch
+    // number got computed at the block-header level).
+    let mut rotated = 0;
+    for n in &net.nodes {
+        if n.output_snapshot()
+            .contains("committee rotated at epoch boundary")
+        {
+            rotated += 1;
+        }
+    }
+    assert!(
+        rotated >= net.nodes.len(),
+        "only {}/{} validators logged 'committee rotated at epoch boundary'",
+        rotated,
+        net.nodes.len()
+    );
+    eprintln!("rotation log observed on {}/{} nodes", rotated, net.nodes.len());
+
+    // ── Post-rotation pubkey snapshot ──────────────────────────────
+    let tpk_post: Vec<Vec<u8>> = (0..net.nodes.len())
+        .map(|i| {
+            net.get_threshold_pubkey(i)
+                .unwrap_or_else(|e| panic!("post tpk node-{}: {}", i, e))
+        })
+        .collect();
+    for (i, pk) in tpk_post.iter().enumerate().skip(1) {
+        assert_eq!(
+            *pk, tpk_post[0],
+            "post-rotation threshold pubkey divergence: node-0 vs node-{}",
+            i
+        );
+    }
+    // PSS refresh preserves the secret `s` and therefore the pubkey
+    // `Y = g^s` — only the share representation rotates. A change
+    // here would mean either the on-chain pubkey advertisement
+    // raced with the refresh (validator coherence bug) or the
+    // protocol implementation regressed.
+    assert_eq!(
+        tpk_post[0], tpk_pre[0],
+        "threshold pubkey changed across epoch boundary — \
+         PSS refresh should preserve Y = g^s (pre len={}, post len={})",
+        tpk_pre[0].len(),
+        tpk_post[0].len()
+    );
+
+    // ── Post-rotation encrypted tx ─────────────────────────────────
+    // submit_encrypted_transfer re-fetches the threshold pk before
+    // each submission, so this tx is encrypted under the same Y
+    // but will be decrypted using the *refreshed* shares.
+    let mid_balances: Vec<u128> = (0..net.nodes.len())
+        .map(|i| {
+            net.get_balance(i, &recipient)
+                .unwrap_or_else(|e| panic!("mid balance node-{}: {}", i, e))
+        })
+        .collect();
+
+    let tx2_hash = net
+        .submit_encrypted_transfer(0, &sender_pk, &sender_sk, &recipient, TRANSFER_VALUE)
+        .unwrap_or_else(|e| panic!("submit encrypted tx #2: {}", e));
+    eprintln!("encrypted tx #2 submitted: {}", tx2_hash);
+
+    wait_for_recipient_credit(
+        &net,
+        &recipient,
+        &mid_balances,
+        TRANSFER_VALUE,
+        Duration::from_secs(60),
+        "tx#2 (post-rotation)",
+    );
+    eprintln!("encrypted tx #2 credited on all 4 nodes — refreshed shares decrypt correctly");
+
+    // ── State-root convergence ─────────────────────────────────────
+    let reference_root = net
+        .state_root(0)
+        .unwrap_or_else(|e| panic!("state_root node-0: {}", e));
+    for n in &net.nodes[1..] {
+        let root = net
+            .state_root(n.index)
+            .unwrap_or_else(|e| panic!("state_root node-{}: {}", n.index, e));
+        assert_eq!(
+            root, reference_root,
+            "state_root divergence after post-rotation encrypted tx:\n  node-0:  {}\n  node-{}: {}",
+            reference_root, n.index, root
+        );
+    }
+    eprintln!("state_root convergence: 4/4 nodes match");
+}
+
+fn wait_for_recipient_credit(
+    net: &TestNetwork,
+    recipient: &[u8; 32],
+    pre_balances: &[u128],
+    expected_delta: u128,
+    timeout: Duration,
+    label: &str,
+) {
+    let deadline = Instant::now() + timeout;
+    let mut last: Vec<u128> = pre_balances.to_vec();
+    while Instant::now() < deadline {
+        let current: Vec<u128> = (0..net.nodes.len())
+            .map(|i| net.get_balance(i, recipient).unwrap_or(0))
+            .collect();
+        last = current.clone();
+        let all_credited = current
+            .iter()
+            .enumerate()
+            .all(|(i, b)| *b == pre_balances[i] + expected_delta);
+        if all_credited {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    panic!(
+        "{}: recipient not credited on all nodes within {:?}\n  pre:  {:?}\n  last: {:?}\n  expected delta: {}\n{}",
+        label,
+        timeout,
+        pre_balances,
+        last,
+        expected_delta,
+        per_node_dump(net)
+    );
+}
+
+fn per_node_dump(net: &TestNetwork) -> String {
+    net.nodes
+        .iter()
+        .map(|n| {
+            format!(
+                "\n=== node-{} (rpc {}) ===\n{}",
+                n.index,
+                n.rpc_port,
+                n.output_snapshot()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}

--- a/crates/node/tests/multi_node_register_pubkey.rs
+++ b/crates/node/tests/multi_node_register_pubkey.rs
@@ -19,8 +19,9 @@
 //!      one-time + correct shape.
 //!   4. Now `transfer` from the fresh wallet succeeds.
 //!
-//! Production-mode (chain_id=1) so block_processor enforces real
-//! FALCON signature verification — no `dev_skip_signature` cheating.
+//! Production-mode (chain_id=7331 — audit 383 refuses mainnet id 1
+//! at the testnet generator) so block_processor enforces real FALCON
+//! signature verification — no `dev_skip_signature` cheating.
 
 mod common;
 
@@ -38,9 +39,13 @@ fn sign_tx(tx: &mut Transaction, sk: &FalconSecretKey) {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "multi-node — subprocess-based, run via --ignored"]
 async fn register_pubkey_unblocks_first_tx_for_fresh_account() {
-    // chain_id=1 → block_processor enforces FALCON sigs on every tx.
-    let net = TestNetwork::spawn_with_chain_id(4, 1)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=1: {}", e));
+    // chain_id=7331 (canonical public testnet id) — block_processor
+    // still enforces FALCON sigs on every tx because
+    // `dev_skip_signature` only fires at 31337. audit 383 refuses
+    // the mainnet id (1) at the `pyde testnet` generator, so we use
+    // 7331 for production-mode subprocess tests.
+    let net = TestNetwork::spawn_with_chain_id(4, 7331)
+        .unwrap_or_else(|e| panic!("spawn 4v@chain_id=7331: {}", e));
 
     // Wait so the first tx has a slot to land in.
     net.wait_for_slot(3, Duration::from_secs(30))
@@ -59,11 +64,17 @@ async fn register_pubkey_unblocks_first_tx_for_fresh_account() {
     let fresh_addr = *fresh.address();
     eprintln!("fresh wallet address: 0x{}", hex::encode(fresh_addr));
 
-    // ── 2. Faucet sends 100 PYDE to fresh address ───────────────
+    // ── 2. Faucet sends 2M PYDE to fresh address ────────────────
+    // Enough to cover a real-base-fee transfer + register pubkey
+    // overhead. At GENESIS_BASE_FEE (50 gwei × 21 K gas ≈ 1 M PYDE
+    // per transfer in the worst case) the previous 100 PYDE was
+    // insufficient — the test was always going to hit
+    // `InsufficientBalance` once `chain_id != 1` (audit 383) forced
+    // it onto the same generator-produced genesis as production.
     let mut faucet_tx = Transaction {
         from: faucet_addr,
         to: fresh_addr,
-        value: 100_000_000_000, // 100 PYDE in quanta (10^9 quanta = 1 PYDE)
+        value: 2_000_000 * 1_000_000_000, // 2M PYDE in quanta (10^9 quanta = 1 PYDE)
         data: vec![],
         gas_limit: 21_000,
         nonce: 0,
@@ -71,7 +82,7 @@ async fn register_pubkey_unblocks_first_tx_for_fresh_account() {
         fee_payer: FeePayer::Sender,
         access_list: vec![],
         deadline: None,
-        chain_id: 1,
+        chain_id: 7331,
         tx_type: TransactionType::Standard,
     };
     sign_tx(&mut faucet_tx, &faucet_sk);
@@ -86,8 +97,9 @@ async fn register_pubkey_unblocks_first_tx_for_fresh_account() {
         .get_balance(0, &fresh_addr)
         .unwrap_or_else(|e| panic!("balance after drip: {}", e));
     assert_eq!(
-        fresh_balance_before, 100_000_000_000,
-        "faucet drip should give fresh wallet 100 PYDE"
+        fresh_balance_before,
+        2_000_000 * 1_000_000_000,
+        "faucet drip should give fresh wallet 2M PYDE"
     );
 
     // ── 3. Confirm normal signed tx is REJECTED before registration
@@ -134,8 +146,8 @@ async fn register_pubkey_unblocks_first_tx_for_fresh_account() {
         "post-register transfer should succeed"
     );
 
-    // Final balance sanity: fresh wallet started with 100 PYDE,
-    // sent 1 PYDE, paid gas. Should have a bit less than 99 PYDE.
+    // Final balance sanity: fresh wallet started with 2M PYDE,
+    // sent 1 PYDE, paid gas. Should be a bit less than 2M PYDE.
     let fresh_balance_after = net
         .get_balance(0, &fresh_addr)
         .unwrap_or_else(|e| panic!("balance after: {}", e));


### PR DESCRIPTION
## Summary
- **node.rs**: scale 3 per-slot timer cadences (`slot_interval`,
  `decryption_share_retry_interval`, proposal-selection threshold) by
  `block_time_ms / 4`. At production 400 ms slot all three resolve to
  the prior hard-coded 100 ms — no behavior change. At 100 ms test
  acceleration they resolve to 25 ms so chains stop wedging at slot 0.
- **block_processor.rs**: fold `adjust_base_fee` for skipped slots
  into both block-apply paths. A node that received slot N while at
  head=M<N-1 (e.g. missed slot N-1's gossip) applied slot N with the
  pre-M base_fee, then adjusted once — producing receipts with the
  wrong `fee_burned` / `fee_paid` / `fee_validator` / `fee_treasury`
  values (8/7-ratio divergence) versus peers that walked the full
  sequence. Catch-up runs `adjust_base_fee` once per skipped slot
  (gas_used=0) before computing the block_ctx. No-op on the happy
  path (`slots_to_skip = 0`).
- **New integration test** `multi_node_encrypted_across_epoch`: closes
  the gap between `_encrypted_lifecycle` (one encrypted tx, no
  rotation) and `_epoch_rotation` (rotation, no encrypted txs).
  Proves PSS share refresh preserves cooperative decrypt across the
  epoch boundary.
- **chain_id sweep**: 4 subprocess tests still hard-coded `chain_id=1`,
  which audit 383's testnet generator now refuses. Switched to 7331
  (canonical public testnet id — still triggers production-mode
  FALCON sig verification). Also bumped `multi_node_register_pubkey`'s
  faucet drip from 100 PYDE to 2M PYDE, fixing a pre-existing
  insufficient-balance failure on a freshly-generated genesis.

## Verification at production 400 ms
- 30-min `soak`: 3546 txs, 120/120 health checks, state roots agreed
  every 15 s
- `multi_node_epoch_rotation` (400 ms): 402.86 s, rotation log on 4/4
- `crash_recovery`, `multi_node_partition_heal`, `validator_churn`,
  `validator_churn_4_of_4`, `multi_node_leader_failure`,
  `multi_node_larger_failure`, `multi_node_sync`,
  `multi_node_finality`, `multi_node_propagation`,
  `multi_node_full_node_relay`: all green
- New `multi_node_encrypted_across_epoch` at 100 ms: 101.83 s,
  encrypted tx pre+post rotation both credited on 4/4 nodes
- 18/18 PSS unit tests in `pyde-crypto::threshold`

## Known follow-ups (not in this PR)
- Intermittent ~45 s subprocess startup wedge (RPC port collision /
  cold-spawn libp2p QUIC) — test-harness flake, not chain
- No 6 h / 24 h soak yet