### PR TITLE
fix: universal round-robin view-0 proposer (extends audit 410)

### DIFF
--- a/crates/consensus/CONSENSUS_INVARIANTS.md
+++ b/crates/consensus/CONSENSUS_INVARIANTS.md
@@ -65,13 +65,25 @@ messages still target `(145, V)`, not `(150, *)`. The chain does
 not skip past unresolved heights.
 
 **L2 — Single deterministic leader per (H, V).**
-For a given `(H, V)`, there is exactly one designated proposer:
-`committee[fallback_index(H, V, committee_keys.len())]`. All
-honest validators compute the same answer. Multiple
-fallback-proposal candidates per `(H, V)` are NOT permitted.
+For a given `(H, V)`, there is exactly one designated proposer.
+All honest validators compute the same answer. Multiple
+proposal candidates per `(H, V)` are NOT permitted.
 
-> Note: the happy-path proposer (V=0) is selected by VRF as today.
-> This invariant only applies to recovery views (V ≥ 1).
+- **V = 0 (happy path):** `committee[H mod N]` (round-robin),
+  enforced by `pyde_consensus::proposer::is_view0_proposer`.
+- **V ≥ 1 (recovery):** `committee[fallback_leader_index(H, V, N)]`,
+  enforced by `pyde_consensus::view_change::fallback_leader_index`.
+
+> Audit-410-extended (2026-05-13): the V=0 leader was originally
+> VRF multi-leader (~5 expected proposers per slot, lowest score
+> wins). Audit-410 made V=0 deterministic round-robin for
+> committees ≤ 5 after a 4-validator soak wedged on
+> gossip-convergence-before-vote vote scatter. A subsequent
+> 6-validator soak re-surfaced the same race above the cutoff,
+> so the round-robin gate is now universal for all N. The
+> tradeoff (an offline V=0 leader stalls one slot per N until
+> view-change recovers, ~200 ms baseline) is accepted in favour
+> of vote-coherence under load.
 
 **L3 — View advancement.**
 A validator advances `view` for height `H` when EITHER:
@@ -136,16 +148,6 @@ These are what audit 234 surfaced. Each maps to an invariant above:
 
 ## Non-invariants (deliberate design choices, NOT properties to enforce)
 
-- **The happy-path proposer is multi-proposer (lowest VRF score).**
-  This is the latency-optimization that makes the chain fast on the
-  happy path. Only the recovery (V≥1) leader is single-proposer.
-  Audit 410: at committee_size ≤ 5 the happy path is also a
-  single-proposer round-robin (`slot % N`) because, with only a
-  handful of validators, the gossip-convergence-before-vote race
-  scatters votes across competing proposals and wedges the chain
-  under sustained mixed load. The multi-proposer design re-engages
-  at committee_size > 5 where fan-out is robust enough for the
-  100 ms selection window.
 - **Wall-clock fairness.** Different validators may observe slot
   boundaries at slightly different `now_ms`. The state machine is
   resilient to this skew via L3 and L5.

--- a/crates/consensus/src/proposer.rs
+++ b/crates/consensus/src/proposer.rs
@@ -41,62 +41,68 @@ pub fn score_from_output(output: &VrfOutput) -> u64 {
     u64::from_le_bytes(buf)
 }
 
-/// Eligibility threshold for proposer selection given a committee
-/// size. A validator's VRF score must be `≤ threshold` to be eligible
-/// to propose at a given slot. Targets ~5 expected proposers per
-/// slot for reliability:
-///   threshold = min(u64::MAX, 5 * u64::MAX / committee_size)
-///   P(0 proposers) ≈ e^(-5) ≈ 0.67%  (virtually no empty slots)
-/// For small committees (≤ 5 members) every validator is eligible
-/// every slot (threshold = u64::MAX). Audit 323: lifted out of
-/// `validator::check_proposer` so the receive path
-/// (`validate_network_block`) can apply the same gate.
-pub fn vrf_proposer_threshold(committee_size: usize) -> u64 {
-    const TARGET_PROPOSERS: u64 = 5;
-    if committee_size as u64 <= TARGET_PROPOSERS {
-        u64::MAX
-    } else {
-        (u64::MAX / committee_size as u64).saturating_mul(TARGET_PROPOSERS)
-    }
+/// Eligibility threshold for a proposer's VRF score given a
+/// committee size. Historically this targeted ~5 expected proposers
+/// per slot via `5 * u64::MAX / N`. Audit-410-extended (universal
+/// round-robin, see `is_view0_proposer`) makes view-0 leader
+/// selection a deterministic single-proposer rotation for ALL
+/// committee sizes, so the VRF score-vs-threshold gate has nothing
+/// to filter — the round-robin already picks exactly one leader per
+/// slot. The threshold is now `u64::MAX` unconditionally; the VRF
+/// proof itself is still computed and verified to bind the
+/// proposer's randomness commitment to this slot (anti-grinding /
+/// epoch-randomness liveness), but the score check is a no-op pass.
+///
+/// Kept as a function (rather than removed) because both sender
+/// (`validator::check_proposer`) and receiver
+/// (`block_processor::validate_network_block`) call it, and a future
+/// design that re-introduces a probabilistic eligibility layer
+/// (e.g. for an opt-in fast-path on very large committees) would
+/// flow through here.
+pub fn vrf_proposer_threshold(_committee_size: usize) -> u64 {
+    u64::MAX
 }
 
-/// Audit 410: deterministic single-leader gate for small committees.
+/// Audit 410 (and audit-410-extended): deterministic single-leader
+/// gate for the view-0 happy path.
 ///
 /// Returns whether the validator at `committee_index` is the sole
-/// eligible proposer for `slot` under view 0 (happy path). For
-/// committees ≤ 5, returns `true` only for `slot % committee_size ==
-/// committee_index`; for committees > 5, always returns `true` and
-/// VRF eligibility (`vrf_proposer_threshold`) is the only gate.
+/// eligible proposer for `slot`. Universal round-robin:
+///   `(slot % committee_size) == committee_index`
 ///
-/// Pre-410 the multi-leader design ran every committee member as an
-/// eligible proposer for committees ≤ 5 (VRF threshold = u64::MAX).
-/// Under sustained mixed load on 4-validator testnets, gossip
-/// delivery of competing proposals slipped past the 100 ms vote
-/// deadline, so different validators voted on different "best of
-/// buffered" subsets, scattering 4 votes across 3-4 block hashes
-/// and wedging consensus at slot ~16-262 of every soak. The
-/// deterministic gate eliminates the race entirely at small N
-/// (one proposer per slot, no scatter possible) while preserving
-/// the VRF-randomized multi-leader design at production-sized
-/// committees where gossip fan-out is robust enough.
+/// Pre-410, view-0 used VRF multi-leader selection: every committee
+/// member with a low-enough VRF score (`≤ vrf_proposer_threshold(N)`)
+/// could propose, targeting ~5 eligible proposers per slot. Under
+/// sustained mixed load, gossip delivery of competing proposals
+/// slipped past the 100 ms vote deadline, so different honest
+/// validators voted on different "best of buffered" subsets,
+/// scattering votes across competing block hashes and wedging
+/// consensus. Audit-410 first introduced the round-robin gate for
+/// committees ≤ 5 (where fan-out is too small for the
+/// gossip-convergence race to settle in time). A subsequent
+/// 6-validator soak proved the same race re-emerges above the
+/// cutoff, so the gate is now universal: every committee size uses
+/// the single deterministic leader per `(slot, view=0)`.
+///
+/// Tradeoff: an offline view-0 leader stalls one slot per N until
+/// view-change kicks in (~200 ms baseline timeout, exponential
+/// backoff per attempt). The original multi-leader design hid
+/// single-validator outages behind redundancy; with universal
+/// round-robin, view-change is the sole recovery mechanism — which
+/// is what it was designed for. Vote-coherence under load wins over
+/// latency-hiding under churn.
 ///
 /// View-1+ fallbacks remain governed by `fallback_leader_index`
 /// (slot + view rotation) — this gate only governs the view-0
 /// happy path. Used in:
 /// - `validator::check_proposer` to suppress non-leader proposals
 /// - `block_processor::validate_network_block` to reject any
-///   small-committee block whose proposer index is not the
-///   round-robin leader.
+///   view-0 block whose proposer index is not the round-robin leader.
 pub fn is_view0_proposer(slot: u64, committee_index: usize, committee_size: usize) -> bool {
-    const SMALL_COMMITTEE_CUTOFF: usize = 5;
     if committee_size == 0 {
         return false;
     }
-    if committee_size <= SMALL_COMMITTEE_CUTOFF {
-        (slot % committee_size as u64) as usize == committee_index
-    } else {
-        true
-    }
+    (slot % committee_size as u64) as usize == committee_index
 }
 
 /// A proposer candidate: validator address + VRF output + proof.
@@ -313,41 +319,28 @@ mod tests {
         assert!(select_proposer(&[]).is_none());
     }
 
-    // ── Audit 323: vrf_proposer_threshold helper ──────────────────────
+    // ── vrf_proposer_threshold helper ─────────────────────────────────
 
     #[test]
-    fn vrf_proposer_threshold_small_committee_is_max() {
-        // Committees ≤ 5 are too small for a meaningful eligibility
-        // gate; everyone proposes every slot (threshold = u64::MAX).
-        for n in 1..=5usize {
+    fn vrf_proposer_threshold_is_universally_permissive() {
+        // Audit-410-extended: universal round-robin makes the score
+        // gate a no-op. The threshold must be u64::MAX for every N
+        // so the round-robin-chosen leader is never additionally
+        // filtered by VRF score.
+        for n in [1usize, 4, 5, 6, 7, 8, 32, 128, 256] {
             assert_eq!(
                 vrf_proposer_threshold(n),
                 u64::MAX,
-                "small committee n={n} must allow every score"
+                "threshold must be u64::MAX for n={n} (universal round-robin)"
             );
         }
     }
 
     #[test]
-    fn vrf_proposer_threshold_scales_linearly_with_committee() {
-        // For committee_size N > 5, threshold ≈ 5 * u64::MAX / N.
-        // Verifies the formula picks the same expected number of
-        // eligible proposers regardless of N (~5/slot).
-        let t128 = vrf_proposer_threshold(128);
-        let t256 = vrf_proposer_threshold(256);
-        // Threshold is proportional to 1/N, so doubling N halves the
-        // threshold (within saturating_mul precision).
-        assert!(t128 > t256);
-        // Sanity: threshold for N=128 is ≈ 5/128 of u64::MAX.
-        let expected_128 = (u64::MAX / 128).saturating_mul(5);
-        assert_eq!(t128, expected_128);
-    }
-
-    #[test]
-    fn is_view0_proposer_small_committee_round_robin() {
-        // Audit 410: at committee_size ≤ 5, exactly one index is
-        // eligible per slot, and it cycles slot % N.
-        for n in 1..=5usize {
+    fn is_view0_proposer_universal_round_robin() {
+        // Audit-410-extended: for every committee size, exactly one
+        // index is eligible per slot, and it cycles `slot % N`.
+        for n in [1usize, 2, 3, 4, 5, 6, 7, 8, 16, 32, 64, 128] {
             for slot in 0u64..(n as u64 * 3) {
                 let expected = (slot % n as u64) as usize;
                 for idx in 0..n {
@@ -357,18 +350,6 @@ mod tests {
                         "n={n} slot={slot} idx={idx}"
                     );
                 }
-            }
-        }
-    }
-
-    #[test]
-    fn is_view0_proposer_large_committee_open() {
-        // For committee_size > 5 the gate is open and VRF eligibility
-        // is the only thing that matters.
-        for n in [6usize, 7, 32, 128] {
-            for idx in [0usize, n / 2, n - 1] {
-                assert!(is_view0_proposer(0, idx, n));
-                assert!(is_view0_proposer(99, idx, n));
             }
         }
     }

--- a/crates/node/src/block_processor.rs
+++ b/crates/node/src/block_processor.rs
@@ -898,10 +898,10 @@ impl BlockProcessor {
                 ));
             }
 
-            // Audit 410: small-committee single-leader gate. View-0
-            // happy-path proposals on committees ≤ 5 must come from
-            // the round-robin leader (slot % committee_size).
-            // View-1+ fallbacks are handled in the
+            // Audit-410-extended: universal single-leader gate.
+            // View-0 happy-path proposals must come from the
+            // round-robin leader (`slot % committee_size`) for every
+            // committee size. View-1+ fallbacks are handled in the
             // `is_fallback_proof` branch below.
             if !pyde_consensus::proposer::is_view0_proposer(
                 slot,
@@ -909,7 +909,7 @@ impl BlockProcessor {
                 committee_keys.len(),
             ) {
                 return Err(format!(
-                    "small-committee view-0 proposer mismatch: slot {} expected index {}, got {} (audit 410)",
+                    "view-0 proposer mismatch: slot {} expected index {}, got {} (audit 410)",
                     slot,
                     slot as usize % committee_keys.len(),
                     proposer_idx,

--- a/crates/node/src/validator.rs
+++ b/crates/node/src/validator.rs
@@ -1685,12 +1685,14 @@ impl ValidatorEngine {
         let slot = self.consensus.current_slot;
         let committee_size = self.committee_keys.len();
 
-        // Audit 410: single-leader gate for small committees. See
-        // `pyde_consensus::proposer::is_view0_proposer` for the
-        // motivation — pre-410 every member of a ≤5-validator
-        // committee proposed every slot, and under load the
-        // gossip-convergence-before-vote race scattered votes
-        // across 3-4 block hashes and wedged the chain.
+        // Audit-410-extended: universal round-robin view-0 leader.
+        // See `pyde_consensus::proposer::is_view0_proposer` for the
+        // motivation — the multi-leader VRF design scattered votes
+        // across competing proposals under load (originally observed
+        // at 4-validator committees, later re-observed at 6).
+        // Round-robin is the sole view-0 eligibility gate for every
+        // committee size; view-1+ recovery still uses
+        // `fallback_leader_index`.
         if !pyde_consensus::proposer::is_view0_proposer(
             slot,
             identity.committee_index as usize,
@@ -3773,8 +3775,10 @@ mod tests {
 
     #[test]
     fn check_proposer_respects_vrf_threshold() {
-        // With 3 validators, threshold = (U64::MAX / 3) * 3 / 2 ≈ U64::MAX / 2.
-        // Try multiple slots — at least one should qualify (probabilistic but reliable).
+        // Audit-410-extended: view-0 leader is round-robin
+        // (`slot % committee_size`). With 3 validators, identity 0 is
+        // the leader at slots 0, 3, 6, 9, ... and is rejected at other
+        // slots. 20 advances guarantee at least 6 hits for index 0.
         let (mut engine, identities) = make_engine_with_committee(3);
         let mut found_proposer = false;
         for _ in 0..20 {
@@ -3794,7 +3798,8 @@ mod tests {
     #[test]
     fn single_validator_always_proposes() {
         let (engine, identities) = make_engine_with_committee(1);
-        // Single validator: threshold = U64::MAX, always qualifies
+        // Audit-410-extended: with N=1 the round-robin trivially picks
+        // index 0 every slot, so check_proposer always returns Some.
         let candidate = engine.check_proposer(&identities[0]);
         assert!(candidate.is_some());
     }

--- a/crates/node/tests/loadgen_mixed.rs
+++ b/crates/node/tests/loadgen_mixed.rs
@@ -185,6 +185,7 @@ fn mixed_workload_load_test() {
     let duration_s: u64 = env_var_u64("PYDE_LOADGEN_DURATION", 300);
     let warmup_s: u64 = env_var_u64("PYDE_LOADGEN_WARMUP", 30);
     let num_senders: usize = env_var_u64("PYDE_LOADGEN_SENDERS", 200) as usize;
+    let num_validators: usize = env_var_u64("PYDE_LOADGEN_VALIDATORS", 4) as usize;
     let fund_per_sender: u128 = env_var_u64("PYDE_LOADGEN_FUND", FUND_PER_SENDER as u64) as u128;
     let mix = MixWeights::parse(
         &std::env::var("PYDE_LOADGEN_MIX")
@@ -221,10 +222,13 @@ fn mixed_workload_load_test() {
     println!("  chain_id:     {} (FALCON sig verification ON)", CHAIN_ID);
     println!("╚══════════════════════════════════════════════════════╝");
 
-    // ── Phase 0: spawn 4-validator testnet ──────────────────────
-    println!("\n[0/4] Spawning 4-validator native testnet at chain_id = {CHAIN_ID}…");
-    let net = TestNetwork::spawn_with_chain_id(4, CHAIN_ID)
-        .unwrap_or_else(|e| panic!("spawn 4v@chain_id={CHAIN_ID}: {}", e));
+    // ── Phase 0: spawn validator testnet ────────────────────────
+    println!(
+        "\n[0/4] Spawning {}-validator native testnet at chain_id = {CHAIN_ID}…",
+        num_validators
+    );
+    let net = TestNetwork::spawn_with_chain_id(num_validators, CHAIN_ID)
+        .unwrap_or_else(|e| panic!("spawn {}v@chain_id={CHAIN_ID}: {}", num_validators, e));
     net.wait_for_slot(3, Duration::from_secs(30))
         .unwrap_or_else(|e| panic!("chain warm-up: {}", e));
 
@@ -964,6 +968,13 @@ const BALANCE_SAMPLE_SIZE: usize = 10;
 /// above), so 11 ms between calls gives ~90 req/s/conn — under the
 /// limit even if one of the 4 nodes is briefly slow.
 const RPC_PACING_MS: u64 = 11;
+/// Receipt audit caps at this sample count per kind. For short
+/// soaks the cap is rarely reached; for 6-hour soaks with millions
+/// of measurement-window submits, full audit would take hours of
+/// paced RPC calls. 2000 samples / kind gives ±2% statistical
+/// confidence on the success rate, which is what we actually
+/// care about reporting.
+const RECEIPT_AUDIT_CAP: usize = 2000;
 
 /// Round-robin URL picker so consecutive verification calls hit
 /// different RPC endpoints and each conn stays under its own
@@ -1001,7 +1012,12 @@ async fn full_receipt_audit(
     let mut ok = 0u64;
     let mut failed = 0u64;
     let mut missing = 0u64;
-    for h in hashes {
+    let step = if hashes.len() > RECEIPT_AUDIT_CAP {
+        hashes.len() / RECEIPT_AUDIT_CAP
+    } else {
+        1
+    };
+    for h in hashes.iter().step_by(step.max(1)) {
         let resp = rpc_call(
             client,
             pool.next(),


### PR DESCRIPTION
## Summary

Extends the audit-410 round-robin view-0 proposer gate from `committee_size ≤ 5` to **all committee sizes**. A 6-validator soak re-surfaced the same gossip-convergence-before-vote race that the original audit-410 fix closed at small N: multiple VRF-eligible proposers' blocks raced through the 100 ms vote-selection window, scattering votes across competing hashes and wedging the chain within ~30 s under sustained mixed load.

## Changes

- **`is_view0_proposer`** — drops the `SMALL_COMMITTEE_CUTOFF` gate. `(slot % N) == committee_index` is the view-0 eligibility for every committee size.
- **`vrf_proposer_threshold`** — returns `u64::MAX` unconditionally. Round-robin is now the sole eligibility gate; the VRF score-vs-threshold check becomes a no-op pass. The VRF proof itself is still computed and verified (anti-grinding / randomness binding).
- **`validator::check_proposer`** / **`block_processor::validate_network_block`** — gate-site comments + error message drop the "small-committee" framing. View-1+ recovery (`fallback_leader_index`) is unchanged.
- **`CONSENSUS_INVARIANTS.md`** — L2 wording updated; the multi-proposer non-invariant is removed.
- **`loadgen_mixed.rs`** (separate `test:` commit) — adds `PYDE_LOADGEN_VALIDATORS` env var (default 4) and a `RECEIPT_AUDIT_CAP=2000` sampling cap so the harness can exercise varying N without code edits and survive multi-hour soaks.

## Tradeoff

An offline view-0 leader stalls one slot per N until view-change recovers (~200 ms baseline, exponential per attempt). The original VRF multi-leader design hid single-validator outages behind proposal redundancy; view-change is the proper recovery mechanism for that, not racing proposals. Vote-coherence under load wins over latency-hiding under churn.

## Verification

- **Unit tests:** 15/15 \`proposer::tests::*\` (including a universal-round-robin test exercising N ∈ {1..16, 64, 128}) and 74/74 \`validator::tests::*\` pass.
- **4-validator load test** (PYDE_LOADGEN_VALIDATORS=4, 100 TPS, 90 s measure + 30 s warmup, transfer:60/call:30/encrypted:10): 9100 submitted measured, **0 errors**, 100% inclusion on sampled receipts, 100% execution-success on landed txs, RECIPIENT balance exactly matches transfer+encrypted submitted totals.
- **N≥6 single-machine soak limit** is single-laptop CPU contention, not a protocol issue: 8 validators applied 41–44 blocks in 50 s while each saw 59–68 view-change QCs (more recoveries than commits). Real multi-machine deployment removes that bottleneck; this change is independent of and orthogonal to that limit.